### PR TITLE
Change README to represent the new and changed URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PlaceholderMC is a custom launcher that will be the continuation of the now dead PolyMC.
+# Prism Launcher is a custom launcher that will be the continuation of the now dead PolyMC.
 #### We are working on a website and other media, for more info we have a discord server.
 #### Logo and branding also coming soon...
 
@@ -6,12 +6,12 @@
 
 ## Installation
 
-- All downloads and instructions for PlaceholderMC will soon be available
-- Last build status: <https://github.com/PlaceholderMC/PlaceholderMC/actions>
+- All downloads and instructions for Prism Launcher will soon be available
+- Last build status: <https://github.com/PlaceholderMC/PrismLauncher/actions>
 
 ### Development Builds
 
-There are development builds available [here](https://github.com/PlaceholderMC/PlaceholderMC/actions). These have debug information in the binaries, so their file sizes are relatively larger.
+There are development builds available [here](https://github.com/PlaceholderMC/PrismLauncher/actions). These have debug information in the binaries, so their file sizes are relatively larger.
 Portable builds are provided for AppImage on Linux, Windows, and macOS.
 
 ## Help & Support


### PR DESCRIPTION
The URL got changed and so the old build status URL won't work correctly anymore soon. (Githubs redirect is only temporary) This PR changes stuff so the GH Actions links are shown correctly.

Signed-off-by: Cleo John <30842467+CutestNekoAqua@users.noreply.github.com>