### PR TITLE
Fix and improve FTB modpack installation

### DIFF
--- a/launcher/modplatform/flame/FileResolvingTask.cpp
+++ b/launcher/modplatform/flame/FileResolvingTask.cpp
@@ -9,9 +9,10 @@ Flame::FileResolvingTask::FileResolvingTask(const shared_qobject_ptr<QNetworkAcc
 
 bool Flame::FileResolvingTask::abort()
 {
+    bool aborted = true;
     if (m_dljob)
-        return m_dljob->abort();
-    return true;
+        aborted &= m_dljob->abort();
+    return aborted ? Task::abort() : false;
 }
 
 void Flame::FileResolvingTask::executeTask()

--- a/launcher/modplatform/modpacksch/FTBPackInstallTask.h
+++ b/launcher/modplatform/modpacksch/FTBPackInstallTask.h
@@ -56,7 +56,6 @@ public:
     explicit PackInstallTask(Modpack pack, QString version, QWidget* parent = nullptr);
     ~PackInstallTask() override = default;
 
-    bool canAbort() const override { return m_abortable; }
     bool abort() override;
 
 protected:
@@ -65,20 +64,20 @@ protected:
 private slots:
     void onManifestDownloadSucceeded();
     void onResolveModsSucceeded();
+    void onCreateInstanceSucceeded();
     void onModDownloadSucceeded();
 
     void onManifestDownloadFailed(QString reason);
     void onResolveModsFailed(QString reason);
+    void onCreateInstanceFailed(QString reason);
     void onModDownloadFailed(QString reason);
 
 private:
     void resolveMods();
+    void createInstance();
     void downloadPack();
-    void install();
 
 private:
-    bool m_abortable = true;
-
     NetJob::Ptr m_net_job = nullptr;
     shared_qobject_ptr<Flame::FileResolvingTask> m_mod_id_resolver_task = nullptr;
 

--- a/launcher/ui/dialogs/NewInstanceDialog.cpp
+++ b/launcher/ui/dialogs/NewInstanceDialog.cpp
@@ -139,6 +139,10 @@ NewInstanceDialog::NewInstanceDialog(const QString & initialGroup, const QString
 void NewInstanceDialog::reject()
 {
     APPLICATION->settings()->set("NewInstanceGeometry", saveGeometry().toBase64());
+
+    // This is just so that the pages get the close() call and can react to it, if needed.
+    m_container->prepareToClose();
+
     QDialog::reject();
 }
 
@@ -146,6 +150,10 @@ void NewInstanceDialog::accept()
 {
     APPLICATION->settings()->set("NewInstanceGeometry", saveGeometry().toBase64());
     importIconNow();
+
+    // This is just so that the pages get the close() call and can react to it, if needed.
+    m_container->prepareToClose();
+
     QDialog::accept();
 }
 

--- a/launcher/ui/dialogs/ProgressDialog.cpp
+++ b/launcher/ui/dialogs/ProgressDialog.cpp
@@ -25,6 +25,7 @@ ProgressDialog::ProgressDialog(QWidget* parent) : QDialog(parent), ui(new Ui::Pr
 {
     ui->setupUi(this);
     this->setWindowFlags(this->windowFlags() & ~Qt::WindowContextHelpButtonHint);
+    setAttribute(Qt::WidgetAttribute::WA_QuitOnClose, true);
     setSkipButton(false);
     changeProgress(0, 100);
 }
@@ -67,7 +68,7 @@ int ProgressDialog::execWithTask(Task* task)
         return QDialog::DialogCode::Accepted;
     }
 
-    QDialog::DialogCode result;
+    QDialog::DialogCode result {};
     if (handleImmediateResult(result)) {
         return result;
     }
@@ -80,7 +81,7 @@ int ProgressDialog::execWithTask(Task* task)
     connect(task, &Task::stepStatus, this, &ProgressDialog::changeStatus);
     connect(task, &Task::progress, this, &ProgressDialog::changeProgress);
 
-    connect(task, &Task::aborted, [this] { QDialog::reject(); });
+    connect(task, &Task::aborted, this, &ProgressDialog::hide);
     connect(task, &Task::abortStatusChanged, ui->skipButton, &QPushButton::setEnabled);
 
     m_is_multi_step = task->isMultiStep();

--- a/launcher/ui/pages/modplatform/ftb/FtbListModel.cpp
+++ b/launcher/ui/pages/modplatform/ftb/FtbListModel.cpp
@@ -103,6 +103,8 @@ void ListModel::getLogo(const QString &logo, const QString &logoUrl, LogoCallbac
 
 void ListModel::request()
 {
+    m_aborted = false;
+
     beginResetModel();
     modpacks.clear();
     endResetModel();
@@ -115,6 +117,12 @@ void ListModel::request()
 
     QObject::connect(netJob, &NetJob::succeeded, this, &ListModel::requestFinished);
     QObject::connect(netJob, &NetJob::failed, this, &ListModel::requestFailed);
+}
+
+void ListModel::abortRequest()
+{
+    m_aborted = jobPtr->abort();
+    jobPtr.reset();
 }
 
 void ListModel::requestFinished()
@@ -162,6 +170,9 @@ void ListModel::requestPack()
 
 void ListModel::packRequestFinished()
 {
+    if (!jobPtr || m_aborted)
+        return;
+
     jobPtr.reset();
     remainingPacks.removeOne(currentPack);
 

--- a/launcher/ui/pages/modplatform/ftb/FtbListModel.h
+++ b/launcher/ui/pages/modplatform/ftb/FtbListModel.h
@@ -47,8 +47,11 @@ public:
     QVariant data(const QModelIndex &index, int role) const override;
 
     void request();
+    void abortRequest();
 
     void getLogo(const QString &logo, const QString &logoUrl, LogoCallback callback);
+
+    [[nodiscard]] bool isMakingRequest() const { return jobPtr.get(); }
 
 private slots:
     void requestFinished();
@@ -65,6 +68,8 @@ private:
     void requestLogo(QString file, QString url);
 
 private:
+    bool m_aborted = false;
+
     QList<ModpacksCH::Modpack> modpacks;
     LogoMap m_logoMap;
 

--- a/launcher/ui/pages/modplatform/ftb/FtbListModel.h
+++ b/launcher/ui/pages/modplatform/ftb/FtbListModel.h
@@ -52,6 +52,7 @@ public:
     void getLogo(const QString &logo, const QString &logoUrl, LogoCallback callback);
 
     [[nodiscard]] bool isMakingRequest() const { return jobPtr.get(); }
+    [[nodiscard]] bool wasAborted() const { return m_aborted; }
 
 private slots:
     void requestFinished();

--- a/launcher/ui/pages/modplatform/ftb/FtbPage.cpp
+++ b/launcher/ui/pages/modplatform/ftb/FtbPage.cpp
@@ -114,6 +114,12 @@ void FtbPage::openedImpl()
     suggestCurrent();
 }
 
+void FtbPage::closedImpl()
+{
+    if (listModel->isMakingRequest())
+        listModel->abortRequest();
+}
+
 void FtbPage::suggestCurrent()
 {
     if(!isOpened)

--- a/launcher/ui/pages/modplatform/ftb/FtbPage.cpp
+++ b/launcher/ui/pages/modplatform/ftb/FtbPage.cpp
@@ -105,7 +105,7 @@ void FtbPage::retranslate()
 
 void FtbPage::openedImpl()
 {
-    if(!initialised)
+    if(!initialised || listModel->wasAborted())
     {
         listModel->request();
         initialised = true;

--- a/launcher/ui/pages/modplatform/ftb/FtbPage.h
+++ b/launcher/ui/pages/modplatform/ftb/FtbPage.h
@@ -78,6 +78,7 @@ public:
     void retranslate() override;
 
     void openedImpl() override;
+    void closedImpl() override;
 
     bool eventFilter(QObject * watched, QEvent * event) override;
 


### PR DESCRIPTION
- Fixes issues with FTB modpacks not installing correctly
- Stop search when selecting a pack for install, to avoid having to wait for it to finish
- Fix some abort problems, which seems to stop working from time to time (this time i had to hide() the dialog instead of doing a reject() for it to close, maybe it's a Qt bug? i'm not sure what's causing it) thinking

Also, i've changed the FTB's "minecraft" folder to ".minecraft", to keep it similar to most other providers. I didn't find anything saying that it needs to be just "minecraft", but maybe i'm missing something? idk.
