### PR TITLE
Make more resource buttons available when the instance is running, and clean-up the code a bit

### DIFF
--- a/launcher/ui/pages/instance/ExternalResourcesPage.cpp
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.cpp
@@ -103,10 +103,6 @@ void ExternalResourcesPage::runningStateChanged(bool running)
         return;
     
     m_controlsEnabled = !running;
-    ui->actionAddItem->setEnabled(m_controlsEnabled);
-    ui->actionDisableItem->setEnabled(m_controlsEnabled);
-    ui->actionEnableItem->setEnabled(m_controlsEnabled);
-    ui->actionRemoveItem->setEnabled(m_controlsEnabled);
 }
 
 bool ExternalResourcesPage::shouldDisplay() const

--- a/launcher/ui/pages/instance/ModFolderPage.cpp
+++ b/launcher/ui/pages/instance/ModFolderPage.cpp
@@ -117,6 +117,10 @@ void ModFolderPage::runningStateChanged(bool running)
     ExternalResourcesPage::runningStateChanged(running);
     ui->actionDownloadItem->setEnabled(!running);
     ui->actionUpdateItem->setEnabled(!running);
+    ui->actionAddItem->setEnabled(!running);
+    ui->actionEnableItem->setEnabled(!running);
+    ui->actionDisableItem->setEnabled(!running);
+    ui->actionRemoveItem->setEnabled(!running);
 }
 
 bool ModFolderPage::shouldDisplay() const


### PR DESCRIPTION
This cleans this and improves source readability. It also makes it so that non-mod resource pages (e.g. resource packs and shader packs) have their buttons enabled even when the game is running, as it is something a lot of people wanted for a long time.

Resolves #35
(was already resolved because the issue was invalid, but this is kinda related at least and it cleans up code related to it in the source)