### PR TITLE
Import config from `multimc.cfg` if available

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -489,7 +489,7 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
     // Initialize application settings
     {
         // Provide a fallback for migration from PolyMC
-        m_settings.reset(new INISettingsObject({ BuildConfig.LAUNCHER_CONFIGFILE, "polymc.cfg" }, this));
+        m_settings.reset(new INISettingsObject({ BuildConfig.LAUNCHER_CONFIGFILE, "polymc.cfg", "multimc.cfg" }, this));
         // Updates
         // Multiple channels are separated by spaces
         m_settings->registerSetting("UpdateChannel", BuildConfig.VERSION_CHANNEL);


### PR DESCRIPTION
Add fallback for multimc.cfg to make migration from MultiMC easier