### PR TITLE
Fix incorrect release titles

### DIFF
--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -65,7 +65,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          name: PrismLauncher ${{ env.VERSION }}
+          name: Prism Launcher ${{ env.VERSION }}
           draft: true
           prerelease: false
           files: |


### PR DESCRIPTION
The `trigger_release` workflow currently uses the word "PrismLauncher" to label releases. However, the name of the project is "Prism Launcher". This PR fixes this inconsistency.

Relevant Discord discussion: https://discord.com/channels/1031648380885147709/1031823065937629267/1032357453653884955

Signed-off-by: MMK21Hub <KAGfan2018@outlook.com>