### PR TITLE
enhancement: update nix derivation and instructions

### DIFF
--- a/nix/NIX.md
+++ b/nix/NIX.md
@@ -1,21 +1,59 @@
-# How to import
+# Running on Nix
 
-To import with flakes use
+## Putting it in your system configuration
+
+### On flakes-enabled nix
+
+#### Directly installing
+
+The `prismlauncher` flake provides a package which you can install along with
+the rest of your packages
 
 ```nix
+# In your flake.nix:
 {
   inputs = {
     prismlauncher.url = "github:PrismLauncher/PrismLauncher";
   };
-
-...
-
-  nixpkgs.overlays = [ inputs.prismlauncher.overlay ]; ## Within configuration.nix
-  environment.systemPackages = with pkgs; [ prismlauncher ]; ##
 }
 ```
 
-To import without flakes use channels:
+```nix
+# And in your system configuration:
+environment.systemPackages = [ prismlauncher.packages.${pkgs.system}.prismlauncher ];
+
+# Or in your home-manager configuration:
+home.packages = [ prismlauncher.packages.${pkgs.system}.prismlauncher ];
+```
+
+#### Using the overlay
+
+Alternatively, you can overlay the prismlauncher version in nixpkgs which will
+allow you to install using `pkgs` as you normally would while also using the
+latest version
+
+```nix
+# In your flake.nix:
+{
+  inputs = {
+    prismlauncher.url = "github:PrismLauncher/PrismLauncher";
+  };
+}
+```
+
+```nix
+# And in your system configuration:
+nixpkgs.overlays = [ inputs.prismlauncher.overlay ];
+environment.systemPackages = [ pkgs.prismlauncher ];
+
+# Or in your home-manager configuration:
+config.nixpkgs.overlays = [ inputs.prismlauncher.overlay ];
+home.packages = [ pkgs.prismlauncher ];
+```
+
+### Without flakes-enabled nix
+
+#### Using channels
 
 ```sh
 nix-channel --add https://github.com/PrismLauncher/PrismLauncher/archive/master.tar.gz prismlauncher
@@ -23,9 +61,10 @@ nix-channel --update prismlauncher
 nix-env -iA prismlauncher
 ```
 
-or alternatively you can use
+#### Using the overlay
 
 ```nix
+# In your configuration.nix:
 {
   nixpkgs.overlays = [
     (import (builtins.fetchTarball "https://github.com/PrismLauncher/PrismLauncher/archive/develop.tar.gz")).overlay
@@ -33,4 +72,12 @@ or alternatively you can use
 
   environment.systemPackages = with pkgs; [ prismlauncher ];
 }
+```
+
+## Running ad-hoc
+
+If you're on a flakes-enabled nix you can run the launcher in one-line
+
+```sh
+nix run github:PrismLauncher/PrismLauncher
 ```

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -59,20 +59,20 @@ stdenv.mkDerivation rec {
     # Copy libnbtplusplus
     rm -rf source/libraries/libnbtplusplus
     mkdir source/libraries/libnbtplusplus
-    cp -a ${libnbtplusplus}/* source/libraries/libnbtplusplus
-    chmod a+r+w source/libraries/libnbtplusplus/*
+    ln -s ${libnbtplusplus}/* source/libraries/libnbtplusplus
+    chmod -R +r+w source/libraries/libnbtplusplus
     # Copy tomlplusplus
     rm -rf source/libraries/tomlplusplus
     mkdir source/libraries/tomlplusplus
-    cp -a ${tomlplusplus}/* source/libraries/tomlplusplus
-    chmod a+r+w source/libraries/tomlplusplus/*
+    ln -s ${tomlplusplus}/* source/libraries/tomlplusplus
+    chmod -R +r+w source/libraries/tomlplusplus
   '';
 
   cmakeFlags = [
     "-GNinja"
     "-DLauncher_QT_VERSION_MAJOR=${lib.versions.major qtbase.version}"
   ] ++ lib.optionals enableLTO [ "-DENABLE_LTO=on" ]
-    ++ lib.optionals (msaClientID != "") [ "-DLauncher_MSA_CLIENT_ID=${msaClientID}" ];
+  ++ lib.optionals (msaClientID != "") [ "-DLauncher_MSA_CLIENT_ID=${msaClientID}" ];
 
   # we have to check if the system is NixOS before adding stdenv.cc.cc.lib (#923)
   postInstall = ''
@@ -96,6 +96,6 @@ stdenv.mkDerivation rec {
     '';
     platforms = platforms.unix;
     license = licenses.gpl3Only;
-    maintainers = with maintainers; [ starcraft66 kloenk ];
+    maintainers = with maintainers; [ minion3665 Scrumplex ];
   };
 }


### PR DESCRIPTION
- Previously the derivation had some differences to nixpkgs' derivation in the way that it worked. These have been reduced
- Previously the old PolyMC maintainers were included as maintainers for the derivation. This has now been changed
- Previously the NIX.md instructions were missing several ways to use it with flakes. I've updated that
- Previously the NIX.md instructions were poorly formatted. I've added headings and split up codeblocks so it all makes a little more sense