### PR TITLE
Multiple Custom Themes (searching the themes folder for directories with theme.json and lone qss files)

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -2,10 +2,8 @@
 /*
  *  Prism Launcher
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
- *  Copyright (C) 2022 Tayou <tayou@gmx.net>
- *
- *  PolyMC - Minecraft Launcher
  *  Copyright (C) 2022 Lenny McLennington <lenny@sneed.church>
+ *  Copyright (C) 2022 Tayou <tayou@gmx.net>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -70,6 +68,8 @@
 #include "ui/dialogs/CustomMessageBox.h"
 
 #include "ui/pagedialog/PageDialog.h"
+
+#include "ui/themes/ThemeManager.h"
 
 #include "ApplicationMessage.h"
 
@@ -747,11 +747,7 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
     }
 
     // Themes
-    {
-        m_themeManager = new ThemeManager(m_mainWindow);
-
-        m_themeManager->InitializeThemes();
-    }
+    m_themeManager = std::make_unique<ThemeManager>(m_mainWindow);
 
     // initialize and load all instances
     {
@@ -858,10 +854,6 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
     }
 
     performMainStartupAction();
-}
-
-ThemeManager* Application::getThemeManager() {
-    return Application::m_themeManager;
 }
 
 bool Application::createSetupWizard()
@@ -1109,7 +1101,7 @@ std::shared_ptr<JavaInstallList> Application::javalist()
     return m_javalist;
 }
 
-std::vector<ITheme *> Application::getValidApplicationThemes()
+QList<ITheme*> Application::getValidApplicationThemes()
 {
     return m_themeManager->getValidApplicationThemes();
 }

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  Prism Launcher
+ *  Prism Launcher - Minecraft Launcher
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
  *  Copyright (C) 2022 Lenny McLennington <lenny@sneed.church>
  *  Copyright (C) 2022 Tayou <tayou@gmx.net>

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  PolyMC - Minecraft Launcher
+ *  Prism Launcher
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022 Tayou <tayou@gmx.net>
+ *
+ *  PolyMC - Minecraft Launcher
  *  Copyright (C) 2022 Lenny McLennington <lenny@sneed.church>
  *
  *  This program is free software: you can redistribute it and/or modify
@@ -53,12 +56,6 @@
 #include "ui/pages/global/AccountListPage.h"
 #include "ui/pages/global/APIPage.h"
 #include "ui/pages/global/CustomCommandsPage.h"
-
-#include "ui/themes/ITheme.h"
-#include "ui/themes/SystemTheme.h"
-#include "ui/themes/DarkTheme.h"
-#include "ui/themes/BrightTheme.h"
-#include "ui/themes/CustomTheme.h"
 
 #ifdef Q_OS_WIN
 #include "ui/WinDarkmode.h"
@@ -749,28 +746,11 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
         qDebug() << "<> Instance icons intialized.";
     }
 
-    // Icon themes
+    // Themes
     {
-        // TODO: icon themes and instance icons do not mesh well together. Rearrange and fix discrepancies!
-        // set icon theme search path!
-        auto searchPaths = QIcon::themeSearchPaths();
-        searchPaths.append("iconthemes");
-        QIcon::setThemeSearchPaths(searchPaths);
-        qDebug() << "<> Icon themes initialized.";
-    }
+        m_themeManager = new ThemeManager(m_mainWindow);
 
-    // Initialize widget themes
-    {
-        auto insertTheme = [this](ITheme * theme)
-        {
-            m_themes.insert(std::make_pair(theme->id(), std::unique_ptr<ITheme>(theme)));
-        };
-        auto darkTheme = new DarkTheme();
-        insertTheme(new SystemTheme());
-        insertTheme(darkTheme);
-        insertTheme(new BrightTheme());
-        insertTheme(new CustomTheme(darkTheme, "custom"));
-        qDebug() << "<> Widget themes initialized.";
+        m_themeManager->InitializeThemes();
     }
 
     // initialize and load all instances
@@ -878,6 +858,10 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
     }
 
     performMainStartupAction();
+}
+
+ThemeManager* Application::getThemeManager() {
+    return Application::m_themeManager;
 }
 
 bool Application::createSetupWizard()
@@ -1127,43 +1111,17 @@ std::shared_ptr<JavaInstallList> Application::javalist()
 
 std::vector<ITheme *> Application::getValidApplicationThemes()
 {
-    std::vector<ITheme *> ret;
-    auto iter = m_themes.cbegin();
-    while (iter != m_themes.cend())
-    {
-        ret.push_back((*iter).second.get());
-        iter++;
-    }
-    return ret;
+    return m_themeManager->getValidApplicationThemes();
 }
 
 void Application::setApplicationTheme(const QString& name, bool initial)
 {
-    auto systemPalette = qApp->palette();
-    auto themeIter = m_themes.find(name);
-    if(themeIter != m_themes.end())
-    {
-        auto & theme = (*themeIter).second;
-        theme->apply(initial);
-#ifdef Q_OS_WIN
-        if (m_mainWindow && IsWindows10OrGreater()) {
-            if (QString::compare(theme->id(), "dark") == 0) {
-                    WinDarkmode::setDarkWinTitlebar(m_mainWindow->winId(), true);
-            } else {
-                    WinDarkmode::setDarkWinTitlebar(m_mainWindow->winId(), false);
-            }
-        }
-#endif
-    }
-    else
-    {
-        qWarning() << "Tried to set invalid theme:" << name;
-    }
+    m_themeManager->setApplicationTheme(name, initial);
 }
 
 void Application::setIconTheme(const QString& name)
 {
-    QIcon::setThemeName(name);
+    m_themeManager->setIconTheme(name);
 }
 
 QIcon Application::getThemedIcon(const QString& name)

--- a/launcher/Application.h
+++ b/launcher/Application.h
@@ -45,8 +45,6 @@
 #include <QUrl>
 #include <updater/GoUpdate.h>
 
-#include "ui/themes/ThemeManager.h"
-
 #include <BaseInstance.h>
 
 #include "minecraft/launch/MinecraftServerTarget.h"
@@ -71,6 +69,7 @@ class BaseDetachedToolFactory;
 class TranslationsModel;
 class ITheme;
 class MCEditTool;
+class ThemeManager;
 
 namespace Meta {
     class Index;
@@ -121,7 +120,7 @@ public:
 
     void setIconTheme(const QString& name);
 
-    std::vector<ITheme *> getValidApplicationThemes();
+    QList<ITheme*> getValidApplicationThemes();
 
     void setApplicationTheme(const QString& name, bool initial);
 
@@ -201,8 +200,6 @@ public:
 
     void ShowGlobalSettings(class QWidget * parent, QString open_page = QString());
 
-    ThemeManager* getThemeManager();
-
 signals:
     void updateAllowedChanged(bool status);
     void globalSettingsAboutToOpen();
@@ -262,7 +259,7 @@ private:
     std::shared_ptr<GenericPageProvider> m_globalSettingsProvider;
     std::unique_ptr<MCEditTool> m_mcedit;
     QSet<QString> m_features;
-    ThemeManager* m_themeManager;
+    std::unique_ptr<ThemeManager> m_themeManager;
 
     QMap<QString, std::shared_ptr<BaseProfilerFactory>> m_profilers;
 

--- a/launcher/Application.h
+++ b/launcher/Application.h
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  PolyMC - Minecraft Launcher
+ *  Prism Launcher
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022 Tayou <tayou@gmx.net>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -43,6 +44,8 @@
 #include <QDateTime>
 #include <QUrl>
 #include <updater/GoUpdate.h>
+
+#include "ui/themes/ThemeManager.h"
 
 #include <BaseInstance.h>
 
@@ -198,6 +201,8 @@ public:
 
     void ShowGlobalSettings(class QWidget * parent, QString open_page = QString());
 
+    ThemeManager* getThemeManager();
+
 signals:
     void updateAllowedChanged(bool status);
     void globalSettingsAboutToOpen();
@@ -255,9 +260,9 @@ private:
     std::shared_ptr<JavaInstallList> m_javalist;
     std::shared_ptr<TranslationsModel> m_translations;
     std::shared_ptr<GenericPageProvider> m_globalSettingsProvider;
-    std::map<QString, std::unique_ptr<ITheme>> m_themes;
     std::unique_ptr<MCEditTool> m_mcedit;
     QSet<QString> m_features;
+    ThemeManager* m_themeManager;
 
     QMap<QString, std::shared_ptr<BaseProfilerFactory>> m_profilers;
 

--- a/launcher/Application.h
+++ b/launcher/Application.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  Prism Launcher
+ *  Prism Launcher - Minecraft Launcher
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
  *  Copyright (C) 2022 Tayou <tayou@gmx.net>
  *

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -650,6 +650,8 @@ SET(LAUNCHER_SOURCES
     ui/themes/ITheme.h
     ui/themes/SystemTheme.cpp
     ui/themes/SystemTheme.h
+    ui/themes/ThemeManager.cpp
+    ui/themes/ThemeManager.h
 
     # Processes
     LaunchController.h

--- a/launcher/ui/pages/global/LauncherPage.cpp
+++ b/launcher/ui/pages/global/LauncherPage.cpp
@@ -384,46 +384,8 @@ void LauncherPage::loadSettings()
     m_currentUpdateChannel = s->get("UpdateChannel").toString();
     //FIXME: make generic
     auto theme = s->get("IconTheme").toString();
-    if (theme == "pe_colored")
-    {
-        ui->themeComboBox->setCurrentIndex(0);
-    }
-    else if (theme == "pe_light")
-    {
-        ui->themeComboBox->setCurrentIndex(1);
-    }
-    else if (theme == "pe_dark")
-    {
-        ui->themeComboBox->setCurrentIndex(2);
-    }
-    else if (theme == "pe_blue")
-    {
-        ui->themeComboBox->setCurrentIndex(3);
-    }
-    else if (theme == "OSX")
-    {
-        ui->themeComboBox->setCurrentIndex(4);
-    }
-    else if (theme == "iOS")
-    {
-        ui->themeComboBox->setCurrentIndex(5);
-    }
-    else if (theme == "flat")
-    {
-        ui->themeComboBox->setCurrentIndex(6);
-    }
-    else if (theme == "flat_white")
-    {
-        ui->themeComboBox->setCurrentIndex(7);
-    }
-    else if (theme == "multimc")
-    {
-        ui->themeComboBox->setCurrentIndex(8);
-    }
-    else if (theme == "custom")
-    {
-        ui->themeComboBox->setCurrentIndex(9);
-    }
+    QStringList iconThemeOptions{"pe_colored", "pe_light", "pe_dark", "pe_blue", "OSX", "iOS", "flat", "flat_white", "multimc", "custom"};
+    ui->themeComboBox->setCurrentIndex(iconThemeOptions.indexOf(theme));
 
     {
         auto currentTheme = s->get("ApplicationTheme").toString();

--- a/launcher/ui/pages/global/LauncherPage.cpp
+++ b/launcher/ui/pages/global/LauncherPage.cpp
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  PolyMC - Minecraft Launcher
+ *  Prism Launcher - Minecraft Launcher
  *  Copyright (c) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
  *  Copyright (c) 2022 dada513 <dada513@protonmail.com>
+ *  Copyright (C) 2022 Tayou <tayou@gmx.net>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/launcher/ui/themes/CustomTheme.cpp
+++ b/launcher/ui/themes/CustomTheme.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  Prism Launcher
+ *  Prism Launcher - Minecraft Launcher
  *  Copyright (C) 2022 Tayou <tayou@gmx.net>
  *
  *  This program is free software: you can redistribute it and/or modify
@@ -19,10 +19,6 @@
  * permission notice:
  *
  *      Copyright 2013-2021 MultiMC Contributors
- *
- *      Authors: Andrew Okin
- *               Peterix
- *               Orochimarufan <orochimarufan.x3@gmail.com>
  *
  *      Licensed under the Apache License, Version 2.0 (the "License");
  *      you may not use this file except in compliance with the License.
@@ -56,7 +52,6 @@ static bool readThemeJson(const QString &path, QPalette &palette, double &fadeAm
             name = Json::requireString(root, "name", "Theme name");
             widgets = Json::requireString(root, "widgets", "Qt widget theme");
             qssFilePath = Json::ensureString(root, "qssFilePath", "themeStyle.css");
-            //auto colorFileList = Json::ensureArray(root, "colorFiles");
             auto colorsRoot = Json::requireObject(root, "colors", "colors object");
             auto readColor = [&](QString colorName) -> QColor
             {
@@ -165,7 +160,6 @@ static bool writeThemeJson(const QString &path, const QPalette &palette, double 
     }
 }
 
-/// @brief 
 /// @param baseTheme Base Theme
 /// @param fileInfo FileInfo object for file to load
 /// @param isManifest whether to load a theme manifest or a qss file
@@ -199,8 +193,6 @@ CustomTheme::CustomTheme(ITheme* baseTheme, QFileInfo& fileInfo, bool isManifest
             m_fadeAmount = baseTheme->fadeAmount();
             m_widgets = baseTheme->qtTheme();
             m_qssFilePath = "themeStyle.css";
-
-            QFileInfo info(themeFilePath);
         }
         else
         {
@@ -212,18 +204,18 @@ CustomTheme::CustomTheme(ITheme* baseTheme, QFileInfo& fileInfo, bool isManifest
             writeThemeJson(fileInfo.absoluteFilePath(), m_palette, m_fadeAmount, m_fadeColor, m_name, m_widgets, m_qssFilePath);
         }
 
-        auto cssFilePath = FS::PathCombine(path, m_qssFilePath);
-        QFileInfo info (cssFilePath);
+        auto qssFilePath = FS::PathCombine(path, m_qssFilePath);
+        QFileInfo info (qssFilePath);
         if(info.isFile())
         {
             try
             {
                 // TODO: validate css?
-                m_styleSheet = QString::fromUtf8(FS::read(cssFilePath));
+                m_styleSheet = QString::fromUtf8(FS::read(qssFilePath));
             }
             catch (const Exception &e)
             {
-                themeWarningLog() << "Couldn't load css:" << e.cause() << "from" << cssFilePath;
+                themeWarningLog() << "Couldn't load css:" << e.cause() << "from" << qssFilePath;
                 m_styleSheet = baseTheme->appStyleSheet();
             }
         }
@@ -233,11 +225,11 @@ CustomTheme::CustomTheme(ITheme* baseTheme, QFileInfo& fileInfo, bool isManifest
             m_styleSheet = baseTheme->appStyleSheet();
             try
             {
-                FS::write(cssFilePath, m_styleSheet.toUtf8());
+                FS::write(qssFilePath, m_styleSheet.toUtf8());
             }
             catch (const Exception &e)
             {
-                themeWarningLog() << "Couldn't write css:" << e.cause() << "to" << cssFilePath;
+                themeWarningLog() << "Couldn't write css:" << e.cause() << "to" << qssFilePath;
             }
         }
     } else {

--- a/launcher/ui/themes/CustomTheme.cpp
+++ b/launcher/ui/themes/CustomTheme.cpp
@@ -66,7 +66,7 @@ static bool readThemeJson(const QString &path, QPalette &palette, double &fadeAm
                     QColor color(colorValue);
                     if(!color.isValid())
                     {
-                        themeWarningLog << "Color value" << colorValue << "for" << colorName << "was not recognized.";
+                        themeWarningLog() << "Color value" << colorValue << "for" << colorName << "was not recognized.";
                         return QColor();
                     }
                     return color;
@@ -82,7 +82,7 @@ static bool readThemeJson(const QString &path, QPalette &palette, double &fadeAm
                 }
                 else
                 {
-                    themeDebugLog << "Color value for" << colorName << "was not present.";
+                    themeDebugLog() << "Color value for" << colorName << "was not present.";
                 }
             };
 
@@ -108,13 +108,13 @@ static bool readThemeJson(const QString &path, QPalette &palette, double &fadeAm
         }
         catch (const Exception &e)
         {
-            themeWarningLog << "Couldn't load theme json: " << e.cause();
+            themeWarningLog() << "Couldn't load theme json: " << e.cause();
             return false;
         }
     }
     else
     {
-        themeDebugLog << "No theme json present.";
+        themeDebugLog() << "No theme json present.";
         return false;
     }
     return true;
@@ -160,7 +160,7 @@ static bool writeThemeJson(const QString &path, const QPalette &palette, double 
     }
     catch (const Exception &e)
     {
-        themeWarningLog << "Failed to write theme json to" << path;
+        themeWarningLog() << "Failed to write theme json to" << path;
         return false;
     }
 }
@@ -179,7 +179,7 @@ CustomTheme::CustomTheme(ITheme* baseTheme, QFileInfo& fileInfo, bool isManifest
 
         if(!FS::ensureFolderPathExists(path) || !FS::ensureFolderPathExists(pathResources))
         {
-            themeWarningLog << "X couldn't create folder for theme!";
+            themeWarningLog() << "couldn't create folder for theme!";
             m_palette = baseTheme->colorScheme();
             m_styleSheet = baseTheme->appStyleSheet();
             return;
@@ -192,7 +192,7 @@ CustomTheme::CustomTheme(ITheme* baseTheme, QFileInfo& fileInfo, bool isManifest
         m_palette = baseTheme->colorScheme();
         if (!readThemeJson(themeFilePath, m_palette, m_fadeAmount, m_fadeColor, m_name, m_widgets, m_qssFilePath, jsonDataIncomplete))
         {
-            themeDebugLog << "Did not read theme json file correctly, writing new one to: " << themeFilePath;
+            themeDebugLog() << "Did not read theme json file correctly, writing new one to: " << themeFilePath;
             m_name = "Custom";
             m_palette = baseTheme->colorScheme();
             m_fadeColor = baseTheme->fadeColor();
@@ -223,13 +223,13 @@ CustomTheme::CustomTheme(ITheme* baseTheme, QFileInfo& fileInfo, bool isManifest
             }
             catch (const Exception &e)
             {
-                themeWarningLog << "X Couldn't load css:" << e.cause() << "from" << cssFilePath;
+                themeWarningLog() << "Couldn't load css:" << e.cause() << "from" << cssFilePath;
                 m_styleSheet = baseTheme->appStyleSheet();
             }
         }
         else
         {
-            themeDebugLog << "X No theme css present.";
+            themeDebugLog() << "No theme css present.";
             m_styleSheet = baseTheme->appStyleSheet();
             try
             {
@@ -237,7 +237,7 @@ CustomTheme::CustomTheme(ITheme* baseTheme, QFileInfo& fileInfo, bool isManifest
             }
             catch (const Exception &e)
             {
-                themeWarningLog << "X Couldn't write css:" << e.cause() << "to" << cssFilePath;
+                themeWarningLog() << "Couldn't write css:" << e.cause() << "to" << cssFilePath;
             }
         }
     } else {
@@ -250,7 +250,7 @@ CustomTheme::CustomTheme(ITheme* baseTheme, QFileInfo& fileInfo, bool isManifest
 
         if(!FS::ensureFilePathExists(path))
         {
-            themeWarningLog << m_name << " Theme file path doesn't exist!";
+            themeWarningLog() << m_name << " Theme file path doesn't exist!";
             m_palette = baseTheme->colorScheme();
             m_styleSheet = baseTheme->appStyleSheet();
             return;
@@ -264,7 +264,7 @@ CustomTheme::CustomTheme(ITheme* baseTheme, QFileInfo& fileInfo, bool isManifest
         }
         catch (const Exception &e)
         {
-            themeWarningLog << "Couldn't load qss:" << e.cause() << "from" << path;
+            themeWarningLog() << "Couldn't load qss:" << e.cause() << "from" << path;
             m_styleSheet = baseTheme->appStyleSheet();
         }
     }

--- a/launcher/ui/themes/CustomTheme.h
+++ b/launcher/ui/themes/CustomTheme.h
@@ -39,8 +39,7 @@
 #pragma once
 
 #include "ITheme.h"
-#include <QFile>
-#include <QDir>
+#include <QFileInfo>
 
 class CustomTheme: public ITheme
 {

--- a/launcher/ui/themes/CustomTheme.h
+++ b/launcher/ui/themes/CustomTheme.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  Prism Launcher
+ *  Prism Launcher - Minecraft Launcher
  *  Copyright (C) 2022 Tayou <tayou@gmx.net>
  *
  *  This program is free software: you can redistribute it and/or modify
@@ -19,10 +19,6 @@
  * permission notice:
  *
  *      Copyright 2013-2021 MultiMC Contributors
- *
- *      Authors: Andrew Okin
- *               Peterix
- *               Orochimarufan <orochimarufan.x3@gmail.com>
  *
  *      Licensed under the Apache License, Version 2.0 (the "License");
  *      you may not use this file except in compliance with the License.

--- a/launcher/ui/themes/CustomTheme.h
+++ b/launcher/ui/themes/CustomTheme.h
@@ -34,13 +34,12 @@
  */
 #pragma once
 
-#include "ITheme.h"
 #include <QFileInfo>
+#include "ITheme.h"
 
-class CustomTheme: public ITheme
-{
-public:
-    CustomTheme(ITheme * baseTheme, QFileInfo& file, bool isManifest);
+class CustomTheme : public ITheme {
+   public:
+    CustomTheme(ITheme* baseTheme, QFileInfo& file, bool isManifest);
     virtual ~CustomTheme() {}
 
     QString id() override;
@@ -54,7 +53,7 @@ public:
     QString qtTheme() override;
     QStringList searchPaths() override;
 
-private: /* data */
+   private: /* data */
     QPalette m_palette;
     QColor m_fadeColor;
     double m_fadeAmount;
@@ -64,4 +63,3 @@ private: /* data */
     QString m_widgets;
     QString m_qssFilePath;
 };
-

--- a/launcher/ui/themes/CustomTheme.h
+++ b/launcher/ui/themes/CustomTheme.h
@@ -1,11 +1,51 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher
+ *  Copyright (C) 2022 Tayou <tayou@gmx.net>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * This file incorporates work covered by the following copyright and
+ * permission notice:
+ *
+ *      Copyright 2013-2021 MultiMC Contributors
+ *
+ *      Authors: Andrew Okin
+ *               Peterix
+ *               Orochimarufan <orochimarufan.x3@gmail.com>
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
 #pragma once
 
 #include "ITheme.h"
+#include <QFile>
+#include <QDir>
 
 class CustomTheme: public ITheme
 {
 public:
-    CustomTheme(ITheme * baseTheme, QString folder);
+    CustomTheme(ITheme * baseTheme, QFileInfo& file, bool isManifest);
     virtual ~CustomTheme() {}
 
     QString id() override;
@@ -27,5 +67,6 @@ private: /* data */
     QString m_name;
     QString m_id;
     QString m_widgets;
+    QString m_qssFilePath;
 };
 

--- a/launcher/ui/themes/SystemTheme.cpp
+++ b/launcher/ui/themes/SystemTheme.cpp
@@ -1,30 +1,69 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher
+ *  Copyright (C) 2022 Tayou <tayou@gmx.net>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * This file incorporates work covered by the following copyright and
+ * permission notice:
+ *
+ *      Copyright 2013-2021 MultiMC Contributors
+ *
+ *      Authors: Andrew Okin
+ *               Peterix
+ *               Orochimarufan <orochimarufan.x3@gmail.com>
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
 #include "SystemTheme.h"
 #include <QApplication>
 #include <QStyle>
 #include <QStyleFactory>
 #include <QDebug>
+#include "ThemeManager.h"
 
 SystemTheme::SystemTheme()
 {
-    qDebug() << "Determining System Theme...";
+    themeDebugLog << "Determining System Theme...";
     const auto & style = QApplication::style();
     systemPalette = style->standardPalette();
     QString lowerThemeName = style->objectName();
-    qDebug() << "System theme seems to be:" << lowerThemeName;
+    themeDebugLog << "System theme seems to be:" << lowerThemeName;
     QStringList styles = QStyleFactory::keys();
     for(auto &st: styles)
     {
-        qDebug() << "Considering theme from theme factory:" << st.toLower();
+        themeDebugLog << "Considering theme from theme factory:" << st.toLower();
         if(st.toLower() == lowerThemeName)
         {
             systemTheme = st;
-            qDebug() << "System theme has been determined to be:" << systemTheme;
+            themeDebugLog << "System theme has been determined to be:" << systemTheme;
             return;
         }
     }
     // fall back to fusion if we can't find the current theme.
     systemTheme = "Fusion";
-    qDebug() << "System theme not found, defaulted to Fusion";
+    themeDebugLog << "System theme not found, defaulted to Fusion";
 }
 
 void SystemTheme::apply(bool initial)

--- a/launcher/ui/themes/SystemTheme.cpp
+++ b/launcher/ui/themes/SystemTheme.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  Prism Launcher
+ *  Prism Launcher - Minecraft Launcher
  *  Copyright (C) 2022 Tayou <tayou@gmx.net>
  *
  *  This program is free software: you can redistribute it and/or modify
@@ -19,10 +19,6 @@
  * permission notice:
  *
  *      Copyright 2013-2021 MultiMC Contributors
- *
- *      Authors: Andrew Okin
- *               Peterix
- *               Orochimarufan <orochimarufan.x3@gmail.com>
  *
  *      Licensed under the Apache License, Version 2.0 (the "License");
  *      you may not use this file except in compliance with the License.

--- a/launcher/ui/themes/SystemTheme.cpp
+++ b/launcher/ui/themes/SystemTheme.cpp
@@ -45,25 +45,25 @@
 
 SystemTheme::SystemTheme()
 {
-    themeDebugLog << "Determining System Theme...";
+    themeDebugLog() << "Determining System Theme...";
     const auto & style = QApplication::style();
     systemPalette = style->standardPalette();
     QString lowerThemeName = style->objectName();
-    themeDebugLog << "System theme seems to be:" << lowerThemeName;
+    themeDebugLog() << "System theme seems to be:" << lowerThemeName;
     QStringList styles = QStyleFactory::keys();
     for(auto &st: styles)
     {
-        themeDebugLog << "Considering theme from theme factory:" << st.toLower();
+        themeDebugLog() << "Considering theme from theme factory:" << st.toLower();
         if(st.toLower() == lowerThemeName)
         {
             systemTheme = st;
-            themeDebugLog << "System theme has been determined to be:" << systemTheme;
+            themeDebugLog() << "System theme has been determined to be:" << systemTheme;
             return;
         }
     }
     // fall back to fusion if we can't find the current theme.
     systemTheme = "Fusion";
-    themeDebugLog << "System theme not found, defaulted to Fusion";
+    themeDebugLog() << "System theme not found, defaulted to Fusion";
 }
 
 void SystemTheme::apply(bool initial)

--- a/launcher/ui/themes/ThemeManager.cpp
+++ b/launcher/ui/themes/ThemeManager.cpp
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher
+ *  Copyright (C) 2022 Tayou <tayou@gmx.net>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "ThemeManager.h"
+
+#include "ui/themes/SystemTheme.h"
+#include "ui/themes/DarkTheme.h"
+#include "ui/themes/BrightTheme.h"
+#include "ui/themes/CustomTheme.h"
+#include <QDir>
+#include <QDirIterator>
+#include <QIcon>
+#include <QApplication>
+
+#include "Application.h"
+
+#ifdef Q_OS_WIN
+#include <versionhelpers.h>
+#include "ui/WinDarkmode.h"
+#endif
+
+ThemeManager::ThemeManager(MainWindow* mainWindow) {
+    m_mainWindow = mainWindow;
+}
+
+/// @brief Adds the Theme to the list of themes
+/// @param theme The Theme to add
+/// @return Theme ID
+QString ThemeManager::AddTheme(ITheme * theme) {
+    m_themes.insert(std::make_pair(theme->id(), std::unique_ptr<ITheme>(theme)));
+    return theme->id();
+}
+
+/// @brief Gets the Theme from the List via ID
+/// @param themeId Theme ID of theme to fetch
+/// @return Theme at themeId
+ITheme* ThemeManager::GetTheme(QString themeId) {
+    return m_themes[themeId].get();
+}
+
+void ThemeManager::InitializeThemes() {
+    
+
+    // Icon themes
+    {
+        // TODO: icon themes and instance icons do not mesh well together. Rearrange and fix discrepancies!
+        // set icon theme search path!
+        auto searchPaths = QIcon::themeSearchPaths();
+        searchPaths.append("iconthemes");
+        QIcon::setThemeSearchPaths(searchPaths);
+        themeDebugLog << "<> Icon themes initialized.";
+    }
+
+    // Initialize widget themes
+    {
+        themeDebugLog << "<> Initializing Widget Themes";
+        themeDebugLog "✓ Loading Built-in Theme:" << AddTheme(new SystemTheme());
+        auto darkThemeId = AddTheme(new DarkTheme());
+        themeDebugLog "✓ Loading Built-in Theme:" << darkThemeId;
+        themeDebugLog "✓ Loading Built-in Theme:" << AddTheme(new BrightTheme());
+
+        // TODO: need some way to differentiate same name themes in different subdirectories (maybe smaller grey text next to theme name in dropdown? Dunno how to do that though)
+        QString themeFolder = (new QDir("./themes/"))->absoluteFilePath("");
+        themeDebugLog << "Theme Folder Path: " << themeFolder;
+
+        QDirIterator directoryIterator(themeFolder, QDir::Dirs | QDir::NoDotAndDotDot, QDirIterator::Subdirectories);
+        while (directoryIterator.hasNext()) {
+            QDir dir(directoryIterator.next());
+            QFileInfo themeJson(dir.absoluteFilePath("theme.json"));
+            if (themeJson.exists()) {
+                // Load "theme.json" based themes
+                themeDebugLog "✓ Loading JSON Theme from:" << themeJson.absoluteFilePath();
+                CustomTheme* theme = new CustomTheme(GetTheme(darkThemeId), themeJson, true);
+                AddTheme(theme);
+            } else {
+                // Load pure QSS Themes
+                QDirIterator stylesheetFileIterator(dir.absoluteFilePath(""), {"*.qss", "*.css"}, QDir::Files);
+                while (stylesheetFileIterator.hasNext()) {
+                    QFile customThemeFile(stylesheetFileIterator.next());
+                    QFileInfo customThemeFileInfo(customThemeFile);
+                    themeDebugLog "✓ Loading QSS Theme from:" << customThemeFileInfo.absoluteFilePath();
+                    CustomTheme* theme = new CustomTheme(GetTheme(darkThemeId), customThemeFileInfo, false);
+                    AddTheme(theme);
+                }
+            }
+        }
+
+        themeDebugLog << "<> Widget themes initialized.";
+    }
+}
+
+std::vector<ITheme *> ThemeManager::getValidApplicationThemes()
+{
+    std::vector<ITheme *> ret;
+    auto iter = m_themes.cbegin();
+    while (iter != m_themes.cend())
+    {
+        ret.push_back((*iter).second.get());
+        iter++;
+    }
+    return ret;
+}
+
+void ThemeManager::setIconTheme(const QString& name)
+{
+    QIcon::setThemeName(name);
+}
+
+void ThemeManager::applyCurrentlySelectedTheme() {
+    setIconTheme(APPLICATION->settings()->get("IconTheme").toString());
+    themeDebugLog() << "<> Icon theme set.";
+    setApplicationTheme(APPLICATION->settings()->get("ApplicationTheme").toString(), true);
+    themeDebugLog() << "<> Application theme set.";
+}
+
+void ThemeManager::setApplicationTheme(const QString& name, bool initial)
+{
+    auto systemPalette = qApp->palette();
+    auto themeIter = m_themes.find(name);
+    if(themeIter != m_themes.end())
+    {
+        auto & theme = (*themeIter).second;
+        theme->apply(initial);
+#ifdef Q_OS_WIN
+        if (m_mainWindow && IsWindows10OrGreater()) {
+            if (QString::compare(theme->id(), "dark") == 0) {
+                    WinDarkmode::setDarkWinTitlebar(m_mainWindow->winId(), true);
+            } else {
+                    WinDarkmode::setDarkWinTitlebar(m_mainWindow->winId(), false);
+            }
+        }
+#endif
+    }
+    else
+    {
+        qWarning() << "Tried to set invalid theme:" << name;
+    }
+}

--- a/launcher/ui/themes/ThemeManager.cpp
+++ b/launcher/ui/themes/ThemeManager.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  Prism Launcher
+ *  Prism Launcher - Minecraft Launcher
  *  Copyright (C) 2022 Tayou <tayou@gmx.net>
  *
  *  This program is free software: you can redistribute it and/or modify

--- a/launcher/ui/themes/ThemeManager.cpp
+++ b/launcher/ui/themes/ThemeManager.cpp
@@ -17,26 +17,27 @@
  */
 #include "ThemeManager.h"
 
-#include "ui/themes/SystemTheme.h"
-#include "ui/themes/DarkTheme.h"
-#include "ui/themes/BrightTheme.h"
-#include "ui/themes/CustomTheme.h"
+#include <QApplication>
 #include <QDir>
 #include <QDirIterator>
 #include <QIcon>
-#include <QApplication>
+#include "ui/themes/BrightTheme.h"
+#include "ui/themes/CustomTheme.h"
+#include "ui/themes/DarkTheme.h"
+#include "ui/themes/SystemTheme.h"
 
 #include "Application.h"
 
 #ifdef Q_OS_WIN
-#include <windows.h> 
-// this is needed for versionhelpers.h, it is also included in WinDarkmode, but we can't rely on that. 
+#include <windows.h>
+// this is needed for versionhelpers.h, it is also included in WinDarkmode, but we can't rely on that.
 // Ultimately this should be included in versionhelpers, but that is outside of the project.
 #include "ui/WinDarkmode.h"
 #include <versionhelpers.h>
 #endif
 
-ThemeManager::ThemeManager(MainWindow* mainWindow) {
+ThemeManager::ThemeManager(MainWindow* mainWindow)
+{
     m_mainWindow = mainWindow;
     InitializeThemes();
 }
@@ -44,7 +45,8 @@ ThemeManager::ThemeManager(MainWindow* mainWindow) {
 /// @brief Adds the Theme to the list of themes
 /// @param theme The Theme to add
 /// @return Theme ID
-QString ThemeManager::AddTheme(std::unique_ptr<ITheme> theme) {
+QString ThemeManager::AddTheme(std::unique_ptr<ITheme> theme)
+{
     QString id = theme->id();
     m_themes.emplace(id, std::move(theme));
     return id;
@@ -53,13 +55,13 @@ QString ThemeManager::AddTheme(std::unique_ptr<ITheme> theme) {
 /// @brief Gets the Theme from the List via ID
 /// @param themeId Theme ID of theme to fetch
 /// @return Theme at themeId
-ITheme* ThemeManager::GetTheme(QString themeId) {
+ITheme* ThemeManager::GetTheme(QString themeId)
+{
     return m_themes[themeId].get();
 }
 
-void ThemeManager::InitializeThemes() {
-    
-
+void ThemeManager::InitializeThemes()
+{
     // Icon themes
     {
         // TODO: icon themes and instance icons do not mesh well together. Rearrange and fix discrepancies!
@@ -78,7 +80,8 @@ void ThemeManager::InitializeThemes() {
         themeDebugLog() << "Loading Built-in Theme:" << darkThemeId;
         themeDebugLog() << "Loading Built-in Theme:" << AddTheme(std::make_unique<BrightTheme>());
 
-        // TODO: need some way to differentiate same name themes in different subdirectories (maybe smaller grey text next to theme name in dropdown?)
+        // TODO: need some way to differentiate same name themes in different subdirectories (maybe smaller grey text next to theme name in
+        // dropdown?)
         QString themeFolder = QDir("./themes/").absoluteFilePath("");
         themeDebugLog() << "Theme Folder Path: " << themeFolder;
 
@@ -92,7 +95,7 @@ void ThemeManager::InitializeThemes() {
                 AddTheme(std::make_unique<CustomTheme>(GetTheme(darkThemeId), themeJson, true));
             } else {
                 // Load pure QSS Themes
-                QDirIterator stylesheetFileIterator(dir.absoluteFilePath(""), {"*.qss", "*.css"}, QDir::Files);
+                QDirIterator stylesheetFileIterator(dir.absoluteFilePath(""), { "*.qss", "*.css" }, QDir::Files);
                 while (stylesheetFileIterator.hasNext()) {
                     QFile customThemeFile(stylesheetFileIterator.next());
                     QFileInfo customThemeFileInfo(customThemeFile);
@@ -121,7 +124,8 @@ void ThemeManager::setIconTheme(const QString& name)
     QIcon::setThemeName(name);
 }
 
-void ThemeManager::applyCurrentlySelectedTheme() {
+void ThemeManager::applyCurrentlySelectedTheme()
+{
     setIconTheme(APPLICATION->settings()->get("IconTheme").toString());
     themeDebugLog() << "<> Icon theme set.";
     setApplicationTheme(APPLICATION->settings()->get("ApplicationTheme").toString(), true);
@@ -132,23 +136,20 @@ void ThemeManager::setApplicationTheme(const QString& name, bool initial)
 {
     auto systemPalette = qApp->palette();
     auto themeIter = m_themes.find(name);
-    if(themeIter != m_themes.end())
-    {
-        auto & theme = themeIter->second;
+    if (themeIter != m_themes.end()) {
+        auto& theme = themeIter->second;
         themeDebugLog() << "applying theme" << theme->name();
         theme->apply(initial);
 #ifdef Q_OS_WIN
         if (m_mainWindow && IsWindows10OrGreater()) {
             if (QString::compare(theme->id(), "dark") == 0) {
-                    WinDarkmode::setDarkWinTitlebar(m_mainWindow->winId(), true);
+                WinDarkmode::setDarkWinTitlebar(m_mainWindow->winId(), true);
             } else {
-                    WinDarkmode::setDarkWinTitlebar(m_mainWindow->winId(), false);
+                WinDarkmode::setDarkWinTitlebar(m_mainWindow->winId(), false);
             }
         }
 #endif
-    }
-    else
-    {
+    } else {
         themeWarningLog() << "Tried to set invalid theme:" << name;
     }
 }

--- a/launcher/ui/themes/ThemeManager.h
+++ b/launcher/ui/themes/ThemeManager.h
@@ -19,18 +19,20 @@
 
 #include <QString>
 
-#include "ui/themes/ITheme.h"
 #include "ui/MainWindow.h"
+#include "ui/themes/ITheme.h"
 
-inline auto themeDebugLog() {
-  return qDebug() << "[Theme]";
+inline auto themeDebugLog()
+{
+    return qDebug() << "[Theme]";
 }
-inline auto themeWarningLog() {
-  return qWarning() << "[Theme]";
+inline auto themeWarningLog()
+{
+    return qWarning() << "[Theme]";
 }
 
 class ThemeManager {
-public:
+   public:
     ThemeManager(MainWindow* mainWindow);
 
     // maybe make private? Or put in ctor?
@@ -41,11 +43,10 @@ public:
     void applyCurrentlySelectedTheme();
     void setApplicationTheme(const QString& name, bool initial);
 
-private:
+   private:
     std::map<QString, std::unique_ptr<ITheme>> m_themes;
     MainWindow* m_mainWindow;
 
     QString AddTheme(std::unique_ptr<ITheme> theme);
     ITheme* GetTheme(QString themeId);
 };
-

--- a/launcher/ui/themes/ThemeManager.h
+++ b/launcher/ui/themes/ThemeManager.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  Prism Launcher
+ *  Prism Launcher - Minecraft Launcher
  *  Copyright (C) 2022 Tayou <tayou@gmx.net>
  *
  *  This program is free software: you can redistribute it and/or modify

--- a/launcher/ui/themes/ThemeManager.h
+++ b/launcher/ui/themes/ThemeManager.h
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher
+ *  Copyright (C) 2022 Tayou <tayou@gmx.net>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <QString>
+
+#include "ui/themes/ITheme.h"
+#include "ui/MainWindow.h"
+
+#define themeDebugLog qDebug() << "[Themes]"
+#define themeWarningLog qWarning() << "[Themes]"
+
+class ThemeManager {
+public:
+    ThemeManager(MainWindow* mainWindow);
+    void InitializeThemes();
+
+    std::vector<ITheme *> getValidApplicationThemes();
+    void setIconTheme(const QString& name);
+    void applyCurrentlySelectedTheme();
+    void setApplicationTheme(const QString& name, bool initial);
+
+private:
+    std::map<QString, std::unique_ptr<ITheme>> m_themes;
+    MainWindow* m_mainWindow;
+
+    QString AddTheme(ITheme * theme);
+    ITheme* GetTheme(QString themeId);
+};
+

--- a/launcher/ui/themes/ThemeManager.h
+++ b/launcher/ui/themes/ThemeManager.h
@@ -15,21 +15,28 @@
  *  You should have received a copy of the GNU General Public License
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+#pragma once
 
 #include <QString>
 
 #include "ui/themes/ITheme.h"
 #include "ui/MainWindow.h"
 
-#define themeDebugLog qDebug() << "[Themes]"
-#define themeWarningLog qWarning() << "[Themes]"
+inline auto themeDebugLog() {
+  return qDebug() << "[Theme]";
+}
+inline auto themeWarningLog() {
+  return qWarning() << "[Theme]";
+}
 
 class ThemeManager {
 public:
     ThemeManager(MainWindow* mainWindow);
+
+    // maybe make private? Or put in ctor?
     void InitializeThemes();
 
-    std::vector<ITheme *> getValidApplicationThemes();
+    QList<ITheme*> getValidApplicationThemes();
     void setIconTheme(const QString& name);
     void applyCurrentlySelectedTheme();
     void setApplicationTheme(const QString& name, bool initial);
@@ -38,7 +45,7 @@ private:
     std::map<QString, std::unique_ptr<ITheme>> m_themes;
     MainWindow* m_mainWindow;
 
-    QString AddTheme(ITheme * theme);
+    QString AddTheme(std::unique_ptr<ITheme> theme);
     ITheme* GetTheme(QString themeId);
 };
 


### PR DESCRIPTION
added theme scanning support
tested with various themes from obs and modorganizer2

The themes(qss file and folder with svg graphics for controls) would be put in Prism Launcher's data folder /themes

![image](https://user-images.githubusercontent.com/31988415/196820958-ce9fb1c2-db51-41d8-ada5-dc11b96ef1c3.png)

I just kind of fiddled this into the existing code for the Custom Theme, so if I should clean something still up or load files in a different structure (e.g. one folder per theme) I will do that!