### PR TITLE
Tell Qt to hide the ProgressDialog when failing and succeeding jobs

### DIFF
--- a/launcher/modplatform/flame/FileResolvingTask.cpp
+++ b/launcher/modplatform/flame/FileResolvingTask.cpp
@@ -66,7 +66,11 @@ void Flame::FileResolvingTask::netJobFinished()
         }
         index++;
     }
-    connect(job, &NetJob::finished, this, &Flame::FileResolvingTask::modrinthCheckFinished);
+    connect(job, &NetJob::finished, this,
+        [this, &job] {
+            modrinthCheckFinished();
+            job->deleteLater();
+        });
 
     job->start();
 }

--- a/launcher/ui/dialogs/ProgressDialog.cpp
+++ b/launcher/ui/dialogs/ProgressDialog.cpp
@@ -136,11 +136,13 @@ void ProgressDialog::onTaskStarted() {}
 void ProgressDialog::onTaskFailed(QString failure)
 {
     reject();
+    hide();
 }
 
 void ProgressDialog::onTaskSucceeded()
 {
     accept();
+    hide();
 }
 
 void ProgressDialog::changeStatus(const QString& status)


### PR DESCRIPTION
Closes #124

look, i have no idea why this is a problem, but apparently it is o.O
thanks Qt

also fixes a small memory leak on `FileResolvingTask`