### PR TITLE
Allow Prism to open an instance's window from command line

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -245,7 +245,8 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
         {{"s", "server"}, "Join the specified server on launch (only valid in combination with --launch)", "address"},
         {{"a", "profile"}, "Use the account specified by its profile name (only valid in combination with --launch)", "profile"},
         {"alive", "Write a small '" + liveCheckFile + "' file after the launcher starts"},
-        {{"I", "import"}, "Import instance from specified zip (local path or URL)", "file"}
+        {{"I", "import"}, "Import instance from specified zip (local path or URL)", "file"},
+        {"show", "Opens the window for the specified instance (by instance ID)", "show"}
     });
     parser.addHelpOption();
     parser.addVersionOption();
@@ -257,6 +258,7 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
     m_profileToUse = parser.value("profile");
     m_liveCheck = parser.isSet("alive");
     m_zipToImport = parser.value("import");
+    m_instanceIdToShowWindowOf = parser.value("show");
 
     // error if --launch is missing with --server or --profile
     if((!m_serverToJoin.isEmpty() || !m_profileToUse.isEmpty()) && m_instanceIdToLaunch.isEmpty())
@@ -983,6 +985,16 @@ void Application::performMainStartupAction()
             }
 
             launch(inst, true, false, nullptr, serverToJoin, accountToUse);
+            return;
+        }
+    }
+    if(!m_instanceIdToShowWindowOf.isEmpty())
+    {
+        auto inst = instances()->getInstanceById(m_instanceIdToShowWindowOf);
+        if(inst)
+        {
+            qDebug() << "<> Showing window of instance " << m_instanceIdToShowWindowOf;
+            showInstanceWindow(inst);
             return;
         }
     }

--- a/launcher/Application.h
+++ b/launcher/Application.h
@@ -301,6 +301,7 @@ public:
     QString m_profileToUse;
     bool m_liveCheck = false;
     QUrl m_zipToImport;
+    QString m_instanceIdToShowWindowOf;
     std::unique_ptr<QFile> logFile;
 };
 

--- a/program_info/prismlauncher.6.scd
+++ b/program_info/prismlauncher.6.scd
@@ -26,6 +26,9 @@ Here are the current features of Prism Launcher.
 *-l, --launch*=INSTANCE_ID
 	Launch the instance specified by INSTANCE_ID.
 
+*--show*=INSTANCE_ID
+	Show the configuration window of the instance specified by INSTANCE_ID.
+
 *--alive*
 	Write a small 'live.check' file after Prism Launcher starts.
 


### PR DESCRIPTION
Really simple change, but I don't know if this has any side effects, if any. Feature works as expected: launching Prism with `--show SomeInstance` will show the instance window on launch.

Would close #146. Included in this PR is an addition to the manual page, mentioning the feature in brief.

Signed-off-by: Hibi <69405847+Hibiii@users.noreply.github.com>