### PR TITLE
Fix segfault when resolving Flame resources

### DIFF
--- a/launcher/modplatform/flame/FileResolvingTask.h
+++ b/launcher/modplatform/flame/FileResolvingTask.h
@@ -30,8 +30,9 @@ protected slots:
 private: /* data */
     shared_qobject_ptr<QNetworkAccessManager> m_network;
     Flame::Manifest m_toProcess;
-    std::shared_ptr<QByteArray> result;
+	std::shared_ptr<QByteArray> result;
     NetJob::Ptr m_dljob;
+	NetJob::Ptr m_checkJob;
 
     void modrinthCheckFinished();
 


### PR DESCRIPTION
Fixes a segfault introduced by #185.

Capturing `job` by reference doesn't work, as the pointer itself will be gone once `netJobFinished` returns. Use smart pointers instead