### PR TITLE
Add 'Create shortcut' button to instance toolbar

### DIFF
--- a/launcher/FileSystem.cpp
+++ b/launcher/FileSystem.cpp
@@ -49,6 +49,7 @@
 #include "StringUtils.h"
 
 #if defined Q_OS_WIN32
+#define WIN32_LEAN_AND_MEAN
 #include <objbase.h>
 #include <objidl.h>
 #include <shlguid.h>
@@ -339,12 +340,12 @@ QString getDesktopDir()
 }
 
 // Cross-platform Shortcut creation
-bool createShortCut(QString location, QString dest, QStringList args, QString name, QString icon)
+bool createShortcut(QString destination, QString target, QStringList args, QString name, QString icon)
 {
 #if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
-    location = PathCombine(location, name + ".desktop");
+    destination = PathCombine(destination, name + ".desktop");
 
-    QFile f(location);
+    QFile f(destination);
     f.open(QIODevice::WriteOnly | QIODevice::Text);
     QTextStream stream(&f);
 
@@ -356,10 +357,13 @@ bool createShortCut(QString location, QString dest, QStringList args, QString na
            << "\n";
     stream << "Type=Application"
            << "\n";
-    stream << "TryExec=" << dest.toLocal8Bit() << "\n";
-    stream << "Exec=" << dest.toLocal8Bit() << argstring.toLocal8Bit() << "\n";
+    stream << "TryExec=" << target.toLocal8Bit() << "\n";
+    stream << "Exec=" << target.toLocal8Bit() << argstring.toLocal8Bit() << "\n";
     stream << "Name=" << name.toLocal8Bit() << "\n";
-    stream << "Icon=" << icon.toLocal8Bit() << "\n";
+    if (!icon.isEmpty())
+    {
+        stream << "Icon=" << icon.toLocal8Bit() << "\n";
+    }
 
     stream.flush();
     f.close();
@@ -368,24 +372,121 @@ bool createShortCut(QString location, QString dest, QStringList args, QString na
 
     return true;
 #elif defined Q_OS_WIN
-    // TODO: Fix
-    //    QFile file(PathCombine(location, name + ".lnk"));
-    //    WCHAR *file_w;
-    //    WCHAR *dest_w;
-    //    WCHAR *args_w;
-    //    file.fileName().toWCharArray(file_w);
-    //    dest.toWCharArray(dest_w);
+    QFileInfo targetInfo(target);
 
-    //    QString argStr;
-    //    for (int i = 0; i < args.count(); i++)
-    //    {
-    //        argStr.append(args[i]);
-    //        argStr.append(" ");
-    //    }
-    //    argStr.toWCharArray(args_w);
+    if (!targetInfo.exists())
+    {
+        qWarning() << "Target file does not exist!";
+        return false;
+    }
 
-    //    return SUCCEEDED(CreateLink(file_w, dest_w, args_w));
-    return false;
+    target = targetInfo.absoluteFilePath();
+
+    if (target.length() >= MAX_PATH)
+    {
+        qWarning() << "Target file path is too long!";
+        return false;
+    }
+
+    if (!icon.isEmpty() && icon.length() >= MAX_PATH)
+    {
+        qWarning() << "Icon path is too long!";
+        return false;
+    }
+
+    destination += ".lnk";
+
+    if (destination.length() >= MAX_PATH)
+    {
+        qWarning() << "Destination path is too long!";
+        return false;
+    }
+
+    QString argStr;
+    int argCount = args.count();
+    for (int i = 0; i < argCount; i++)
+    {
+        if (args[i].contains(' '))
+        {
+            argStr.append('"').append(args[i]).append('"');
+        }
+        else
+        {
+            argStr.append(args[i]);
+        }
+
+        if (i < argCount - 1)
+        {
+            argStr.append(" ");
+        }
+    }
+
+    if (argStr.length() >= MAX_PATH)
+    {
+        qWarning() << "Arguments string is too long!";
+        return false;
+    }
+
+    WCHAR wsz[MAX_PATH];
+
+    // ...yes, you need to initialize the entire COM stack to make a shortcut in Windows
+    CoInitialize(nullptr);
+
+    HRESULT hres;
+    IShellLink* psl;
+
+    hres = CoCreateInstance(CLSID_ShellLink, NULL, CLSCTX_INPROC_SERVER, IID_IShellLink, (LPVOID*)&psl);
+    if (SUCCEEDED(hres))
+    {
+        wmemset(wsz, 0, MAX_PATH);
+        target.toWCharArray(wsz);
+        psl->SetPath(wsz);
+
+        wmemset(wsz, 0, MAX_PATH);
+        argStr.toWCharArray(wsz);
+        psl->SetArguments(wsz);
+
+        wmemset(wsz, 0, MAX_PATH);
+        targetInfo.absolutePath().toWCharArray(wsz);
+        psl->SetWorkingDirectory(wsz);
+
+        if (!icon.isEmpty())
+        {
+            wmemset(wsz, 0, MAX_PATH);
+            icon.toWCharArray(wsz);
+            psl->SetIconLocation(wsz, 0);
+        }
+
+        IPersistFile* ppf;
+        hres = psl->QueryInterface(IID_IPersistFile, (LPVOID*)&ppf);
+        if (SUCCEEDED(hres))
+        {
+            wmemset(wsz, 0, MAX_PATH);
+            destination.toWCharArray(wsz);
+            hres = ppf->Save(wsz, TRUE);
+            if (FAILED(hres))
+            {
+                qWarning() << "IPresistFile->Save() failed";
+                qWarning() << "hres = " << hres;
+            }
+            ppf->Release();
+        }
+        else
+        {
+            qWarning() << "Failed to query IPersistFile interface from IShellLink instance";
+            qWarning() << "hres = " << hres;
+        }
+        psl->Release();
+    }
+    else
+    {
+        qWarning() << "Failed to create IShellLink instance";
+        qWarning() << "hres = " << hres;
+    }
+
+    CoUninitialize();
+
+    return SUCCEEDED(hres);
 #else
     qWarning("Desktop Shortcuts not supported on your platform!");
     return false;

--- a/launcher/FileSystem.cpp
+++ b/launcher/FileSystem.cpp
@@ -382,7 +382,6 @@ bool createShortcut(QString destination, QString target, QStringList args, QStri
            << "\n";
     stream << "Type=Application"
            << "\n";
-    stream << "TryExec=\"" << target.toLocal8Bit() << "\"\n";
     stream << "Exec=\"" << target.toLocal8Bit() << "\"" << argstring.toLocal8Bit() << "\n";
     stream << "Name=" << name.toLocal8Bit() << "\n";
     if (!icon.isEmpty())

--- a/launcher/FileSystem.cpp
+++ b/launcher/FileSystem.cpp
@@ -342,7 +342,31 @@ QString getDesktopDir()
 // Cross-platform Shortcut creation
 bool createShortcut(QString destination, QString target, QStringList args, QString name, QString icon)
 {
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD) || defined(Q_OS_OPENBSD)
+#if defined(Q_OS_MACOS)
+    destination += ".sh";
+
+    QFile f(destination);
+    f.open(QIODevice::WriteOnly | QIODevice::Text);
+    QTextStream stream(&f);
+
+    QString argstring;
+    if (!args.empty())
+        argstring = " \"" + args.join("\" \"") + "\"";
+
+    stream << "#!/bin/bash"
+           << "\n";
+    stream << target
+           << " "
+           << argstring
+           << "\n";
+
+    stream.flush();
+    f.close();
+
+    f.setPermissions(f.permissions() | QFileDevice::ExeOwner | QFileDevice::ExeGroup | QFileDevice::ExeOther);
+
+    return true;
+#elif defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD) || defined(Q_OS_OPENBSD)
     destination += ".desktop";
 
     QFile f(destination);

--- a/launcher/FileSystem.cpp
+++ b/launcher/FileSystem.cpp
@@ -395,7 +395,7 @@ bool createShortcut(QString destination, QString target, QStringList args, QStri
     f.setPermissions(f.permissions() | QFileDevice::ExeOwner | QFileDevice::ExeGroup | QFileDevice::ExeOther);
 
     return true;
-#elif defined Q_OS_WIN
+#elif defined(Q_OS_WIN)
     QFileInfo targetInfo(target);
 
     if (!targetInfo.exists())

--- a/launcher/FileSystem.cpp
+++ b/launcher/FileSystem.cpp
@@ -342,7 +342,7 @@ QString getDesktopDir()
 // Cross-platform Shortcut creation
 bool createShortcut(QString destination, QString target, QStringList args, QString name, QString icon)
 {
-#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD)
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD) || defined(Q_OS_OPENBSD)
     destination = PathCombine(destination, name + ".desktop");
 
     QFile f(destination);

--- a/launcher/FileSystem.cpp
+++ b/launcher/FileSystem.cpp
@@ -343,7 +343,7 @@ QString getDesktopDir()
 bool createShortcut(QString destination, QString target, QStringList args, QString name, QString icon)
 {
 #if defined(Q_OS_MACOS)
-    destination += ".sh";
+    destination += ".command";
 
     QFile f(destination);
     f.open(QIODevice::WriteOnly | QIODevice::Text);
@@ -355,8 +355,9 @@ bool createShortcut(QString destination, QString target, QStringList args, QStri
 
     stream << "#!/bin/bash"
            << "\n";
-    stream << target
-           << " "
+    stream << "\""
+           << target
+           << "\" "
            << argstring
            << "\n";
 

--- a/launcher/FileSystem.cpp
+++ b/launcher/FileSystem.cpp
@@ -343,7 +343,7 @@ QString getDesktopDir()
 bool createShortcut(QString destination, QString target, QStringList args, QString name, QString icon)
 {
 #if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD) || defined(Q_OS_OPENBSD)
-    destination = PathCombine(destination, name + ".desktop");
+    destination += ".desktop";
 
     QFile f(destination);
     f.open(QIODevice::WriteOnly | QIODevice::Text);

--- a/launcher/FileSystem.cpp
+++ b/launcher/FileSystem.cpp
@@ -382,8 +382,8 @@ bool createShortcut(QString destination, QString target, QStringList args, QStri
            << "\n";
     stream << "Type=Application"
            << "\n";
-    stream << "TryExec=" << target.toLocal8Bit() << "\n";
-    stream << "Exec=" << target.toLocal8Bit() << argstring.toLocal8Bit() << "\n";
+    stream << "TryExec=\"" << target.toLocal8Bit() << "\"\n";
+    stream << "Exec=\"" << target.toLocal8Bit() << "\"" << argstring.toLocal8Bit() << "\n";
     stream << "Name=" << name.toLocal8Bit() << "\n";
     if (!icon.isEmpty())
     {

--- a/launcher/FileSystem.h
+++ b/launcher/FileSystem.h
@@ -156,4 +156,9 @@ QString getDesktopDir();
 // Overrides one folder with the contents of another, preserving items exclusive to the first folder
 // Equivalent to doing QDir::rename, but allowing for overrides
 bool overrideFolder(QString overwritten_path, QString override_path);
+
+/**
+ * Creates a shortcut to the specified target file at the specified destination path.
+ */
+bool createShortcut(QString destination, QString target, QStringList args, QString name, QString icon);
 }

--- a/launcher/resources/OSX/OSX.qrc
+++ b/launcher/resources/OSX/OSX.qrc
@@ -1,5 +1,4 @@
-<!DOCTYPE RCC>
-<RCC version="1.0">
+<RCC>
     <qresource prefix="/icons/OSX">
         <file>index.theme</file>
         <file>scalable/about.svg</file>
@@ -39,5 +38,6 @@
         <file>scalable/export.svg</file>
         <file>scalable/rename.svg</file>
         <file>scalable/launch.svg</file>
+        <file>scalable/shortcut.svg</file>
     </qresource>
 </RCC>

--- a/launcher/resources/OSX/OSX.qrc
+++ b/launcher/resources/OSX/OSX.qrc
@@ -1,4 +1,5 @@
-<RCC>
+<!DOCTYPE RCC>
+<RCC version="1.0">
     <qresource prefix="/icons/OSX">
         <file>index.theme</file>
         <file>scalable/about.svg</file>

--- a/launcher/resources/OSX/scalable/shortcut.svg
+++ b/launcher/resources/OSX/scalable/shortcut.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 18.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+<rect fill="none" width="24" height="24"/>
+<g id="_x35__1_">
+	<g>
+		<path fill="#585858" d="M9.5,9.5C9.8,9.5,10,9.2,10,9l0-2.4l7.6,7.3c0.2,0.2,0.5,0.2,0.7,0c0.2-0.2,0.2-0.5,0-0.7L10.8,6L13,6
+			c0.3,0,0.5-0.2,0.5-0.5S13.3,5,13,5H9.5C9.2,5,9,5.2,9,5.5V9C9,9.2,9.2,9.5,9.5,9.5z M21,5h-5.5v1H21c0.5,0,1,0.5,1,1l0,10
+			c0,0.5-0.4,1-1,1l-10,0c-0.5,0-1-0.5-1-1v-5.5H9V17c0,1.1,1.1,2,2.2,2H21c1.1,0,2-0.9,2-2V7.2C23,6.1,22.1,5,21,5z"/>
+	</g>
+</g>
+</svg>

--- a/launcher/resources/iOS/iOS.qrc
+++ b/launcher/resources/iOS/iOS.qrc
@@ -1,4 +1,5 @@
-<RCC>
+<!DOCTYPE RCC>
+<RCC version="1.0">
     <qresource prefix="/icons/iOS">
         <file>index.theme</file>
         <file>scalable/about.svg</file>

--- a/launcher/resources/iOS/iOS.qrc
+++ b/launcher/resources/iOS/iOS.qrc
@@ -1,5 +1,4 @@
-<!DOCTYPE RCC>
-<RCC version="1.0">
+<RCC>
     <qresource prefix="/icons/iOS">
         <file>index.theme</file>
         <file>scalable/about.svg</file>
@@ -39,5 +38,6 @@
         <file>scalable/export.svg</file>
         <file>scalable/rename.svg</file>
         <file>scalable/launch.svg</file>
+        <file>scalable/shortcut.svg</file>
     </qresource>
 </RCC>

--- a/launcher/resources/iOS/scalable/shortcut.svg
+++ b/launcher/resources/iOS/scalable/shortcut.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 18.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
+<g id="_x35__5_">
+	<g>
+		<path fill="#3366CC" d="M3,11c0.6,0,1-0.5,1-1l0-4.8l15.2,14.5c0.4,0.4,1,0.4,1.4,0c0.4-0.4,0.4-1,0-1.4L5.6,4L10,4
+			c0.6,0,1-0.5,1-1s-0.4-1-1-1H3C2.5,2,2,2.4,2,3v7C2,10.5,2.4,11,3,11z M26,2H15v2h11c1.1,0,2,0.9,2,2l0,20.1c0,1.1-0.9,2-2,2L6,28
+			c-1.1,0-2-0.9-2-2V15H2v11c0,2.2,2.2,4,4.4,4h19.7c2.2,0,3.9-1.8,3.9-3.9V6.4C30,4.2,28.2,2,26,2z"/>
+	</g>
+</g>
+</svg>

--- a/launcher/resources/pe_blue/pe_blue.qrc
+++ b/launcher/resources/pe_blue/pe_blue.qrc
@@ -1,4 +1,5 @@
-<RCC>
+<!DOCTYPE RCC>
+<RCC version="1.0">
     <qresource prefix="/icons/pe_blue">
         <file>index.theme</file>
         <file>scalable/about.svg</file>

--- a/launcher/resources/pe_blue/pe_blue.qrc
+++ b/launcher/resources/pe_blue/pe_blue.qrc
@@ -1,5 +1,4 @@
-<!DOCTYPE RCC>
-<RCC version="1.0">
+<RCC>
     <qresource prefix="/icons/pe_blue">
         <file>index.theme</file>
         <file>scalable/about.svg</file>
@@ -39,5 +38,6 @@
         <file>scalable/export.svg</file>
         <file>scalable/rename.svg</file>
         <file>scalable/launch.svg</file>
+        <file>scalable/shortcut.svg</file>
     </qresource>
 </RCC>

--- a/launcher/resources/pe_blue/scalable/shortcut.svg
+++ b/launcher/resources/pe_blue/scalable/shortcut.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 18.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
+<path fill-rule="evenodd" clip-rule="evenodd" fill="#3366CC" d="M6,32h20c3.3,0,6-2.7,6-6V6c0-3.3-2.7-6-6-6h-9.1
+	C17.6,1.2,18,2.6,18,4h8c1.1,0,2,0.9,2,2v20c0,1.1-0.9,2-2,2H6c-1.1,0-2-0.9-2-2v-4.5l-4-3V26C0,29.3,2.7,32,6,32z"/>
+<path fill-rule="evenodd" clip-rule="evenodd" fill="#39B54A" d="M8.8,17.6C9.2,17.9,9.6,18,10,18c0.3,0,0.6-0.1,0.9-0.2
+	c0.7-0.3,1.1-1,1.1-1.8v-1.9V14c6.3,0,11.7,4.2,13.4,10c0.4-1.3,0.6-2.6,0.6-4c0-7.7-6.3-14-14-14V4c0-0.8-0.4-1.5-1.1-1.8
+	C10.6,2.1,10.3,2,10,2C9.6,2,9.2,2.1,8.8,2.4l-8,6C0.3,8.8,0,9.4,0,10c0,0.6,0.3,1.2,0.8,1.6L8.8,17.6z"/>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+</svg>

--- a/launcher/resources/pe_colored/pe_colored.qrc
+++ b/launcher/resources/pe_colored/pe_colored.qrc
@@ -1,5 +1,4 @@
-<!DOCTYPE RCC>
-<RCC version="1.0">
+<RCC>
     <qresource prefix="/icons/pe_colored">
         <file>index.theme</file>
         <file>scalable/about.svg</file>
@@ -39,5 +38,6 @@
         <file>scalable/export.svg</file>
         <file>scalable/rename.svg</file>
         <file>scalable/launch.svg</file>
+        <file>scalable/shortcut.svg</file>
     </qresource>
 </RCC>

--- a/launcher/resources/pe_colored/pe_colored.qrc
+++ b/launcher/resources/pe_colored/pe_colored.qrc
@@ -1,4 +1,5 @@
-<RCC>
+<!DOCTYPE RCC>
+<RCC version="1.0">
     <qresource prefix="/icons/pe_colored">
         <file>index.theme</file>
         <file>scalable/about.svg</file>

--- a/launcher/resources/pe_colored/scalable/shortcut.svg
+++ b/launcher/resources/pe_colored/scalable/shortcut.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 18.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
+<g>
+	<path fill="#39B54A" d="M26,0h-9.1C17.6,1.2,18,2.6,18,4h8c1.1,0,2,0.9,2,2v3h4V6C32,2.7,29.3,0,26,0z"/>
+	<path fill="#8C6239" d="M28,26c0,1.1-0.9,2-2,2H6c-1.1,0-2-0.9-2-2v-4.5l-4-3V26c0,3.3,2.7,6,6,6h20c3.3,0,6-2.7,6-6V9h-4V26z"/>
+</g>
+<path fill-rule="evenodd" clip-rule="evenodd" fill="#009245" d="M8.8,17.6C9.2,17.9,9.6,18,10,18c0.3,0,0.6-0.1,0.9-0.2
+	c0.7-0.3,1.1-1,1.1-1.8v-1.9V14c6.3,0,11.7,4.2,13.4,10c0.4-1.3,0.6-2.6,0.6-4c0-7.7-6.3-14-14-14V4c0-0.8-0.4-1.5-1.1-1.8
+	C10.6,2.1,10.3,2,10,2C9.6,2,9.2,2.1,8.8,2.4l-8,6C0.3,8.8,0,9.4,0,10c0,0.6,0.3,1.2,0.8,1.6L8.8,17.6z"/>
+</svg>

--- a/launcher/resources/pe_dark/pe_dark.qrc
+++ b/launcher/resources/pe_dark/pe_dark.qrc
@@ -1,4 +1,5 @@
-<RCC>
+<!DOCTYPE RCC>
+<RCC version="1.0">
     <qresource prefix="/icons/pe_dark">
         <file>index.theme</file>
         <file>scalable/about.svg</file>

--- a/launcher/resources/pe_dark/pe_dark.qrc
+++ b/launcher/resources/pe_dark/pe_dark.qrc
@@ -1,5 +1,4 @@
-<!DOCTYPE RCC>
-<RCC version="1.0">
+<RCC>
     <qresource prefix="/icons/pe_dark">
         <file>index.theme</file>
         <file>scalable/about.svg</file>
@@ -39,5 +38,6 @@
         <file>scalable/export.svg</file>
         <file>scalable/rename.svg</file>
         <file>scalable/launch.svg</file>
+        <file>scalable/shortcut.svg</file>
     </qresource>
 </RCC>

--- a/launcher/resources/pe_dark/scalable/shortcut.svg
+++ b/launcher/resources/pe_dark/scalable/shortcut.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 18.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M6,32h20c3.3,0,6-2.7,6-6V6c0-3.3-2.7-6-6-6h-9.1C17.6,1.2,18,2.6,18,4h8
+	c1.1,0,2,0.9,2,2v20c0,1.1-0.9,2-2,2H6c-1.1,0-2-0.9-2-2v-4.5l-4-3V26C0,29.3,2.7,32,6,32z"/>
+<path fill-rule="evenodd" clip-rule="evenodd" fill="#666666" d="M8.8,17.6C9.2,17.9,9.6,18,10,18c0.3,0,0.6-0.1,0.9-0.2
+	c0.7-0.3,1.1-1,1.1-1.8v-1.9V14c6.3,0,11.7,4.2,13.4,10c0.4-1.3,0.6-2.6,0.6-4c0-7.7-6.3-14-14-14V4c0-0.8-0.4-1.5-1.1-1.8
+	C10.6,2.1,10.3,2,10,2C9.6,2,9.2,2.1,8.8,2.4l-8,6C0.3,8.8,0,9.4,0,10c0,0.6,0.3,1.2,0.8,1.6L8.8,17.6z"/>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+</svg>

--- a/launcher/resources/pe_light/pe_light.qrc
+++ b/launcher/resources/pe_light/pe_light.qrc
@@ -1,5 +1,4 @@
-<!DOCTYPE RCC>
-<RCC version="1.0">
+<RCC>
     <qresource prefix="/icons/pe_light">
         <file>index.theme</file>
         <file>scalable/about.svg</file>
@@ -39,5 +38,6 @@
         <file>scalable/export.svg</file>
         <file>scalable/rename.svg</file>
         <file>scalable/launch.svg</file>
+        <file>scalable/shortcut.svg</file>
     </qresource>
 </RCC>

--- a/launcher/resources/pe_light/pe_light.qrc
+++ b/launcher/resources/pe_light/pe_light.qrc
@@ -1,4 +1,5 @@
-<RCC>
+<!DOCTYPE RCC>
+<RCC version="1.0">
     <qresource prefix="/icons/pe_light">
         <file>index.theme</file>
         <file>scalable/about.svg</file>

--- a/launcher/resources/pe_light/scalable/shortcut.svg
+++ b/launcher/resources/pe_light/scalable/shortcut.svg
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 18.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Calque_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 32 32" enable-background="new 0 0 32 32" xml:space="preserve">
+<path fill-rule="evenodd" clip-rule="evenodd" fill="#F2F2F2" d="M6,32h20c3.3,0,6-2.7,6-6V6c0-3.3-2.7-6-6-6h-9.1
+	C17.6,1.2,18,2.6,18,4h8c1.1,0,2,0.9,2,2v20c0,1.1-0.9,2-2,2H6c-1.1,0-2-0.9-2-2v-4.5l-4-3V26C0,29.3,2.7,32,6,32z"/>
+<path fill-rule="evenodd" clip-rule="evenodd" fill="#FFFFFF" d="M8.8,17.6C9.2,17.9,9.6,18,10,18c0.3,0,0.6-0.1,0.9-0.2
+	c0.7-0.3,1.1-1,1.1-1.8v-1.9V14c6.3,0,11.7,4.2,13.4,10c0.4-1.3,0.6-2.6,0.6-4c0-7.7-6.3-14-14-14V4c0-0.8-0.4-1.5-1.1-1.8
+	C10.6,2.1,10.3,2,10,2C9.6,2,9.2,2.1,8.8,2.4l-8,6C0.3,8.8,0,9.4,0,10c0,0.6,0.3,1.2,0.8,1.6L8.8,17.6z"/>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+<g>
+</g>
+</svg>

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -2100,13 +2100,14 @@ void MainWindow::on_actionCreateInstanceShortcut_triggered()
         }
 
 #if defined(Q_OS_MACOS)
-        // handle macOS bundle weirdness
-        QFileInfo appFileInfo(QApplication::applicationFilePath());
-        QString appName = appFileInfo.baseName();
-        QString exeName = FS::PathCombine(appFileInfo.filePath(), "Contents/MacOS/" + appName);
+        QString appPath = QApplication::applicationFilePath();
+		if (appPath.startsWith("/private/var")) {
+            QMessageBox::critical(this, tr("Create instance shortcut"), tr("The launcher is in the folder it was extracted from, therefore it cannot create shortcuts."));
+            return;
+		}
 
         if (FS::createShortcut(FS::PathCombine(desktopPath, m_selectedInstance->name()),
-                           exeName, { "--launch", m_selectedInstance->id() }, m_selectedInstance->name(), "")) {
+                           appPath, { "--launch", m_selectedInstance->id() }, m_selectedInstance->name(), "")) {
             QMessageBox::information(this, tr("Create instance shortcut"), tr("Created a shortcut to this instance on your desktop!"));
         }
         else

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -2101,10 +2101,10 @@ void MainWindow::on_actionCreateInstanceShortcut_triggered()
 
 #if defined(Q_OS_MACOS)
         QString appPath = QApplication::applicationFilePath();
-		if (appPath.startsWith("/private/var")) {
+        if (appPath.startsWith("/private/var")) {
             QMessageBox::critical(this, tr("Create instance shortcut"), tr("The launcher is in the folder it was extracted from, therefore it cannot create shortcuts."));
             return;
-		}
+        }
 
         if (FS::createShortcut(FS::PathCombine(desktopPath, m_selectedInstance->name()),
                            appPath, { "--launch", m_selectedInstance->id() }, m_selectedInstance->name(), "")) {

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -2112,7 +2112,7 @@ void MainWindow::on_actionCreateInstanceShortcut_triggered()
         // TODO
         // need to convert icon to ICO format and save it somewhere...
         iconPath = "";
-#elif defined(Q_OS_UNIX)
+#else
         iconPath = icon->getFilePath();
 #endif
         if (FS::createShortcut(FS::PathCombine(desktopPath, m_selectedInstance->name()),

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -2104,6 +2104,8 @@ void MainWindow::on_actionCreateInstanceShortcut_triggered()
         // TODO actually write this path
         QMessageBox::critical(this, tr("Create instance shortcut"), tr("Not supported on macOSX yet!"));
 #else
+        auto icon = APPLICATION->icons()->icon(m_selectedInstance->iconKey());
+
         QString iconPath;
 
 #if defined(Q_OS_WIN)
@@ -2111,7 +2113,7 @@ void MainWindow::on_actionCreateInstanceShortcut_triggered()
         // need to convert icon to ICO format and save it somewhere...
         iconPath = "";
 #elif defined(Q_OS_UNIX)
-        iconPath = ""; // TODO get instance icon path
+        iconPath = icon->getFilePath();
 #endif
         if (FS::createShortcut(FS::PathCombine(desktopPath, m_selectedInstance->name()),
                            QApplication::applicationFilePath(), { "--launch", m_selectedInstance->id() }, m_selectedInstance->name(), iconPath)) {

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -2112,6 +2112,10 @@ void MainWindow::on_actionCreateInstanceShortcut_triggered()
 #if defined(Q_OS_WIN)
         iconPath = FS::PathCombine(m_selectedInstance->instanceRoot(), "icon.ico");
 
+        // part of fix for weird bug involving the window icon being replaced
+        // dunno why it happens, but this 2-line fix seems to be enough, so w/e
+        auto appIcon = QGuiApplication::windowIcon();
+
         QFile iconFile(iconPath);
         if (!iconFile.open(QFile::WriteOnly))
         {
@@ -2129,6 +2133,9 @@ void MainWindow::on_actionCreateInstanceShortcut_triggered()
 
         iconFile.close();
         iconGenerated = true;
+
+        // restore original window icon
+        QGuiApplication::setWindowIcon(appIcon);
 #else
         iconPath = icon->getFilePath();
 #endif

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -2100,7 +2100,20 @@ void MainWindow::on_actionCreateInstanceShortcut_triggered()
         }
 
 #ifdef Q_OS_MACOS
-        QMessageBox::critical(this, tr("Create instance shortcut"), tr("Not supported on macOS yet!"));
+        // handle macOS bundle weirdness
+        QFileInfo appFileInfo(QApplication::applicationFilePath()));
+        QString appName = appFileInfo.baseName();
+        QString exeName = FS::PathCombine(appFileInfo.filePath(), "Contents/MacOS/" + appName);
+
+		if (FS::createShortcut(FS::PathCombine(desktopPath, m_selectedInstance->name()),
+                           exeName, { "--launch", m_selectedInstance->id() }, m_selectedInstance->name(), "")) {
+            QMessageBox::information(this, tr("Create instance shortcut"), tr("Created a shortcut to this instance on your desktop!"));
+        }
+        else
+        {
+            QMessageBox::critical(this, tr("Create instance shortcut"), tr("Failed to create instance shortcut!"));
+        }
+		
         return;
 #endif
         auto icon = APPLICATION->icons()->icon(m_selectedInstance->iconKey());

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -784,6 +784,8 @@ public:
         instanceToolBar->addAction(actionCopyInstance);
         instanceToolBar->addAction(actionDeleteInstance);
 
+        instanceToolBar->addAction(actionCreateInstanceShortcut); // TODO find better position for this
+
         QLayout * lay = instanceToolBar->layout();
         for(int i = 0; i < lay->count(); i++)
         {
@@ -793,8 +795,6 @@ public:
                 item->setAlignment(Qt::AlignLeft);
             }
         }
-
-        instanceToolBar->addAction(actionCreateInstanceShortcut); // TODO find better position for this
 
         all_toolbars.append(&instanceToolBar);
         MainWindow->addToolBar(Qt::RightToolBarArea, instanceToolBar);

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -2158,6 +2158,7 @@ void MainWindow::on_actionCreateInstanceShortcut_triggered()
         }
         else
         {
+            iconFile.remove();
             QMessageBox::critical(this, tr("Create instance shortcut"), tr("Failed to create instance shortcut!"));
         }
 #else

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -2113,7 +2113,7 @@ void MainWindow::on_actionCreateInstanceShortcut_triggered()
 
         // part of fix for weird bug involving the window icon being replaced
         // dunno why it happens, but this 2-line fix seems to be enough, so w/e
-        auto appIcon = Application::getThemedIcon("logo");
+        auto appIcon = APPLICATION->getThemedIcon("logo");
 
         QFile iconFile(iconPath);
         if (!iconFile.open(QFile::WriteOnly))
@@ -2121,20 +2121,22 @@ void MainWindow::on_actionCreateInstanceShortcut_triggered()
             QMessageBox::critical(this, tr("Create instance shortcut"), tr("Failed to create instance shortcut!"));
             return;
         }
+        bool success = icon->icon().pixmap(64, 64).save(&iconFile, "ICO");
+        iconFile.close();
 
-        if (!icon->icon().pixmap(64, 64).save(&iconFile, "ICO"))
+        // restore original window icon
+        QGuiApplication::setWindowIcon(appIcon);
+
+        if (success)
         {
-            iconFile.close();
+            iconGenerated = true;
+        }
+        else
+        {
             iconFile.remove();
             QMessageBox::critical(this, tr("Create instance shortcut"), tr("Failed to create instance shortcut!"));
             return;
         }
-
-        iconFile.close();
-        iconGenerated = true;
-
-        // restore original window icon
-        QGuiApplication::setWindowIcon(appIcon);
 #else
         iconPath = icon->getFilePath();
 #endif

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -743,7 +743,8 @@ public:
         actionCreateInstanceShortcut.setTextId(QT_TRANSLATE_NOOP("MainWindow", "Create Shortcut"));
         actionCreateInstanceShortcut.setTooltipId(QT_TRANSLATE_NOOP("MainWindow", "Creates a shortcut on your desktop to launch the selected instance."));
         //actionCreateInstanceShortcut->setShortcut(QKeySequence(tr("Ctrl+D")));     // TODO
-        //actionCreateInstanceShortcut->setIcon(APPLICATION->getThemedIcon("copy")); // TODO
+        // FIXME missing on Legacy, Flat and Flat (White)
+        actionCreateInstanceShortcut->setIcon(APPLICATION->getThemedIcon("shortcut"));
         all_actions.append(&actionCreateInstanceShortcut);
 
         setInstanceActionsEnabled(false);

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -2101,7 +2101,7 @@ void MainWindow::on_actionCreateInstanceShortcut_triggered()
 
 #if defined(Q_OS_MACOS)
         // handle macOS bundle weirdness
-        QFileInfo appFileInfo(QApplication::applicationFilePath()));
+        QFileInfo appFileInfo(QApplication::applicationFilePath());
         QString appName = appFileInfo.baseName();
         QString exeName = FS::PathCombine(appFileInfo.filePath(), "Contents/MacOS/" + appName);
 

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -2131,7 +2131,11 @@ void MainWindow::on_actionCreateInstanceShortcut_triggered()
         }
 
         auto icon = APPLICATION->icons()->icon(m_selectedInstance->iconKey());
-        
+        if (icon == nullptr)
+        {
+            icon = APPLICATION->icons()->icon("grass");
+        }
+
         QString iconPath = FS::PathCombine(m_selectedInstance->instanceRoot(), "icon.png");
         
         QFile iconFile(iconPath);
@@ -2162,7 +2166,11 @@ void MainWindow::on_actionCreateInstanceShortcut_triggered()
         }
 #elif defined(Q_OS_WIN)
         auto icon = APPLICATION->icons()->icon(m_selectedInstance->iconKey());
-        
+        if (icon == nullptr)
+        {
+            icon = APPLICATION->icons()->icon("grass");
+        }
+
         QString iconPath = FS::PathCombine(m_selectedInstance->instanceRoot(), "icon.ico");
         
         // part of fix for weird bug involving the window icon being replaced

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -2103,7 +2103,8 @@ void MainWindow::on_actionCreateInstanceShortcut_triggered()
         // macOSX
         // TODO actually write this path
         QMessageBox::critical(this, tr("Create instance shortcut"), tr("Not supported on macOSX yet!"));
-#else
+		return;
+#endif
         auto icon = APPLICATION->icons()->icon(m_selectedInstance->iconKey());
 
         QString iconPath;
@@ -2151,7 +2152,6 @@ void MainWindow::on_actionCreateInstanceShortcut_triggered()
             }
             QMessageBox::critical(this, tr("Create instance shortcut"), tr("Failed to create instance shortcut!"));
         }
-#endif
     }
 }
 

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -2107,11 +2107,28 @@ void MainWindow::on_actionCreateInstanceShortcut_triggered()
         auto icon = APPLICATION->icons()->icon(m_selectedInstance->iconKey());
 
         QString iconPath;
+        bool iconGenerated = false;
 
 #if defined(Q_OS_WIN)
-        // TODO
-        // need to convert icon to ICO format and save it somewhere...
-        iconPath = "";
+        iconPath = FS::PathCombine(m_selectedInstance->instanceRoot(), "icon.ico");
+
+        QFile iconFile(iconPath);
+        if (!iconFile.open(QFile::WriteOnly))
+        {
+            QMessageBox::critical(this, tr("Create instance shortcut"), tr("Failed to create instance shortcut!"));
+            return;
+        }
+
+        if (!icon->icon().pixmap(64, 64).save(&iconFile, "ICO"))
+        {
+            iconFile.close();
+            iconFile.remove();
+            QMessageBox::critical(this, tr("Create instance shortcut"), tr("Failed to create instance shortcut!"));
+            return;
+        }
+
+        iconFile.close();
+        iconGenerated = true;
 #else
         iconPath = icon->getFilePath();
 #endif
@@ -2121,6 +2138,10 @@ void MainWindow::on_actionCreateInstanceShortcut_triggered()
         }
         else
         {
+            if (iconGenerated)
+            {
+                QFile::remove(iconPath);
+            }
             QMessageBox::critical(this, tr("Create instance shortcut"), tr("Failed to create instance shortcut!"));
         }
 #endif

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -2099,23 +2099,21 @@ void MainWindow::on_actionCreateInstanceShortcut_triggered()
             return;
         }
 
-#if defined(Q_OS_MACOS)
-        // macOSX
-        // TODO actually write this path
-        QMessageBox::critical(this, tr("Create instance shortcut"), tr("Not supported on macOSX yet!"));
-		return;
+#ifdef Q_OS_MACOS
+        QMessageBox::critical(this, tr("Create instance shortcut"), tr("Not supported on macOS yet!"));
+        return;
 #endif
         auto icon = APPLICATION->icons()->icon(m_selectedInstance->iconKey());
 
         QString iconPath;
         bool iconGenerated = false;
 
-#if defined(Q_OS_WIN)
+#ifdef Q_OS_WIN
         iconPath = FS::PathCombine(m_selectedInstance->instanceRoot(), "icon.ico");
 
         // part of fix for weird bug involving the window icon being replaced
         // dunno why it happens, but this 2-line fix seems to be enough, so w/e
-        auto appIcon = QGuiApplication::windowIcon();
+        auto appIcon = Application::getThemedIcon("logo");
 
         QFile iconFile(iconPath);
         if (!iconFile.open(QFile::WriteOnly))

--- a/launcher/ui/MainWindow.h
+++ b/launcher/ui/MainWindow.h
@@ -157,6 +157,8 @@ private slots:
 
     void on_actionEditInstance_triggered();
 
+    void on_actionCreateInstanceShortcut_triggered();
+
     void taskEnd();
 
     /**


### PR DESCRIPTION
Closes #210.

This PR also makes `FileSystem::createShortcut` function on Windows systems.

### TODO
- [x] Icon for "Create Shortcut" action
  - Missing in Legacy, Flat, and Flat (White)
- [ ] Shortcut for "Create Shortcut" action
- [x] Platform-specific behavior
  - [x] Windows
    - [x] Use instance icon for shortcuts
  - [x] Linux
    - [x] Testing!!
  - [x] macOSX
    - [x] Write shell script
    - [x] Testing!!