### PR TITLE
update macos plist contents (fixes #132 / #137)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -249,8 +249,8 @@ jobs:
           cmake --install ${{ env.BUILD_DIR }}
 
           cd ${{ env.INSTALL_DIR }}
-          chmod +x "PrismLauncher.app/Contents/MacOS/prismlauncher"
-          sudo codesign --sign - --deep --force --entitlements "../program_info/App.entitlements" --options runtime "PrismLauncher.app/Contents/MacOS/prismlauncher"
+          chmod +x "Prism Launcher.app/Contents/MacOS/prismlauncher"
+          sudo codesign --sign - --deep --force --entitlements "../program_info/App.entitlements" --options runtime "Prism Launcher.app/Contents/MacOS/prismlauncher"
           tar -czf ../PrismLauncher.tar.gz *
 
       - name: Make Sparkle signature (macOS)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -249,8 +249,9 @@ jobs:
           cmake --install ${{ env.BUILD_DIR }}
 
           cd ${{ env.INSTALL_DIR }}
-          chmod +x "Prism Launcher.app/Contents/MacOS/prismlauncher"
-          sudo codesign --sign - --deep --force --entitlements "../program_info/App.entitlements" --options runtime "Prism Launcher.app/Contents/MacOS/prismlauncher"
+          chmod +x "PrismLauncher.app/Contents/MacOS/prismlauncher"
+          sudo codesign --sign - --deep --force --entitlements "../program_info/App.entitlements" --options runtime "PrismLauncher.app/Contents/MacOS/prismlauncher"
+          mv "PrismLauncher.app" "Prism Launcher.app"
           tar -czf ../PrismLauncher.tar.gz *
 
       - name: Make Sparkle signature (macOS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,19 +211,19 @@ if(NOT (UNIX AND APPLE))
 endif()
 
 if(UNIX AND APPLE)
-    set(BINARY_DEST_DIR "${Launcher_Name}.app/Contents/MacOS")
-    set(LIBRARY_DEST_DIR "${Launcher_Name}.app/Contents/MacOS")
-    set(PLUGIN_DEST_DIR "${Launcher_Name}.app/Contents/MacOS")
-    set(FRAMEWORK_DEST_DIR "${Launcher_Name}.app/Contents/Frameworks")
-    set(RESOURCES_DEST_DIR "${Launcher_Name}.app/Contents/Resources")
-    set(JARS_DEST_DIR "${Launcher_Name}.app/Contents/MacOS/jars")
+    set(BINARY_DEST_DIR "${Launcher_DisplayName}.app/Contents/MacOS")
+    set(LIBRARY_DEST_DIR "${Launcher_DisplayName}.app/Contents/MacOS")
+    set(PLUGIN_DEST_DIR "${Launcher_DisplayName}.app/Contents/MacOS")
+    set(FRAMEWORK_DEST_DIR "${Launcher_DisplayName}.app/Contents/Frameworks")
+    set(RESOURCES_DEST_DIR "${Launcher_DisplayName}.app/Contents/Resources")
+    set(JARS_DEST_DIR "${Launcher_DisplayName}.app/Contents/MacOS/jars")
 
     # Apps to bundle
-    set(APPS "\${CMAKE_INSTALL_PREFIX}/${Launcher_Name}.app")
+    set(APPS "\${CMAKE_INSTALL_PREFIX}/${Launcher_DisplayName}.app")
 
     # Mac bundle settings
-    set(MACOSX_BUNDLE_BUNDLE_NAME "${Launcher_Name}")
-    set(MACOSX_BUNDLE_INFO_STRING "${Launcher_Name}: A custom launcher for Minecraft that allows you to easily manage multiple installations of Minecraft at once.")
+    set(MACOSX_BUNDLE_BUNDLE_NAME "${Launcher_DisplayName}")
+    set(MACOSX_BUNDLE_INFO_STRING "${Launcher_DisplayName}: A custom launcher for Minecraft that allows you to easily manage multiple installations of Minecraft at once.")
     set(MACOSX_BUNDLE_GUI_IDENTIFIER "org.prismlauncher.${Launcher_Name}")
     set(MACOSX_BUNDLE_BUNDLE_VERSION "${Launcher_VERSION_NAME}")
     set(MACOSX_BUNDLE_SHORT_VERSION_STRING "${Launcher_VERSION_NAME}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,7 +229,7 @@ if(UNIX AND APPLE)
     set(MACOSX_BUNDLE_SHORT_VERSION_STRING "${Launcher_VERSION_NAME}")
     set(MACOSX_BUNDLE_LONG_VERSION_STRING "${Launcher_VERSION_NAME}")
     set(MACOSX_BUNDLE_ICON_FILE ${Launcher_Name}.icns)
-    set(MACOSX_BUNDLE_COPYRIGHT "© 2021-2022 ${Launcher_Copyright_Mac}")
+    set(MACOSX_BUNDLE_COPYRIGHT "© 2022 ${Launcher_Copyright_Mac}")
     set(MACOSX_SPARKLE_UPDATE_PUBLIC_KEY "v55ZWWD6QlPoXGV6VLzOTZxZUggWeE51X8cRQyQh6vA=")
     set(MACOSX_SPARKLE_UPDATE_FEED_URL "https://prismlauncher.org/feed/appcast.xml")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,15 +211,15 @@ if(NOT (UNIX AND APPLE))
 endif()
 
 if(UNIX AND APPLE)
-    set(BINARY_DEST_DIR "${Launcher_DisplayName}.app/Contents/MacOS")
-    set(LIBRARY_DEST_DIR "${Launcher_DisplayName}.app/Contents/MacOS")
-    set(PLUGIN_DEST_DIR "${Launcher_DisplayName}.app/Contents/MacOS")
-    set(FRAMEWORK_DEST_DIR "${Launcher_DisplayName}.app/Contents/Frameworks")
-    set(RESOURCES_DEST_DIR "${Launcher_DisplayName}.app/Contents/Resources")
-    set(JARS_DEST_DIR "${Launcher_DisplayName}.app/Contents/MacOS/jars")
+    set(BINARY_DEST_DIR "${Launcher_Name}.app/Contents/MacOS")
+    set(LIBRARY_DEST_DIR "${Launcher_Name}.app/Contents/MacOS")
+    set(PLUGIN_DEST_DIR "${Launcher_Name}.app/Contents/MacOS")
+    set(FRAMEWORK_DEST_DIR "${Launcher_Name}.app/Contents/Frameworks")
+    set(RESOURCES_DEST_DIR "${Launcher_Name}.app/Contents/Resources")
+    set(JARS_DEST_DIR "${Launcher_Name}.app/Contents/MacOS/jars")
 
     # Apps to bundle
-    set(APPS "\${CMAKE_INSTALL_PREFIX}/${Launcher_DisplayName}.app")
+    set(APPS "\${CMAKE_INSTALL_PREFIX}/${Launcher_Name}.app")
 
     # Mac bundle settings
     set(MACOSX_BUNDLE_BUNDLE_NAME "${Launcher_DisplayName}")
@@ -229,7 +229,7 @@ if(UNIX AND APPLE)
     set(MACOSX_BUNDLE_SHORT_VERSION_STRING "${Launcher_VERSION_NAME}")
     set(MACOSX_BUNDLE_LONG_VERSION_STRING "${Launcher_VERSION_NAME}")
     set(MACOSX_BUNDLE_ICON_FILE ${Launcher_Name}.icns)
-    set(MACOSX_BUNDLE_COPYRIGHT "Copyright 2021-2022 ${Launcher_Copyright}")
+    set(MACOSX_BUNDLE_COPYRIGHT "© 2021-2022 ${Launcher_Copyright_Mac}")
     set(MACOSX_SPARKLE_UPDATE_PUBLIC_KEY "v55ZWWD6QlPoXGV6VLzOTZxZUggWeE51X8cRQyQh6vA=")
     set(MACOSX_SPARKLE_UPDATE_FEED_URL "https://prismlauncher.org/feed/appcast.xml")
 

--- a/program_info/CMakeLists.txt
+++ b/program_info/CMakeLists.txt
@@ -15,6 +15,7 @@ set(Launcher_Name "${Launcher_CommonName}" PARENT_SCOPE)
 set(Launcher_DisplayName "${Launcher_DisplayName}" PARENT_SCOPE)
 
 set(Launcher_Copyright "Prism Launcher Contributors\\n© 2021-2022 PolyMC Contributors \\n© 2012-2021 MultiMC Contributors")
+set(Launcher_Copyright_Mac "Prism Launcher Contributors, © 2021-2022 PolyMC Contributors and © 2012-2021 MultiMC Contributors" PARENT_SCOPE)
 set(Launcher_Copyright "${Launcher_Copyright}" PARENT_SCOPE)
 set(Launcher_Domain "prismlauncher.org" PARENT_SCOPE)
 set(Launcher_UserAgent "${Launcher_CommonName}/${Launcher_VERSION_NAME}" PARENT_SCOPE)


### PR DESCRIPTION
This should fix the issues mentioned in #132.

Besides that, the copyright string should also be changed, as macOS doesn't recognize /n as new line.
<img width="360" alt="CleanShot 2022-10-22 at 15 02 05@2x" src="https://user-images.githubusercontent.com/29142128/197340414-33671998-1d3f-4a2f-9487-52de04c3eea5.png">

I suggest it should be replaced with a hyphen, but this would need a change of the global variable that defines the copyright or a variable specific for macOS only, so it might be a good idea to specify how you'd address that further.