### PR TITLE
ATLauncher: Fix pack installation always aborting

### DIFF
--- a/launcher/ui/pages/modplatform/atlauncher/AtlOptionalModDialog.cpp
+++ b/launcher/ui/pages/modplatform/atlauncher/AtlOptionalModDialog.cpp
@@ -331,7 +331,7 @@ AtlOptionalModDialog::AtlOptionalModDialog(QWidget* parent, ATLauncher::PackVers
     connect(ui->clearAllButton, &QPushButton::clicked,
             listModel, &AtlOptionalModListModel::clearAll);
     connect(ui->installButton, &QPushButton::clicked,
-            this, &QDialog::close);
+            this, &QDialog::accept);
 }
 
 AtlOptionalModDialog::~AtlOptionalModDialog() {


### PR DESCRIPTION
I made a mistake during when cherry picking a previous commit, this
applies the change - and fixes installing ATLauncher packs.
