### PR TITLE
Fix version labels width

### DIFF
--- a/launcher/ui/dialogs/AboutDialog.ui
+++ b/launcher/ui/dialogs/AboutDialog.ui
@@ -87,13 +87,10 @@
      </property>
     </widget>
    </item>
-   <item>
+   <item alignment="Qt::AlignHCenter">
     <widget class="QLabel" name="versionLabel">
      <property name="cursor">
       <cursorShape>IBeamCursor</cursorShape>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignCenter</set>
      </property>
      <property name="textInteractionFlags">
       <set>Qt::TextSelectableByMouse</set>
@@ -167,7 +164,7 @@
          </property>
         </widget>
        </item>
-       <item>
+       <item alignment="Qt::AlignHCenter">
         <widget class="QLabel" name="platformLabel">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
@@ -183,7 +180,7 @@
          </property>
         </widget>
        </item>
-       <item>
+       <item alignment="Qt::AlignHCenter">
         <widget class="QLabel" name="buildDateLabel">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
@@ -199,7 +196,7 @@
          </property>
         </widget>
        </item>
-       <item>
+       <item alignment="Qt::AlignHCenter">
         <widget class="QLabel" name="commitLabel">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>
@@ -215,7 +212,7 @@
          </property>
         </widget>
        </item>
-       <item>
+       <item alignment="Qt::AlignHCenter">
         <widget class="QLabel" name="channelLabel">
          <property name="cursor">
           <cursorShape>IBeamCursor</cursorShape>


### PR DESCRIPTION
Make labels fit to the contents, so Ibeam cursor doesn't appear over empty space. Should have been done with 90025ed :sweat_smile: 