### PR TITLE
Add more options to copy instance dialog

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -31,6 +31,7 @@ set(CORE_SOURCES
     # Basic instance manipulation tasks (derived from InstanceTask)
     InstanceCreationTask.h
     InstanceCreationTask.cpp
+    InstanceCopyPrefs.h
     InstanceCopyTask.h
     InstanceCopyTask.cpp
     InstanceImportTask.h

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -32,6 +32,7 @@ set(CORE_SOURCES
     InstanceCreationTask.h
     InstanceCreationTask.cpp
     InstanceCopyPrefs.h
+    InstanceCopyPrefs.cpp
     InstanceCopyTask.h
     InstanceCopyTask.cpp
     InstanceImportTask.h

--- a/launcher/InstanceCopyPrefs.cpp
+++ b/launcher/InstanceCopyPrefs.cpp
@@ -1,0 +1,15 @@
+//
+// Created by marcelohdez on 10/22/22.
+//
+
+#include "InstanceCopyPrefs.h"
+
+InstanceCopyPrefs::InstanceCopyPrefs(bool setAll)
+    : copySaves(setAll),
+    keepPlaytime(setAll),
+    copyGameOptions(setAll),
+    copyResourcePacks(setAll),
+    copyShaderPacks(setAll),
+    copyServers(setAll),
+    copyMods(setAll)
+{}

--- a/launcher/InstanceCopyPrefs.cpp
+++ b/launcher/InstanceCopyPrefs.cpp
@@ -4,12 +4,13 @@
 
 #include "InstanceCopyPrefs.h"
 
-InstanceCopyPrefs::InstanceCopyPrefs(bool setAll)
-    : copySaves(setAll),
-    keepPlaytime(setAll),
-    copyGameOptions(setAll),
-    copyResourcePacks(setAll),
-    copyShaderPacks(setAll),
-    copyServers(setAll),
-    copyMods(setAll)
-{}
+bool InstanceCopyPrefs::allTrue() const
+{
+    return copySaves &&
+        keepPlaytime &&
+        copyGameOptions &&
+        copyResourcePacks &&
+        copyShaderPacks &&
+        copyServers &&
+        copyMods;
+}

--- a/launcher/InstanceCopyPrefs.cpp
+++ b/launcher/InstanceCopyPrefs.cpp
@@ -14,3 +14,36 @@ bool InstanceCopyPrefs::allTrue() const
         copyServers &&
         copyMods;
 }
+
+// Returns a single RegEx string of the selected folders/files to filter out (ex: ".minecraft/saves|.minecraft/server.dat")
+QString InstanceCopyPrefs::getSelectedFiltersAsRegex() const
+{
+    QStringList filters;
+
+    if(!copySaves)
+        filters << "saves";
+
+    if(!copyGameOptions)
+        filters << "options.txt";
+
+    if(!copyResourcePacks)
+        filters << "resourcepacks" << "texturepacks";
+
+    if(!copyShaderPacks)
+        filters << "shaderpacks";
+
+    if(!copyServers)
+        filters << "servers.dat" << "servers.dat_old" << "server-resource-packs";
+
+    if(!copyMods)
+        filters << "coremods" << "mods" << "config";
+
+    // If we have any filters to add, join them as a single regex string to return:
+    if (!filters.isEmpty()) {
+        const QString MC_ROOT = "[.]?minecraft/";
+        // Ensure first filter starts with root, then join other filters with OR regex before root (ex: ".minecraft/saves|.minecraft/mods"):
+        return MC_ROOT + filters.join("|" + MC_ROOT);
+    }
+
+    return {};
+}

--- a/launcher/InstanceCopyPrefs.cpp
+++ b/launcher/InstanceCopyPrefs.cpp
@@ -47,3 +47,75 @@ QString InstanceCopyPrefs::getSelectedFiltersAsRegex() const
 
     return {};
 }
+
+// ======= Getters =======
+bool InstanceCopyPrefs::isCopySavesEnabled() const
+{
+    return copySaves;
+}
+
+bool InstanceCopyPrefs::isKeepPlaytimeEnabled() const
+{
+    return keepPlaytime;
+}
+
+bool InstanceCopyPrefs::isCopyGameOptionsEnabled() const
+{
+    return copyGameOptions;
+}
+
+bool InstanceCopyPrefs::isCopyResourcePacksEnabled() const
+{
+    return copyResourcePacks;
+}
+
+bool InstanceCopyPrefs::isCopyShaderPacksEnabled() const
+{
+    return copyShaderPacks;
+}
+
+bool InstanceCopyPrefs::isCopyServersEnabled() const
+{
+    return copyServers;
+}
+
+bool InstanceCopyPrefs::isCopyModsEnabled() const
+{
+    return copyMods;
+}
+
+// ======= Setters =======
+void InstanceCopyPrefs::enableCopySaves(bool b)
+{
+    copySaves = b;
+}
+
+void InstanceCopyPrefs::enableKeepPlaytime(bool b)
+{
+    keepPlaytime = b;
+}
+
+void InstanceCopyPrefs::enableCopyGameOptions(bool b)
+{
+    copyGameOptions = b;
+}
+
+void InstanceCopyPrefs::enableCopyResourcePacks(bool b)
+{
+    copyResourcePacks = b;
+}
+
+void InstanceCopyPrefs::enableCopyShaderPacks(bool b)
+{
+    copyShaderPacks = b;
+}
+
+void InstanceCopyPrefs::enableCopyServers(bool b)
+{
+    copyServers = b;
+}
+
+void InstanceCopyPrefs::enableCopyMods(bool b)
+{
+    copyMods = b;
+}

--- a/launcher/InstanceCopyPrefs.cpp
+++ b/launcher/InstanceCopyPrefs.cpp
@@ -12,7 +12,8 @@ bool InstanceCopyPrefs::allTrue() const
         copyResourcePacks &&
         copyShaderPacks &&
         copyServers &&
-        copyMods;
+        copyMods &&
+        copyScreenshots;
 }
 
 // Returns a single RegEx string of the selected folders/files to filter out (ex: ".minecraft/saves|.minecraft/server.dat")
@@ -37,6 +38,9 @@ QString InstanceCopyPrefs::getSelectedFiltersAsRegex() const
 
     if(!copyMods)
         filters << "coremods" << "mods" << "config";
+
+    if(!copyScreenshots)
+        filters << "screenshots";
 
     // If we have any filters to add, join them as a single regex string to return:
     if (!filters.isEmpty()) {
@@ -84,6 +88,11 @@ bool InstanceCopyPrefs::isCopyModsEnabled() const
     return copyMods;
 }
 
+bool InstanceCopyPrefs::isCopyScreenshotsEnabled() const
+{
+    return copyScreenshots;
+}
+
 // ======= Setters =======
 void InstanceCopyPrefs::enableCopySaves(bool b)
 {
@@ -118,4 +127,9 @@ void InstanceCopyPrefs::enableCopyServers(bool b)
 void InstanceCopyPrefs::enableCopyMods(bool b)
 {
     copyMods = b;
+}
+
+void InstanceCopyPrefs::enableCopyScreenshots(bool b)
+{
+    copyScreenshots = b;
 }

--- a/launcher/InstanceCopyPrefs.h
+++ b/launcher/InstanceCopyPrefs.h
@@ -2,12 +2,32 @@
 // Created by marcelohdez on 10/22/22.
 //
 
-#ifndef LAUNCHER_INSTANCECOPYPREFS_H
-#define LAUNCHER_INSTANCECOPYPREFS_H
+#pragma once
 
 #include <QStringList>
 
 struct InstanceCopyPrefs {
+   public:
+    [[nodiscard]] bool allTrue() const;
+    [[nodiscard]] QString getSelectedFiltersAsRegex() const;
+    // Getters
+    [[nodiscard]] bool isCopySavesEnabled() const;
+    [[nodiscard]] bool isKeepPlaytimeEnabled() const;
+    [[nodiscard]] bool isCopyGameOptionsEnabled() const;
+    [[nodiscard]] bool isCopyResourcePacksEnabled() const;
+    [[nodiscard]] bool isCopyShaderPacksEnabled() const;
+    [[nodiscard]] bool isCopyServersEnabled() const;
+    [[nodiscard]] bool isCopyModsEnabled() const;
+    // Setters
+    void enableCopySaves(bool b);
+    void enableKeepPlaytime(bool b);
+    void enableCopyGameOptions(bool b);
+    void enableCopyResourcePacks(bool b);
+    void enableCopyShaderPacks(bool b);
+    void enableCopyServers(bool b);
+    void enableCopyMods(bool b);
+
+   protected: // data
     bool copySaves = true;
     bool keepPlaytime = true;
     bool copyGameOptions = true;
@@ -15,9 +35,4 @@ struct InstanceCopyPrefs {
     bool copyShaderPacks = true;
     bool copyServers = true;
     bool copyMods = true;
-
-    [[nodiscard]] bool allTrue() const;
-    [[nodiscard]] QString getSelectedFiltersAsRegex() const;
 };
-
-#endif  // LAUNCHER_INSTANCECOPYPREFS_H

--- a/launcher/InstanceCopyPrefs.h
+++ b/launcher/InstanceCopyPrefs.h
@@ -5,6 +5,8 @@
 #ifndef LAUNCHER_INSTANCECOPYPREFS_H
 #define LAUNCHER_INSTANCECOPYPREFS_H
 
+#include <QStringList>
+
 struct InstanceCopyPrefs {
     bool copySaves = true;
     bool keepPlaytime = true;
@@ -14,7 +16,8 @@ struct InstanceCopyPrefs {
     bool copyServers = true;
     bool copyMods = true;
 
-    bool allTrue() const;
+    [[nodiscard]] bool allTrue() const;
+    [[nodiscard]] QString getSelectedFiltersAsRegex() const;
 };
 
 #endif  // LAUNCHER_INSTANCECOPYPREFS_H

--- a/launcher/InstanceCopyPrefs.h
+++ b/launcher/InstanceCopyPrefs.h
@@ -6,16 +6,15 @@
 #define LAUNCHER_INSTANCECOPYPREFS_H
 
 struct InstanceCopyPrefs {
-    explicit InstanceCopyPrefs(bool setAll);
-    ~InstanceCopyPrefs() = default;
+    bool copySaves = true;
+    bool keepPlaytime = true;
+    bool copyGameOptions = true;
+    bool copyResourcePacks = true;
+    bool copyShaderPacks = true;
+    bool copyServers = true;
+    bool copyMods = true;
 
-    bool copySaves;
-    bool keepPlaytime;
-    bool copyGameOptions;
-    bool copyResourcePacks;
-    bool copyShaderPacks;
-    bool copyServers;
-    bool copyMods;
+    bool allTrue() const;
 };
 
 #endif  // LAUNCHER_INSTANCECOPYPREFS_H

--- a/launcher/InstanceCopyPrefs.h
+++ b/launcher/InstanceCopyPrefs.h
@@ -1,0 +1,18 @@
+//
+// Created by marcelohdez on 10/22/22.
+//
+
+#ifndef LAUNCHER_INSTANCECOPYPREFS_H
+#define LAUNCHER_INSTANCECOPYPREFS_H
+
+struct InstanceCopyPrefs {
+    bool copySaves;
+    bool keepPlaytime;
+    bool copyGameOptions;
+    bool copyResourcePacks;
+    bool copyShaderPacks;
+    bool copyServers;
+    bool copyMods;
+};
+
+#endif  // LAUNCHER_INSTANCECOPYPREFS_H

--- a/launcher/InstanceCopyPrefs.h
+++ b/launcher/InstanceCopyPrefs.h
@@ -6,6 +6,9 @@
 #define LAUNCHER_INSTANCECOPYPREFS_H
 
 struct InstanceCopyPrefs {
+    explicit InstanceCopyPrefs(bool setAll);
+    ~InstanceCopyPrefs() = default;
+
     bool copySaves;
     bool keepPlaytime;
     bool copyGameOptions;

--- a/launcher/InstanceCopyPrefs.h
+++ b/launcher/InstanceCopyPrefs.h
@@ -18,6 +18,7 @@ struct InstanceCopyPrefs {
     [[nodiscard]] bool isCopyShaderPacksEnabled() const;
     [[nodiscard]] bool isCopyServersEnabled() const;
     [[nodiscard]] bool isCopyModsEnabled() const;
+    [[nodiscard]] bool isCopyScreenshotsEnabled() const;
     // Setters
     void enableCopySaves(bool b);
     void enableKeepPlaytime(bool b);
@@ -26,6 +27,7 @@ struct InstanceCopyPrefs {
     void enableCopyShaderPacks(bool b);
     void enableCopyServers(bool b);
     void enableCopyMods(bool b);
+    void enableCopyScreenshots(bool b);
 
    protected: // data
     bool copySaves = true;
@@ -35,4 +37,5 @@ struct InstanceCopyPrefs {
     bool copyShaderPacks = true;
     bool copyServers = true;
     bool copyMods = true;
+    bool copyScreenshots = true;
 };

--- a/launcher/InstanceCopyTask.cpp
+++ b/launcher/InstanceCopyTask.cpp
@@ -8,7 +8,7 @@
 InstanceCopyTask::InstanceCopyTask(InstancePtr origInstance, const InstanceCopyPrefs& prefs)
 {
     m_origInstance = origInstance;
-    m_keepPlaytime = prefs.keepPlaytime;
+    m_keepPlaytime = prefs.isKeepPlaytimeEnabled();
 
     QString filters = prefs.getSelectedFiltersAsRegex();
     if (!filters.isEmpty())

--- a/launcher/InstanceCopyTask.cpp
+++ b/launcher/InstanceCopyTask.cpp
@@ -9,62 +9,16 @@ InstanceCopyTask::InstanceCopyTask(InstancePtr origInstance, const InstanceCopyP
 {
     m_origInstance = origInstance;
     m_keepPlaytime = prefs.keepPlaytime;
-    QString filter;
 
-    if(!prefs.copySaves)
+    QString filters = prefs.getSelectedFiltersAsRegex();
+    if (!filters.isEmpty())
     {
-        appendToFilter(filter, "saves");
+        // Set regex filter:
+        // FIXME: get this from the original instance type...
+        auto matcherReal = new RegexpMatcher(filters);
+        matcherReal->caseSensitive(false);
+        m_matcher.reset(matcherReal);
     }
-
-    if(!prefs.copyGameOptions) {
-        appendToFilter(filter, "options.txt");
-    }
-
-    if(!prefs.copyResourcePacks)
-    {
-        appendToFilter(filter, "resourcepacks");
-        appendToFilter(filter, "texturepacks");
-    }
-
-    if(!prefs.copyShaderPacks)
-    {
-        appendToFilter(filter, "shaderpacks");
-    }
-
-    if(!prefs.copyServers)
-    {
-        appendToFilter(filter, "servers.dat");
-        appendToFilter(filter, "servers.dat_old");
-        appendToFilter(filter, "server-resource-packs");
-    }
-
-    if(!prefs.copyMods)
-    {
-        appendToFilter(filter, "coremods");
-        appendToFilter(filter, "mods");
-        appendToFilter(filter, "config");
-    }
-
-    if (!filter.isEmpty())
-    {
-        resetFromMatcher(filter);
-    }
-}
-
-void InstanceCopyTask::appendToFilter(QString& filter, const QString& append)
-{
-    if (!filter.isEmpty())
-        filter.append('|'); // OR regex
-
-    filter.append("[.]?minecraft/" + append);
-}
-
-void InstanceCopyTask::resetFromMatcher(const QString& regexp)
-{
-    // FIXME: get this from the original instance type...
-    auto matcherReal = new RegexpMatcher(regexp);
-    matcherReal->caseSensitive(false);
-    m_matcher.reset(matcherReal);
 }
 
 void InstanceCopyTask::executeTask()

--- a/launcher/InstanceCopyTask.cpp
+++ b/launcher/InstanceCopyTask.cpp
@@ -5,7 +5,7 @@
 #include "pathmatcher/RegexpMatcher.h"
 #include <QtConcurrentRun>
 
-InstanceCopyTask::InstanceCopyTask(InstancePtr origInstance, InstanceCopyPrefs prefs)
+InstanceCopyTask::InstanceCopyTask(InstancePtr origInstance, const InstanceCopyPrefs& prefs)
 {
     m_origInstance = origInstance;
     m_keepPlaytime = prefs.keepPlaytime;
@@ -51,7 +51,7 @@ InstanceCopyTask::InstanceCopyTask(InstancePtr origInstance, InstanceCopyPrefs p
     }
 }
 
-void InstanceCopyTask::appendToFilter(QString& filter, const QString &append)
+void InstanceCopyTask::appendToFilter(QString& filter, const QString& append)
 {
     if (!filter.isEmpty())
         filter.append('|'); // OR regex

--- a/launcher/InstanceCopyTask.cpp
+++ b/launcher/InstanceCopyTask.cpp
@@ -5,18 +5,66 @@
 #include "pathmatcher/RegexpMatcher.h"
 #include <QtConcurrentRun>
 
-InstanceCopyTask::InstanceCopyTask(InstancePtr origInstance, bool copySaves, bool keepPlaytime)
+InstanceCopyTask::InstanceCopyTask(InstancePtr origInstance, InstanceCopyPrefs prefs)
 {
     m_origInstance = origInstance;
-    m_keepPlaytime = keepPlaytime;
+    m_keepPlaytime = prefs.keepPlaytime;
+    QString filter;
 
-    if(!copySaves)
+    if(!prefs.copySaves)
     {
-        // FIXME: get this from the original instance type...
-        auto matcherReal = new RegexpMatcher("[.]?minecraft/saves");
-        matcherReal->caseSensitive(false);
-        m_matcher.reset(matcherReal);
+        appendToFilter(filter, "saves");
     }
+
+    if(!prefs.copyGameOptions) {
+        appendToFilter(filter, "options.txt");
+    }
+
+    if(!prefs.copyResourcePacks)
+    {
+        appendToFilter(filter, "resourcepacks");
+        appendToFilter(filter, "texturepacks");
+    }
+
+    if(!prefs.copyShaderPacks)
+    {
+        appendToFilter(filter, "shaderpacks");
+    }
+
+    if(!prefs.copyServers)
+    {
+        appendToFilter(filter, "servers.dat");
+        appendToFilter(filter, "servers.dat_old");
+        appendToFilter(filter, "server-resource-packs");
+    }
+
+    if(!prefs.copyMods)
+    {
+        appendToFilter(filter, "coremods");
+        appendToFilter(filter, "mods");
+        appendToFilter(filter, "config");
+    }
+
+    if (!filter.isEmpty())
+    {
+        resetFromMatcher(filter);
+    }
+}
+
+void InstanceCopyTask::appendToFilter(QString& filter, const QString &append)
+{
+    if (!filter.isEmpty())
+        filter.append('|'); // OR regex
+
+    filter.append("[.]?minecraft/" + append);
+}
+
+void InstanceCopyTask::resetFromMatcher(const QString& regexp)
+{
+    // FIXME: get this from the original instance type...
+    auto matcherReal = new RegexpMatcher(regexp);
+    matcherReal->caseSensitive(false);
+    m_matcher.reset(matcherReal);
 }
 
 void InstanceCopyTask::executeTask()

--- a/launcher/InstanceCopyTask.h
+++ b/launcher/InstanceCopyTask.h
@@ -24,10 +24,6 @@ protected:
     void copyAborted();
 
 private:
-    // Helper functions to avoid repeating code
-    static void appendToFilter(QString &filter, const QString &append);
-    void resetFromMatcher(const QString &regexp);
-
     /* data */
     InstancePtr m_origInstance;
     QFuture<bool> m_copyFuture;

--- a/launcher/InstanceCopyTask.h
+++ b/launcher/InstanceCopyTask.h
@@ -1,20 +1,21 @@
 #pragma once
 
-#include "tasks/Task.h"
-#include "net/NetJob.h"
-#include <QUrl>
 #include <QFuture>
 #include <QFutureWatcher>
-#include "settings/SettingsObject.h"
-#include "BaseVersion.h"
+#include <QUrl>
 #include "BaseInstance.h"
+#include "BaseVersion.h"
+#include "InstanceCopyPrefs.h"
 #include "InstanceTask.h"
+#include "net/NetJob.h"
+#include "settings/SettingsObject.h"
+#include "tasks/Task.h"
 
 class InstanceCopyTask : public InstanceTask
 {
     Q_OBJECT
 public:
-    explicit InstanceCopyTask(InstancePtr origInstance, bool copySaves, bool keepPlaytime);
+    explicit InstanceCopyTask(InstancePtr origInstance, InstanceCopyPrefs prefs);
 
 protected:
     //! Entry point for tasks.
@@ -22,7 +23,12 @@ protected:
     void copyFinished();
     void copyAborted();
 
-private: /* data */
+private:
+    // Helper functions to avoid repeating code
+    static void appendToFilter(QString &filter, const QString &append);
+    void resetFromMatcher(const QString &regexp);
+
+    /* data */
     InstancePtr m_origInstance;
     QFuture<bool> m_copyFuture;
     QFutureWatcher<bool> m_copyFutureWatcher;

--- a/launcher/InstanceCopyTask.h
+++ b/launcher/InstanceCopyTask.h
@@ -15,7 +15,7 @@ class InstanceCopyTask : public InstanceTask
 {
     Q_OBJECT
 public:
-    explicit InstanceCopyTask(InstancePtr origInstance, InstanceCopyPrefs prefs);
+    explicit InstanceCopyTask(InstancePtr origInstance, const InstanceCopyPrefs& prefs);
 
 protected:
     //! Entry point for tasks.

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -1616,7 +1616,17 @@ void MainWindow::on_actionCopyInstance_triggered()
     if (!copyInstDlg.exec())
         return;
 
-    auto copyTask = new InstanceCopyTask(m_selectedInstance, copyInstDlg.shouldCopySaves(), copyInstDlg.shouldKeepPlaytime());
+    auto copyTask = new InstanceCopyTask(
+        m_selectedInstance,
+        InstanceCopyPrefs {
+            copyInstDlg.shouldCopySaves(),
+            copyInstDlg.shouldKeepPlaytime(),
+            copyInstDlg.shouldCopyGameOptions(),
+            copyInstDlg.shouldCopyResourcePacks(),
+            copyInstDlg.shouldCopyShaderPacks(),
+            copyInstDlg.shouldCopyServers(),
+            copyInstDlg.shouldCopyMods()
+        });
     copyTask->setName(copyInstDlg.instName());
     copyTask->setGroup(copyInstDlg.instGroup());
     copyTask->setIcon(copyInstDlg.iconKey());

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -1616,17 +1616,7 @@ void MainWindow::on_actionCopyInstance_triggered()
     if (!copyInstDlg.exec())
         return;
 
-    auto copyTask = new InstanceCopyTask(
-        m_selectedInstance,
-        InstanceCopyPrefs {
-            copyInstDlg.shouldCopySaves(),
-            copyInstDlg.shouldKeepPlaytime(),
-            copyInstDlg.shouldCopyGameOptions(),
-            copyInstDlg.shouldCopyResourcePacks(),
-            copyInstDlg.shouldCopyShaderPacks(),
-            copyInstDlg.shouldCopyServers(),
-            copyInstDlg.shouldCopyMods()
-        });
+    auto copyTask = new InstanceCopyTask(m_selectedInstance, copyInstDlg.getChosenOptions());
     copyTask->setName(copyInstDlg.instName());
     copyTask->setGroup(copyInstDlg.instGroup());
     copyTask->setIcon(copyInstDlg.iconKey());

--- a/launcher/ui/dialogs/CopyInstanceDialog.cpp
+++ b/launcher/ui/dialogs/CopyInstanceDialog.cpp
@@ -138,12 +138,9 @@ void CopyInstanceDialog::checkAllCheckboxes(const bool& b)
     ui->copyModsCheckbox->setChecked(b);
 }
 
-// Sets b to true if state is a checked checkbox
-void CopyInstanceDialog::checkBool(bool& b, const int& state)
+// Check the "Select all" checkbox checked if all options are already checked:
+void CopyInstanceDialog::updateSelectAllCheckbox()
 {
-    b = (state == Qt::Checked);
-
-    // Have "Select all" checkbox checked if all options are already checked:
     ui->selectAllCheckbox->blockSignals(true);
     ui->selectAllCheckbox->setChecked(m_selectedOptions.allTrue());
     ui->selectAllCheckbox->blockSignals(false);
@@ -170,42 +167,49 @@ void CopyInstanceDialog::on_instNameTextBox_textChanged(const QString &arg1)
 void CopyInstanceDialog::on_selectAllCheckbox_stateChanged(int state)
 {
     bool checked;
-    checkBool(checked, state);
+    checked = (state == Qt::Checked);
     checkAllCheckboxes(checked);
 }
 
 void CopyInstanceDialog::on_copySavesCheckbox_stateChanged(int state)
 {
-    checkBool(m_selectedOptions.copySaves, state);
+    m_selectedOptions.copySaves = (state == Qt::Checked);
+    updateSelectAllCheckbox();
 }
 
 
 void CopyInstanceDialog::on_keepPlaytimeCheckbox_stateChanged(int state)
 {
-    checkBool(m_selectedOptions.keepPlaytime, state);
+    m_selectedOptions.keepPlaytime = (state == Qt::Checked);
+    updateSelectAllCheckbox();
 }
 
 void CopyInstanceDialog::on_copyGameOptionsCheckbox_stateChanged(int state)
 {
-    checkBool(m_selectedOptions.copyGameOptions, state);
+    m_selectedOptions.copyGameOptions = (state == Qt::Checked);
+    updateSelectAllCheckbox();
 }
 
 void CopyInstanceDialog::on_copyResPacksCheckbox_stateChanged(int state)
 {
-    checkBool(m_selectedOptions.copyResourcePacks, state);
+    m_selectedOptions.copyResourcePacks = (state == Qt::Checked);
+    updateSelectAllCheckbox();
 }
 
 void CopyInstanceDialog::on_copyShaderPacksCheckbox_stateChanged(int state)
 {
-    checkBool(m_selectedOptions.copyShaderPacks, state);
+    m_selectedOptions.copyShaderPacks = (state == Qt::Checked);
+    updateSelectAllCheckbox();
 }
 
 void CopyInstanceDialog::on_copyServersCheckbox_stateChanged(int state)
 {
-    checkBool(m_selectedOptions.copyServers, state);
+    m_selectedOptions.copyServers = (state == Qt::Checked);
+    updateSelectAllCheckbox();
 }
 
 void CopyInstanceDialog::on_copyModsCheckbox_stateChanged(int state)
 {
-    checkBool(m_selectedOptions.copyMods, state);
+    m_selectedOptions.copyMods = (state == Qt::Checked);
+    updateSelectAllCheckbox();
 }

--- a/launcher/ui/dialogs/CopyInstanceDialog.cpp
+++ b/launcher/ui/dialogs/CopyInstanceDialog.cpp
@@ -80,6 +80,11 @@ CopyInstanceDialog::CopyInstanceDialog(InstancePtr original, QWidget *parent)
     ui->groupBox->lineEdit()->setPlaceholderText(tr("No group"));
     ui->copySavesCheckbox->setChecked(m_copySaves);
     ui->keepPlaytimeCheckbox->setChecked(m_keepPlaytime);
+    ui->copyGameOptionsCheckbox->setChecked(m_copyGameOptions);
+    ui->copyResPacksCheckbox->setChecked(m_copyResourcePacks);
+    ui->copyShaderPacksCheckbox->setChecked(m_copyShaderPacks);
+    ui->copyServersCheckbox->setChecked(m_copyServers);
+    ui->copyModsCheckbox->setChecked(m_copyMods);
 }
 
 CopyInstanceDialog::~CopyInstanceDialog()
@@ -166,5 +171,90 @@ void CopyInstanceDialog::on_keepPlaytimeCheckbox_stateChanged(int state)
     else if(state == Qt::Checked)
     {
         m_keepPlaytime = true;
+    }
+}
+
+bool CopyInstanceDialog::shouldCopyGameOptions() const
+{
+    return m_copyGameOptions;
+}
+
+void CopyInstanceDialog::on_copyGameOptionsCheckbox_stateChanged(int state)
+{
+    if(state == Qt::Unchecked)
+    {
+        m_copyGameOptions = false;
+    }
+    else if(state == Qt::Checked)
+    {
+        m_copyGameOptions = true;
+    }
+}
+
+bool CopyInstanceDialog::shouldCopyResourcePacks() const
+{
+    return m_copyResourcePacks;
+}
+
+void CopyInstanceDialog::on_copyResPacksCheckbox_stateChanged(int state)
+{
+    if(state == Qt::Unchecked)
+    {
+        m_copyResourcePacks = false;
+    }
+    else if(state == Qt::Checked)
+    {
+        m_copyResourcePacks = true;
+    }
+}
+
+bool CopyInstanceDialog::shouldCopyShaderPacks() const
+{
+    return m_copyShaderPacks;
+}
+
+void CopyInstanceDialog::on_copyShaderPacksCheckbox_stateChanged(int state)
+{
+    if(state == Qt::Unchecked)
+    {
+        m_copyShaderPacks = false;
+    }
+    else if(state == Qt::Checked)
+    {
+        m_copyShaderPacks = true;
+    }
+}
+
+bool CopyInstanceDialog::shouldCopyServers() const
+{
+    return m_copyServers;
+}
+
+void CopyInstanceDialog::on_copyServersCheckbox_stateChanged(int state)
+{
+    if(state == Qt::Unchecked)
+    {
+        m_copyServers = false;
+    }
+    else if(state == Qt::Checked)
+    {
+        m_copyServers = true;
+    }
+}
+
+bool CopyInstanceDialog::shouldCopyMods() const
+{
+    return m_copyMods;
+}
+
+void CopyInstanceDialog::on_copyModsCheckbox_stateChanged(int state)
+{
+    if(state == Qt::Unchecked)
+    {
+        m_copyMods = false;
+    }
+    else if(state == Qt::Checked)
+    {
+        m_copyMods = true;
     }
 }

--- a/launcher/ui/dialogs/CopyInstanceDialog.cpp
+++ b/launcher/ui/dialogs/CopyInstanceDialog.cpp
@@ -77,13 +77,13 @@ CopyInstanceDialog::CopyInstanceDialog(InstancePtr original, QWidget *parent)
     }
     ui->groupBox->setCurrentIndex(index);
     ui->groupBox->lineEdit()->setPlaceholderText(tr("No group"));
-    ui->copySavesCheckbox->setChecked(m_selectedOptions.copySaves);
-    ui->keepPlaytimeCheckbox->setChecked(m_selectedOptions.keepPlaytime);
-    ui->copyGameOptionsCheckbox->setChecked(m_selectedOptions.copyGameOptions);
-    ui->copyResPacksCheckbox->setChecked(m_selectedOptions.copyResourcePacks);
-    ui->copyShaderPacksCheckbox->setChecked(m_selectedOptions.copyShaderPacks);
-    ui->copyServersCheckbox->setChecked(m_selectedOptions.copyServers);
-    ui->copyModsCheckbox->setChecked(m_selectedOptions.copyMods);
+    ui->copySavesCheckbox->setChecked(m_selectedOptions.isCopySavesEnabled());
+    ui->keepPlaytimeCheckbox->setChecked(m_selectedOptions.isKeepPlaytimeEnabled());
+    ui->copyGameOptionsCheckbox->setChecked(m_selectedOptions.isCopyGameOptionsEnabled());
+    ui->copyResPacksCheckbox->setChecked(m_selectedOptions.isCopyResourcePacksEnabled());
+    ui->copyShaderPacksCheckbox->setChecked(m_selectedOptions.isCopyShaderPacksEnabled());
+    ui->copyServersCheckbox->setChecked(m_selectedOptions.isCopyServersEnabled());
+    ui->copyModsCheckbox->setChecked(m_selectedOptions.isCopyModsEnabled());
 }
 
 CopyInstanceDialog::~CopyInstanceDialog()
@@ -172,43 +172,43 @@ void CopyInstanceDialog::on_selectAllCheckbox_stateChanged(int state)
 
 void CopyInstanceDialog::on_copySavesCheckbox_stateChanged(int state)
 {
-    m_selectedOptions.copySaves = (state == Qt::Checked);
+    m_selectedOptions.enableCopySaves(state == Qt::Checked);
     updateSelectAllCheckbox();
 }
 
 
 void CopyInstanceDialog::on_keepPlaytimeCheckbox_stateChanged(int state)
 {
-    m_selectedOptions.keepPlaytime = (state == Qt::Checked);
+    m_selectedOptions.enableKeepPlaytime(state == Qt::Checked);
     updateSelectAllCheckbox();
 }
 
 void CopyInstanceDialog::on_copyGameOptionsCheckbox_stateChanged(int state)
 {
-    m_selectedOptions.copyGameOptions = (state == Qt::Checked);
+    m_selectedOptions.enableCopyGameOptions(state == Qt::Checked);
     updateSelectAllCheckbox();
 }
 
 void CopyInstanceDialog::on_copyResPacksCheckbox_stateChanged(int state)
 {
-    m_selectedOptions.copyResourcePacks = (state == Qt::Checked);
+    m_selectedOptions.enableCopyResourcePacks(state == Qt::Checked);
     updateSelectAllCheckbox();
 }
 
 void CopyInstanceDialog::on_copyShaderPacksCheckbox_stateChanged(int state)
 {
-    m_selectedOptions.copyShaderPacks = (state == Qt::Checked);
+    m_selectedOptions.enableCopyShaderPacks(state == Qt::Checked);
     updateSelectAllCheckbox();
 }
 
 void CopyInstanceDialog::on_copyServersCheckbox_stateChanged(int state)
 {
-    m_selectedOptions.copyServers = (state == Qt::Checked);
+    m_selectedOptions.enableCopyServers(state == Qt::Checked);
     updateSelectAllCheckbox();
 }
 
 void CopyInstanceDialog::on_copyModsCheckbox_stateChanged(int state)
 {
-    m_selectedOptions.copyMods = (state == Qt::Checked);
+    m_selectedOptions.enableCopyMods(state == Qt::Checked);
     updateSelectAllCheckbox();
 }

--- a/launcher/ui/dialogs/CopyInstanceDialog.cpp
+++ b/launcher/ui/dialogs/CopyInstanceDialog.cpp
@@ -84,6 +84,7 @@ CopyInstanceDialog::CopyInstanceDialog(InstancePtr original, QWidget *parent)
     ui->copyShaderPacksCheckbox->setChecked(m_selectedOptions.isCopyShaderPacksEnabled());
     ui->copyServersCheckbox->setChecked(m_selectedOptions.isCopyServersEnabled());
     ui->copyModsCheckbox->setChecked(m_selectedOptions.isCopyModsEnabled());
+    ui->copyScreenshotsCheckbox->setChecked(m_selectedOptions.isCopyScreenshotsEnabled());
 }
 
 CopyInstanceDialog::~CopyInstanceDialog()
@@ -135,6 +136,7 @@ void CopyInstanceDialog::checkAllCheckboxes(const bool& b)
     ui->copyShaderPacksCheckbox->setChecked(b);
     ui->copyServersCheckbox->setChecked(b);
     ui->copyModsCheckbox->setChecked(b);
+    ui->copyScreenshotsCheckbox->setChecked(b);
 }
 
 // Check the "Select all" checkbox if all options are already selected:
@@ -210,5 +212,11 @@ void CopyInstanceDialog::on_copyServersCheckbox_stateChanged(int state)
 void CopyInstanceDialog::on_copyModsCheckbox_stateChanged(int state)
 {
     m_selectedOptions.enableCopyMods(state == Qt::Checked);
+    updateSelectAllCheckbox();
+}
+
+void CopyInstanceDialog::on_copyScreenshotsCheckbox_stateChanged(int state)
+{
+    m_selectedOptions.enableCopyScreenshots(state == Qt::Checked);
     updateSelectAllCheckbox();
 }

--- a/launcher/ui/dialogs/CopyInstanceDialog.cpp
+++ b/launcher/ui/dialogs/CopyInstanceDialog.cpp
@@ -78,13 +78,13 @@ CopyInstanceDialog::CopyInstanceDialog(InstancePtr original, QWidget *parent)
     }
     ui->groupBox->setCurrentIndex(index);
     ui->groupBox->lineEdit()->setPlaceholderText(tr("No group"));
-    ui->copySavesCheckbox->setChecked(m_copySaves);
-    ui->keepPlaytimeCheckbox->setChecked(m_keepPlaytime);
-    ui->copyGameOptionsCheckbox->setChecked(m_copyGameOptions);
-    ui->copyResPacksCheckbox->setChecked(m_copyResourcePacks);
-    ui->copyShaderPacksCheckbox->setChecked(m_copyShaderPacks);
-    ui->copyServersCheckbox->setChecked(m_copyServers);
-    ui->copyModsCheckbox->setChecked(m_copyMods);
+    ui->copySavesCheckbox->setChecked(m_selectedOptions.copySaves);
+    ui->keepPlaytimeCheckbox->setChecked(m_selectedOptions.keepPlaytime);
+    ui->copyGameOptionsCheckbox->setChecked(m_selectedOptions.copyGameOptions);
+    ui->copyResPacksCheckbox->setChecked(m_selectedOptions.copyResourcePacks);
+    ui->copyShaderPacksCheckbox->setChecked(m_selectedOptions.copyShaderPacks);
+    ui->copyServersCheckbox->setChecked(m_selectedOptions.copyServers);
+    ui->copyModsCheckbox->setChecked(m_selectedOptions.copyMods);
 }
 
 CopyInstanceDialog::~CopyInstanceDialog()
@@ -139,26 +139,47 @@ void CopyInstanceDialog::on_instNameTextBox_textChanged(const QString &arg1)
     updateDialogState();
 }
 
-bool CopyInstanceDialog::shouldCopySaves() const
+const InstanceCopyPrefs& CopyInstanceDialog::getChosenOptions() const
 {
-    return m_copySaves;
+    return m_selectedOptions;
+}
+
+void CopyInstanceDialog::on_selectAllCheckbox_stateChanged(int state)
+{
+    bool checked;
+    if(state == Qt::Unchecked)
+    {
+        checked = false;
+    }
+    else if(state == Qt::Checked)
+    {
+        checked = true;
+    }
+
+    checkAllCheckboxes(checked);
+}
+
+void CopyInstanceDialog::checkAllCheckboxes(bool b)
+{
+    ui->keepPlaytimeCheckbox->setChecked(b);
+    ui->copySavesCheckbox->setChecked(b);
+    ui->copyGameOptionsCheckbox->setChecked(b);
+    ui->copyResPacksCheckbox->setChecked(b);
+    ui->copyShaderPacksCheckbox->setChecked(b);
+    ui->copyServersCheckbox->setChecked(b);
+    ui->copyModsCheckbox->setChecked(b);
 }
 
 void CopyInstanceDialog::on_copySavesCheckbox_stateChanged(int state)
 {
     if(state == Qt::Unchecked)
     {
-        m_copySaves = false;
+        m_selectedOptions.copySaves = false;
     }
     else if(state == Qt::Checked)
     {
-        m_copySaves = true;
+        m_selectedOptions.copySaves = true;
     }
-}
-
-bool CopyInstanceDialog::shouldKeepPlaytime() const
-{
-    return m_keepPlaytime;
 }
 
 
@@ -166,95 +187,70 @@ void CopyInstanceDialog::on_keepPlaytimeCheckbox_stateChanged(int state)
 {
     if(state == Qt::Unchecked)
     {
-        m_keepPlaytime = false;
+        m_selectedOptions.keepPlaytime = false;
     }
     else if(state == Qt::Checked)
     {
-        m_keepPlaytime = true;
+        m_selectedOptions.keepPlaytime = true;
     }
-}
-
-bool CopyInstanceDialog::shouldCopyGameOptions() const
-{
-    return m_copyGameOptions;
 }
 
 void CopyInstanceDialog::on_copyGameOptionsCheckbox_stateChanged(int state)
 {
     if(state == Qt::Unchecked)
     {
-        m_copyGameOptions = false;
+        m_selectedOptions.copyGameOptions = false;
     }
     else if(state == Qt::Checked)
     {
-        m_copyGameOptions = true;
+        m_selectedOptions.copyGameOptions = true;
     }
-}
-
-bool CopyInstanceDialog::shouldCopyResourcePacks() const
-{
-    return m_copyResourcePacks;
 }
 
 void CopyInstanceDialog::on_copyResPacksCheckbox_stateChanged(int state)
 {
     if(state == Qt::Unchecked)
     {
-        m_copyResourcePacks = false;
+        m_selectedOptions.copyResourcePacks = false;
     }
     else if(state == Qt::Checked)
     {
-        m_copyResourcePacks = true;
+        m_selectedOptions.copyResourcePacks = true;
     }
-}
-
-bool CopyInstanceDialog::shouldCopyShaderPacks() const
-{
-    return m_copyShaderPacks;
 }
 
 void CopyInstanceDialog::on_copyShaderPacksCheckbox_stateChanged(int state)
 {
     if(state == Qt::Unchecked)
     {
-        m_copyShaderPacks = false;
+        m_selectedOptions.copyShaderPacks = false;
     }
     else if(state == Qt::Checked)
     {
-        m_copyShaderPacks = true;
+        m_selectedOptions.copyShaderPacks = true;
     }
-}
-
-bool CopyInstanceDialog::shouldCopyServers() const
-{
-    return m_copyServers;
 }
 
 void CopyInstanceDialog::on_copyServersCheckbox_stateChanged(int state)
 {
     if(state == Qt::Unchecked)
     {
-        m_copyServers = false;
+        m_selectedOptions.copyServers = false;
     }
     else if(state == Qt::Checked)
     {
-        m_copyServers = true;
+        m_selectedOptions.copyServers = true;
     }
-}
-
-bool CopyInstanceDialog::shouldCopyMods() const
-{
-    return m_copyMods;
 }
 
 void CopyInstanceDialog::on_copyModsCheckbox_stateChanged(int state)
 {
     if(state == Qt::Unchecked)
     {
-        m_copyMods = false;
+        m_selectedOptions.copyMods = false;
     }
     else if(state == Qt::Checked)
     {
-        m_copyMods = true;
+        m_selectedOptions.copyMods = true;
     }
 }

--- a/launcher/ui/dialogs/CopyInstanceDialog.cpp
+++ b/launcher/ui/dialogs/CopyInstanceDialog.cpp
@@ -44,7 +44,6 @@
 
 #include "BaseVersion.h"
 #include "icons/IconList.h"
-#include "tasks/Task.h"
 #include "BaseInstance.h"
 #include "InstanceList.h"
 
@@ -138,7 +137,7 @@ void CopyInstanceDialog::checkAllCheckboxes(const bool& b)
     ui->copyModsCheckbox->setChecked(b);
 }
 
-// Check the "Select all" checkbox checked if all options are already checked:
+// Check the "Select all" checkbox if all options are already selected:
 void CopyInstanceDialog::updateSelectAllCheckbox()
 {
     ui->selectAllCheckbox->blockSignals(true);

--- a/launcher/ui/dialogs/CopyInstanceDialog.cpp
+++ b/launcher/ui/dialogs/CopyInstanceDialog.cpp
@@ -122,6 +122,40 @@ QString CopyInstanceDialog::instGroup() const
     return ui->groupBox->currentText();
 }
 
+const InstanceCopyPrefs& CopyInstanceDialog::getChosenOptions() const
+{
+    return m_selectedOptions;
+}
+
+void CopyInstanceDialog::checkAllCheckboxes(const bool& b)
+{
+    ui->keepPlaytimeCheckbox->setChecked(b);
+    ui->copySavesCheckbox->setChecked(b);
+    ui->copyGameOptionsCheckbox->setChecked(b);
+    ui->copyResPacksCheckbox->setChecked(b);
+    ui->copyShaderPacksCheckbox->setChecked(b);
+    ui->copyServersCheckbox->setChecked(b);
+    ui->copyModsCheckbox->setChecked(b);
+}
+
+// Sets b to true if state is a checked checkbox
+void CopyInstanceDialog::checkBool(bool& b, const int& state)
+{
+    if(state == Qt::Unchecked)
+    {
+        b = false;
+    }
+    else if(state == Qt::Checked)
+    {
+        b = true;
+    }
+
+    // Have "Select all" checkbox checked if all options are already checked:
+    ui->selectAllCheckbox->blockSignals(true);
+    ui->selectAllCheckbox->setChecked(m_selectedOptions.allTrue());
+    ui->selectAllCheckbox->blockSignals(false);
+}
+
 void CopyInstanceDialog::on_iconButton_clicked()
 {
     IconPickerDialog dlg(this);
@@ -134,123 +168,51 @@ void CopyInstanceDialog::on_iconButton_clicked()
     }
 }
 
+
 void CopyInstanceDialog::on_instNameTextBox_textChanged(const QString &arg1)
 {
     updateDialogState();
 }
 
-const InstanceCopyPrefs& CopyInstanceDialog::getChosenOptions() const
-{
-    return m_selectedOptions;
-}
-
 void CopyInstanceDialog::on_selectAllCheckbox_stateChanged(int state)
 {
     bool checked;
-    if(state == Qt::Unchecked)
-    {
-        checked = false;
-    }
-    else if(state == Qt::Checked)
-    {
-        checked = true;
-    }
-
+    checkBool(checked, state);
     checkAllCheckboxes(checked);
-}
-
-void CopyInstanceDialog::checkAllCheckboxes(bool b)
-{
-    ui->keepPlaytimeCheckbox->setChecked(b);
-    ui->copySavesCheckbox->setChecked(b);
-    ui->copyGameOptionsCheckbox->setChecked(b);
-    ui->copyResPacksCheckbox->setChecked(b);
-    ui->copyShaderPacksCheckbox->setChecked(b);
-    ui->copyServersCheckbox->setChecked(b);
-    ui->copyModsCheckbox->setChecked(b);
 }
 
 void CopyInstanceDialog::on_copySavesCheckbox_stateChanged(int state)
 {
-    if(state == Qt::Unchecked)
-    {
-        m_selectedOptions.copySaves = false;
-    }
-    else if(state == Qt::Checked)
-    {
-        m_selectedOptions.copySaves = true;
-    }
+    checkBool(m_selectedOptions.copySaves, state);
 }
 
 
 void CopyInstanceDialog::on_keepPlaytimeCheckbox_stateChanged(int state)
 {
-    if(state == Qt::Unchecked)
-    {
-        m_selectedOptions.keepPlaytime = false;
-    }
-    else if(state == Qt::Checked)
-    {
-        m_selectedOptions.keepPlaytime = true;
-    }
+    checkBool(m_selectedOptions.keepPlaytime, state);
 }
 
 void CopyInstanceDialog::on_copyGameOptionsCheckbox_stateChanged(int state)
 {
-    if(state == Qt::Unchecked)
-    {
-        m_selectedOptions.copyGameOptions = false;
-    }
-    else if(state == Qt::Checked)
-    {
-        m_selectedOptions.copyGameOptions = true;
-    }
+    checkBool(m_selectedOptions.copyGameOptions, state);
 }
 
 void CopyInstanceDialog::on_copyResPacksCheckbox_stateChanged(int state)
 {
-    if(state == Qt::Unchecked)
-    {
-        m_selectedOptions.copyResourcePacks = false;
-    }
-    else if(state == Qt::Checked)
-    {
-        m_selectedOptions.copyResourcePacks = true;
-    }
+    checkBool(m_selectedOptions.copyResourcePacks, state);
 }
 
 void CopyInstanceDialog::on_copyShaderPacksCheckbox_stateChanged(int state)
 {
-    if(state == Qt::Unchecked)
-    {
-        m_selectedOptions.copyShaderPacks = false;
-    }
-    else if(state == Qt::Checked)
-    {
-        m_selectedOptions.copyShaderPacks = true;
-    }
+    checkBool(m_selectedOptions.copyShaderPacks, state);
 }
 
 void CopyInstanceDialog::on_copyServersCheckbox_stateChanged(int state)
 {
-    if(state == Qt::Unchecked)
-    {
-        m_selectedOptions.copyServers = false;
-    }
-    else if(state == Qt::Checked)
-    {
-        m_selectedOptions.copyServers = true;
-    }
+    checkBool(m_selectedOptions.copyServers, state);
 }
 
 void CopyInstanceDialog::on_copyModsCheckbox_stateChanged(int state)
 {
-    if(state == Qt::Unchecked)
-    {
-        m_selectedOptions.copyMods = false;
-    }
-    else if(state == Qt::Checked)
-    {
-        m_selectedOptions.copyMods = true;
-    }
+    checkBool(m_selectedOptions.copyMods, state);
 }

--- a/launcher/ui/dialogs/CopyInstanceDialog.cpp
+++ b/launcher/ui/dialogs/CopyInstanceDialog.cpp
@@ -141,14 +141,7 @@ void CopyInstanceDialog::checkAllCheckboxes(const bool& b)
 // Sets b to true if state is a checked checkbox
 void CopyInstanceDialog::checkBool(bool& b, const int& state)
 {
-    if(state == Qt::Unchecked)
-    {
-        b = false;
-    }
-    else if(state == Qt::Checked)
-    {
-        b = true;
-    }
+    b = (state == Qt::Checked);
 
     // Have "Select all" checkbox checked if all options are already checked:
     ui->selectAllCheckbox->blockSignals(true);

--- a/launcher/ui/dialogs/CopyInstanceDialog.h
+++ b/launcher/ui/dialogs/CopyInstanceDialog.h
@@ -54,6 +54,7 @@ slots:
     void on_copyShaderPacksCheckbox_stateChanged(int state);
     void on_copyServersCheckbox_stateChanged(int state);
     void on_copyModsCheckbox_stateChanged(int state);
+    void on_copyScreenshotsCheckbox_stateChanged(int state);
 
 private:
     void checkAllCheckboxes(const bool& b);

--- a/launcher/ui/dialogs/CopyInstanceDialog.h
+++ b/launcher/ui/dialogs/CopyInstanceDialog.h
@@ -47,7 +47,9 @@ slots:
     void on_instNameTextBox_textChanged(const QString &arg1);
 
     // Checkbox options:
-    void checkAllCheckboxes(bool b);
+    void checkAllCheckboxes(const bool& b);
+    void checkBool(bool& b, const int& state);
+
     void on_selectAllCheckbox_stateChanged(int state);
     void on_copySavesCheckbox_stateChanged(int state);
     void on_keepPlaytimeCheckbox_stateChanged(int state);
@@ -61,5 +63,5 @@ private:
     Ui::CopyInstanceDialog *ui;
     QString InstIconKey;
     InstancePtr m_original;
-    InstanceCopyPrefs m_selectedOptions = InstanceCopyPrefs(true); // Default to all options as true
+    InstanceCopyPrefs m_selectedOptions;
 };

--- a/launcher/ui/dialogs/CopyInstanceDialog.h
+++ b/launcher/ui/dialogs/CopyInstanceDialog.h
@@ -45,11 +45,7 @@ private
 slots:
     void on_iconButton_clicked();
     void on_instNameTextBox_textChanged(const QString &arg1);
-
-    // Checkbox options:
-    void checkAllCheckboxes(const bool& b);
-    void checkBool(bool& b, const int& state);
-
+    // Checkboxes
     void on_selectAllCheckbox_stateChanged(int state);
     void on_copySavesCheckbox_stateChanged(int state);
     void on_keepPlaytimeCheckbox_stateChanged(int state);
@@ -60,6 +56,9 @@ slots:
     void on_copyModsCheckbox_stateChanged(int state);
 
 private:
+    void checkAllCheckboxes(const bool& b);
+    void updateSelectAllCheckbox();
+    /* data */
     Ui::CopyInstanceDialog *ui;
     QString InstIconKey;
     InstancePtr m_original;

--- a/launcher/ui/dialogs/CopyInstanceDialog.h
+++ b/launcher/ui/dialogs/CopyInstanceDialog.h
@@ -41,6 +41,11 @@ public:
     QString iconKey() const;
     bool shouldCopySaves() const;
     bool shouldKeepPlaytime() const;
+    bool shouldCopyGameOptions() const;
+    bool shouldCopyResourcePacks() const;
+    bool shouldCopyShaderPacks() const;
+    bool shouldCopyServers() const;
+    bool shouldCopyMods() const;
 
 private
 slots:
@@ -48,6 +53,11 @@ slots:
     void on_instNameTextBox_textChanged(const QString &arg1);
     void on_copySavesCheckbox_stateChanged(int state);
     void on_keepPlaytimeCheckbox_stateChanged(int state);
+    void on_copyGameOptionsCheckbox_stateChanged(int state);
+    void on_copyResPacksCheckbox_stateChanged(int state);
+    void on_copyShaderPacksCheckbox_stateChanged(int state);
+    void on_copyServersCheckbox_stateChanged(int state);
+    void on_copyModsCheckbox_stateChanged(int state);
 
 private:
     Ui::CopyInstanceDialog *ui;
@@ -55,4 +65,9 @@ private:
     InstancePtr m_original;
     bool m_copySaves = true;
     bool m_keepPlaytime = true;
+    bool m_copyGameOptions = true;
+    bool m_copyResourcePacks = true;
+    bool m_copyShaderPacks = true;
+    bool m_copyServers = true;
+    bool m_copyMods = true;
 };

--- a/launcher/ui/dialogs/CopyInstanceDialog.h
+++ b/launcher/ui/dialogs/CopyInstanceDialog.h
@@ -17,7 +17,7 @@
 
 #include <QDialog>
 #include "BaseVersion.h"
-#include <BaseInstance.h>
+#include "InstanceCopyPrefs.h"
 
 class BaseInstance;
 
@@ -39,18 +39,16 @@ public:
     QString instName() const;
     QString instGroup() const;
     QString iconKey() const;
-    bool shouldCopySaves() const;
-    bool shouldKeepPlaytime() const;
-    bool shouldCopyGameOptions() const;
-    bool shouldCopyResourcePacks() const;
-    bool shouldCopyShaderPacks() const;
-    bool shouldCopyServers() const;
-    bool shouldCopyMods() const;
+    const InstanceCopyPrefs& getChosenOptions() const;
 
 private
 slots:
     void on_iconButton_clicked();
     void on_instNameTextBox_textChanged(const QString &arg1);
+
+    // Checkbox options:
+    void checkAllCheckboxes(bool b);
+    void on_selectAllCheckbox_stateChanged(int state);
     void on_copySavesCheckbox_stateChanged(int state);
     void on_keepPlaytimeCheckbox_stateChanged(int state);
     void on_copyGameOptionsCheckbox_stateChanged(int state);
@@ -63,11 +61,5 @@ private:
     Ui::CopyInstanceDialog *ui;
     QString InstIconKey;
     InstancePtr m_original;
-    bool m_copySaves = true;
-    bool m_keepPlaytime = true;
-    bool m_copyGameOptions = true;
-    bool m_copyResourcePacks = true;
-    bool m_copyShaderPacks = true;
-    bool m_copyServers = true;
-    bool m_copyMods = true;
+    InstanceCopyPrefs m_selectedOptions = InstanceCopyPrefs(true); // Default to all options as true
 };

--- a/launcher/ui/dialogs/CopyInstanceDialog.ui
+++ b/launcher/ui/dialogs/CopyInstanceDialog.ui
@@ -10,7 +10,7 @@
     <x>0</x>
     <y>0</y>
     <width>341</width>
-    <height>385</height>
+    <height>399</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -113,24 +113,30 @@
     </layout>
    </item>
    <item>
+    <layout class="QHBoxLayout" name="selectAllButtonLayout">
+     <item>
+      <widget class="QCheckBox" name="selectAllCheckbox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="layoutDirection">
+        <enum>Qt::LeftToRight</enum>
+       </property>
+       <property name="text">
+        <string>Select all</string>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
     <layout class="QGridLayout" name="copyOptionsLayout">
-     <item row="3" column="0">
-      <widget class="QCheckBox" name="copySavesCheckbox">
-       <property name="text">
-        <string>Copy saves</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="0">
-      <widget class="QCheckBox" name="copyResPacksCheckbox">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="text">
-        <string>Copy resource packs</string>
-       </property>
-      </widget>
-     </item>
      <item row="6" column="1">
       <widget class="QCheckBox" name="copyModsCheckbox">
        <property name="toolTip">
@@ -151,17 +157,10 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
-      <widget class="QCheckBox" name="copyServersCheckbox">
+     <item row="3" column="0">
+      <widget class="QCheckBox" name="copySavesCheckbox">
        <property name="text">
-        <string>Copy servers</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QCheckBox" name="keepPlaytimeCheckbox">
-       <property name="text">
-        <string>Keep play time</string>
+        <string>Copy saves</string>
        </property>
       </widget>
      </item>
@@ -172,10 +171,34 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
-      <widget class="QCheckBox" name="selectAllCheckbox">
+     <item row="5" column="1">
+      <widget class="QCheckBox" name="copyServersCheckbox">
        <property name="text">
-        <string>Select all</string>
+        <string>Copy servers</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QCheckBox" name="copyResPacksCheckbox">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="text">
+        <string>Copy resource packs</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QCheckBox" name="keepPlaytimeCheckbox">
+       <property name="text">
+        <string>Keep play time</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QCheckBox" name="copyScreenshotsCheckbox">
+       <property name="text">
+        <string>Copy screenshots</string>
        </property>
       </widget>
      </item>

--- a/launcher/ui/dialogs/CopyInstanceDialog.ui
+++ b/launcher/ui/dialogs/CopyInstanceDialog.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>265</width>
-    <height>425</height>
+    <width>341</width>
+    <height>385</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -60,7 +60,7 @@
        </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>40</width>
+         <width>60</width>
          <height>20</height>
         </size>
        </property>
@@ -83,7 +83,10 @@
     </widget>
    </item>
    <item>
-    <layout class="QGridLayout" name="gridLayout">
+    <layout class="QGridLayout" name="groupDropdownLayout">
+     <property name="verticalSpacing">
+      <number>6</number>
+     </property>
      <item row="0" column="0">
       <widget class="QLabel" name="labelVersion_3">
        <property name="text">
@@ -110,62 +113,73 @@
     </layout>
    </item>
    <item>
-    <widget class="QCheckBox" name="copySavesCheckbox">
-     <property name="text">
-      <string>Copy saves</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="keepPlaytimeCheckbox">
-     <property name="text">
-      <string>Keep play time</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="copyGameOptionsCheckbox">
-     <property name="toolTip">
-      <string>Copy the in-game options like FOV, max framerate, etc.</string>
-     </property>
-     <property name="text">
-      <string>Copy game options</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="copyResPacksCheckbox">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="text">
-      <string>Copy resource packs</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="copyShaderPacksCheckbox">
-     <property name="text">
-      <string>Copy shader packs</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="copyServersCheckbox">
-     <property name="text">
-      <string>Copy servers</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="copyModsCheckbox">
-     <property name="toolTip">
-      <string>Disabling this will still keep the mod loader (ex: Fabric, Quilt, etc.) but erase the mods folder and their configs.</string>
-     </property>
-     <property name="text">
-      <string>Copy mods</string>
-     </property>
-    </widget>
+    <layout class="QGridLayout" name="copyOptionsLayout">
+     <item row="3" column="0">
+      <widget class="QCheckBox" name="copySavesCheckbox">
+       <property name="text">
+        <string>Copy saves</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QCheckBox" name="copyResPacksCheckbox">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="text">
+        <string>Copy resource packs</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="QCheckBox" name="copyModsCheckbox">
+       <property name="toolTip">
+        <string>Disabling this will still keep the mod loader (ex: Fabric, Quilt, etc.) but erase the mods folder and their configs.</string>
+       </property>
+       <property name="text">
+        <string>Copy mods</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QCheckBox" name="copyGameOptionsCheckbox">
+       <property name="toolTip">
+        <string>Copy the in-game options like FOV, max framerate, etc.</string>
+       </property>
+       <property name="text">
+        <string>Copy game options</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QCheckBox" name="copyServersCheckbox">
+       <property name="text">
+        <string>Copy servers</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QCheckBox" name="keepPlaytimeCheckbox">
+       <property name="text">
+        <string>Keep play time</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QCheckBox" name="copyShaderPacksCheckbox">
+       <property name="text">
+        <string>Copy shader packs</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QCheckBox" name="selectAllCheckbox">
+       <property name="text">
+        <string>Select all</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
@@ -183,8 +197,6 @@
   <tabstop>iconButton</tabstop>
   <tabstop>instNameTextBox</tabstop>
   <tabstop>groupBox</tabstop>
-  <tabstop>copySavesCheckbox</tabstop>
-  <tabstop>keepPlaytimeCheckbox</tabstop>
  </tabstops>
  <resources>
   <include location="../../graphics.qrc"/>

--- a/launcher/ui/dialogs/CopyInstanceDialog.ui
+++ b/launcher/ui/dialogs/CopyInstanceDialog.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>345</width>
-    <height>323</height>
+    <width>265</width>
+    <height>425</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -33,7 +33,7 @@
        </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>40</width>
+         <width>60</width>
          <height>20</height>
         </size>
        </property>
@@ -124,6 +124,50 @@
     </widget>
    </item>
    <item>
+    <widget class="QCheckBox" name="copyGameOptionsCheckbox">
+     <property name="toolTip">
+      <string>Copy the in-game options like FOV, max framerate, etc.</string>
+     </property>
+     <property name="text">
+      <string>Copy game options</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="copyResPacksCheckbox">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>Copy resource packs</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="copyShaderPacksCheckbox">
+     <property name="text">
+      <string>Copy shader packs</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="copyServersCheckbox">
+     <property name="text">
+      <string>Copy servers</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="copyModsCheckbox">
+     <property name="toolTip">
+      <string>Disabling this will still keep the mod loader (ex: Fabric, Quilt, etc.) but erase the mods folder and their configs.</string>
+     </property>
+     <property name="text">
+      <string>Copy mods</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -153,8 +197,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
+     <x>254</x>
+     <y>316</y>
     </hint>
     <hint type="destinationlabel">
      <x>157</x>
@@ -169,8 +213,8 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
+     <x>322</x>
+     <y>316</y>
     </hint>
     <hint type="destinationlabel">
      <x>286</x>


### PR DESCRIPTION
Hello, I've added extra options to the copy instance dialog to not copy certain aspects of the instance like:
* Game options (options.txt)
* Resource packs
* Shaders
* Servers
* Mods ("coremods", "mods", and "config" folders, not mod loader)

And would like to know if this is a worthwhile addition to the project.

This is my first contribution to open source :D, and really my first C++ code outside of school so I apologize in advance if I did something incorrectly -.- let me know and I will fix it. (I've programmed in Java and a little Rust before, also idk how Qt Designer works so I most likely broke something in the .ui file)

*Video showcase:* https://drive.google.com/file/d/1ZSipakoZ0QZAdFY-E2RjdnQVVKDHQouV/view?usp=sharing