### PR TITLE
feat(actions): use clang32 for building on windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,12 +30,12 @@ jobs:
 
           - os: windows-2022
             name: "Windows-Legacy"
-            msystem: mingw32
+            msystem: clang32
             qt_ver: 5
 
           - os: windows-2022
             name: "Windows"
-            msystem: mingw32
+            msystem: clang32
             qt_ver: 6
 
           - os: macos-12
@@ -89,6 +89,7 @@ jobs:
           update: true
           install: >-
             git
+            mingw-w64-x86_64-binutils
           pacboy: >-
             toolchain:p
             cmake:p
@@ -99,7 +100,6 @@ jobs:
             qt${{ matrix.qt_ver }}-imageformats:p
             quazip-qt${{ matrix.qt_ver }}:p
             ccache:p
-            nsis:p
             ${{ matrix.qt_ver == 6 && 'qt6-5compat:p' || '' }}
 
       - name: Setup ccache
@@ -194,7 +194,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: msys2 {0}
         run: |
-          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DENABLE_LTO=ON -DLauncher_BUILD_PLATFORM=${{ matrix.name }} -DCMAKE_C_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DLauncher_QT_VERSION_MAJOR=${{ matrix.qt_ver }} -G Ninja
+          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DENABLE_LTO=ON -DLauncher_BUILD_PLATFORM=${{ matrix.name }} -DCMAKE_C_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DLauncher_QT_VERSION_MAJOR=${{ matrix.qt_ver }} -DCMAKE_OBJDUMP=/mingw64/bin/objdump.exe -G Ninja
 
       - name: Configure CMake (Linux)
         if: runner.os == 'Linux'
@@ -280,7 +280,7 @@ jobs:
 
           cd ${{ env.INSTALL_DIR }}
           if [ "${{ matrix.qt_ver }}" == "5" ]; then
-            cp /mingw32/bin/libcrypto-1_1.dll /mingw32/bin/libssl-1_1.dll ./
+            cp /clang32/bin/libcrypto-1_1.dll /clang32/bin/libssl-1_1.dll ./
           fi
 
       - name: Package (Windows, portable)
@@ -292,7 +292,6 @@ jobs:
 
       - name: Package (Windows, installer)
         if: runner.os == 'Windows'
-        shell: msys2 {0}
         run: |
           cd ${{ env.INSTALL_DIR }}
           makensis -NOCD "${{ github.workspace }}/${{ env.BUILD_DIR }}/program_info/win_install.nsi"

--- a/launcher/FileSystem.cpp
+++ b/launcher/FileSystem.cpp
@@ -401,6 +401,7 @@ bool overrideFolder(QString overwritten_path, QString override_path)
     std::error_code err;
     fs::copy_options opt = copy_opts::recursive | copy_opts::overwrite_existing;
 
+    // FIXME: hello traveller! Apparently std::copy does NOT overwrite existing files on GNU libstdc++ on Windows?
     fs::copy(toStdString(override_path), toStdString(overwritten_path), opt, err);
 
     if (err) {


### PR DESCRIPTION
Closes #262 

this makes compile times considerably faster, but:

- we have to make it use binutils' objdump because cmake doesn't like llvm's for some reason
- uses a more modern libc, the universal c runtime, which is better and more modern but preinstalled only on Windows 10/11, however can be installed in Vista, 7 and 8.1 too
- we have to use official builds of nsis because nsis doesn't compile on clang
- on windows 7/8.1 it just fails to load after wizard even on develop/debug builds

works towards #167 