### PR TITLE
Fix: Don't specify x86 in manifest

### DIFF
--- a/program_info/prismlauncher.manifest.in
+++ b/program_info/prismlauncher.manifest.in
@@ -10,7 +10,7 @@
   </trustInfo>
   <dependency>
     <dependentAssembly>
-      <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="x86" publicKeyToken="6595b64144ccf1df" language="*"/>
+      <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*"/>
     </dependentAssembly>
   </dependency>
   <description>Custom Minecraft launcher for managing multiple installs.</description>


### PR DESCRIPTION
Discovered this when trying to build Prism with msvc

An msvc build would fail to launch with the incorrect `processorArchitecture`, due to loading the x86 comclt dll
Instead leave it as '*' to not force an architecture
