### PR TITLE
feat: use clang64 on qt6 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
 
           - os: windows-2022
             name: "Windows"
-            msystem: clang32
+            msystem: clang64
             qt_ver: 6
 
           - os: macos-12


### PR DESCRIPTION
Thanks to #318, we can now do 64 bit builds, so why not switching from clang32 to clang64 for qt6 builds? 
