### PR TITLE
Fix: Check if Windows 10 before calling setDarkWinTitlebar()

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -62,6 +62,7 @@
 
 #ifdef Q_OS_WIN
 #include "ui/WinDarkmode.h"
+#include <versionhelpers.h>
 #endif
 
 #include "ui/setupwizard/SetupWizard.h"
@@ -1154,7 +1155,7 @@ void Application::setApplicationTheme(const QString& name, bool initial)
         auto & theme = (*themeIter).second;
         theme->apply(initial);
 #ifdef Q_OS_WIN
-        if (m_mainWindow) {
+        if (m_mainWindow && IsWindows10OrGreater()) {
             if (QString::compare(theme->id(), "dark") == 0) {
                     WinDarkmode::setDarkWinTitlebar(m_mainWindow->winId(), true);
             } else {
@@ -1395,10 +1396,13 @@ MainWindow* Application::showMainWindow(bool minimized)
         m_mainWindow->restoreState(QByteArray::fromBase64(APPLICATION->settings()->get("MainWindowState").toByteArray()));
         m_mainWindow->restoreGeometry(QByteArray::fromBase64(APPLICATION->settings()->get("MainWindowGeometry").toByteArray()));
 #ifdef Q_OS_WIN
-        if (QString::compare(settings()->get("ApplicationTheme").toString(), "dark") == 0) {
-            WinDarkmode::setDarkWinTitlebar(m_mainWindow->winId(), true);
-        } else {
-            WinDarkmode::setDarkWinTitlebar(m_mainWindow->winId(), false);
+        if (IsWindows10OrGreater())
+        {
+            if (QString::compare(settings()->get("ApplicationTheme").toString(), "dark") == 0) {
+                WinDarkmode::setDarkWinTitlebar(m_mainWindow->winId(), true);
+            } else {
+                WinDarkmode::setDarkWinTitlebar(m_mainWindow->winId(), false);
+            }
         }
 #endif
         if(minimized)


### PR DESCRIPTION
I setup a Window 7 VM to see if my msvc builds worked in Windows 7
It didn't, so I pulled a debugger to see what the issue was and `setDarkWinTitlebar()` which seems windows 10 specific.

Check that we are running on Windows 10 before calling `setDarkWinTitlebar()` 

This was enough to my msvc builds to launch properly, so hopefully it's enough for the msys2 builds.