### PR TITLE
Implement "jumping" to other mods inside the mod browser

### DIFF
--- a/launcher/ui/dialogs/ModDownloadDialog.cpp
+++ b/launcher/ui/dialogs/ModDownloadDialog.cpp
@@ -132,6 +132,8 @@ QList<BasePage*> ModDownloadDialog::getPages()
     if (APPLICATION->capabilities() & Application::SupportsFlame)
         pages.append(FlameModPage::create(this, m_instance));
 
+    m_selected_page = dynamic_cast<ModPage*>(pages[0]);
+
     return pages;
 }
 
@@ -179,17 +181,22 @@ void ModDownloadDialog::selectedPageChanged(BasePage* previous, BasePage* select
         return;
     }
 
-    auto* selected_page = dynamic_cast<ModPage*>(selected);
-    if (!selected_page) {
+    m_selected_page = dynamic_cast<ModPage*>(selected);
+    if (!m_selected_page) {
         qCritical() << "Page '" << selected->displayName() << "' in ModDownloadDialog is not a ModPage!";
         return;
     }
 
     // Same effect as having a global search bar
-    selected_page->setSearchTerm(prev_page->getSearchTerm());
+    m_selected_page->setSearchTerm(prev_page->getSearchTerm());
 }
 
 bool ModDownloadDialog::selectPage(QString pageId)
 {
     return m_container->selectPage(pageId);
+}
+
+ModPage* ModDownloadDialog::getSelectedPage()
+{
+    return m_selected_page;
 }

--- a/launcher/ui/dialogs/ModDownloadDialog.cpp
+++ b/launcher/ui/dialogs/ModDownloadDialog.cpp
@@ -132,7 +132,7 @@ QList<BasePage*> ModDownloadDialog::getPages()
     if (APPLICATION->capabilities() & Application::SupportsFlame)
         pages.append(FlameModPage::create(this, m_instance));
 
-    m_selected_page = dynamic_cast<ModPage*>(pages[0]);
+    m_selectedPage = dynamic_cast<ModPage*>(pages[0]);
 
     return pages;
 }
@@ -181,14 +181,14 @@ void ModDownloadDialog::selectedPageChanged(BasePage* previous, BasePage* select
         return;
     }
 
-    m_selected_page = dynamic_cast<ModPage*>(selected);
-    if (!m_selected_page) {
+    m_selectedPage = dynamic_cast<ModPage*>(selected);
+    if (!m_selectedPage) {
         qCritical() << "Page '" << selected->displayName() << "' in ModDownloadDialog is not a ModPage!";
         return;
     }
 
     // Same effect as having a global search bar
-    m_selected_page->setSearchTerm(prev_page->getSearchTerm());
+    m_selectedPage->setSearchTerm(prev_page->getSearchTerm());
 }
 
 bool ModDownloadDialog::selectPage(QString pageId)
@@ -198,5 +198,5 @@ bool ModDownloadDialog::selectPage(QString pageId)
 
 ModPage* ModDownloadDialog::getSelectedPage()
 {
-    return m_selected_page;
+    return m_selectedPage;
 }

--- a/launcher/ui/dialogs/ModDownloadDialog.cpp
+++ b/launcher/ui/dialogs/ModDownloadDialog.cpp
@@ -2,6 +2,7 @@
 /*
  *  PolyMC - Minecraft Launcher
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/launcher/ui/dialogs/ModDownloadDialog.cpp
+++ b/launcher/ui/dialogs/ModDownloadDialog.cpp
@@ -187,3 +187,8 @@ void ModDownloadDialog::selectedPageChanged(BasePage* previous, BasePage* select
     // Same effect as having a global search bar
     selected_page->setSearchTerm(prev_page->getSearchTerm());
 }
+
+bool ModDownloadDialog::selectPage(QString pageId)
+{
+    return m_container->selectPage(pageId);
+}

--- a/launcher/ui/dialogs/ModDownloadDialog.cpp
+++ b/launcher/ui/dialogs/ModDownloadDialog.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  PolyMC - Minecraft Launcher
+ *  Prism Launcher - Minecraft Launcher
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
  *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *

--- a/launcher/ui/dialogs/ModDownloadDialog.h
+++ b/launcher/ui/dialogs/ModDownloadDialog.h
@@ -53,6 +53,8 @@ public:
     const QList<ModDownloadTask*> getTasks();
     const std::shared_ptr<ModFolderModel> &mods;
 
+    bool selectPage(QString pageId);
+
 public slots:
     void confirm();
     void accept() override;

--- a/launcher/ui/dialogs/ModDownloadDialog.h
+++ b/launcher/ui/dialogs/ModDownloadDialog.h
@@ -2,6 +2,7 @@
 /*
  *  PolyMC - Minecraft Launcher
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/launcher/ui/dialogs/ModDownloadDialog.h
+++ b/launcher/ui/dialogs/ModDownloadDialog.h
@@ -25,7 +25,6 @@
 #include "ModDownloadTask.h"
 #include "minecraft/mod/ModFolderModel.h"
 #include "ui/pages/BasePageProvider.h"
-#include "ui/pages/modplatform/ModPage.h"
 
 namespace Ui
 {
@@ -34,13 +33,14 @@ class ModDownloadDialog;
 
 class PageContainer;
 class QDialogButtonBox;
+class ModPage;
 class ModrinthModPage;
 
 class ModDownloadDialog final : public QDialog, public BasePageProvider
 {
     Q_OBJECT
 
-public:
+   public:
     explicit ModDownloadDialog(const std::shared_ptr<ModFolderModel>& mods, QWidget* parent, BaseInstance* instance);
     ~ModDownloadDialog() override = default;
 
@@ -53,27 +53,26 @@ public:
     bool isModSelected(QString name) const;
 
     const QList<ModDownloadTask*> getTasks();
-    const std::shared_ptr<ModFolderModel> &mods;
+    const std::shared_ptr<ModFolderModel>& mods;
 
     bool selectPage(QString pageId);
-
     ModPage* getSelectedPage();
 
-public slots:
+   public slots:
     void confirm();
     void accept() override;
     void reject() override;
 
-private slots:
+   private slots:
     void selectedPageChanged(BasePage* previous, BasePage* selected);
 
-private:
-    Ui::ModDownloadDialog *ui = nullptr;
-    PageContainer * m_container = nullptr;
-    QDialogButtonBox * m_buttons = nullptr;
-    QVBoxLayout *m_verticalLayout = nullptr;
-    ModPage *m_selected_page = nullptr;
+   private:
+    Ui::ModDownloadDialog* ui = nullptr;
+    PageContainer* m_container = nullptr;
+    QDialogButtonBox* m_buttons = nullptr;
+    QVBoxLayout* m_verticalLayout = nullptr;
+    ModPage* m_selectedPage = nullptr;
 
     QHash<QString, ModDownloadTask*> modTask;
-    BaseInstance *m_instance;
+    BaseInstance* m_instance;
 };

--- a/launcher/ui/dialogs/ModDownloadDialog.h
+++ b/launcher/ui/dialogs/ModDownloadDialog.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  PolyMC - Minecraft Launcher
+ *  Prism Launcher - Minecraft Launcher
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
  *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *

--- a/launcher/ui/dialogs/ModDownloadDialog.h
+++ b/launcher/ui/dialogs/ModDownloadDialog.h
@@ -25,6 +25,7 @@
 #include "ModDownloadTask.h"
 #include "minecraft/mod/ModFolderModel.h"
 #include "ui/pages/BasePageProvider.h"
+#include "ui/pages/modplatform/ModPage.h"
 
 namespace Ui
 {
@@ -56,6 +57,8 @@ public:
 
     bool selectPage(QString pageId);
 
+    ModPage* getSelectedPage();
+
 public slots:
     void confirm();
     void accept() override;
@@ -69,6 +72,7 @@ private:
     PageContainer * m_container = nullptr;
     QDialogButtonBox * m_buttons = nullptr;
     QVBoxLayout *m_verticalLayout = nullptr;
+    ModPage *m_selected_page = nullptr;
 
     QHash<QString, ModDownloadTask*> modTask;
     BaseInstance *m_instance;

--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -282,11 +282,13 @@ void ModPage::openUrl(const QUrl& url)
         // intended to view in their web browser
         if (!slug.isEmpty() && !slug.contains('/') && slug != current.slug) {
             dialog->selectPage(page);
-            ui->searchEdit->setText(slug);
 
-            triggerSearch();
-            connect(listModel->activeJob(), &Task::finished, [this] {
-                ui->packView->setCurrentIndex(listModel->index(0));
+            ModPage* newPage = dialog->getSelectedPage();
+            newPage->ui->searchEdit->setText(slug);
+            newPage->triggerSearch();
+
+            connect(newPage->listModel->activeJob(), &Task::finished, [newPage] {
+                newPage->ui->packView->setCurrentIndex(newPage->listModel->index(0));
             });
 
             return;

--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -287,12 +287,15 @@ void ModPage::openUrl(const QUrl& url)
             newPage->ui->searchEdit->setText(slug);
             newPage->triggerSearch();
 
-            connect(newPage->listModel->activeJob(), &Task::finished, [slug, newPage] {
-                for (int row = 0; row < newPage->listModel->rowCount({}); row++) {
-                    QModelIndex index = newPage->listModel->index(row);
-                    auto pack = newPage->listModel->data(index, Qt::UserRole).value<ModPlatform::IndexedPack>();
+            ModPlatform::ListModel* model = newPage->listModel;
+            QListView* view = newPage->ui->packView;
+
+            connect(model->activeJob(), &Task::finished, [slug, model, view] {
+                for (int row = 0; row < model->rowCount({}); row++) {
+                    QModelIndex index = model->index(row);
+                    ModPlatform::IndexedPack pack = model->data(index, Qt::UserRole).value<ModPlatform::IndexedPack>();
                     if (pack.slug == slug) {
-                        newPage->ui->packView->setCurrentIndex(index);
+                        view->setCurrentIndex(index);
                         break;
                     }
                 }

--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -261,8 +261,7 @@ void ModPage::openUrl(const QUrl& url)
             && url.path().startsWith("/mod/")) {
         prefixLength = 5;
         page = "modrinth";
-    }
-    else if (APPLICATION->capabilities() & Application::SupportsFlame
+    } else if (APPLICATION->capabilities() & Application::SupportsFlame
             && url.host() == "www.curseforge.com"
             && url.path().toLower().startsWith("/minecraft/mc-mods/")) {
         prefixLength = 19;
@@ -282,9 +281,14 @@ void ModPage::openUrl(const QUrl& url)
         // and the user isn't opening the same mod; they probably
         // intended to view in their web browser
         if (!slug.isEmpty() && !slug.contains('/') && slug != current.slug) {
-            ui->searchEdit->setText(slug);
             dialog->selectPage(page);
+            ui->searchEdit->setText(slug);
+
             triggerSearch();
+            connect(listModel->activeJob(), &Task::finished, [this] {
+                ui->packView->setCurrentIndex(listModel->index(0));
+            });
+
             return;
         }
     }

--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -308,9 +308,8 @@ void ModPage::openUrl(const QUrl& url)
 
             if (!model->activeJob())
                 jump();
-            else {
+            else
                 connect(model->activeJob(), &Task::finished, jump);
-            }
 
             return;
         }

--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -282,27 +282,31 @@ void ModPage::openUrl(const QUrl& url)
             dialog->selectPage(page);
 
             ModPage* newPage = dialog->getSelectedPage();
-            newPage->ui->searchEdit->setText(slug);
-            newPage->triggerSearch();
+            QLineEdit* searchEdit = newPage->ui->searchEdit;
 
-            ModPlatform::ListModel* model = newPage->listModel;
-            QListView* view = newPage->ui->packView;
+            if (searchEdit->text() != slug) {
+                searchEdit->setText(slug);
+                newPage->triggerSearch();
 
-            connect(model->activeJob(), &Task::finished, [url, slug, model, view] {
-                for (int row = 0; row < model->rowCount({}); row++) {
-                    QModelIndex index = model->index(row);
-                    auto pack = model->data(index, Qt::UserRole).value<ModPlatform::IndexedPack>();
-                    if (pack.slug == slug) {
-                        view->setCurrentIndex(index);
-                        return;
+                ModPlatform::ListModel* model = newPage->listModel;
+                QListView* view = newPage->ui->packView;
+
+                connect(model->activeJob(), &Task::finished, [url, slug, model, view] {
+                    for (int row = 0; row < model->rowCount({}); row++) {
+                        QModelIndex index = model->index(row);
+                        auto pack = model->data(index, Qt::UserRole).value<ModPlatform::IndexedPack>();
+                        if (pack.slug == slug) {
+                            view->setCurrentIndex(index);
+                            return;
+                        }
                     }
-                }
 
-                // The final fallback.
-                QDesktopServices::openUrl(url);
-            });
+                    // The final fallback.
+                    QDesktopServices::openUrl(url);
+                });
 
-            return;
+                return;
+            }
         }
     }
 

--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -262,7 +262,7 @@ void ModPage::openUrl(const QUrl& url)
         prefixLength = 5;
         page = "modrinth";
     } else if (APPLICATION->capabilities() & Application::SupportsFlame
-            && url.host() == "www.curseforge.com"
+            && (url.host() == "curseforge.com" || url.host() == "www.curseforge.com")
             && url.path().toLower().startsWith("/minecraft/mc-mods/")) {
         prefixLength = 19;
         page = "curseforge";
@@ -287,8 +287,15 @@ void ModPage::openUrl(const QUrl& url)
             newPage->ui->searchEdit->setText(slug);
             newPage->triggerSearch();
 
-            connect(newPage->listModel->activeJob(), &Task::finished, [newPage] {
-                newPage->ui->packView->setCurrentIndex(newPage->listModel->index(0));
+            connect(newPage->listModel->activeJob(), &Task::finished, [slug, newPage] {
+                for (int row = 0; row < newPage->listModel->rowCount({}); row++) {
+                    QModelIndex index = newPage->listModel->index(row);
+                    auto pack = newPage->listModel->data(index, Qt::UserRole).value<ModPlatform::IndexedPack>();
+                    if (pack.slug == slug) {
+                        newPage->ui->packView->setCurrentIndex(index);
+                        break;
+                    }
+                }
             });
 
             return;

--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -257,17 +257,15 @@ void ModPage::openUrl(const QUrl& url)
     int prefixLength;
     const char* page;
 
-    if ((url.host() == "modrinth.com" || url.host() == "www.modrinth.com")
-            && url.path().startsWith("/mod/")) {
+    if ((url.host() == "modrinth.com" || url.host() == "www.modrinth.com") && url.path().startsWith("/mod/")) {
         prefixLength = 5;
         page = "modrinth";
-    } else if (APPLICATION->capabilities() & Application::SupportsFlame
-            && (url.host() == "curseforge.com" || url.host() == "www.curseforge.com")
-            && url.path().toLower().startsWith("/minecraft/mc-mods/")) {
+    } else if (APPLICATION->capabilities() & Application::SupportsFlame &&
+               (url.host() == "curseforge.com" || url.host() == "www.curseforge.com") &&
+               url.path().toLower().startsWith("/minecraft/mc-mods/")) {
         prefixLength = 19;
         page = "curseforge";
-    }
-    else
+    } else
         prefixLength = 0;
 
     if (prefixLength != 0) {
@@ -311,7 +309,6 @@ void ModPage::openUrl(const QUrl& url)
     // open in the user's web browser
     QDesktopServices::openUrl(url);
 }
-
 
 /******** Make changes to the UI ********/
 

--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -290,15 +290,18 @@ void ModPage::openUrl(const QUrl& url)
             ModPlatform::ListModel* model = newPage->listModel;
             QListView* view = newPage->ui->packView;
 
-            connect(model->activeJob(), &Task::finished, [slug, model, view] {
+            connect(model->activeJob(), &Task::finished, [url, slug, model, view] {
                 for (int row = 0; row < model->rowCount({}); row++) {
                     QModelIndex index = model->index(row);
                     ModPlatform::IndexedPack pack = model->data(index, Qt::UserRole).value<ModPlatform::IndexedPack>();
                     if (pack.slug == slug) {
                         view->setCurrentIndex(index);
-                        break;
+                        return;
                     }
                 }
+
+                // The final fallback.
+                QDesktopServices::openUrl(url);
             });
 
             return;

--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -291,7 +291,7 @@ void ModPage::openUrl(const QUrl& url)
             connect(model->activeJob(), &Task::finished, [url, slug, model, view] {
                 for (int row = 0; row < model->rowCount({}); row++) {
                     QModelIndex index = model->index(row);
-                    ModPlatform::IndexedPack pack = model->data(index, Qt::UserRole).value<ModPlatform::IndexedPack>();
+                    auto pack = model->data(index, Qt::UserRole).value<ModPlatform::IndexedPack>();
                     if (pack.slug == slug) {
                         view->setCurrentIndex(index);
                         return;

--- a/launcher/ui/pages/modplatform/ModPage.h
+++ b/launcher/ui/pages/modplatform/ModPage.h
@@ -82,6 +82,7 @@ class ModPage : public QWidget, public BasePage {
     void onSelectionChanged(QModelIndex first, QModelIndex second);
     void onVersionSelectionChanged(QString data);
     void onModSelected();
+    virtual void openUrl(const QUrl& url);
 
    protected:
     Ui::ModPage* ui = nullptr;

--- a/launcher/ui/pages/modplatform/ModPage.ui
+++ b/launcher/ui/pages/modplatform/ModPage.ui
@@ -16,10 +16,10 @@
      <item row="1" column="2">
       <widget class="ProjectDescriptionPage" name="packDescription">
        <property name="openExternalLinks">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
        <property name="openLinks">
-        <bool>true</bool>
+        <bool>false</bool>
        </property>
       </widget>
      </item>

--- a/launcher/ui/pages/modplatform/flame/FlameModPage.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameModPage.cpp
@@ -39,7 +39,7 @@
 #include "FlameModModel.h"
 #include "ui/dialogs/ModDownloadDialog.h"
 
-FlameModPage::FlameModPage(ModDownloadDialog* dialog, BaseInstance* instance) 
+FlameModPage::FlameModPage(ModDownloadDialog* dialog, BaseInstance* instance)
     : ModPage(dialog, instance, new FlameAPI())
 {
     listModel = new FlameMod::ListModel(this);
@@ -53,7 +53,7 @@ FlameModPage::FlameModPage(ModDownloadDialog* dialog, BaseInstance* instance)
     ui->sortByBox->addItem(tr("Sort by Author"));
     ui->sortByBox->addItem(tr("Sort by Downloads"));
 
-    // sometimes Qt just ignores virtual slots and doesn't work as intended it seems, 
+    // sometimes Qt just ignores virtual slots and doesn't work as intended it seems,
     // so it's best not to connect them in the parent's contructor...
     connect(ui->sortByBox, SIGNAL(currentIndexChanged(int)), this, SLOT(triggerSearch()));
     connect(ui->packView->selectionModel(), &QItemSelectionModel::currentChanged, this, &FlameModPage::onSelectionChanged);
@@ -78,3 +78,18 @@ bool FlameModPage::optedOut(ModPlatform::IndexedVersion& ver) const
 // other mod providers start loading before being selected, at least with
 // my Qt, so we need to implement this in every derived class...
 auto FlameModPage::shouldDisplay() const -> bool { return true; }
+
+void FlameModPage::openUrl(const QUrl& url)
+{
+    if (url.scheme().isEmpty()) {
+        QString query = url.query(QUrl::FullyDecoded);
+        if (query.startsWith("remoteUrl=")) {
+            // attempt to resolve url from warning page
+            query.remove(0, 10);
+            ModPage::openUrl({QUrl::fromPercentEncoding(query.toUtf8())}); // double decoding is necessary
+            return;
+        }
+    }
+
+    ModPage::openUrl(url);
+}

--- a/launcher/ui/pages/modplatform/flame/FlameModPage.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameModPage.cpp
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  PolyMC - Minecraft Launcher
+ *  Prism Launcher - Minecraft Launcher
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
  *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *
@@ -84,6 +84,7 @@ void FlameModPage::openUrl(const QUrl& url)
 {
     if (url.scheme().isEmpty()) {
         QString query = url.query(QUrl::FullyDecoded);
+
         if (query.startsWith("remoteUrl=")) {
             // attempt to resolve url from warning page
             query.remove(0, 10);

--- a/launcher/ui/pages/modplatform/flame/FlameModPage.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameModPage.cpp
@@ -2,6 +2,7 @@
 /*
  *  PolyMC - Minecraft Launcher
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/launcher/ui/pages/modplatform/flame/FlameModPage.h
+++ b/launcher/ui/pages/modplatform/flame/FlameModPage.h
@@ -64,4 +64,6 @@ class FlameModPage : public ModPage {
     bool optedOut(ModPlatform::IndexedVersion& ver) const override;
 
     auto shouldDisplay() const -> bool override;
+
+    void openUrl(const QUrl& url) override;
 };

--- a/launcher/ui/pages/modplatform/flame/FlameModPage.h
+++ b/launcher/ui/pages/modplatform/flame/FlameModPage.h
@@ -2,6 +2,7 @@
 /*
  *  PolyMC - Minecraft Launcher
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/launcher/ui/pages/modplatform/flame/FlameModPage.h
+++ b/launcher/ui/pages/modplatform/flame/FlameModPage.h
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  PolyMC - Minecraft Launcher
+ *  Prism Launcher - Minecraft Launcher
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
  *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModPage.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModPage.cpp
@@ -53,7 +53,7 @@ ModrinthModPage::ModrinthModPage(ModDownloadDialog* dialog, BaseInstance* instan
     ui->sortByBox->addItem(tr("Sort by Last Updated"));
     ui->sortByBox->addItem(tr("Sort by Newest"));
 
-    // sometimes Qt just ignores virtual slots and doesn't work as intended it seems, 
+    // sometimes Qt just ignores virtual slots and doesn't work as intended it seems,
     // so it's best not to connect them in the parent's constructor...
     connect(ui->sortByBox, SIGNAL(currentIndexChanged(int)), this, SLOT(triggerSearch()));
     connect(ui->packView->selectionModel(), &QItemSelectionModel::currentChanged, this, &ModrinthModPage::onSelectionChanged);


### PR DESCRIPTION
Attempts to (badly) fix #363. Sorry about the code.

Alternatively, a solution which doesn't involve changing the search query could be used. That may be a bit better.

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
