### PR TITLE
Make javacheck return the platform bitness instead of guessing

### DIFF
--- a/launcher/JavaCommon.cpp
+++ b/launcher/JavaCommon.cpp
@@ -73,7 +73,8 @@ void JavaCommon::javaWasOk(QWidget *parent, JavaCheckResult result)
     QString text;
     text += QObject::tr("Java test succeeded!<br />Platform reported: %1<br />Java version "
         "reported: %2<br />Java vendor "
-        "reported: %3<br />").arg(result.realPlatform, result.javaVersion.toString(), result.javaVendor);
+        "reported: %3<br />64-bit "
+        "reported: %4<br />").arg(result.realPlatform, result.javaVersion.toString(), result.javaVendor, result.is_64bit ? "Yes" : "No");
     if (result.errorLog.size())
     {
         auto htmlError = result.errorLog;

--- a/launcher/java/JavaChecker.cpp
+++ b/launcher/java/JavaChecker.cpp
@@ -173,7 +173,7 @@ void JavaChecker::finished(int exitcode, QProcess::ExitStatus status)
         }
     }
 
-    if(!results.contains("os.arch") || !results.contains("java.version") || !results.contains("java.vendor") || !success)
+    if(!results.contains("os.arch") || !results.contains("java.version") || !results.contains("java.vendor") || !results.contains("sun.arch.data.model") || !success)
     {
         result.validity = JavaCheckResult::Validity::ReturnedInvalidData;
         emit checkFinished(result);
@@ -183,7 +183,7 @@ void JavaChecker::finished(int exitcode, QProcess::ExitStatus status)
     auto os_arch = results["os.arch"];
     auto java_version = results["java.version"];
     auto java_vendor = results["java.vendor"];
-    bool is_64 = os_arch == "x86_64" || os_arch == "amd64" || os_arch == "aarch64" || os_arch == "arm64";
+    bool is_64 = results["sun.arch.data.model"] == "64";
 
 
     result.validity = JavaCheckResult::Validity::Valid;

--- a/libraries/javacheck/JavaCheck.java
+++ b/libraries/javacheck/JavaCheck.java
@@ -3,7 +3,8 @@ public final class JavaCheck {
     private static final String[] CHECKED_PROPERTIES = new String[] {
             "os.arch",
             "java.version",
-            "java.vendor"
+            "java.vendor",
+            "sun.arch.data.model"
     };
 
     public static void main(String[] args) {


### PR DESCRIPTION
This PR makes the JavaCheck program determine if the JVM is 64-bit or not, instead of relying on a hardcoded comparison on the CPU architecture. I originally noticed this when I saw my ppc64 system was being detected as 32-bit. Instead of having to add a giant list of architectures, I figured it made more sense to make this automatic.

This relies on the `sun.arch.data.model` JVM property being present - I have never seen a case of it not being supported, but if that is a concern the old hardcoded check can be put back as a fallback.

It's also worth noting this detects if the *JVM* is 64-bit, not necessarily the entire system. As an example, if someone is running a 32-bit JVM on a 64-bit system, this will return 32. It looks like this was the intention for that check, but if not please let me know so I can fix that.