### PR TITLE
Fix LTO compilation with `-Werror=odr` flag

### DIFF
--- a/launcher/BaseInstaller.h
+++ b/launcher/BaseInstaller.h
@@ -17,13 +17,14 @@
 
 #include <memory>
 
+#include "BaseVersion.h"
+
 class MinecraftInstance;
 class QDir;
 class QString;
 class QObject;
 class Task;
 class BaseVersion;
-typedef std::shared_ptr<BaseVersion> BaseVersionPtr;
 
 class BaseInstaller
 {
@@ -35,7 +36,7 @@ public:
     virtual bool add(MinecraftInstance *to);
     virtual bool remove(MinecraftInstance *from);
 
-    virtual Task *createInstallTask(MinecraftInstance *instance, BaseVersionPtr version, QObject *parent) = 0;
+    virtual Task *createInstallTask(MinecraftInstance *instance, BaseVersion::Ptr version, QObject *parent) = 0;
 
 protected:
     virtual QString id() const = 0;

--- a/launcher/BaseVersion.h
+++ b/launcher/BaseVersion.h
@@ -25,6 +25,7 @@
 class BaseVersion
 {
 public:
+    using Ptr = std::shared_ptr<BaseVersion>;
     virtual ~BaseVersion() {}
     /*!
      * A string used to identify this version in config files.
@@ -54,6 +55,4 @@ public:
     };
 };
 
-typedef std::shared_ptr<BaseVersion> BaseVersionPtr;
-
-Q_DECLARE_METATYPE(BaseVersionPtr)
+Q_DECLARE_METATYPE(BaseVersion::Ptr)

--- a/launcher/BaseVersionList.cpp
+++ b/launcher/BaseVersionList.cpp
@@ -40,20 +40,20 @@ BaseVersionList::BaseVersionList(QObject *parent) : QAbstractListModel(parent)
 {
 }
 
-BaseVersionPtr BaseVersionList::findVersion(const QString &descriptor)
+BaseVersion::Ptr BaseVersionList::findVersion(const QString &descriptor)
 {
     for (int i = 0; i < count(); i++)
     {
         if (at(i)->descriptor() == descriptor)
             return at(i);
     }
-    return BaseVersionPtr();
+    return nullptr;
 }
 
-BaseVersionPtr BaseVersionList::getRecommended() const
+BaseVersion::Ptr BaseVersionList::getRecommended() const
 {
     if (count() <= 0)
-        return BaseVersionPtr();
+        return nullptr;
     else
         return at(0);
 }
@@ -66,7 +66,7 @@ QVariant BaseVersionList::data(const QModelIndex &index, int role) const
     if (index.row() > count())
         return QVariant();
 
-    BaseVersionPtr version = at(index.row());
+    BaseVersion::Ptr version = at(index.row());
 
     switch (role)
     {

--- a/launcher/BaseVersionList.h
+++ b/launcher/BaseVersionList.h
@@ -70,7 +70,7 @@ public:
     virtual bool isLoaded() = 0;
 
     //! Gets the version at the given index.
-    virtual const BaseVersionPtr at(int i) const = 0;
+    virtual const BaseVersion::Ptr at(int i) const = 0;
 
     //! Returns the number of versions in the list.
     virtual int count() const = 0;
@@ -90,13 +90,13 @@ public:
      * \return A const pointer to the version with the given descriptor. NULL if
      * one doesn't exist.
      */
-    virtual BaseVersionPtr findVersion(const QString &descriptor);
+    virtual BaseVersion::Ptr findVersion(const QString &descriptor);
 
     /*!
      * \brief Gets the recommended version from this list
      * If the list doesn't support recommended versions, this works exactly as getLatestStable
      */
-    virtual BaseVersionPtr getRecommended() const;
+    virtual BaseVersion::Ptr getRecommended() const;
 
     /*!
      * Sorts the version list.
@@ -117,5 +117,5 @@ slots:
      * then copies the versions and sets their parents correctly.
      * \param versions List of versions whose parents should be set.
      */
-    virtual void updateListData(QList<BaseVersionPtr> versions) = 0;
+    virtual void updateListData(QList<BaseVersion::Ptr> versions) = 0;
 };

--- a/launcher/java/JavaInstallList.cpp
+++ b/launcher/java/JavaInstallList.cpp
@@ -73,7 +73,7 @@ void JavaInstallList::load()
     }
 }
 
-const BaseVersionPtr JavaInstallList::at(int i) const
+const BaseVersion::Ptr JavaInstallList::at(int i) const
 {
     return m_vlist.at(i);
 }
@@ -122,7 +122,7 @@ BaseVersionList::RoleList JavaInstallList::providesRoles() const
 }
 
 
-void JavaInstallList::updateListData(QList<BaseVersionPtr> versions)
+void JavaInstallList::updateListData(QList<BaseVersion::Ptr> versions)
 {
     beginResetModel();
     m_vlist = versions;
@@ -137,7 +137,7 @@ void JavaInstallList::updateListData(QList<BaseVersionPtr> versions)
     m_loadTask.reset();
 }
 
-bool sortJavas(BaseVersionPtr left, BaseVersionPtr right)
+bool sortJavas(BaseVersion::Ptr left, BaseVersion::Ptr right)
 {
     auto rleft = std::dynamic_pointer_cast<JavaInstall>(right);
     auto rright = std::dynamic_pointer_cast<JavaInstall>(left);
@@ -210,11 +210,11 @@ void JavaListLoadTask::javaCheckerFinished()
         }
     }
 
-    QList<BaseVersionPtr> javas_bvp;
+    QList<BaseVersion::Ptr> javas_bvp;
     for (auto java : candidates)
     {
         //qDebug() << java->id << java->arch << " at " << java->path;
-        BaseVersionPtr bp_java = std::dynamic_pointer_cast<BaseVersion>(java);
+        BaseVersion::Ptr bp_java = std::dynamic_pointer_cast<BaseVersion>(java);
 
         if (bp_java)
         {

--- a/launcher/java/JavaInstallList.h
+++ b/launcher/java/JavaInstallList.h
@@ -42,7 +42,7 @@ public:
 
     Task::Ptr getLoadTask() override;
     bool isLoaded() override;
-    const BaseVersionPtr at(int i) const override;
+    const BaseVersion::Ptr at(int i) const override;
     int count() const override;
     void sortVersions() override;
 
@@ -50,7 +50,7 @@ public:
     RoleList providesRoles() const override;
 
 public slots:
-    void updateListData(QList<BaseVersionPtr> versions) override;
+    void updateListData(QList<BaseVersion::Ptr> versions) override;
 
 protected:
     void load();
@@ -59,7 +59,7 @@ protected:
 protected:
     Status m_status = Status::NotDone;
     shared_qobject_ptr<JavaListLoadTask> m_loadTask;
-    QList<BaseVersionPtr> m_vlist;
+    QList<BaseVersion::Ptr> m_vlist;
 };
 
 class JavaListLoadTask : public Task

--- a/launcher/meta/Index.cpp
+++ b/launcher/meta/Index.cpp
@@ -24,7 +24,7 @@ Index::Index(QObject *parent)
     : QAbstractListModel(parent)
 {
 }
-Index::Index(const QVector<VersionListPtr> &lists, QObject *parent)
+Index::Index(const QVector<VersionList::Ptr> &lists, QObject *parent)
     : QAbstractListModel(parent), m_lists(lists)
 {
     for (int i = 0; i < m_lists.size(); ++i)
@@ -41,7 +41,7 @@ QVariant Index::data(const QModelIndex &index, int role) const
         return QVariant();
     }
 
-    VersionListPtr list = m_lists.at(index.row());
+    VersionList::Ptr list = m_lists.at(index.row());
     switch (role)
     {
     case Qt::DisplayRole:
@@ -81,9 +81,9 @@ bool Index::hasUid(const QString &uid) const
     return m_uids.contains(uid);
 }
 
-VersionListPtr Index::get(const QString &uid)
+VersionList::Ptr Index::get(const QString &uid)
 {
-    VersionListPtr out = m_uids.value(uid, nullptr);
+    VersionList::Ptr out = m_uids.value(uid, nullptr);
     if(!out)
     {
         out = std::make_shared<VersionList>(uid);
@@ -92,7 +92,7 @@ VersionListPtr Index::get(const QString &uid)
     return out;
 }
 
-VersionPtr Index::get(const QString &uid, const QString &version)
+Version::Ptr Index::get(const QString &uid, const QString &version)
 {
     auto list = get(uid);
     return list->getVersion(version);
@@ -105,7 +105,7 @@ void Index::parse(const QJsonObject& obj)
 
 void Index::merge(const std::shared_ptr<Index> &other)
 {
-    const QVector<VersionListPtr> lists = std::dynamic_pointer_cast<Index>(other)->m_lists;
+    const QVector<VersionList::Ptr> lists = std::dynamic_pointer_cast<Index>(other)->m_lists;
     // initial load, no need to merge
     if (m_lists.isEmpty())
     {
@@ -120,7 +120,7 @@ void Index::merge(const std::shared_ptr<Index> &other)
     }
     else
     {
-        for (const VersionListPtr &list : lists)
+        for (const VersionList::Ptr &list : lists)
         {
             if (m_uids.contains(list->uid()))
             {
@@ -138,7 +138,7 @@ void Index::merge(const std::shared_ptr<Index> &other)
     }
 }
 
-void Index::connectVersionList(const int row, const VersionListPtr &list)
+void Index::connectVersionList(const int row, const VersionList::Ptr &list)
 {
     connect(list.get(), &VersionList::nameChanged, this, [this, row]()
     {

--- a/launcher/meta/Index.h
+++ b/launcher/meta/Index.h
@@ -19,20 +19,19 @@
 #include <memory>
 
 #include "BaseEntity.h"
+#include "meta/VersionList.h"
 
 class Task;
 
 namespace Meta
 {
-using VersionListPtr = std::shared_ptr<class VersionList>;
-using VersionPtr = std::shared_ptr<class Version>;
 
 class Index : public QAbstractListModel, public BaseEntity
 {
     Q_OBJECT
 public:
     explicit Index(QObject *parent = nullptr);
-    explicit Index(const QVector<VersionListPtr> &lists, QObject *parent = nullptr);
+    explicit Index(const QVector<VersionList::Ptr> &lists, QObject *parent = nullptr);
 
     enum
     {
@@ -49,21 +48,21 @@ public:
     QString localFilename() const override { return "index.json"; }
 
     // queries
-    VersionListPtr get(const QString &uid);
-    VersionPtr get(const QString &uid, const QString &version);
+    VersionList::Ptr get(const QString &uid);
+    Version::Ptr get(const QString &uid, const QString &version);
     bool hasUid(const QString &uid) const;
 
-    QVector<VersionListPtr> lists() const { return m_lists; }
+    QVector<VersionList::Ptr> lists() const { return m_lists; }
 
 public: // for usage by parsers only
     void merge(const std::shared_ptr<Index> &other);
     void parse(const QJsonObject &obj) override;
 
 private:
-    QVector<VersionListPtr> m_lists;
-    QHash<QString, VersionListPtr> m_uids;
+    QVector<VersionList::Ptr> m_lists;
+    QHash<QString, VersionList::Ptr> m_uids;
 
-    void connectVersionList(const int row, const VersionListPtr &list);
+    void connectVersionList(const int row, const VersionList::Ptr &list);
 };
 }
 

--- a/launcher/meta/JsonFormat.cpp
+++ b/launcher/meta/JsonFormat.cpp
@@ -37,11 +37,11 @@ MetadataVersion currentFormatVersion()
 static std::shared_ptr<Index> parseIndexInternal(const QJsonObject &obj)
 {
     const QVector<QJsonObject> objects = requireIsArrayOf<QJsonObject>(obj, "packages");
-    QVector<VersionListPtr> lists;
+    QVector<VersionList::Ptr> lists;
     lists.reserve(objects.size());
     std::transform(objects.begin(), objects.end(), std::back_inserter(lists), [](const QJsonObject &obj)
     {
-        VersionListPtr list = std::make_shared<VersionList>(requireString(obj, "uid"));
+        VersionList::Ptr list = std::make_shared<VersionList>(requireString(obj, "uid"));
         list->setName(ensureString(obj, "name", QString()));
         return list;
     });
@@ -49,9 +49,9 @@ static std::shared_ptr<Index> parseIndexInternal(const QJsonObject &obj)
 }
 
 // Version
-static VersionPtr parseCommonVersion(const QString &uid, const QJsonObject &obj)
+static Version::Ptr parseCommonVersion(const QString &uid, const QJsonObject &obj)
 {
-    VersionPtr version = std::make_shared<Version>(uid, requireString(obj, "version"));
+    Version::Ptr version = std::make_shared<Version>(uid, requireString(obj, "version"));
     version->setTime(QDateTime::fromString(requireString(obj, "releaseTime"), Qt::ISODate).toMSecsSinceEpoch() / 1000);
     version->setType(ensureString(obj, "type", QString()));
     version->setRecommended(ensureBoolean(obj, QString("recommended"), false));
@@ -63,9 +63,9 @@ static VersionPtr parseCommonVersion(const QString &uid, const QJsonObject &obj)
     return version;
 }
 
-static std::shared_ptr<Version> parseVersionInternal(const QJsonObject &obj)
+static Version::Ptr parseVersionInternal(const QJsonObject &obj)
 {
-    VersionPtr version = parseCommonVersion(requireString(obj, "uid"), obj);
+    Version::Ptr version = parseCommonVersion(requireString(obj, "uid"), obj);
 
     version->setData(OneSixVersionFormat::versionFileFromJson(QJsonDocument(obj),
                                            QString("%1/%2.json").arg(version->uid(), version->version()),
@@ -74,12 +74,12 @@ static std::shared_ptr<Version> parseVersionInternal(const QJsonObject &obj)
 }
 
 // Version list / package
-static std::shared_ptr<VersionList> parseVersionListInternal(const QJsonObject &obj)
+static VersionList::Ptr parseVersionListInternal(const QJsonObject &obj)
 {
     const QString uid = requireString(obj, "uid");
 
     const QVector<QJsonObject> versionsRaw = requireIsArrayOf<QJsonObject>(obj, "versions");
-    QVector<VersionPtr> versions;
+    QVector<Version::Ptr> versions;
     versions.reserve(versionsRaw.size());
     std::transform(versionsRaw.begin(), versionsRaw.end(), std::back_inserter(versions), [uid](const QJsonObject &vObj)
     {
@@ -88,7 +88,7 @@ static std::shared_ptr<VersionList> parseVersionListInternal(const QJsonObject &
         return version;
     });
 
-    VersionListPtr list = std::make_shared<VersionList>(uid);
+    VersionList::Ptr list = std::make_shared<VersionList>(uid);
     list->setName(ensureString(obj, "name", QString()));
     list->setVersions(versions);
     return list;

--- a/launcher/meta/Version.cpp
+++ b/launcher/meta/Version.cpp
@@ -54,7 +54,7 @@ void Meta::Version::parse(const QJsonObject& obj)
     parseVersion(obj, this);
 }
 
-void Meta::Version::mergeFromList(const Meta::VersionPtr& other)
+void Meta::Version::mergeFromList(const Meta::Version::Ptr& other)
 {
     if(other->m_providesRecommendations)
     {
@@ -85,7 +85,7 @@ void Meta::Version::mergeFromList(const Meta::VersionPtr& other)
     }
 }
 
-void Meta::Version::merge(const VersionPtr &other)
+void Meta::Version::merge(const Version::Ptr &other)
 {
     mergeFromList(other);
     if(other->m_data)

--- a/launcher/meta/Version.h
+++ b/launcher/meta/Version.h
@@ -30,13 +30,14 @@
 
 namespace Meta
 {
-using VersionPtr = std::shared_ptr<class Version>;
 
 class Version : public QObject, public BaseVersion, public BaseEntity
 {
     Q_OBJECT
 
-public: /* con/des */
+public:
+    using Ptr = std::shared_ptr<Version>;
+
     explicit Version(const QString &uid, const QString &version);
     virtual ~Version();
 
@@ -78,8 +79,8 @@ public: /* con/des */
         return m_data != nullptr;
     }
 
-    void merge(const VersionPtr &other);
-    void mergeFromList(const VersionPtr &other);
+    void merge(const Version::Ptr &other);
+    void mergeFromList(const Version::Ptr &other);
     void parse(const QJsonObject &obj) override;
 
     QString localFilename() const override;
@@ -113,4 +114,4 @@ private:
 };
 }
 
-Q_DECLARE_METATYPE(Meta::VersionPtr)
+Q_DECLARE_METATYPE(Meta::Version::Ptr)

--- a/launcher/meta/VersionList.h
+++ b/launcher/meta/VersionList.h
@@ -20,10 +20,10 @@
 #include <QJsonObject>
 #include <memory>
 
+#include "meta/Version.h"
+
 namespace Meta
 {
-using VersionPtr = std::shared_ptr<class Version>;
-using VersionListPtr = std::shared_ptr<class VersionList>;
 
 class VersionList : public BaseVersionList, public BaseEntity
 {
@@ -32,6 +32,8 @@ class VersionList : public BaseVersionList, public BaseEntity
     Q_PROPERTY(QString name READ name NOTIFY nameChanged)
 public:
     explicit VersionList(const QString &uid, QObject *parent = nullptr);
+
+    using Ptr = std::shared_ptr<VersionList>;
 
     enum Roles
     {
@@ -43,11 +45,11 @@ public:
 
     Task::Ptr getLoadTask() override;
     bool isLoaded() override;
-    const BaseVersionPtr at(int i) const override;
+    const BaseVersion::Ptr at(int i) const override;
     int count() const override;
     void sortVersions() override;
 
-    BaseVersionPtr getRecommended() const override;
+    BaseVersion::Ptr getRecommended() const override;
 
     QVariant data(const QModelIndex &index, int role) const override;
     RoleList providesRoles() const override;
@@ -65,38 +67,38 @@ public:
     }
     QString humanReadable() const;
 
-    VersionPtr getVersion(const QString &version);
+    Version::Ptr getVersion(const QString &version);
     bool hasVersion(QString version) const;
 
-    QVector<VersionPtr> versions() const
+    QVector<Version::Ptr> versions() const
     {
         return m_versions;
     }
 
 public: // for usage only by parsers
     void setName(const QString &name);
-    void setVersions(const QVector<VersionPtr> &versions);
-    void merge(const VersionListPtr &other);
-    void mergeFromIndex(const VersionListPtr &other);
+    void setVersions(const QVector<Version::Ptr> &versions);
+    void merge(const VersionList::Ptr &other);
+    void mergeFromIndex(const VersionList::Ptr &other);
     void parse(const QJsonObject &obj) override;
 
 signals:
     void nameChanged(const QString &name);
 
 protected slots:
-    void updateListData(QList<BaseVersionPtr>) override
+    void updateListData(QList<BaseVersion::Ptr>) override
     {
     }
 
 private:
-    QVector<VersionPtr> m_versions;
-    QHash<QString, VersionPtr> m_lookup;
+    QVector<Version::Ptr> m_versions;
+    QHash<QString, Version::Ptr> m_lookup;
     QString m_uid;
     QString m_name;
 
-    VersionPtr m_recommended;
+    Version::Ptr m_recommended;
 
-    void setupAddedVersion(const int row, const VersionPtr &version);
+    void setupAddedVersion(const int row, const Version::Ptr &version);
 };
 }
-Q_DECLARE_METATYPE(Meta::VersionListPtr)
+Q_DECLARE_METATYPE(Meta::VersionList::Ptr)

--- a/launcher/minecraft/VanillaInstanceCreationTask.cpp
+++ b/launcher/minecraft/VanillaInstanceCreationTask.cpp
@@ -7,7 +7,7 @@
 #include "minecraft/PackProfile.h"
 #include "settings/INISettingsObject.h"
 
-VanillaCreationTask::VanillaCreationTask(BaseVersionPtr version, QString loader, BaseVersionPtr loader_version)
+VanillaCreationTask::VanillaCreationTask(BaseVersion::Ptr version, QString loader, BaseVersion::Ptr loader_version)
     : InstanceCreationTask(), m_version(std::move(version)), m_using_loader(true), m_loader(std::move(loader)), m_loader_version(std::move(loader_version))
 {}
 

--- a/launcher/minecraft/VanillaInstanceCreationTask.h
+++ b/launcher/minecraft/VanillaInstanceCreationTask.h
@@ -7,16 +7,16 @@
 class VanillaCreationTask final : public InstanceCreationTask {
     Q_OBJECT
    public:
-    VanillaCreationTask(BaseVersionPtr version) : InstanceCreationTask(), m_version(std::move(version)) {}
-    VanillaCreationTask(BaseVersionPtr version, QString loader, BaseVersionPtr loader_version);
+    VanillaCreationTask(BaseVersion::Ptr version) : InstanceCreationTask(), m_version(std::move(version)) {}
+    VanillaCreationTask(BaseVersion::Ptr version, QString loader, BaseVersion::Ptr loader_version);
 
     bool createInstance() override;
 
    private:
     // Version to update to / create of the instance.
-    BaseVersionPtr m_version;
+    BaseVersion::Ptr m_version;
 
     bool m_using_loader = false;
     QString m_loader;
-    BaseVersionPtr m_loader_version;
+    BaseVersion::Ptr m_loader_version;
 };

--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
@@ -58,7 +58,7 @@
 
 namespace ATLauncher {
 
-static Meta::VersionPtr getComponentVersion(const QString& uid, const QString& version);
+static Meta::Version::Ptr getComponentVersion(const QString& uid, const QString& version);
 
 PackInstallTask::PackInstallTask(UserInteractionSupport *support, QString packName, QString version, InstallMode installMode)
 {
@@ -1037,7 +1037,7 @@ void PackInstallTask::install()
     emitSucceeded();
 }
 
-static Meta::VersionPtr getComponentVersion(const QString& uid, const QString& version)
+static Meta::Version::Ptr getComponentVersion(const QString& uid, const QString& version)
 {
     auto vlist = APPLICATION->metadataIndex()->get(uid);
     if (!vlist)

--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.h
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.h
@@ -68,7 +68,7 @@ public:
      * Requests a user interaction to select a component version from a given version list
      * and constrained to a given Minecraft version.
      */
-    virtual QString chooseVersion(Meta::VersionListPtr vlist, QString minecraftVersion) = 0;
+    virtual QString chooseVersion(Meta::VersionList::Ptr vlist, QString minecraftVersion) = 0;
 
     /**
      * Requests a user interaction to display a message.
@@ -137,8 +137,8 @@ private:
 
     QString archivePath;
     QStringList jarmods;
-    Meta::VersionPtr minecraftVersion;
-    QMap<QString, Meta::VersionPtr> componentsToInstall;
+    Meta::Version::Ptr minecraftVersion;
+    QMap<QString, Meta::Version::Ptr> componentsToInstall;
 
     QFuture<std::optional<QStringList>> m_extractFuture;
     QFutureWatcher<std::optional<QStringList>> m_extractFutureWatcher;

--- a/launcher/ui/dialogs/VersionSelectDialog.cpp
+++ b/launcher/ui/dialogs/VersionSelectDialog.cpp
@@ -120,7 +120,7 @@ void VersionSelectDialog::selectRecommended()
     m_versionWidget->selectRecommended();
 }
 
-BaseVersionPtr VersionSelectDialog::selectedVersion() const
+BaseVersion::Ptr VersionSelectDialog::selectedVersion() const
 {
     return m_versionWidget->selectedVersion();
 }

--- a/launcher/ui/dialogs/VersionSelectDialog.h
+++ b/launcher/ui/dialogs/VersionSelectDialog.h
@@ -44,7 +44,7 @@ public:
 
     int exec() override;
 
-    BaseVersionPtr selectedVersion() const;
+    BaseVersion::Ptr selectedVersion() const;
 
     void setCurrentVersion(const QString & version);
     void setFuzzyFilter(BaseVersionList::ModelRoles role, QString filter);

--- a/launcher/ui/pages/modplatform/VanillaPage.cpp
+++ b/launcher/ui/pages/modplatform/VanillaPage.cpp
@@ -187,12 +187,12 @@ void VanillaPage::retranslate()
     ui->retranslateUi(this);
 }
 
-BaseVersionPtr VanillaPage::selectedVersion() const
+BaseVersion::Ptr VanillaPage::selectedVersion() const
 {
     return m_selectedVersion;
 }
 
-BaseVersionPtr VanillaPage::selectedLoaderVersion() const
+BaseVersion::Ptr VanillaPage::selectedLoaderVersion() const
 {
     return m_selectedLoaderVersion;
 }
@@ -227,14 +227,14 @@ void VanillaPage::suggestCurrent()
     dialog->setSuggestedIcon("default");
 }
 
-void VanillaPage::setSelectedVersion(BaseVersionPtr version)
+void VanillaPage::setSelectedVersion(BaseVersion::Ptr version)
 {
     m_selectedVersion = version;
     suggestCurrent();
     loaderFilterChanged();
 }
 
-void VanillaPage::setSelectedLoaderVersion(BaseVersionPtr version)
+void VanillaPage::setSelectedLoaderVersion(BaseVersion::Ptr version)
 {
     m_selectedLoaderVersion = version;
     suggestCurrent();

--- a/launcher/ui/pages/modplatform/VanillaPage.h
+++ b/launcher/ui/pages/modplatform/VanillaPage.h
@@ -76,13 +76,13 @@ public:
 
     void openedImpl() override;
 
-    BaseVersionPtr selectedVersion() const;
-    BaseVersionPtr selectedLoaderVersion() const;
+    BaseVersion::Ptr selectedVersion() const;
+    BaseVersion::Ptr selectedLoaderVersion() const;
     QString selectedLoader() const;
 
 public slots:
-    void setSelectedVersion(BaseVersionPtr version);
-    void setSelectedLoaderVersion(BaseVersionPtr version);
+    void setSelectedVersion(BaseVersion::Ptr version);
+    void setSelectedLoaderVersion(BaseVersion::Ptr version);
 
 private slots:
     void filterChanged();
@@ -98,7 +98,7 @@ private:
     NewInstanceDialog *dialog = nullptr;
     Ui::VanillaPage *ui = nullptr;
     bool m_versionSetByUser = false;
-    BaseVersionPtr m_selectedVersion;
-    BaseVersionPtr m_selectedLoaderVersion;
+    BaseVersion::Ptr m_selectedVersion;
+    BaseVersion::Ptr m_selectedLoaderVersion;
     QString m_selectedLoader;
 };

--- a/launcher/ui/pages/modplatform/atlauncher/AtlUserInteractionSupportImpl.cpp
+++ b/launcher/ui/pages/modplatform/atlauncher/AtlUserInteractionSupportImpl.cpp
@@ -53,7 +53,7 @@ std::optional<QVector<QString>> AtlUserInteractionSupportImpl::chooseOptionalMod
     return optionalModDialog.getResult();
 }
 
-QString AtlUserInteractionSupportImpl::chooseVersion(Meta::VersionListPtr vlist, QString minecraftVersion)
+QString AtlUserInteractionSupportImpl::chooseVersion(Meta::VersionList::Ptr vlist, QString minecraftVersion)
 {
     VersionSelectDialog vselect(vlist.get(), "Choose Version", m_parent, false);
     if (minecraftVersion != nullptr) {

--- a/launcher/ui/pages/modplatform/atlauncher/AtlUserInteractionSupportImpl.h
+++ b/launcher/ui/pages/modplatform/atlauncher/AtlUserInteractionSupportImpl.h
@@ -46,7 +46,7 @@ public:
     AtlUserInteractionSupportImpl(QWidget* parent);
 
 private:
-    QString chooseVersion(Meta::VersionListPtr vlist, QString minecraftVersion) override;
+    QString chooseVersion(Meta::VersionList::Ptr vlist, QString minecraftVersion) override;
     std::optional<QVector<QString>> chooseOptionalMods(ATLauncher::PackVersion version, QVector<ATLauncher::VersionMod> mods) override;
     void displayMessage(QString message) override;
 

--- a/launcher/ui/widgets/JavaSettingsWidget.cpp
+++ b/launcher/ui/widgets/JavaSettingsWidget.cpp
@@ -245,7 +245,7 @@ void JavaSettingsWidget::memoryValueChanged(int)
     }
 }
 
-void JavaSettingsWidget::javaVersionSelected(BaseVersionPtr version)
+void JavaSettingsWidget::javaVersionSelected(BaseVersion::Ptr version)
 {
     auto java = std::dynamic_pointer_cast<JavaInstall>(version);
     if(!java)

--- a/launcher/ui/widgets/JavaSettingsWidget.h
+++ b/launcher/ui/widgets/JavaSettingsWidget.h
@@ -60,7 +60,7 @@ public:
 protected slots:
     void memoryValueChanged(int);
     void javaPathEdited(const QString &path);
-    void javaVersionSelected(BaseVersionPtr version);
+    void javaVersionSelected(BaseVersion::Ptr version);
     void on_javaBrowseBtn_clicked();
     void on_javaStatusBtn_clicked();
     void checkFinished(JavaCheckResult result);

--- a/launcher/ui/widgets/ModFilterWidget.h
+++ b/launcher/ui/widgets/ModFilterWidget.h
@@ -49,7 +49,7 @@ public:
     auto getFilter() -> std::shared_ptr<Filter>;
     auto changed() const -> bool { return m_last_version_id != m_version_id; }
 
-    Meta::VersionListPtr versionList() { return m_version_list; }
+    Meta::VersionList::Ptr versionList() { return m_version_list; }
 
 private:
     ModFilterWidget(Version def, QWidget* parent = nullptr);
@@ -73,7 +73,7 @@ private:
 /* Version stuff */
     QButtonGroup m_mcVersion_buttons;
 
-    Meta::VersionListPtr m_version_list;
+    Meta::VersionList::Ptr m_version_list;
 
     /* Used to tell if the filter was changed since the last getFilter() call */
     VersionButtonID m_last_version_id = VersionButtonID::Strict;

--- a/launcher/ui/widgets/VersionSelectWidget.cpp
+++ b/launcher/ui/widgets/VersionSelectWidget.cpp
@@ -142,7 +142,7 @@ void VersionSelectWidget::changeProgress(qint64 current, qint64 total)
 void VersionSelectWidget::currentRowChanged(const QModelIndex& current, const QModelIndex&)
 {
     auto variant = m_proxyModel->data(current, BaseVersionList::VersionPointerRole);
-    emit selectedVersionChanged(variant.value<BaseVersionPtr>());
+    emit selectedVersionChanged(variant.value<BaseVersion::Ptr>());
 }
 
 void VersionSelectWidget::preselect()
@@ -186,11 +186,11 @@ bool VersionSelectWidget::hasVersions() const
     return m_proxyModel->rowCount(QModelIndex()) != 0;
 }
 
-BaseVersionPtr VersionSelectWidget::selectedVersion() const
+BaseVersion::Ptr VersionSelectWidget::selectedVersion() const
 {
     auto currentIndex = listView->selectionModel()->currentIndex();
     auto variant = m_proxyModel->data(currentIndex, BaseVersionList::VersionPointerRole);
-    return variant.value<BaseVersionPtr>();
+    return variant.value<BaseVersion::Ptr>();
 }
 
 void VersionSelectWidget::setExactFilter(BaseVersionList::ModelRoles role, QString filter)

--- a/launcher/ui/widgets/VersionSelectWidget.h
+++ b/launcher/ui/widgets/VersionSelectWidget.h
@@ -40,7 +40,7 @@ public:
     void loadList();
 
     bool hasVersions() const;
-    BaseVersionPtr selectedVersion() const;
+    BaseVersion::Ptr selectedVersion() const;
     void selectRecommended();
     void selectCurrent();
 
@@ -54,7 +54,7 @@ public:
     void setResizeOn(int column);
 
 signals:
-    void selectedVersionChanged(BaseVersionPtr version);
+    void selectedVersionChanged(BaseVersion::Ptr version);
 
 protected:
     virtual void closeEvent ( QCloseEvent* );


### PR DESCRIPTION
It also makes this more inline to how smart pointers are handled in other places (like for `Task::Ptr`)