### PR TITLE
Fix: Increase stack size on Windows to 8MiB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,11 @@ set(CMAKE_C_STANDARD 11)
 include(GenerateExportHeader)
 set(CMAKE_CXX_FLAGS "-Wall -pedantic -fstack-protector-strong --param=ssp-buffer-size=4 ${CMAKE_CXX_FLAGS}")
 
+# ATL's packlist needs more than the default 1 Mib stack on windows
+if(WIN32)
+    set(CMAKE_EXE_LINKER_FLAGS "-Wl,--stack,8388608 ${CMAKE_EXE_LINKER_FLAGS}")
+endif()
+
 # Fix build with Qt 5.13
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DQT_NO_DEPRECATED_WARNINGS=Y")
 


### PR DESCRIPTION
Increases the stack-size on windows to match a Linux

This fixes the crash with AT Launcher's modpack list

Best I can tell the cause seems to be the large amount of `NetJobs` spawned in quick succession to download pack logos, along with the recursive nature of the PrismLauncher's task system, although I wasn't able to completely understand this setup.

When testing in my MSVC branch, A debug build needed a stack size of 3-4MiB to not crash, a max stack size of 8MiB should give a sufficient margin of safety for this to not be an issue.

Fixes #376 