### PR TITLE
Save metacache after clearing

### DIFF
--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -1899,6 +1899,7 @@ void MainWindow::on_actionReportBug_triggered()
 void MainWindow::on_actionClearMetadata_triggered()
 {
     APPLICATION->metacache()->evictAll();
+    APPLICATION->metacache()->SaveNow();
 }
 
 void MainWindow::on_actionOpenWiki_triggered()


### PR DESCRIPTION
If the user closes the launcher right after clearing, it probably didn't actually clear the cache yet.
