### PR TITLE
Fix warning in main function

### DIFF
--- a/launcher/main.cpp
+++ b/launcher/main.cpp
@@ -91,5 +91,7 @@ int main(int argc, char *argv[])
         return 1;
     case Application::Succeeded:
         return 0;
+    default:
+        return -1;
     }
 }


### PR DESCRIPTION
main could according to the compiler end up not returning. of course it will always return, but I satisfied the compiler by adding a default case.

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
