### PR TITLE
update bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -63,3 +63,9 @@ body:
     options:
     - label: I have searched the issue tracker and did not find an issue describing my bug.
       required: true
+- type: checkboxes
+  attributes:
+    label: This issue occurs on at least the latest stable release
+    options:
+    - label: This issue occurs on at least the latest stable version of Prism Launcher
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -23,18 +23,18 @@ body:
     - macOS
     - Linux
     - Other
-- type: textarea
+- type: input
   attributes:
     label: Version of Prism Launcher
     description: The version of Prism Launcher used in the bug report.
-    placeholder: Prism Launcher 5.0
+    placeholder: Prism Launcher 5.1
   validations:
     required: true
-- type: textarea
+- type: input
   attributes:
     label: Version of Qt
     description: The version of Qt used in the bug report. You can find it in Help -> About Prism Launcher -> About Qt.
-    placeholder: Qt 6.3.0
+    placeholder: Qt 6.4.0
   validations:
     required: true
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -30,6 +30,12 @@ body:
     placeholder: Prism Launcher 5.1
   validations:
     required: true
+- type: checkboxes
+  attributes:
+    label: I've tried reproducing this issue on the latest stable release.
+    options:
+    - label: I've tried reproducing this issue on the latest stable release.
+      required: true
 - type: input
   attributes:
     label: Version of Qt
@@ -62,10 +68,4 @@ body:
     label: This issue is unique
     options:
     - label: I have searched the issue tracker and did not find an issue describing my bug.
-      required: true
-- type: checkboxes
-  attributes:
-    label: I've tried reproducing this issue on the latest stable release.
-    options:
-    - label: I've tried reproducing this issue on the latest stable release.
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -32,7 +32,7 @@ body:
     required: true
 - type: checkboxes
   attributes:
-    label: I've tried reproducing this issue on the latest stable release.
+    label: I've tried reproducing this issue on the latest stable release
     options:
     - label: I've tried reproducing this issue on the latest stable release.
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -32,9 +32,9 @@ body:
     required: true
 - type: checkboxes
   attributes:
-    label: I've tried reproducing this issue on the latest stable release
+    label: I've tried reproducing this issue on the latest stable release.
     options:
-    - label: I've tried reproducing this issue on the latest stable release.
+    - label: I've tried reproducing this issue on the latest stable release
       required: true
 - type: input
   attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -65,7 +65,7 @@ body:
       required: true
 - type: checkboxes
   attributes:
-    label: This issue occurs on at least the latest stable release
+    label: I've tried reproducing this issue on the latest stable release.
     options:
     - label: I've tried reproducing this issue on the latest stable release.
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -32,7 +32,7 @@ body:
     required: true
 - type: checkboxes
   attributes:
-    label: I've tried reproducing this issue on the latest stable release.
+    label: I've tried reproducing this issue on at least the latest stable release.
     options:
     - label: This bug occurs on at least the latest stable release.
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -67,5 +67,5 @@ body:
   attributes:
     label: This issue occurs on at least the latest stable release
     options:
-    - label: This issue occurs on at least the latest stable version of Prism Launcher
+    - label: I've tried reproducing this issue on the latest stable release.
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -34,7 +34,7 @@ body:
   attributes:
     label: I've tried reproducing this issue on the latest stable release.
     options:
-    - label: I've tried reproducing this issue on the latest stable release
+    - label: This bug occurs on the latest stable release.
       required: true
 - type: input
   attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -34,7 +34,7 @@ body:
   attributes:
     label: I've tried reproducing this issue on the latest stable release.
     options:
-    - label: This bug occurs on the latest stable release.
+    - label: This bug occurs on at least the latest stable release.
       required: true
 - type: input
   attributes:


### PR DESCRIPTION
Signed-off-by: OldWorldOrdr <joey.t.reinhart@gmail.com>

Not sure why it wasn't already a requirement to test your bugs in the latest version of Prism Launcher.  If theres a reason ill make an edit to revert that part but keep the change from textareas to inputs.