### PR TITLE
Button to add agents

### DIFF
--- a/launcher/minecraft/Agent.h
+++ b/launcher/minecraft/Agent.h
@@ -10,7 +10,7 @@ typedef std::shared_ptr<Agent> AgentPtr;
 
 class Agent {
 public:
-    Agent(LibraryPtr library, QString &argument)
+    Agent(LibraryPtr library, const QString &argument)
     {
         m_library = library;
         m_argument = argument;

--- a/launcher/minecraft/PackProfile.cpp
+++ b/launcher/minecraft/PackProfile.cpp
@@ -838,15 +838,12 @@ bool PackProfile::installJarMods_internal(QStringList filepaths)
         QFileInfo sourceInfo(filepath);
         QString id = QUuid::createUuid().toString(QUuid::WithoutBraces);
         QString target_filename = id + ".jar";
-        QString target_id = "org.multimc.jarmod." + id;
+        QString target_id = "custom.jarmod." + id;
         QString target_name = sourceInfo.completeBaseName() + " (jar mod)";
         QString finalPath = FS::PathCombine(d->m_instance->jarModsDir(), target_filename);
 
         QFileInfo targetInfo(finalPath);
-        if(targetInfo.exists())
-        {
-            return false;
-        }
+        Q_ASSERT(!targetInfo.exists());
 
         if (!QFile::copy(sourceInfo.absoluteFilePath(),QFileInfo(finalPath).absoluteFilePath()))
         {
@@ -855,7 +852,7 @@ bool PackProfile::installJarMods_internal(QStringList filepaths)
 
         auto f = std::make_shared<VersionFile>();
         auto jarMod = std::make_shared<Library>();
-        jarMod->setRawName(GradleSpecifier("org.multimc.jarmods:" + id + ":1"));
+        jarMod->setRawName(GradleSpecifier("custom.jarmods:" + id + ":1"));
         jarMod->setFilename(target_filename);
         jarMod->setDisplayName(sourceInfo.completeBaseName());
         jarMod->setHint("local");
@@ -895,7 +892,7 @@ bool PackProfile::installCustomJar_internal(QString filepath)
         return false;
     }
 
-    auto specifier = GradleSpecifier("org.multimc:customjar:1");
+    auto specifier = GradleSpecifier("custom:customjar:1");
     QFileInfo sourceInfo(filepath);
     QString target_filename = specifier.getFileName();
     QString target_id = specifier.artifactId();
@@ -957,13 +954,12 @@ bool PackProfile::installAgents_internal(QStringList filepaths)
         const QFileInfo sourceInfo(source);
         const QString id = QUuid::createUuid().toString(QUuid::WithoutBraces);
         const QString targetBaseName = id + ".jar";
-        const QString targetId = "org.prismlauncher.agent." + id;
+        const QString targetId = "custom.agent." + id;
         const QString targetName = sourceInfo.completeBaseName() + " (agent)";
         const QString target = FS::PathCombine(d->m_instance->getLocalLibraryPath(), targetBaseName);
 
         const QFileInfo targetInfo(target);
-        if (targetInfo.exists())
-            return false;
+        Q_ASSERT(!targetInfo.exists());
 
         if (!QFile::copy(source, target))
             return false;
@@ -972,7 +968,7 @@ bool PackProfile::installAgents_internal(QStringList filepaths)
 
         auto agent = std::make_shared<Library>();
 
-        agent->setRawName("org.prismlauncher.agents:" + id + ":1");
+        agent->setRawName("custom.agents:" + id + ":1");
         agent->setFilename(targetBaseName);
         agent->setDisplayName(sourceInfo.completeBaseName());
         agent->setHint("local");

--- a/launcher/minecraft/PackProfile.cpp
+++ b/launcher/minecraft/PackProfile.cpp
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  PolyMC - Minecraft Launcher
+ *  Prism Launcher - Minecraft Launcher
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -47,7 +48,6 @@
 #include "Exception.h"
 #include "minecraft/OneSixVersionFormat.h"
 #include "FileSystem.h"
-#include "meta/Index.h"
 #include "minecraft/MinecraftInstance.h"
 #include "Json.h"
 
@@ -55,7 +55,6 @@
 #include "PackProfile_p.h"
 #include "ComponentUpdateTask.h"
 
-#include "Application.h"
 #include "modplatform/ModAPI.h"
 
 static const QMap<QString, ModAPI::ModLoaderType> modloaderMapping{
@@ -738,6 +737,11 @@ void PackProfile::installCustomJar(QString selectedFile)
     installCustomJar_internal(selectedFile);
 }
 
+void PackProfile::installAgents(QStringList selectedFiles)
+{
+    installAgents_internal(selectedFiles);
+}
+
 bool PackProfile::installEmpty(const QString& uid, const QString& name)
 {
     QString patchDir = FS::PathCombine(d->m_instance->instanceRoot(), "patches");
@@ -832,8 +836,7 @@ bool PackProfile::installJarMods_internal(QStringList filepaths)
     for(auto filepath:filepaths)
     {
         QFileInfo sourceInfo(filepath);
-        auto uuid = QUuid::createUuid();
-        QString id = uuid.toString().remove('{').remove('}');
+        QString id = QUuid::createUuid().toString(QUuid::WithoutBraces);
         QString target_filename = id + ".jar";
         QString target_id = "org.multimc.jarmod." + id;
         QString target_name = sourceInfo.completeBaseName() + " (jar mod)";
@@ -936,6 +939,65 @@ bool PackProfile::installCustomJar_internal(QString filepath)
 
     scheduleSave();
     invalidateLaunchProfile();
+    return true;
+}
+
+bool PackProfile::installAgents_internal(QStringList filepaths)
+{
+    // FIXME code duplication
+    const QString patchDir = FS::PathCombine(d->m_instance->instanceRoot(), "patches");
+    if (!FS::ensureFolderPathExists(patchDir))
+        return false;
+
+    const QString libDir = d->m_instance->getLocalLibraryPath();
+    if (!FS::ensureFolderPathExists(libDir))
+        return false;
+
+    for (const QString& source : filepaths) {
+        const QFileInfo sourceInfo(source);
+        const QString id = QUuid::createUuid().toString(QUuid::WithoutBraces);
+        const QString targetBaseName = id + ".jar";
+        const QString targetId = "org.prismlauncher.agent." + id;
+        const QString targetName = sourceInfo.completeBaseName() + " (agent)";
+        const QString target = FS::PathCombine(d->m_instance->getLocalLibraryPath(), targetBaseName);
+
+        const QFileInfo targetInfo(target);
+        if (targetInfo.exists())
+            return false;
+
+        if (!QFile::copy(source, target))
+            return false;
+
+        auto versionFile = std::make_shared<VersionFile>();
+
+        auto agent = std::make_shared<Library>();
+
+        agent->setRawName("org.prismlauncher.agents:" + id + ":1");
+        agent->setFilename(targetBaseName);
+        agent->setDisplayName(sourceInfo.completeBaseName());
+        agent->setHint("local");
+
+        versionFile->agents.append(std::make_shared<Agent>(agent, QString()));
+
+        versionFile->name = targetName;
+        versionFile->uid = targetId;
+
+        QFile patchFile(FS::PathCombine(patchDir, targetId + ".json"));
+
+        if (!patchFile.open(QFile::WriteOnly)) {
+            qCritical() << "Error opening" << patchFile.fileName() << "for reading:" << patchFile.errorString();
+            return false;
+        }
+
+        patchFile.write(OneSixVersionFormat::versionFileToJson(versionFile).toJson());
+        patchFile.close();
+
+        appendComponent(new Component(this, versionFile->uid, versionFile));
+    }
+
+    scheduleSave();
+    invalidateLaunchProfile();
+
     return true;
 }
 

--- a/launcher/minecraft/PackProfile.h
+++ b/launcher/minecraft/PackProfile.h
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  PolyMC - Minecraft Launcher
+ *  Prism Launcher - Minecraft Launcher
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -85,6 +86,9 @@ public:
     /// install a jar/zip as a replacement for the main jar
     void installCustomJar(QString selectedFile);
 
+    /// install Java agent files
+    void installAgents(QStringList selectedFiles);
+
     enum MoveDirection { MoveUp, MoveDown };
     /// move component file # up or down the list
     void move(const int index, const MoveDirection direction);
@@ -167,6 +171,7 @@ private:
     bool load();
     bool installJarMods_internal(QStringList filepaths);
     bool installCustomJar_internal(QString filepath);
+    bool installAgents_internal(QStringList filepaths);
     bool removeComponent_internal(ComponentPtr patch);
 
 private: /* data */

--- a/launcher/ui/pages/instance/VersionPage.cpp
+++ b/launcher/ui/pages/instance/VersionPage.cpp
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  PolyMC - Minecraft Launcher
+ *  Prism Launcher - Minecraft Launcher
  *  Copyright (c) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -270,6 +271,7 @@ void VersionPage::updateButtons(int row)
     ui->actionInstall_mods->setEnabled(controlsEnabled);
     ui->actionReplace_Minecraft_jar->setEnabled(controlsEnabled);
     ui->actionAdd_to_Minecraft_jar->setEnabled(controlsEnabled);
+    ui->actionAdd_Agents->setEnabled(controlsEnabled);
 }
 
 bool VersionPage::reloadPackProfile()
@@ -339,6 +341,18 @@ void VersionPage::on_actionReplace_Minecraft_jar_triggered()
     {
         m_profile->installCustomJar(jarPath);
     }
+    updateButtons();
+}
+
+
+void VersionPage::on_actionAdd_Agents_triggered()
+{
+    QStringList list = GuiUtil::BrowseForFiles("agent", tr("Select agents"), tr("Java agents (*.jar)"),
+                                               APPLICATION->settings()->get("CentralModsDir").toString(), this->parentWidget());
+
+    if (!list.isEmpty())
+        m_profile->installAgents(list);
+
     updateButtons();
 }
 

--- a/launcher/ui/pages/instance/VersionPage.h
+++ b/launcher/ui/pages/instance/VersionPage.h
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  PolyMC - Minecraft Launcher
+ *  Prism Launcher - Minecraft Launcher
  *  Copyright (c) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
+ *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -82,6 +83,7 @@ private slots:
     void on_actionMove_down_triggered();
     void on_actionAdd_to_Minecraft_jar_triggered();
     void on_actionReplace_Minecraft_jar_triggered();
+    void on_actionAdd_Agents_triggered();
     void on_actionRevert_triggered();
     void on_actionEdit_triggered();
     void on_actionInstall_mods_triggered();

--- a/launcher/ui/pages/instance/VersionPage.ui
+++ b/launcher/ui/pages/instance/VersionPage.ui
@@ -109,6 +109,7 @@
    <addaction name="separator"/>
    <addaction name="actionAdd_to_Minecraft_jar"/>
    <addaction name="actionReplace_Minecraft_jar"/>
+   <addaction name="actionAdd_Agents"/>
    <addaction name="actionAdd_Empty"/>
    <addaction name="separator"/>
    <addaction name="actionMinecraftFolder"/>
@@ -224,6 +225,14 @@
   <action name="actionReplace_Minecraft_jar">
    <property name="text">
     <string>Replace Minecraft.jar</string>
+   </property>
+  </action>
+  <action name="actionAdd_Agents">
+   <property name="text">
+	<string>Add Agents</string>
+   </property>
+   <property name="toolTip">
+	<string>Add Java agents.</string>
    </property>
   </action>
   <action name="actionAdd_Empty">


### PR DESCRIPTION
This is an alternative (and hopefully better) implementation to the first one I suggested with a separate setting. It acts similar to the Minecraft.jar buttons. Fixes #414. Could potentially be tweaked to have its own folder like jarmods.
Unfortunately duplicates code.

![image](https://user-images.githubusercontent.com/57493648/200552753-0a1f9cd1-5ec8-476f-8765-c52e0415ad0b.png)


<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
