### PR TITLE
Remove memory allocation restrictions for JVM arguments

### DIFF
--- a/launcher/JavaCommon.cpp
+++ b/launcher/JavaCommon.cpp
@@ -41,11 +41,10 @@
 
 bool JavaCommon::checkJVMArgs(QString jvmargs, QWidget *parent)
 {
-    if (jvmargs.contains("-XX:PermSize=") || jvmargs.contains(QRegularExpression("-Xm[sx]"))
-        || jvmargs.contains("-XX-MaxHeapSize") || jvmargs.contains("-XX:InitialHeapSize"))
+    if (jvmargs.contains("-XX:PermSize=") || jvmargs.contains("-XX-MaxHeapSize") || jvmargs.contains("-XX:InitialHeapSize"))
     {
         auto warnStr = QObject::tr(
-            "You tried to manually set a JVM memory option (using \"-XX:PermSize\", \"-XX-MaxHeapSize\", \"-XX:InitialHeapSize\", \"-Xmx\" or \"-Xms\").\n"
+            "You tried to manually set a JVM memory option (using \"-XX:PermSize\", \"-XX-MaxHeapSize\", \"-XX:InitialHeapSize\").\n"
             "There are dedicated boxes for these in the settings (Java tab, in the Memory group at the top).\n"
             "This message will be displayed until you remove them from the JVM arguments.");
         CustomMessageBox::selectable(

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -383,9 +383,6 @@ QStringList MinecraftInstance::javaArguments()
 {
     QStringList args;
 
-    // custom args go first. we want to override them if we have our own here.
-    args.append(extraArguments());
-
     // OSX dock icon and name
 #ifdef Q_OS_MAC
     args << "-Xdock:icon=icon.png";
@@ -432,6 +429,9 @@ QStringList MinecraftInstance::javaArguments()
     }
 
     args << "-Duser.language=en";
+    
+    // override if any custom arg is set
+    args.append(extraArguments());
 
     return args;
 }


### PR DESCRIPTION
-- also check first for boxses then with custom args to override it.

Signed-off-by: Edgars Cīrulis <edgarsscirulis@gmail.com>