### PR TITLE
Better Blocked Mods Dialog

### DIFF
--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -393,8 +393,12 @@ void FlameCreationTask::idResolverSucceeded(QEventLoop& loop)
         qWarning() << "Blocked mods found, displaying mod list";
 
         auto message_dialog = new BlockedModsDialog(m_parent, tr("Blocked mods found"),
-                                                   tr("The following mods were blocked on third party launchers.<br/>"
-                                                      "You will need to manually download them and add them to the modpack"),
+                                                   tr("The following files are not available for download in third party launchers.<br/>"
+                                                      "You will need to manually download them and add them to the instance.<br/><br/>"
+                                                      "Your configured global mods folder and default downloads folder<br/>"
+                                                      "are automatically checked for the downloaded mods.<br/>"
+                                                      "Optionally, you may drag and drop the downloaded mods onto this dialog or add a folder to watch<br/>"
+                                                      "if you did not download the mods to a default location."),
                                                    blocked_mods);
         message_dialog->setModal(true);
 

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -393,13 +393,10 @@ void FlameCreationTask::idResolverSucceeded(QEventLoop& loop)
         qWarning() << "Blocked mods found, displaying mod list";
 
         auto message_dialog = new BlockedModsDialog(m_parent, tr("Blocked mods found"),
-                                                   tr("The following files are not available for download in third party launchers.<br/>"
-                                                      "You will need to manually download them and add them to the instance.<br/><br/>"
-                                                      "Your configured global mods folder and default downloads folder<br/>"
-                                                      "are automatically checked for the downloaded mods and they will be copied to the instance if found.<br/>"
-                                                      "Optionally, you may drag and drop the downloaded mods onto this dialog or add a folder to watch<br/>"
-                                                      "if you did not download the mods to a default location."),
-                                                   blocked_mods);
+                                                    tr("The following files are not available for download in third party launchers.<br/>"
+                                                       "You will need to manually download them and add them to the instance."),
+                                                    blocked_mods);
+
         message_dialog->setModal(true);
 
         if (message_dialog->exec()) {

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -396,7 +396,7 @@ void FlameCreationTask::idResolverSucceeded(QEventLoop& loop)
                                                    tr("The following files are not available for download in third party launchers.<br/>"
                                                       "You will need to manually download them and add them to the instance.<br/><br/>"
                                                       "Your configured global mods folder and default downloads folder<br/>"
-                                                      "are automatically checked for the downloaded mods.<br/>"
+                                                      "are automatically checked for the downloaded mods and they will be copied to the instance if found.<br/>"
                                                       "Optionally, you may drag and drop the downloaded mods onto this dialog or add a folder to watch<br/>"
                                                       "if you did not download the mods to a default location."),
                                                    blocked_mods);

--- a/launcher/modplatform/modpacksch/FTBPackInstallTask.cpp
+++ b/launcher/modplatform/modpacksch/FTBPackInstallTask.cpp
@@ -211,22 +211,17 @@ void PackInstallTask::onResolveModsSucceeded()
         qDebug() << "Blocked files found, displaying file list";
 
         auto message_dialog = new BlockedModsDialog(m_parent, tr("Blocked files found"),
-                                                   tr("The following files are not available for download in third party launchers.<br/>"
-                                                      "You will need to manually download them and add them to the instance.<br/><br/>"
-                                                      "Your configured global mods folder and default downloads folder<br/>"
-                                                      "are automatically checked for the downloaded mods and they will be copied to the instance if found.<br/>"
-                                                      "Optionally, you may drag and drop the downloaded mods onto this dialog or add a folder to watch<br/>"
-                                                      "if you did not download the mods to a default location."),
-                                                   m_blocked_mods);
+                                                    tr("The following files are not available for download in third party launchers.<br/>"
+                                                       "You will need to manually download them and add them to the instance."),
+                                                    m_blocked_mods);
 
         if (message_dialog->exec() == QDialog::Accepted) {
             qDebug() << "Post dialog blocked mods list: " << m_blocked_mods;
             createInstance();
-        }  
-        else {
+        } else {
             abort();
         }
-            
+
     } else {
         createInstance();
     }

--- a/launcher/modplatform/modpacksch/FTBPackInstallTask.cpp
+++ b/launcher/modplatform/modpacksch/FTBPackInstallTask.cpp
@@ -214,7 +214,7 @@ void PackInstallTask::onResolveModsSucceeded()
                                                    tr("The following files are not available for download in third party launchers.<br/>"
                                                       "You will need to manually download them and add them to the instance.<br/><br/>"
                                                       "Your configured global mods folder and default downloads folder<br/>"
-                                                      "are automatically checked for the downloaded mods.<br/>"
+                                                      "are automatically checked for the downloaded mods and they will be copied to the instance if found.<br/>"
                                                       "Optionally, you may drag and drop the downloaded mods onto this dialog or add a folder to watch<br/>"
                                                       "if you did not download the mods to a default location."),
                                                    m_blocked_mods);

--- a/launcher/modplatform/modpacksch/FTBPackInstallTask.cpp
+++ b/launcher/modplatform/modpacksch/FTBPackInstallTask.cpp
@@ -212,7 +212,11 @@ void PackInstallTask::onResolveModsSucceeded()
 
         auto message_dialog = new BlockedModsDialog(m_parent, tr("Blocked files found"),
                                                    tr("The following files are not available for download in third party launchers.<br/>"
-                                                      "You will need to manually download them and add them to the instance."),
+                                                      "You will need to manually download them and add them to the instance.<br/><br/>"
+                                                      "Your configured global mods folder and default downloads folder<br/>"
+                                                      "are automatically checked for the downloaded mods.<br/>"
+                                                      "Optionally, you may drag and drop the downloaded mods onto this dialog or add a folder to watch<br/>"
+                                                      "if you did not download the mods to a default location."),
                                                    m_blocked_mods);
 
         if (message_dialog->exec() == QDialog::Accepted) {

--- a/launcher/ui/dialogs/BlockedModsDialog.cpp
+++ b/launcher/ui/dialogs/BlockedModsDialog.cpp
@@ -39,11 +39,14 @@ BlockedModsDialog::BlockedModsDialog(QWidget* parent, const QString& title, cons
                    "are automatically checked for the downloaded mods and they will be copied to the instance if found.<br/>"
                    "Optionally, you may drag and drop the downloaded mods onto this dialog or add a folder to watch "
                    "if you did not download the mods to a default location.<br/><br/>"
-                   "Global Mods Folder: %1<br/>"
-                   "Default Downloads Folder: %2"))
+                   "Global Mods Folder: <a href=\"%1\">%1</a><br/>"
+                   "Default Downloads Folder: <a href=\"%2\">%2</a>"))
             .arg(APPLICATION->settings()->get("CentralModsDir").toString(),
                  QStandardPaths::writableLocation(QStandardPaths::DownloadLocation)));
     ui->labelModsFound->setText(tr("Please download the missing mods."));
+
+    // force all URL handeling as external
+    connect(ui->textBrowserWatched, &QTextBrowser::anchorClicked, this, [](const QUrl url) { QDesktopServices::openUrl(url); });
 
     setAcceptDrops(true);
 
@@ -118,7 +121,7 @@ void BlockedModsDialog::update()
 
     QString watching;
     for (auto& dir : m_watcher.directories()) {
-        watching += QString("%1<br/>").arg(dir);
+        watching += QString("<a href=\"%1\">%1</a><br/>").arg(dir);
     }
 
     ui->textBrowserWatched->setText(watching);

--- a/launcher/ui/dialogs/BlockedModsDialog.cpp
+++ b/launcher/ui/dialogs/BlockedModsDialog.cpp
@@ -1,4 +1,5 @@
 #include "BlockedModsDialog.h"
+#include <qfileinfo.h>
 #include <QDesktopServices>
 #include <QDialogButtonBox>
 #include <QPushButton>
@@ -13,9 +14,10 @@
 #include <QFileInfo>
 
 BlockedModsDialog::BlockedModsDialog(QWidget* parent, const QString& title, const QString& text, QList<BlockedMod>& mods)
-    : QDialog(parent), ui(new Ui::BlockedModsDialog), mods(mods)
+    : QDialog(parent), ui(new Ui::BlockedModsDialog), m_mods(mods)
 {
-    hashing_task = shared_qobject_ptr<ConcurrentTask>(new ConcurrentTask(this, "MakeHashesTask", 10));
+    m_hashing_task = shared_qobject_ptr<ConcurrentTask>(new ConcurrentTask(this, "MakeHashesTask", 10));
+    connect(m_hashing_task.get(), &Task::finished, this, &BlockedModsDialog::hashTaskFinished);
     
     ui->setupUi(this);
 
@@ -25,11 +27,11 @@ BlockedModsDialog::BlockedModsDialog(QWidget* parent, const QString& title, cons
     auto downloadFolderButton = ui->buttonBox->addButton(tr("Add Download Folder"), QDialogButtonBox::ActionRole);
     connect(downloadFolderButton, &QPushButton::clicked, this, &BlockedModsDialog::addDownloadFolder);
 
-    connect(&watcher, &QFileSystemWatcher::directoryChanged, this, &BlockedModsDialog::directoryChanged);
+    connect(&m_watcher, &QFileSystemWatcher::directoryChanged, this, &BlockedModsDialog::directoryChanged);
 
     
 
-    qDebug() << "Mods List: " << mods;
+    qDebug() << "[Blocked Mods Dialog] Mods List: " << mods;
 
     setupWatch();
     scanPaths();
@@ -57,16 +59,23 @@ void BlockedModsDialog::dragEnterEvent(QDragEnterEvent *e) {
 void BlockedModsDialog::dropEvent(QDropEvent *e)
 {
     foreach (const QUrl &url, e->mimeData()->urls()) {
-        QString file = url.toLocalFile();
-        qDebug() << "Dropped file:" << file;
-        addHashTask(file);
+        QString filePath = url.toLocalFile();
+        qDebug() << "[Blocked Mods Dialog] Dropped file:" << filePath;
+        addHashTask(filePath);
+
+        // watch for changes
+        QFileInfo file = QFileInfo(filePath);
+        QString path = file.dir().absolutePath();
+        qDebug() << "[Blocked Mods Dialog] Adding watch path:" << path;
+        m_watcher.addPath(path);
     }
-    hashing_task->start();
+    scanPaths();
+    update();
 }
 
 void BlockedModsDialog::openAll()
 {
-    for (auto& mod : mods) {
+    for (auto& mod : m_mods) {
         QDesktopServices::openUrl(mod.websiteUrl);
     }
 }
@@ -77,8 +86,10 @@ void BlockedModsDialog::addDownloadFolder() {
         tr("Select directory where you downloaded the mods"),
         QStandardPaths::writableLocation(QStandardPaths::DownloadLocation),
         QFileDialog::ShowDirsOnly);
-    watcher.addPath(dir);
-    scanPath(dir);
+    qDebug() << "[Blocked Mods Dialog] Adding watch path:" << dir;
+    m_watcher.addPath(dir);
+    scanPath(dir, true);
+    update();
 }
 
 /// @brief update UI with current status of the blocked mod detection
@@ -87,7 +98,7 @@ void BlockedModsDialog::update()
     QString text;
     QString span;
 
-    for (auto& mod : mods) {
+    for (auto& mod : m_mods) {
         if (mod.matched) {
             // &#x2714; -> html for HEAVY CHECK MARK : ✔
             span = QString(tr("<span style=\"color:green\"> &#x2714; Found at %1 </span>")).arg(mod.localPath);
@@ -111,9 +122,9 @@ void BlockedModsDialog::update()
 /// @param path the path to the changed directory
 void BlockedModsDialog::directoryChanged(QString path)
 {
-    qDebug() << "Directory changed: " << path;
+    qDebug() << "[Blocked Mods Dialog] Directory changed: " << path;
     validateMatchedMods();
-    scanPath(path);
+    scanPath(path, true);
 }
 
 /// @brief add the user downloads folder and the global mods folder to the filesystem watcher
@@ -121,22 +132,23 @@ void BlockedModsDialog::setupWatch()
 {
     const QString downloadsFolder = QStandardPaths::writableLocation(QStandardPaths::DownloadLocation);
     const QString modsFolder = APPLICATION->settings()->get("CentralModsDir").toString();
-    watcher.addPath(downloadsFolder);
-    watcher.addPath(modsFolder);
+    m_watcher.addPath(downloadsFolder);
+    m_watcher.addPath(modsFolder);
 }
 
 /// @brief scan all watched folder
 void BlockedModsDialog::scanPaths()
 {
-    for (auto& dir : watcher.directories()) {
-        scanPath(dir);
+    for (auto& dir : m_watcher.directories()) {
+        scanPath(dir, false);
     }
+    runHashTask();
 }
 
 /// @brief Scan the directory at path, skip paths that do not contain a file name
 ///        of a blocked mod we are looking for
 /// @param path the directory to scan
-void BlockedModsDialog::scanPath(QString path)
+void BlockedModsDialog::scanPath(QString path, bool start_task)
 {
     QDir scan_dir(path);
     QDirIterator scan_it(path, QDir::Filter::Files | QDir::Filter::Hidden, QDirIterator::NoIteratorFlags);
@@ -150,21 +162,35 @@ void BlockedModsDialog::scanPath(QString path)
         addHashTask(file);
     }
 
-    hashing_task->start();
+    if (start_task) {
+        runHashTask();
+    }
+
+}
+
+/// @brief add a hashing task for the file located at path, add the path to the pending set if the hasing task is already running
+/// @param path the path to the local file being hashed
+void BlockedModsDialog::addHashTask(QString path) {
+    if (m_hashing_task->isRunning()) {
+        qDebug() << "[Blocked Mods Dialog] adding a Hash task for" << path << "to the pending set.";
+        m_pending_hash_paths.insert(path);
+    } else {
+        buildHashTask(path);
+    }
 }
 
 /// @brief add a hashing task for the file located at path and connect it to check that hash against 
 ///        our blocked mods list
 /// @param path the path to the local file being hashed
-void BlockedModsDialog::addHashTask(QString path) {
+void BlockedModsDialog::buildHashTask(QString path) {
     auto hash_task = Hashing::createBlockedModHasher(path, ModPlatform::Provider::FLAME, "sha1");
 
-    qDebug() << "Creating Hash task for path: " << path;
+    qDebug() << "[Blocked Mods Dialog] Creating Hash task for path: " << path;
 
     connect(hash_task.get(), &Task::succeeded, [this, hash_task, path] { checkMatchHash(hash_task->getResult(), path); });
     connect(hash_task.get(), &Task::failed, [path] { qDebug() << "Failed to hash path: " << path; });
 
-    hashing_task->addTask(hash_task);
+    m_hashing_task->addTask(hash_task);
 }
 
 /// @brief check if the computed hash for the provided path matches a blocked
@@ -175,9 +201,9 @@ void BlockedModsDialog::checkMatchHash(QString hash, QString path)
 {
     bool match = false;
 
-    qDebug() << "Checking for match on hash: " << hash << "| From path:" << path;
+    qDebug() << "[Blocked Mods Dialog] Checking for match on hash: " << hash << "| From path:" << path;
 
-    for (auto& mod : mods) {
+    for (auto& mod : m_mods) {
         if (mod.matched) {
             continue;
         }
@@ -186,7 +212,7 @@ void BlockedModsDialog::checkMatchHash(QString hash, QString path)
             mod.localPath = path;
             match = true;
 
-            qDebug() << "Hash match found:" << mod.name << hash << "| From path:" << path;
+            qDebug() << "[Blocked Mods Dialog] Hash match found:" << mod.name << hash << "| From path:" << path;
 
             break;
         }
@@ -205,9 +231,9 @@ bool BlockedModsDialog::checkValidPath(QString path)
     QFileInfo file = QFileInfo(path);
     QString filename = file.fileName();
 
-    for (auto& mod : mods) {
+    for (auto& mod : m_mods) {
         if (mod.name.compare(filename, Qt::CaseInsensitive) == 0) {
-            qDebug() << "Name match found:" << mod.name << "| From path:" << path;
+            qDebug() << "[Blocked Mods Dialog] Name match found:" << mod.name << "| From path:" << path;
             return true;
         }
     }
@@ -217,13 +243,13 @@ bool BlockedModsDialog::checkValidPath(QString path)
 
 bool BlockedModsDialog::allModsMatched()
 {
-    return std::all_of(mods.begin(), mods.end(), [](auto const& mod) { return mod.matched; });
+    return std::all_of(m_mods.begin(), m_mods.end(), [](auto const& mod) { return mod.matched; });
 }
 
 /// @brief ensure matched file paths still exist
 void BlockedModsDialog::validateMatchedMods() {
     bool changed = false;
-    for (auto& mod : mods) {
+    for (auto& mod : m_mods) {
         if (mod.matched) {
             QFileInfo file = QFileInfo(mod.localPath);
             if (!file.exists() || !file.isFile()) {
@@ -235,6 +261,33 @@ void BlockedModsDialog::validateMatchedMods() {
     }
     if (changed) {
         update();
+    }
+}
+
+/// @brief run hast task or mark a pending run if it is already runing
+void BlockedModsDialog::runHashTask() {
+    if (!m_hashing_task->isRunning()) {
+        m_rehash_pending = false;
+        m_hashing_task->start();
+    } else {
+        qDebug() << "[Blocked Mods Dialog] queueing another run of the hashing task";
+        qDebug() << "[Blocked Mods Dialog] pending hash tasks:" << m_pending_hash_paths;
+        m_rehash_pending = true;
+    }
+}
+
+void BlockedModsDialog::hashTaskFinished() {
+    qDebug() << "[Blocked Mods Dialog] All hash tasks finished";
+    if (m_rehash_pending) {
+        qDebug() << "[Blocked Mods Dialog] there was a pending rehash, building and running tasks";
+
+        auto path = m_pending_hash_paths.begin();
+        while (path != m_pending_hash_paths.end()) {
+            buildHashTask(*path);
+            path = m_pending_hash_paths.erase(path);
+        }
+
+        runHashTask();
     }
 }
 

--- a/launcher/ui/dialogs/BlockedModsDialog.cpp
+++ b/launcher/ui/dialogs/BlockedModsDialog.cpp
@@ -6,19 +6,18 @@
 #include "Application.h"
 #include "ui_BlockedModsDialog.h"
 
-
 #include <QDebug>
-#include <QStandardPaths>
 #include <QDragEnterEvent>
 #include <QFileDialog>
 #include <QFileInfo>
+#include <QStandardPaths>
 
 BlockedModsDialog::BlockedModsDialog(QWidget* parent, const QString& title, const QString& text, QList<BlockedMod>& mods)
     : QDialog(parent), ui(new Ui::BlockedModsDialog), m_mods(mods)
 {
     m_hashing_task = shared_qobject_ptr<ConcurrentTask>(new ConcurrentTask(this, "MakeHashesTask", 10));
     connect(m_hashing_task.get(), &Task::finished, this, &BlockedModsDialog::hashTaskFinished);
-    
+
     ui->setupUi(this);
 
     auto openAllButton = ui->buttonBox->addButton(tr("Open All"), QDialogButtonBox::ActionRole);
@@ -28,8 +27,6 @@ BlockedModsDialog::BlockedModsDialog(QWidget* parent, const QString& title, cons
     connect(downloadFolderButton, &QPushButton::clicked, this, &BlockedModsDialog::addDownloadFolder);
 
     connect(&m_watcher, &QFileSystemWatcher::directoryChanged, this, &BlockedModsDialog::directoryChanged);
-
-    
 
     qDebug() << "[Blocked Mods Dialog] Mods List: " << mods;
 
@@ -50,15 +47,16 @@ BlockedModsDialog::~BlockedModsDialog()
     delete ui;
 }
 
-void BlockedModsDialog::dragEnterEvent(QDragEnterEvent *e) {
+void BlockedModsDialog::dragEnterEvent(QDragEnterEvent* e)
+{
     if (e->mimeData()->hasUrls()) {
         e->acceptProposedAction();
     }
 }
 
-void BlockedModsDialog::dropEvent(QDropEvent *e)
+void BlockedModsDialog::dropEvent(QDropEvent* e)
 {
-    foreach (const QUrl &url, e->mimeData()->urls()) {
+    foreach (const QUrl& url, e->mimeData()->urls()) {
         QString filePath = url.toLocalFile();
         qDebug() << "[Blocked Mods Dialog] Dropped file:" << filePath;
         addHashTask(filePath);
@@ -80,12 +78,11 @@ void BlockedModsDialog::openAll()
     }
 }
 
-void BlockedModsDialog::addDownloadFolder() {
-    QString dir = QFileDialog::getExistingDirectory(
-        this,
-        tr("Select directory where you downloaded the mods"),
-        QStandardPaths::writableLocation(QStandardPaths::DownloadLocation),
-        QFileDialog::ShowDirsOnly);
+void BlockedModsDialog::addDownloadFolder()
+{
+    QString dir =
+        QFileDialog::getExistingDirectory(this, tr("Select directory where you downloaded the mods"),
+                                          QStandardPaths::writableLocation(QStandardPaths::DownloadLocation), QFileDialog::ShowDirsOnly);
     qDebug() << "[Blocked Mods Dialog] Adding watch path:" << dir;
     m_watcher.addPath(dir);
     scanPath(dir, true);
@@ -165,12 +162,12 @@ void BlockedModsDialog::scanPath(QString path, bool start_task)
     if (start_task) {
         runHashTask();
     }
-
 }
 
 /// @brief add a hashing task for the file located at path, add the path to the pending set if the hasing task is already running
 /// @param path the path to the local file being hashed
-void BlockedModsDialog::addHashTask(QString path) {
+void BlockedModsDialog::addHashTask(QString path)
+{
     if (m_hashing_task->isRunning()) {
         qDebug() << "[Blocked Mods Dialog] adding a Hash task for" << path << "to the pending set.";
         m_pending_hash_paths.insert(path);
@@ -179,10 +176,11 @@ void BlockedModsDialog::addHashTask(QString path) {
     }
 }
 
-/// @brief add a hashing task for the file located at path and connect it to check that hash against 
+/// @brief add a hashing task for the file located at path and connect it to check that hash against
 ///        our blocked mods list
 /// @param path the path to the local file being hashed
-void BlockedModsDialog::buildHashTask(QString path) {
+void BlockedModsDialog::buildHashTask(QString path)
+{
     auto hash_task = Hashing::createBlockedModHasher(path, ModPlatform::Provider::FLAME, "sha1");
 
     qDebug() << "[Blocked Mods Dialog] Creating Hash task for path: " << path;
@@ -247,7 +245,8 @@ bool BlockedModsDialog::allModsMatched()
 }
 
 /// @brief ensure matched file paths still exist
-void BlockedModsDialog::validateMatchedMods() {
+void BlockedModsDialog::validateMatchedMods()
+{
     bool changed = false;
     for (auto& mod : m_mods) {
         if (mod.matched) {
@@ -264,8 +263,9 @@ void BlockedModsDialog::validateMatchedMods() {
     }
 }
 
-/// @brief run hast task or mark a pending run if it is already runing
-void BlockedModsDialog::runHashTask() {
+/// @brief run hash task or mark a pending run if it is already runing
+void BlockedModsDialog::runHashTask()
+{
     if (!m_hashing_task->isRunning()) {
         m_rehash_pending = false;
         m_hashing_task->start();
@@ -276,7 +276,8 @@ void BlockedModsDialog::runHashTask() {
     }
 }
 
-void BlockedModsDialog::hashTaskFinished() {
+void BlockedModsDialog::hashTaskFinished()
+{
     qDebug() << "[Blocked Mods Dialog] All hash tasks finished";
     if (m_rehash_pending) {
         qDebug() << "[Blocked Mods Dialog] there was a pending rehash, building and running tasks";

--- a/launcher/ui/dialogs/BlockedModsDialog.cpp
+++ b/launcher/ui/dialogs/BlockedModsDialog.cpp
@@ -38,12 +38,9 @@ BlockedModsDialog::BlockedModsDialog(QWidget* parent, const QString& title, cons
         QString(tr("Your configured global mods folder and default downloads folder "
                    "are automatically checked for the downloaded mods and they will be copied to the instance if found.<br/>"
                    "Optionally, you may drag and drop the downloaded mods onto this dialog or add a folder to watch "
-                   "if you did not download the mods to a default location.<br/><br/>"
-                   "Global Mods Folder: <a href=\"%1\">%1</a><br/>"
-                   "Default Downloads Folder: <a href=\"%2\">%2</a>"))
+                   "if you did not download the mods to a default location."))
             .arg(APPLICATION->settings()->get("CentralModsDir").toString(),
                  QStandardPaths::writableLocation(QStandardPaths::DownloadLocation)));
-    ui->labelModsFound->setText(tr("Please download the missing mods."));
 
     // force all URL handeling as external
     connect(ui->textBrowserWatched, &QTextBrowser::anchorClicked, this, [](const QUrl url) { QDesktopServices::openUrl(url); });
@@ -127,7 +124,7 @@ void BlockedModsDialog::update()
     ui->textBrowserWatched->setText(watching);
 
     if (allModsMatched()) {
-        ui->labelModsFound->setText(tr("All mods found ✔"));
+        ui->labelModsFound->setText("<span style=\"color:green\">✔</span>" + tr("All mods found"));
     } else {
         ui->labelModsFound->setText(tr("Please download the missing mods."));
     }

--- a/launcher/ui/dialogs/BlockedModsDialog.h
+++ b/launcher/ui/dialogs/BlockedModsDialog.h
@@ -33,8 +33,6 @@ public:
 
 protected:
     void dragEnterEvent(QDragEnterEvent *event) override;
-    // void dragMoveEvent(QDragMoveEvent *event) override;
-    // void dragLeaveEvent(QDragLeaveEvent *event) override;
     void dropEvent(QDropEvent *event) override;
 
 private:

--- a/launcher/ui/dialogs/BlockedModsDialog.h
+++ b/launcher/ui/dialogs/BlockedModsDialog.h
@@ -31,6 +31,11 @@ public:
 
     ~BlockedModsDialog() override;
 
+protected:
+    void dragEnterEvent(QDragEnterEvent *event) override;
+    // void dragMoveEvent(QDragMoveEvent *event) override;
+    // void dragLeaveEvent(QDragLeaveEvent *event) override;
+    void dropEvent(QDropEvent *event) override;
 
 private:
     Ui::BlockedModsDialog *ui;
@@ -39,12 +44,15 @@ private:
     shared_qobject_ptr<ConcurrentTask> hashing_task;
 
     void openAll();
+    void addDownloadFolder();
     void update();
     void directoryChanged(QString path);
     void setupWatch();
     void scanPaths();
     void scanPath(QString path);
+    void addHashTask(QString path);
     void checkMatchHash(QString hash, QString path);
+    void validateMatchedMods();
 
     bool checkValidPath(QString path);
     bool allModsMatched();

--- a/launcher/ui/dialogs/BlockedModsDialog.h
+++ b/launcher/ui/dialogs/BlockedModsDialog.h
@@ -39,9 +39,11 @@ protected:
 
 private:
     Ui::BlockedModsDialog *ui;
-    QList<BlockedMod> &mods;
-    QFileSystemWatcher watcher;
-    shared_qobject_ptr<ConcurrentTask> hashing_task;
+    QList<BlockedMod> &m_mods;
+    QFileSystemWatcher m_watcher;
+    shared_qobject_ptr<ConcurrentTask> m_hashing_task;
+    QSet<QString> m_pending_hash_paths;
+    bool m_rehash_pending;
 
     void openAll();
     void addDownloadFolder();
@@ -49,10 +51,13 @@ private:
     void directoryChanged(QString path);
     void setupWatch();
     void scanPaths();
-    void scanPath(QString path);
+    void scanPath(QString path, bool start_task);
     void addHashTask(QString path);
+    void buildHashTask(QString path);
     void checkMatchHash(QString hash, QString path);
     void validateMatchedMods();
+    void runHashTask();
+    void hashTaskFinished();
 
     bool checkValidPath(QString path);
     bool allModsMatched();

--- a/launcher/ui/dialogs/BlockedModsDialog.ui
+++ b/launcher/ui/dialogs/BlockedModsDialog.ui
@@ -15,22 +15,76 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QLabel" name="label">
+    <widget class="QLabel" name="labelDescription">
      <property name="text">
       <string notr="true"/>
      </property>
      <property name="textFormat">
       <enum>Qt::RichText</enum>
      </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item>
-    <widget class="QTextBrowser" name="textBrowser">
+    <widget class="QLabel" name="labelExplain">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTextBrowser" name="textBrowserModsListing">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>165</height>
+      </size>
+     </property>
      <property name="acceptRichText">
       <bool>true</bool>
      </property>
      <property name="openExternalLinks">
       <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="labelWatched">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>1</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Watched Folders:</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTextBrowser" name="textBrowserWatched">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>16</height>
+      </size>
+     </property>
+     <property name="baseSize">
+      <size>
+       <width>0</width>
+       <height>12</height>
+      </size>
      </property>
     </widget>
    </item>

--- a/launcher/ui/dialogs/BlockedModsDialog.ui
+++ b/launcher/ui/dialogs/BlockedModsDialog.ui
@@ -35,6 +35,9 @@
      <property name="wordWrap">
       <bool>true</bool>
      </property>
+     <property name="openExternalLinks">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item>
@@ -85,6 +88,12 @@
        <width>0</width>
        <height>12</height>
       </size>
+     </property>
+     <property name="openExternalLinks">
+      <bool>true</bool>
+     </property>
+     <property name="openLinks">
+      <bool>false</bool>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
In the now merged PR it was brought up that drag and drop and a browse button would help things along.

I looked into it and it was *super* easy so here we go.

Additionally I added a better description to the dialog and added a check to ensure the matched mod paths still exist if the watcher detects a change.

also ensured that if a hash task was already running a new has task would get properly enqueued.

![image](https://user-images.githubusercontent.com/508861/201441366-2027012e-ccc1-4158-befa-dd715650db35.png)

