### PR TITLE
Remove the clear button in the instance settings page's filter edits

### DIFF
--- a/launcher/ui/pages/instance/ExternalResourcesPage.ui
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.ui
@@ -27,11 +27,7 @@
     <item row="4" column="1" colspan="3">
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="1">
-       <widget class="QLineEdit" name="filterEdit">
-        <property name="clearButtonEnabled">
-         <bool>true</bool>
-        </property>
-       </widget>
+       <widget class="QLineEdit" name="filterEdit"/>
       </item>
       <item row="0" column="0">
        <widget class="QLabel" name="filterLabel">

--- a/launcher/ui/pages/instance/VersionPage.ui
+++ b/launcher/ui/pages/instance/VersionPage.ui
@@ -48,11 +48,7 @@
       <item>
        <layout class="QGridLayout" name="gridLayout_2">
         <item row="0" column="1">
-         <widget class="QLineEdit" name="filterEdit">
-          <property name="clearButtonEnabled">
-           <bool>true</bool>
-          </property>
-         </widget>
+         <widget class="QLineEdit" name="filterEdit"/>
         </item>
         <item row="0" column="0">
          <widget class="QLabel" name="filterLabel">


### PR DESCRIPTION
Should improve a bit the time it takes to open the instance settings after clicking the 'Edit' button

From my tests, I got, opening the same instance 6 times in a row:
Without this patch: `InstancePageProvider::getPages` takes 33.1% of the inclusive cost overall 
With the patch: `InstancePageProvider::getPages` takes 17.4% of the inclusive cost overall

(inclusive cost = cost of self + cost of all called functions)

big :iea: