### PR TITLE
Fixup Warnings in MSVC build

### DIFF
--- a/launcher/BaseInstance.h
+++ b/launcher/BaseInstance.h
@@ -151,7 +151,7 @@ public:
     void copyManagedPack(BaseInstance& other);
 
     /// guess log level from a line of game log
-    virtual MessageLevel::Enum guessLevel(const QString &line, MessageLevel::Enum level)
+    virtual MessageLevel::Enum guessLevel([[maybe_unused]] const QString &line, MessageLevel::Enum level)
     {
         return level;
     };

--- a/launcher/BaseVersionList.cpp
+++ b/launcher/BaseVersionList.cpp
@@ -95,12 +95,12 @@ BaseVersionList::RoleList BaseVersionList::providesRoles() const
 int BaseVersionList::rowCount(const QModelIndex &parent) const
 {
     // Return count
-    return count();
+    return parent.isValid() ? 0 : count();
 }
 
 int BaseVersionList::columnCount(const QModelIndex &parent) const
 {
-    return 1;
+    return parent.isValid() ? 0 : 1;
 }
 
 QHash<int, QByteArray> BaseVersionList::roleNames() const

--- a/launcher/VersionProxyModel.cpp
+++ b/launcher/VersionProxyModel.cpp
@@ -311,14 +311,14 @@ QModelIndex VersionProxyModel::index(int row, int column, const QModelIndex &par
 
 int VersionProxyModel::columnCount(const QModelIndex &parent) const
 {
-    return m_columns.size();
+    return parent.isValid() ? 0 : m_columns.size();
 }
 
 int VersionProxyModel::rowCount(const QModelIndex &parent) const
 {
     if(sourceModel())
     {
-        return sourceModel()->rowCount();
+        return sourceModel()->rowCount(parent);
     }
     return 0;
 }

--- a/launcher/icons/IconList.cpp
+++ b/launcher/icons/IconList.cpp
@@ -302,7 +302,7 @@ QVariant IconList::data(const QModelIndex &index, int role) const
 
 int IconList::rowCount(const QModelIndex &parent) const
 {
-    return icons.size();
+    return parent.isValid() ? 0 : icons.size();
 }
 
 void IconList::installIcons(const QStringList &iconFiles)

--- a/launcher/icons/IconList.cpp
+++ b/launcher/icons/IconList.cpp
@@ -242,7 +242,7 @@ Qt::DropActions IconList::supportedDropActions() const
     return Qt::CopyAction;
 }
 
-bool IconList::dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent)
+bool IconList::dropMimeData(const QMimeData *data, Qt::DropAction action, [[maybe_unused]] int row, [[maybe_unused]] int column, [[maybe_unused]] const QModelIndex &parent)
 {
     if (action == Qt::IgnoreAction)
         return true;

--- a/launcher/meta/Index.cpp
+++ b/launcher/meta/Index.cpp
@@ -58,11 +58,11 @@ QVariant Index::data(const QModelIndex &index, int role) const
 }
 int Index::rowCount(const QModelIndex &parent) const
 {
-    return m_lists.size();
+    return parent.isValid() ? 0 : m_lists.size();
 }
 int Index::columnCount(const QModelIndex &parent) const
 {
-    return 1;
+    return parent.isValid() ? 0 : 1;
 }
 QVariant Index::headerData(int section, Qt::Orientation orientation, int role) const
 {

--- a/launcher/meta/JsonFormat.h
+++ b/launcher/meta/JsonFormat.h
@@ -60,11 +60,6 @@ struct Require
     QString suggests;
 };
 
-inline Q_DECL_PURE_FUNCTION uint qHash(const Require &key, uint seed = 0) Q_DECL_NOTHROW
-{
-    return qHash(key.uid, seed);
-}
-
 using RequireSet = std::set<Require>;
 
 void parseIndex(const QJsonObject &obj, Index *ptr);

--- a/launcher/minecraft/PackProfile.cpp
+++ b/launcher/minecraft/PackProfile.cpp
@@ -675,12 +675,12 @@ Qt::ItemFlags PackProfile::flags(const QModelIndex &index) const
 
 int PackProfile::rowCount(const QModelIndex &parent) const
 {
-    return d->components.size();
+    return parent.isValid() ? 0 : d->components.size();
 }
 
 int PackProfile::columnCount(const QModelIndex &parent) const
 {
-    return NUM_COLUMNS;
+    return parent.isValid() ? 0 : NUM_COLUMNS;
 }
 
 void PackProfile::move(const int index, const MoveDirection direction)

--- a/launcher/minecraft/PackProfile.cpp
+++ b/launcher/minecraft/PackProfile.cpp
@@ -613,7 +613,7 @@ QVariant PackProfile::data(const QModelIndex &index, int role) const
 
 bool PackProfile::setData(const QModelIndex& index, const QVariant& value, int role)
 {
-    if (!index.isValid() || index.row() < 0 || index.row() >= rowCount(index))
+    if (!index.isValid() || index.row() < 0 || index.row() >= rowCount(index.parent()))
     {
         return false;
     }

--- a/launcher/minecraft/Rule.h
+++ b/launcher/minecraft/Rule.h
@@ -104,7 +104,7 @@ public:
 class ImplicitRule : public Rule
 {
 protected:
-    virtual bool applies(const Library *, const RuntimeContext & runtimeContext)
+    virtual bool applies(const Library *, [[maybe_unused]] const RuntimeContext & runtimeContext)
     {
         return true;
     }

--- a/launcher/minecraft/WorldList.cpp
+++ b/launcher/minecraft/WorldList.cpp
@@ -398,8 +398,8 @@ void WorldList::installWorld(QFileInfo filename)
     w.install(m_dir.absolutePath());
 }
 
-bool WorldList::dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column,
-                             const QModelIndex &parent)
+bool WorldList::dropMimeData(const QMimeData *data, Qt::DropAction action, [[maybe_unused]] int row, [[maybe_unused]] int column,
+                             [[maybe_unused]] const QModelIndex &parent)
 {
     if (action == Qt::IgnoreAction)
         return true;

--- a/launcher/minecraft/WorldList.cpp
+++ b/launcher/minecraft/WorldList.cpp
@@ -173,7 +173,7 @@ bool WorldList::resetIcon(int row)
 
 int WorldList::columnCount(const QModelIndex &parent) const
 {
-    return 4;
+    return parent.isValid()? 0 : 4;
 }
 
 QVariant WorldList::data(const QModelIndex &index, int role) const

--- a/launcher/minecraft/WorldList.h
+++ b/launcher/minecraft/WorldList.h
@@ -54,7 +54,7 @@ public:
 
     virtual int rowCount(const QModelIndex &parent = QModelIndex()) const
     {
-        return size();
+        return parent.isValid() ? 0 : static_cast<int>(size());
     };
     virtual QVariant headerData(int section, Qt::Orientation orientation,
                                 int role = Qt::DisplayRole) const;

--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -408,15 +408,15 @@ QVariant AccountList::headerData(int section, Qt::Orientation orientation, int r
     }
 }
 
-int AccountList::rowCount(const QModelIndex &) const
+int AccountList::rowCount(const QModelIndex &parent) const
 {
     // Return count
-    return count();
+    return parent.isValid() ? 0 : count();
 }
 
-int AccountList::columnCount(const QModelIndex &) const
+int AccountList::columnCount(const QModelIndex &parent) const
 {
-    return NUM_COLUMNS;
+    return parent.isValid() ? 0 : NUM_COLUMNS;
 }
 
 Qt::ItemFlags AccountList::flags(const QModelIndex &index) const

--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -421,7 +421,7 @@ int AccountList::columnCount(const QModelIndex &parent) const
 
 Qt::ItemFlags AccountList::flags(const QModelIndex &index) const
 {
-    if (index.row() < 0 || index.row() >= rowCount(index) || !index.isValid())
+    if (index.row() < 0 || index.row() >= rowCount(index.parent()) || !index.isValid())
     {
         return Qt::NoItemFlags;
     }

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -144,7 +144,7 @@ QVariant ModFolderModel::headerData(int section, Qt::Orientation orientation, in
 
 int ModFolderModel::columnCount(const QModelIndex &parent) const
 {
-    return NUM_COLUMNS;
+    return parent.isValid() ? 0 : NUM_COLUMNS;
 }
 
 Task* ModFolderModel::createUpdateTask()

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -426,7 +426,7 @@ QVariant ResourceFolderModel::data(const QModelIndex& index, int role) const
 bool ResourceFolderModel::setData(const QModelIndex& index, const QVariant& value, int role)
 {
     int row = index.row();
-    if (row < 0 || row >= rowCount(index) || !index.isValid())
+    if (row < 0 || row >= rowCount(index.parent()) || !index.isValid())
         return false;
 
     if (role == Qt::CheckStateRole)

--- a/launcher/minecraft/mod/ResourceFolderModel.h
+++ b/launcher/minecraft/mod/ResourceFolderModel.h
@@ -176,7 +176,7 @@ class ResourceFolderModel : public QAbstractListModel {
      *  if the resource is complex and has more stuff to parse.
      */
     virtual void onParseSucceeded(int ticket, QString resource_id);
-    virtual void onParseFailed([[maybe_unused]] int ticket, [[maybe_unused]] QString resource_id) {}
+    virtual void onParseFailed(int ticket, QString resource_id) { Q_UNUSED(ticket); Q_UNUSED(resource_id); }
 
    protected:
     // Represents the relationship between a column's index (represented by the list index), and it's sorting key.

--- a/launcher/minecraft/mod/ResourceFolderModel.h
+++ b/launcher/minecraft/mod/ResourceFolderModel.h
@@ -90,8 +90,8 @@ class ResourceFolderModel : public QAbstractListModel {
     /* Basic columns */
     enum Columns { ACTIVE_COLUMN = 0, NAME_COLUMN, DATE_COLUMN, NUM_COLUMNS };
 
-    [[nodiscard]] int rowCount(const QModelIndex& = {}) const override { return size(); }
-    [[nodiscard]] int columnCount(const QModelIndex& = {}) const override { return NUM_COLUMNS; };
+    [[nodiscard]] int rowCount(const QModelIndex& parent = {}) const override { return parent.isValid() ? 0 : static_cast<int>(size()); }
+    [[nodiscard]] int columnCount(const QModelIndex& parent = {}) const override { return parent.isValid() ? 0 : NUM_COLUMNS; };
 
     [[nodiscard]] Qt::DropActions supportedDropActions() const override;
 

--- a/launcher/minecraft/mod/ResourceFolderModel.h
+++ b/launcher/minecraft/mod/ResourceFolderModel.h
@@ -176,7 +176,7 @@ class ResourceFolderModel : public QAbstractListModel {
      *  if the resource is complex and has more stuff to parse.
      */
     virtual void onParseSucceeded(int ticket, QString resource_id);
-    virtual void onParseFailed(int ticket, QString resource_id) {}
+    virtual void onParseFailed([[maybe_unused]] int ticket, [[maybe_unused]] QString resource_id) {}
 
    protected:
     // Represents the relationship between a column's index (represented by the list index), and it's sorting key.

--- a/launcher/minecraft/mod/ResourcePackFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourcePackFolderModel.cpp
@@ -137,7 +137,7 @@ QVariant ResourcePackFolderModel::headerData(int section, Qt::Orientation orient
 
 int ResourcePackFolderModel::columnCount(const QModelIndex& parent) const
 {
-    return NUM_COLUMNS;
+    return parent.isValid() ? 0 : NUM_COLUMNS;
 }
 
 Task* ResourcePackFolderModel::createUpdateTask()

--- a/launcher/net/HttpMetaCache.cpp
+++ b/launcher/net/HttpMetaCache.cpp
@@ -47,7 +47,7 @@
 auto MetaEntry::getFullPath() -> QString
 {
     // FIXME: make local?
-    return FS::PathCombine(basePath, relativePath);
+    return FS::PathCombine(m_basePath, m_relativePath);
 }
 
 HttpMetaCache::HttpMetaCache(QString path) : QObject(), m_index_file(path)
@@ -99,7 +99,7 @@ auto HttpMetaCache::resolveEntry(QString base, QString resource_path, QString ex
         return staleEntry(base, resource_path);
     }
 
-    if (!expected_etag.isEmpty() && expected_etag != entry->etag) {
+    if (!expected_etag.isEmpty() && expected_etag != entry->m_etag) {
         // if the etag doesn't match expected, we disown the entry
         selected_base.entry_list.remove(resource_path);
         return staleEntry(base, resource_path);
@@ -107,17 +107,17 @@ auto HttpMetaCache::resolveEntry(QString base, QString resource_path, QString ex
 
     // if the file changed, check md5sum
     qint64 file_last_changed = finfo.lastModified().toUTC().toMSecsSinceEpoch();
-    if (file_last_changed != entry->local_changed_timestamp) {
+    if (file_last_changed != entry->m_local_changed_timestamp) {
         QFile input(real_path);
         input.open(QIODevice::ReadOnly);
         QString md5sum = QCryptographicHash::hash(input.readAll(), QCryptographicHash::Md5).toHex().constData();
-        if (entry->md5sum != md5sum) {
+        if (entry->m_md5sum != md5sum) {
             selected_base.entry_list.remove(resource_path);
             return staleEntry(base, resource_path);
         }
 
         // md5sums matched... keep entry and save the new state to file
-        entry->local_changed_timestamp = file_last_changed;
+        entry->m_local_changed_timestamp = file_last_changed;
         SaveEventually();
     }
 
@@ -130,23 +130,23 @@ auto HttpMetaCache::resolveEntry(QString base, QString resource_path, QString ex
     }
 
     // entry passed all the checks we cared about.
-    entry->basePath = getBasePath(base);
+    entry->m_basePath = getBasePath(base);
     return entry;
 }
 
 auto HttpMetaCache::updateEntry(MetaEntryPtr stale_entry) -> bool
 {
-    if (!m_entries.contains(stale_entry->baseId)) {
-        qCritical() << "Cannot add entry with unknown base: " << stale_entry->baseId.toLocal8Bit();
+    if (!m_entries.contains(stale_entry->m_baseId)) {
+        qCritical() << "Cannot add entry with unknown base: " << stale_entry->m_baseId.toLocal8Bit();
         return false;
     }
 
-    if (stale_entry->stale) {
+    if (stale_entry->m_stale) {
         qCritical() << "Cannot add stale entry: " << stale_entry->getFullPath().toLocal8Bit();
         return false;
     }
 
-    m_entries[stale_entry->baseId].entry_list[stale_entry->relativePath] = stale_entry;
+    m_entries[stale_entry->m_baseId].entry_list[stale_entry->m_relativePath] = stale_entry;
     SaveEventually();
 
     return true;
@@ -157,7 +157,7 @@ auto HttpMetaCache::evictEntry(MetaEntryPtr entry) -> bool
     if (!entry)
         return false;
 
-    entry->stale = true;
+    entry->m_stale = true;
     SaveEventually();
     return true;
 }
@@ -169,7 +169,7 @@ void HttpMetaCache::evictAll()
         qDebug() << "Evicting base" << base;
         for (MetaEntryPtr entry : map.entry_list) {
             if (!evictEntry(entry))
-                qWarning() << "Unexpected missing cache entry" << entry->basePath;
+                qWarning() << "Unexpected missing cache entry" << entry->m_basePath;
         }
     }
 }
@@ -177,10 +177,10 @@ void HttpMetaCache::evictAll()
 auto HttpMetaCache::staleEntry(QString base, QString resource_path) -> MetaEntryPtr
 {
     auto foo = new MetaEntry();
-    foo->baseId = base;
-    foo->basePath = getBasePath(base);
-    foo->relativePath = resource_path;
-    foo->stale = true;
+    foo->m_baseId = base;
+    foo->m_basePath = getBasePath(base);
+    foo->m_relativePath = resource_path;
+    foo->m_stale = true;
 
     return MetaEntryPtr(foo);
 }
@@ -235,23 +235,23 @@ void HttpMetaCache::Load()
         auto& entrymap = m_entries[base];
 
         auto foo = new MetaEntry();
-        foo->baseId = base;
-        foo->relativePath = Json::ensureString(element_obj, "path");
-        foo->md5sum = Json::ensureString(element_obj, "md5sum");
-        foo->etag = Json::ensureString(element_obj, "etag");
-        foo->local_changed_timestamp = Json::ensureDouble(element_obj, "last_changed_timestamp");
-        foo->remote_changed_timestamp = Json::ensureString(element_obj, "remote_changed_timestamp");
+        foo->m_baseId = base;
+        foo->m_relativePath = Json::ensureString(element_obj, "path");
+        foo->m_md5sum = Json::ensureString(element_obj, "md5sum");
+        foo->m_etag = Json::ensureString(element_obj, "etag");
+        foo->m_local_changed_timestamp = Json::ensureDouble(element_obj, "last_changed_timestamp");
+        foo->m_remote_changed_timestamp = Json::ensureString(element_obj, "remote_changed_timestamp");
 
         foo->makeEternal(Json::ensureBoolean(element_obj, (const QString)QStringLiteral("eternal"), false));
         if (!foo->isEternal()) {
-            foo->current_age = Json::ensureDouble(element_obj, "current_age");
-            foo->max_age = Json::ensureDouble(element_obj, "max_age");
+            foo->m_current_age = Json::ensureDouble(element_obj, "current_age");
+            foo->m_max_age = Json::ensureDouble(element_obj, "max_age");
         }
 
         // presumed innocent until closer examination
-        foo->stale = false;
+        foo->m_stale = false;
 
-        entrymap.entry_list[foo->relativePath] = MetaEntryPtr(foo);
+        entrymap.entry_list[foo->m_relativePath] = MetaEntryPtr(foo);
     }
 }
 
@@ -276,23 +276,23 @@ void HttpMetaCache::SaveNow()
     for (auto group : m_entries) {
         for (auto entry : group.entry_list) {
             // do not save stale entries. they are dead.
-            if (entry->stale) {
+            if (entry->m_stale) {
                 continue;
             }
 
             QJsonObject entryObj;
-            Json::writeString(entryObj, "base", entry->baseId);
-            Json::writeString(entryObj, "path", entry->relativePath);
-            Json::writeString(entryObj, "md5sum", entry->md5sum);
-            Json::writeString(entryObj, "etag", entry->etag);
-            entryObj.insert("last_changed_timestamp", QJsonValue(double(entry->local_changed_timestamp)));
-            if (!entry->remote_changed_timestamp.isEmpty())
-                entryObj.insert("remote_changed_timestamp", QJsonValue(entry->remote_changed_timestamp));
+            Json::writeString(entryObj, "base", entry->m_baseId);
+            Json::writeString(entryObj, "path", entry->m_relativePath);
+            Json::writeString(entryObj, "md5sum", entry->m_md5sum);
+            Json::writeString(entryObj, "etag", entry->m_etag);
+            entryObj.insert("last_changed_timestamp", QJsonValue(double(entry->m_local_changed_timestamp)));
+            if (!entry->m_remote_changed_timestamp.isEmpty())
+                entryObj.insert("remote_changed_timestamp", QJsonValue(entry->m_remote_changed_timestamp));
             if (entry->isEternal()) {
                 entryObj.insert("eternal", true);
             } else {
-                entryObj.insert("current_age", QJsonValue(double(entry->current_age)));
-                entryObj.insert("max_age", QJsonValue(double(entry->max_age)));
+                entryObj.insert("current_age", QJsonValue(double(entry->m_current_age)));
+                entryObj.insert("max_age", QJsonValue(double(entry->m_max_age)));
             }
             entriesArr.append(entryObj);
         }

--- a/launcher/net/HttpMetaCache.h
+++ b/launcher/net/HttpMetaCache.h
@@ -49,47 +49,47 @@ class MetaEntry {
     MetaEntry() = default;
 
    public:
-    auto isStale() -> bool { return stale; }
-    void setStale(bool stale) { this->stale = stale; }
+    auto isStale() -> bool { return m_stale; }
+    void setStale(bool stale) { m_stale = stale; }
 
     auto getFullPath() -> QString;
 
-    auto getRemoteChangedTimestamp() -> QString { return remote_changed_timestamp; }
-    void setRemoteChangedTimestamp(QString remote_changed_timestamp) { this->remote_changed_timestamp = remote_changed_timestamp; }
-    void setLocalChangedTimestamp(qint64 timestamp) { local_changed_timestamp = timestamp; }
+    auto getRemoteChangedTimestamp() -> QString { return m_remote_changed_timestamp; }
+    void setRemoteChangedTimestamp(QString remote_changed_timestamp) { m_remote_changed_timestamp = remote_changed_timestamp; }
+    void setLocalChangedTimestamp(qint64 timestamp) { m_local_changed_timestamp = timestamp; }
 
-    auto getETag() -> QString { return etag; }
-    void setETag(QString etag) { this->etag = etag; }
+    auto getETag() -> QString { return m_etag; }
+    void setETag(QString etag) { m_etag = etag; }
 
-    auto getMD5Sum() -> QString { return md5sum; }
-    void setMD5Sum(QString md5sum) { this->md5sum = md5sum; }
+    auto getMD5Sum() -> QString { return m_md5sum; }
+    void setMD5Sum(QString md5sum) { m_md5sum = md5sum; }
 
     /* Whether the entry expires after some time (false) or not (true). */
-    void makeEternal(bool eternal) { is_eternal = eternal; }
-    [[nodiscard]] bool isEternal() const { return is_eternal; }
+    void makeEternal(bool eternal) { m_is_eternal = eternal; }
+    [[nodiscard]] bool isEternal() const { return m_is_eternal; }
 
-    auto getCurrentAge() -> qint64 { return current_age; }
-    void setCurrentAge(qint64 age) { current_age = age; }
+    auto getCurrentAge() -> qint64 { return m_current_age; }
+    void setCurrentAge(qint64 age) { m_current_age = age; }
 
-    auto getMaximumAge() -> qint64 { return max_age; }
-    void setMaximumAge(qint64 age) { max_age = age; }
+    auto getMaximumAge() -> qint64 { return m_max_age; }
+    void setMaximumAge(qint64 age) { m_max_age = age; }
 
-    bool isExpired(qint64 offset) { return !is_eternal && (current_age >= max_age - offset); };
+    bool isExpired(qint64 offset) { return !m_is_eternal && (m_current_age >= m_max_age - offset); };
 
    protected:
-    QString baseId;
-    QString basePath;
-    QString relativePath;
-    QString md5sum;
-    QString etag;
+    QString m_baseId;
+    QString m_basePath;
+    QString m_relativePath;
+    QString m_md5sum;
+    QString m_etag;
 
-    qint64 local_changed_timestamp = 0;
-    QString remote_changed_timestamp;  // QString for now, RFC 2822 encoded time
-    qint64 current_age = 0;
-    qint64 max_age = 0;
-    bool is_eternal = false;
+    qint64 m_local_changed_timestamp = 0;
+    QString m_remote_changed_timestamp;  // QString for now, RFC 2822 encoded time
+    qint64 m_current_age = 0;
+    qint64 m_max_age = 0;
+    bool m_is_eternal = false;
 
-    bool stale = true;
+    bool m_stale = true;
 };
 
 using MetaEntryPtr = std::shared_ptr<MetaEntry>;

--- a/launcher/ui/pages/instance/ServersPage.cpp
+++ b/launcher/ui/pages/instance/ServersPage.cpp
@@ -400,11 +400,11 @@ public:
 
     virtual int rowCount(const QModelIndex &parent = QModelIndex()) const override
     {
-        return m_servers.size();
+        return parent.isValid() ? 0 : m_servers.size();
     }
     int columnCount(const QModelIndex & parent) const override
     {
-        return COLUMN_COUNT;
+        return parent.isValid() ? 0 : COLUMN_COUNT;
     }
 
     Server * at(int index)

--- a/launcher/ui/pages/modplatform/ModModel.h
+++ b/launcher/ui/pages/modplatform/ModModel.h
@@ -20,8 +20,8 @@ class ListModel : public QAbstractListModel {
     ListModel(ModPage* parent);
     ~ListModel() override;
 
-    inline auto rowCount(const QModelIndex& parent) const -> int override { return modpacks.size(); };
-    inline auto columnCount(const QModelIndex& parent) const -> int override { return 1; };
+    inline auto rowCount(const QModelIndex& parent) const -> int override { return parent.isValid() ? 0 : modpacks.size(); };
+    inline auto columnCount(const QModelIndex& parent) const -> int override { return parent.isValid() ? 0 : 1; };
     inline auto flags(const QModelIndex& index) const -> Qt::ItemFlags override { return QAbstractListModel::flags(index); };
 
     auto debugName() const -> QString;
@@ -46,7 +46,7 @@ class ListModel : public QAbstractListModel {
 
     void getLogo(const QString& logo, const QString& logoUrl, LogoCallback callback);
 
-    inline auto canFetchMore(const QModelIndex& parent) const -> bool override { return searchState == CanPossiblyFetchMore; };
+    inline auto canFetchMore(const QModelIndex& parent) const -> bool override { return parent.isValid() ? false : searchState == CanPossiblyFetchMore; };
 
    public slots:
     void searchRequestFinished(QJsonDocument& doc);

--- a/launcher/ui/pages/modplatform/ModModel.h
+++ b/launcher/ui/pages/modplatform/ModModel.h
@@ -41,7 +41,7 @@ class ListModel : public QAbstractListModel {
     void requestModVersions(const ModPlatform::IndexedPack& current, QModelIndex index);
 
     virtual void loadIndexedPack(ModPlatform::IndexedPack& m, QJsonObject& obj) = 0;
-    virtual void loadExtraPackInfo(ModPlatform::IndexedPack& m, QJsonObject& obj) {};
+    virtual void loadExtraPackInfo(ModPlatform::IndexedPack& m, QJsonObject& obj) = 0;
     virtual void loadIndexedPackVersions(ModPlatform::IndexedPack& m, QJsonArray& arr) = 0;
 
     void getLogo(const QString& logo, const QString& logoUrl, LogoCallback callback);

--- a/launcher/ui/pages/modplatform/atlauncher/AtlListModel.cpp
+++ b/launcher/ui/pages/modplatform/atlauncher/AtlListModel.cpp
@@ -32,12 +32,12 @@ ListModel::~ListModel()
 
 int ListModel::rowCount(const QModelIndex &parent) const
 {
-    return modpacks.size();
+    return parent.isValid() ? 0 : modpacks.size();
 }
 
 int ListModel::columnCount(const QModelIndex &parent) const
 {
-    return 1;
+    return parent.isValid() ? 0 : 1;
 }
 
 QVariant ListModel::data(const QModelIndex &index, int role) const

--- a/launcher/ui/pages/modplatform/atlauncher/AtlOptionalModDialog.cpp
+++ b/launcher/ui/pages/modplatform/atlauncher/AtlOptionalModDialog.cpp
@@ -75,12 +75,12 @@ QVector<QString> AtlOptionalModListModel::getResult() {
 }
 
 int AtlOptionalModListModel::rowCount(const QModelIndex &parent) const {
-    return m_mods.size();
+    return parent.isValid() ? 0 : m_mods.size();
 }
 
 int AtlOptionalModListModel::columnCount(const QModelIndex &parent) const {
     // Enabled, Name, Description
-    return 3;
+    return parent.isValid() ? 0 : 3;
 }
 
 QVariant AtlOptionalModListModel::data(const QModelIndex &index, int role) const {

--- a/launcher/ui/pages/modplatform/flame/FlameModel.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameModel.cpp
@@ -15,12 +15,12 @@ ListModel::~ListModel() {}
 
 int ListModel::rowCount(const QModelIndex& parent) const
 {
-    return modpacks.size();
+    return parent.isValid() ? 0 : modpacks.size();
 }
 
 int ListModel::columnCount(const QModelIndex& parent) const
 {
-    return 1;
+    return parent.isValid() ? 0 : 1;
 }
 
 QVariant ListModel::data(const QModelIndex& index, int role) const

--- a/launcher/ui/pages/modplatform/ftb/FtbListModel.cpp
+++ b/launcher/ui/pages/modplatform/ftb/FtbListModel.cpp
@@ -34,12 +34,12 @@ ListModel::~ListModel()
 
 int ListModel::rowCount(const QModelIndex &parent) const
 {
-    return modpacks.size();
+    return parent.isValid() ? 0 : modpacks.size();
 }
 
 int ListModel::columnCount(const QModelIndex &parent) const
 {
-    return 1;
+    return parent.isValid() ? 0 : 1;
 }
 
 QVariant ListModel::data(const QModelIndex &index, int role) const

--- a/launcher/ui/pages/modplatform/legacy_ftb/ListModel.cpp
+++ b/launcher/ui/pages/modplatform/legacy_ftb/ListModel.cpp
@@ -125,12 +125,12 @@ QString ListModel::translatePackType(PackType type) const
 
 int ListModel::rowCount(const QModelIndex &parent) const
 {
-    return modpacks.size();
+    return parent.isValid() ? 0 : modpacks.size();
 }
 
 int ListModel::columnCount(const QModelIndex &parent) const
 {
-    return 1;
+    return parent.isValid() ? 0 : 1;
 }
 
 QVariant ListModel::data(const QModelIndex &index, int role) const

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModel.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModel.h
@@ -55,8 +55,8 @@ class ModpackListModel : public QAbstractListModel {
     ModpackListModel(ModrinthPage* parent);
     ~ModpackListModel() override = default;
 
-    inline auto rowCount(const QModelIndex& parent) const -> int override { return modpacks.size(); };
-    inline auto columnCount(const QModelIndex& parent) const -> int override { return 1; };
+    inline auto rowCount(const QModelIndex& parent) const -> int override { return parent.isValid() ? 0 : modpacks.size(); };
+    inline auto columnCount(const QModelIndex& parent) const -> int override { return parent.isValid() ? 0 : 1; };
     inline auto flags(const QModelIndex& index) const -> Qt::ItemFlags override { return QAbstractListModel::flags(index); };
 
     auto debugName() const -> QString;
@@ -74,7 +74,7 @@ class ModpackListModel : public QAbstractListModel {
 
     void getLogo(const QString& logo, const QString& logoUrl, LogoCallback callback);
 
-    inline auto canFetchMore(const QModelIndex& parent) const -> bool override { return searchState == CanPossiblyFetchMore; };
+    inline auto canFetchMore(const QModelIndex& parent) const -> bool override { return parent.isValid() ? false : searchState == CanPossiblyFetchMore; };
 
    public slots:
     void searchRequestFinished(QJsonDocument& doc_all);

--- a/launcher/ui/pages/modplatform/technic/TechnicModel.cpp
+++ b/launcher/ui/pages/modplatform/technic/TechnicModel.cpp
@@ -80,14 +80,14 @@ QVariant Technic::ListModel::data(const QModelIndex& index, int role) const
     return QVariant();
 }
 
-int Technic::ListModel::columnCount(const QModelIndex&) const
+int Technic::ListModel::columnCount(const QModelIndex& parent) const
 {
-    return 1;
+    return parent.isValid() ? 0 : 1;
 }
 
-int Technic::ListModel::rowCount(const QModelIndex&) const
+int Technic::ListModel::rowCount(const QModelIndex& parent) const
 {
-    return modpacks.size();
+    return parent.isValid() ? 0 : modpacks.size();
 }
 
 void Technic::ListModel::searchWithTerm(const QString& term)


### PR DESCRIPTION
MSVC build spits out a large number of warnings during building, this pr tackles some of those warnings

I had removed a definition for `qhash` in `JsonFormat.h`, as far as I could tell nothing used it.

During this I noted that the parent parameter was not being used in rowCount & columnCount, this has been changed to match the advice given in the documentation of `QAbstractItemModel`, some of the classes where tested with `QAbstractItemModelTester `, which also picked up on the issue.

I also marked `loadExtraPackInfo` as an abstract method, since any class deriving from ListModel overrode this method.

