### PR TITLE
feat: Change the theme via alt menu

### DIFF
--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -1315,9 +1315,7 @@ void MainWindow::updateThemeMenu()
 
     QActionGroup* ThemesGroup = new QActionGroup( this );
 
-    for (int i = 0; i < themes.size(); i++)
-    {
-        auto *theme = themes[i];
+    for (auto* theme : themes) {
         QAction * themeAction = themeMenu->addAction(theme->name());
 
         themeAction->setCheckable(true);

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -49,7 +49,7 @@
 
 #include <QKeyEvent>
 #include <QAction>
-
+#include <QActionGroup>
 #include <QApplication>
 #include <QButtonGroup>
 #include <QHBoxLayout>

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -106,6 +106,7 @@
 #include "ui/dialogs/UpdateDialog.h"
 #include "ui/dialogs/EditAccountDialog.h"
 #include "ui/dialogs/ExportInstanceDialog.h"
+#include "ui/themes/ITheme.h"
 
 #include "UpdateController.h"
 #include "KonamiCode.h"
@@ -1311,6 +1312,25 @@ void MainWindow::updateThemeMenu()
     else
     {
         themeMenu = new QMenu(this);
+    }
+
+    auto themes = APPLICATION->getValidApplicationThemes();
+
+    QActionGroup* ThemesGroup = new QActionGroup( this );
+
+    for (int i = 0; i < themes.size(); i++)
+    {
+
+        auto *theme = themes[i];
+        QAction * themeAction = themeMenu->addAction(theme->name());
+
+        themeAction->setCheckable(true);
+        themeAction->setActionGroup(ThemesGroup);
+
+        connect(themeAction, &QAction::triggered, [theme]() {
+            APPLICATION->setApplicationTheme(theme->name().toLower(),false);
+
+        });
     }
 
     ui->actionChangeTheme->setMenu(themeMenu);

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -1327,8 +1327,8 @@ void MainWindow::updateThemeMenu()
         themeAction->setActionGroup(ThemesGroup);
 
         connect(themeAction, &QAction::triggered, [theme]() {
-            APPLICATION->setApplicationTheme(theme->name().toLower(),false);
-
+            APPLICATION->setApplicationTheme(theme->id(),false);
+            APPLICATION->settings()->set("ApplicationTheme", theme->id());
         });
     }
 

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -1305,12 +1305,9 @@ void MainWindow::updateThemeMenu()
 {
     QMenu *themeMenu = ui->actionChangeTheme->menu();
 
-    if (themeMenu)
-    {
+    if (themeMenu) {
         themeMenu->clear();
-    }
-    else
-    {
+    } else {
         themeMenu = new QMenu(this);
     }
 
@@ -1320,11 +1317,13 @@ void MainWindow::updateThemeMenu()
 
     for (int i = 0; i < themes.size(); i++)
     {
-
         auto *theme = themes[i];
         QAction * themeAction = themeMenu->addAction(theme->name());
 
         themeAction->setCheckable(true);
+        if (APPLICATION->settings()->get("ApplicationTheme").toString() == theme->id()) {
+            themeAction->setChecked(true);
+        }
         themeAction->setActionGroup(ThemesGroup);
 
         connect(themeAction, &QAction::triggered, [theme]() {

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -264,6 +264,8 @@ public:
 
     TranslatedAction actionLockToolbars;
 
+    TranslatedAction actionChangeTheme;
+
     QVector<TranslatedToolButton *> all_toolbuttons;
 
     QWidget *centralWidget = nullptr;
@@ -428,6 +430,11 @@ public:
         actionLockToolbars.setTextId(QT_TRANSLATE_NOOP("MainWindow", "Lock Toolbars"));
         actionLockToolbars->setCheckable(true);
         all_actions.append(&actionLockToolbars);
+
+        actionChangeTheme = TranslatedAction(MainWindow);
+        actionChangeTheme->setObjectName(QStringLiteral("actionChangeTheme"));
+        actionChangeTheme.setTextId(QT_TRANSLATE_NOOP("MainWindow", "Themes"));
+        all_actions.append(&actionChangeTheme);
     }
 
     void createMainToolbar(QMainWindow *MainWindow)
@@ -528,6 +535,8 @@ public:
 
         viewMenu = menuBar->addMenu(tr("&View"));
         viewMenu->setSeparatorsCollapsible(false);
+        viewMenu->addAction(actionChangeTheme);
+        viewMenu->addSeparator();
         viewMenu->addAction(actionCAT);
         viewMenu->addSeparator();
 
@@ -822,6 +831,7 @@ public:
         createInstanceToolbar(MainWindow);
 
         MainWindow->updateToolsMenu();
+        MainWindow->updateThemeMenu();
 
         retranslateUi(MainWindow);
 
@@ -1269,6 +1279,22 @@ void MainWindow::updateToolsMenu()
         }
     }
     ui->actionLaunchInstance->setMenu(launchMenu);
+}
+
+void MainWindow::updateThemeMenu()
+{
+    QMenu *themeMenu = ui->actionChangeTheme->menu();
+
+    if (themeMenu)
+    {
+        themeMenu->clear();
+    }
+    else
+    {
+        themeMenu = new QMenu(this);
+    }
+
+    ui->actionChangeTheme->setMenu(themeMenu);
 }
 
 void MainWindow::repopulateAccountsMenu()

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -1322,7 +1322,7 @@ void MainWindow::updateThemeMenu()
         if (APPLICATION->settings()->get("ApplicationTheme").toString() == theme->id()) {
             themeAction->setChecked(true);
         }
-        themeAction->setActionGroup(ThemesGroup);
+        themeAction->setActionGroup(themesGroup);
 
         connect(themeAction, &QAction::triggered, [theme]() {
             APPLICATION->setApplicationTheme(theme->id(),false);

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -1313,7 +1313,7 @@ void MainWindow::updateThemeMenu()
 
     auto themes = APPLICATION->getValidApplicationThemes();
 
-    QActionGroup* ThemesGroup = new QActionGroup( this );
+    QActionGroup* themesGroup = new QActionGroup( this );
 
     for (auto* theme : themes) {
         QAction * themeAction = themeMenu->addAction(theme->name());

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -1965,6 +1965,7 @@ void MainWindow::globalSettingsClosed()
     proxymodel->sort(0);
     updateMainToolBar();
     updateToolsMenu();
+    updateThemeMenu();
     updateStatusCenter();
     // This needs to be done to prevent UI elements disappearing in the event the config is changed
     // but Prism Launcher exits abnormally, causing the window state to never be saved:

--- a/launcher/ui/MainWindow.h
+++ b/launcher/ui/MainWindow.h
@@ -170,6 +170,8 @@ private slots:
 
     void updateToolsMenu();
 
+    void updateThemeMenu();
+
     void instanceActivated(QModelIndex);
 
     void instanceChanged(const QModelIndex &current, const QModelIndex &previous);


### PR DESCRIPTION
Today is my birthday(:tada:), but who gets the gift is PrismLauncher. Now you can set the theme via alt menu, soon i'll be making the same thing but for icons.

![image](https://user-images.githubusercontent.com/61910521/201798007-8819d9fa-d80b-42e0-bc7c-a2537346700c.png)



## Todo:
 - [x] fix: Check the current theme box on startup.
 - [x] Save the changes on settings.