### PR TITLE
Added url handler for curseforge

### DIFF
--- a/cmake/MacOSXBundleInfo.plist.in
+++ b/cmake/MacOSXBundleInfo.plist.in
@@ -67,5 +67,16 @@
             <string>Alternate</string>
         </dict>
     </array>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleURLName</key>
+            <string>Curseforge</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+            <string>curseforge</string>
+            </array>
+        </dict>
+    </array>
 </dict>
 </plist>

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -246,6 +246,8 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
         {{"I", "import"}, "Import instance from specified zip (local path or URL)", "file"},
         {"show", "Opens the window for the specified instance (by instance ID)", "show"}
     });
+    // Has to be positional for some OS to handle that properly
+    parser.addPositionalArgument("link","Opens the given link as a link to a modpack","[url]");
     parser.addHelpOption();
     parser.addVersionOption();
 
@@ -258,8 +260,8 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
     m_zipToImport = parser.value("import");
     m_instanceIdToShowWindowOf = parser.value("show");
 
-    if(args.contains("0")){
-        m_zipToImport = args["0"].toUrl();
+    if(parser.isSet("link")){
+        m_zipToImport = parser.value("link");
     }
 
     // error if --launch is missing with --server or --profile

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -258,6 +258,10 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
     m_zipToImport = parser.value("import");
     m_instanceIdToShowWindowOf = parser.value("show");
 
+    if(args.contains("0")){
+        m_zipToImport = args["0"].toUrl();
+    }
+
     // error if --launch is missing with --server or --profile
     if((!m_serverToJoin.isEmpty() || !m_profileToUse.isEmpty()) && m_instanceIdToLaunch.isEmpty())
     {

--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -103,14 +103,21 @@ void InstanceImportTask::executeTask()
             connect(req, &NetJob::failed, this, &InstanceImportTask::downloadFailed);
             connect(req, &NetJob::succeeded, [array, this] {
                 auto doc = Json::requireDocument(*array);
-                // Have to use ensureString then use QUrl to get proper url encoding
-                m_sourceUrl = QUrl(
-                    Json::ensureString(Json::ensureObject(Json::ensureObject(doc.object()), "data"), "downloadUrl", "", "downloadUrl"));
-                if (!m_sourceUrl.isValid()) {
-                    emitFailed(tr("The modpack is blocked ! Please download it manually"));
-                    return;
+                // No way to find out if it's a mod or a modpack before here
+                // And also we need to check if it ends with .zip, instead of any better way
+                auto fileName = Json::ensureString(Json::ensureObject(Json::ensureObject(doc.object()), "data"), "fileName");
+                if (fileName.endsWith(".zip")) {
+                    // Have to use ensureString then use QUrl to get proper url encoding
+                    m_sourceUrl = QUrl(
+                        Json::ensureString(Json::ensureObject(Json::ensureObject(doc.object()), "data"), "downloadUrl", "", "downloadUrl"));
+                    if (!m_sourceUrl.isValid()) {
+                        emitFailed(tr("The modpack is blocked ! Please download it manually"));
+                        return;
+                    }
+                    downloadFromUrl();
+                } else {
+                    emitFailed(tr("This url isn't a valid modpack !"));
                 }
-                downloadFromUrl();
             });
             connect(req, &NetJob::aborted, this, &InstanceImportTask::downloadAborted);
             req->start();

--- a/launcher/InstanceImportTask.h
+++ b/launcher/InstanceImportTask.h
@@ -103,4 +103,5 @@ private: /* data */
 
     //FIXME: nuke
     QWidget* m_parent;
+    void downloadFromUrl();
 };

--- a/program_info/org.prismlauncher.PrismLauncher.desktop.in
+++ b/program_info/org.prismlauncher.PrismLauncher.desktop.in
@@ -10,4 +10,4 @@ Icon=org.prismlauncher.PrismLauncher
 Categories=Game;ActionGame;AdventureGame;Simulation;
 Keywords=game;minecraft;launcher;mc;multimc;polymc;
 StartupWMClass=PrismLauncher
-MimeType=application/zip;application/x-modrinth-modpack+zip
+MimeType=application/zip;application/x-modrinth-modpack+zip;x-scheme-handler/curseforge;

--- a/program_info/win_install.nsi.in
+++ b/program_info/win_install.nsi.in
@@ -270,6 +270,10 @@ Section "@Launcher_DisplayName@"
   ; Write the installation path into the registry
   WriteRegStr HKCU Software\@Launcher_CommonName@ "InstallDir" "$INSTDIR"
 
+  ; Write the URL Handler into registry for curseforge
+  WriteRegStr HKCU Software\Classes\curseforge "URL Protocol" ""
+  WriteRegStr HKCU Software\Classes\curseforge\shell\open\command "" '"$INSTDIR\@Launcher_APP_BINARY_NAME@.exe" "%1"'
+
   ; Write the uninstall keys for Windows
   ${GetParameters} $R0
   ${GetOptions} $R0 "/NoUninstaller" $R1


### PR DESCRIPTION
Makes it so that when you click on curseforge's install button, it downloads the modpack

Old pr just putting it back in

Should be *mostly* working, needs a bit of testing on different platforms

Also needs a bit of cleaning up, probably moving the downloading of the modpack over to the flame instance creation