### PR TITLE
Fix serialization of components with custom metadata

### DIFF
--- a/launcher/minecraft/MojangVersionFormat.cpp
+++ b/launcher/minecraft/MojangVersionFormat.cpp
@@ -306,6 +306,15 @@ void MojangVersionFormat::writeVersionProperties(const VersionFile* in, QJsonObj
         }
         out.insert("downloads", downloadsOut);
     }
+    if(in->compatibleJavaMajors.size())
+    {
+        QJsonArray compatibleJavaMajorsOut;
+        for(auto compatibleJavaMajor : in->compatibleJavaMajors)
+        {
+            compatibleJavaMajorsOut.append(compatibleJavaMajor);
+        }
+        out.insert("compatibleJavaMajors", compatibleJavaMajorsOut);
+    }
 }
 
 QJsonDocument MojangVersionFormat::versionFileToJson(const VersionFilePtr &patch)

--- a/launcher/minecraft/MojangVersionFormat.cpp
+++ b/launcher/minecraft/MojangVersionFormat.cpp
@@ -135,7 +135,7 @@ QJsonObject libDownloadInfoToJson(MojangLibraryDownloadInfo::Ptr libinfo)
     {
         out.insert("artifact", downloadInfoToJson(libinfo->artifact));
     }
-    if(libinfo->classifiers.size())
+    if(!libinfo->classifiers.isEmpty())
     {
         QJsonObject classifiersOut;
         for(auto iter = libinfo->classifiers.begin(); iter != libinfo->classifiers.end(); iter++)
@@ -297,7 +297,7 @@ void MojangVersionFormat::writeVersionProperties(const VersionFile* in, QJsonObj
     {
         out.insert("assetIndex", assetIndexToJson(in->mojangAssetIndex));
     }
-    if(in->mojangDownloads.size())
+    if(!in->mojangDownloads.isEmpty())
     {
         QJsonObject downloadsOut;
         for(auto iter = in->mojangDownloads.begin(); iter != in->mojangDownloads.end(); iter++)
@@ -306,7 +306,7 @@ void MojangVersionFormat::writeVersionProperties(const VersionFile* in, QJsonObj
         }
         out.insert("downloads", downloadsOut);
     }
-    if(in->compatibleJavaMajors.size())
+    if(!in->compatibleJavaMajors.isEmpty())
     {
         QJsonArray compatibleJavaMajorsOut;
         for(auto compatibleJavaMajor : in->compatibleJavaMajors)
@@ -405,7 +405,7 @@ QJsonObject MojangVersionFormat::libraryToJson(Library *library)
             iter++;
         }
         libRoot.insert("natives", nativeList);
-        if (library->m_extractExcludes.size())
+        if (!library->m_extractExcludes.isEmpty())
         {
             QJsonArray excludes;
             QJsonObject extract;
@@ -417,7 +417,7 @@ QJsonObject MojangVersionFormat::libraryToJson(Library *library)
             libRoot.insert("extract", extract);
         }
     }
-    if (library->m_rules.size())
+    if (!library->m_rules.isEmpty())
     {
         QJsonArray allRules;
         for (auto &rule : library->m_rules)

--- a/launcher/minecraft/OneSixVersionFormat.cpp
+++ b/launcher/minecraft/OneSixVersionFormat.cpp
@@ -225,11 +225,10 @@ VersionFilePtr OneSixVersionFormat::versionFileFromJson(const QJsonDocument &doc
         {
             QJsonObject agentObj = requireObject(agentVal);
             auto lib = libraryFromJson(*out, agentObj, filename);
+
             QString arg = "";
-            if (agentObj.contains("argument"))
-            {
-                readString(agentObj, "argument", arg);
-            }
+            readString(agentObj, "argument", arg);
+
             AgentPtr agent(new Agent(lib, arg));
             out->agents.append(agent);
         }

--- a/launcher/minecraft/OneSixVersionFormat.cpp
+++ b/launcher/minecraft/OneSixVersionFormat.cpp
@@ -331,6 +331,20 @@ QJsonDocument OneSixVersionFormat::versionFileToJson(const VersionFilePtr &patch
     writeString(root, "appletClass", patch->appletClass);
     writeStringList(root, "+tweakers", patch->addTweakers);
     writeStringList(root, "+traits", patch->traits.values());
+    writeStringList(root, "+jvmArgs", patch->addnJvmArguments);
+    if (!patch->agents.isEmpty())
+    {
+        QJsonArray array;
+        for (auto value: patch->agents)
+        {
+            QJsonObject agentOut = OneSixVersionFormat::libraryToJson(value->library().get());
+            if (!value->argument().isEmpty())
+                agentOut.insert("argument", value->argument());
+
+            array.append(agentOut);
+        }
+        root.insert("+agents", array);
+    }
     if (!patch->libraries.isEmpty())
     {
         QJsonArray array;

--- a/launcher/minecraft/OneSixVersionFormat.cpp
+++ b/launcher/minecraft/OneSixVersionFormat.cpp
@@ -63,13 +63,13 @@ LibraryPtr OneSixVersionFormat::libraryFromJson(ProblemContainer & problems, con
 QJsonObject OneSixVersionFormat::libraryToJson(Library *library)
 {
     QJsonObject libRoot = MojangVersionFormat::libraryToJson(library);
-    if (library->m_absoluteURL.size())
+    if (!library->m_absoluteURL.isEmpty())
         libRoot.insert("MMC-absoluteUrl", library->m_absoluteURL);
-    if (library->m_hint.size())
+    if (!library->m_hint.isEmpty())
         libRoot.insert("MMC-hint", library->m_hint);
-    if (library->m_filename.size())
+    if (!library->m_filename.isEmpty())
         libRoot.insert("MMC-filename", library->m_filename);
-    if (library->m_displayname.size())
+    if (!library->m_displayname.isEmpty())
         libRoot.insert("MMC-displayname", library->m_displayname);
     return libRoot;
 }


### PR DESCRIPTION
Prism has introduced a few extensions to the meta component version
format, which were not exported as JSON in the launcher. This caused the
`Customize` button on the version page to not write these new properties
to the custom component file.