### PR TITLE
Allow hiding buttons in WideBar

### DIFF
--- a/launcher/ui/pages/instance/ExternalResourcesPage.cpp
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.cpp
@@ -70,11 +70,21 @@ void ExternalResourcesPage::ShowContextMenu(const QPoint& pos)
 void ExternalResourcesPage::openedImpl()
 {
     m_model->startWatching();
+
+    auto const setting_name = QString("WideBarVisibility_%1").arg(id());
+    if (!APPLICATION->settings()->contains(setting_name))
+        m_wide_bar_setting = APPLICATION->settings()->registerSetting(setting_name);
+    else
+        m_wide_bar_setting = APPLICATION->settings()->getSetting(setting_name);
+
+    ui->actionsToolbar->setVisibilityState(m_wide_bar_setting->get().toByteArray());
 }
 
 void ExternalResourcesPage::closedImpl()
 {
     m_model->stopWatching();
+
+    m_wide_bar_setting->set(ui->actionsToolbar->getVisibilityState());
 }
 
 void ExternalResourcesPage::retranslate()

--- a/launcher/ui/pages/instance/ExternalResourcesPage.h
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.h
@@ -4,6 +4,7 @@
 #include <QSortFilterProxyModel>
 
 #include "Application.h"
+#include "settings/Setting.h"
 #include "minecraft/MinecraftInstance.h"
 #include "ui/pages/BasePage.h"
 
@@ -71,4 +72,6 @@ class ExternalResourcesPage : public QMainWindow, public BasePage {
     QString m_viewFilter;
 
     bool m_controlsEnabled = true;
+
+    std::shared_ptr<Setting> m_wide_bar_setting = nullptr;
 };

--- a/launcher/ui/pages/instance/ScreenshotsPage.cpp
+++ b/launcher/ui/pages/instance/ScreenshotsPage.cpp
@@ -537,6 +537,19 @@ void ScreenshotsPage::openedImpl()
             ui->listView->setModel(nullptr);
         }
     }
+
+    auto const setting_name = QString("WideBarVisibility_%1").arg(id());
+    if (!APPLICATION->settings()->contains(setting_name))
+        m_wide_bar_setting = APPLICATION->settings()->registerSetting(setting_name);
+    else
+        m_wide_bar_setting = APPLICATION->settings()->getSetting(setting_name);
+
+    ui->toolBar->setVisibilityState(m_wide_bar_setting->get().toByteArray());
+}
+
+void ScreenshotsPage::closedImpl()
+{
+    m_wide_bar_setting->set(ui->toolBar->getVisibilityState());
 }
 
 #include "ScreenshotsPage.moc"

--- a/launcher/ui/pages/instance/ScreenshotsPage.h
+++ b/launcher/ui/pages/instance/ScreenshotsPage.h
@@ -40,6 +40,8 @@
 #include "ui/pages/BasePage.h"
 #include <Application.h>
 
+#include "settings/Setting.h"
+
 class QFileSystemModel;
 class QIdentityProxyModel;
 namespace Ui
@@ -59,7 +61,8 @@ public:
     explicit ScreenshotsPage(QString path, QWidget *parent = 0);
     virtual ~ScreenshotsPage();
 
-    virtual void openedImpl() override;
+    void openedImpl() override;
+    void closedImpl() override;
 
     enum
     {
@@ -110,4 +113,6 @@ private:
     QString m_folder;
     bool m_valid = false;
     bool m_uploadActive = false;
+
+    std::shared_ptr<Setting> m_wide_bar_setting = nullptr;
 };

--- a/launcher/ui/pages/instance/ServersPage.cpp
+++ b/launcher/ui/pages/instance/ServersPage.cpp
@@ -765,11 +765,21 @@ void ServersPage::updateState()
 void ServersPage::openedImpl()
 {
     m_model->observe();
+
+    auto const setting_name = QString("WideBarVisibility_%1").arg(id());
+    if (!APPLICATION->settings()->contains(setting_name))
+        m_wide_bar_setting = APPLICATION->settings()->registerSetting(setting_name);
+    else
+        m_wide_bar_setting = APPLICATION->settings()->getSetting(setting_name);
+
+    ui->toolBar->setVisibilityState(m_wide_bar_setting->get().toByteArray());
 }
 
 void ServersPage::closedImpl()
 {
     m_model->unobserve();
+
+    m_wide_bar_setting->set(ui->toolBar->getVisibilityState());
 }
 
 void ServersPage::on_actionAdd_triggered()

--- a/launcher/ui/pages/instance/ServersPage.h
+++ b/launcher/ui/pages/instance/ServersPage.h
@@ -42,6 +42,8 @@
 #include "ui/pages/BasePage.h"
 #include <Application.h>
 
+#include "settings/Setting.h"
+
 namespace Ui
 {
 class ServersPage;
@@ -112,5 +114,7 @@ private: // data
     Ui::ServersPage *ui = nullptr;
     ServersModel * m_model = nullptr;
     InstancePtr m_inst = nullptr;
+
+    std::shared_ptr<Setting> m_wide_bar_setting = nullptr;
 };
 

--- a/launcher/ui/pages/instance/VersionPage.cpp
+++ b/launcher/ui/pages/instance/VersionPage.cpp
@@ -125,6 +125,21 @@ void VersionPage::retranslate()
     ui->retranslateUi(this);
 }
 
+void VersionPage::openedImpl()
+{
+    auto const setting_name = QString("WideBarVisibility_%1").arg(id());
+    if (!APPLICATION->settings()->contains(setting_name))
+        m_wide_bar_setting = APPLICATION->settings()->registerSetting(setting_name);
+    else
+        m_wide_bar_setting = APPLICATION->settings()->getSetting(setting_name);
+
+    ui->toolBar->setVisibilityState(m_wide_bar_setting->get().toByteArray());
+}
+void VersionPage::closedImpl()
+{
+    m_wide_bar_setting->set(ui->toolBar->getVisibilityState());
+}
+
 QMenu * VersionPage::createPopupMenu()
 {
     QMenu* filteredMenu = QMainWindow::createPopupMenu();

--- a/launcher/ui/pages/instance/VersionPage.h
+++ b/launcher/ui/pages/instance/VersionPage.h
@@ -69,6 +69,9 @@ public:
     virtual bool shouldDisplay() const override;
     void retranslate() override;
 
+    void openedImpl() override;
+    void closedImpl() override;
+
 private slots:
     void on_actionChange_version_triggered();
     void on_actionInstall_Forge_triggered();
@@ -113,6 +116,8 @@ private:
     MinecraftInstance *m_inst;
     int currentIdx = 0;
     bool controlsEnabled = false;
+
+    std::shared_ptr<Setting> m_wide_bar_setting = nullptr;
 
 public slots:
     void versionCurrent(const QModelIndex &current, const QModelIndex &previous);

--- a/launcher/ui/pages/instance/WorldListPage.cpp
+++ b/launcher/ui/pages/instance/WorldListPage.cpp
@@ -113,11 +113,21 @@ WorldListPage::WorldListPage(BaseInstance *inst, std::shared_ptr<WorldList> worl
 void WorldListPage::openedImpl()
 {
     m_worlds->startWatching();
+
+    auto const setting_name = QString("WideBarVisibility_%1").arg(id());
+    if (!APPLICATION->settings()->contains(setting_name))
+        m_wide_bar_setting = APPLICATION->settings()->registerSetting(setting_name);
+    else
+        m_wide_bar_setting = APPLICATION->settings()->getSetting(setting_name);
+
+    ui->toolBar->setVisibilityState(m_wide_bar_setting->get().toByteArray());
 }
 
 void WorldListPage::closedImpl()
 {
     m_worlds->stopWatching();
+
+    m_wide_bar_setting->set(ui->toolBar->getVisibilityState());
 }
 
 WorldListPage::~WorldListPage()

--- a/launcher/ui/pages/instance/WorldListPage.h
+++ b/launcher/ui/pages/instance/WorldListPage.h
@@ -42,6 +42,8 @@
 #include <Application.h>
 #include <LoggedProcess.h>
 
+#include "settings/Setting.h"
+
 class WorldList;
 namespace Ui
 {
@@ -101,6 +103,8 @@ private:
     std::shared_ptr<WorldList> m_worlds;
     unique_qobject_ptr<LoggedProcess> m_mceditProcess;
     bool m_mceditStarting = false;
+
+    std::shared_ptr<Setting> m_wide_bar_setting = nullptr;
 
 private slots:
     void on_actionCopy_Seed_triggered();

--- a/launcher/ui/widgets/WideBar.cpp
+++ b/launcher/ui/widgets/WideBar.cpp
@@ -38,7 +38,8 @@ WideBar::WideBar(const QString& title, QWidget* parent) : QToolBar(title, parent
     setFloatable(false);
     setMovable(false);
 
-    m_bar_menu = std::make_unique<QMenu>(this);
+    setContextMenuPolicy(Qt::ContextMenuPolicy::CustomContextMenu);
+    connect(this, &QToolBar::customContextMenuRequested, this, &WideBar::showVisibilityMenu);
 }
 
 WideBar::WideBar(QWidget* parent) : QToolBar(parent)
@@ -46,7 +47,8 @@ WideBar::WideBar(QWidget* parent) : QToolBar(parent)
     setFloatable(false);
     setMovable(false);
 
-    m_bar_menu = std::make_unique<QMenu>(this);
+    setContextMenuPolicy(Qt::ContextMenuPolicy::CustomContextMenu);
+    connect(this, &QToolBar::customContextMenuRequested, this, &WideBar::showVisibilityMenu);
 }
 
 void WideBar::addAction(QAction* action)
@@ -167,8 +169,11 @@ static void copyAction(QAction* from, QAction* to)
     to->setToolTip(from->toolTip());
 }
 
-void WideBar::contextMenuEvent(QContextMenuEvent* event)
+void WideBar::showVisibilityMenu(QPoint const& position)
 {
+    if (!m_bar_menu)
+        m_bar_menu = std::make_unique<QMenu>(this);
+
     if (m_menu_state == MenuState::Dirty) {
         for (auto* old_action : m_bar_menu->actions())
             old_action->deleteLater();
@@ -198,7 +203,7 @@ void WideBar::contextMenuEvent(QContextMenuEvent* event)
         m_menu_state = MenuState::Fresh;
     }
 
-    m_bar_menu->popup(event->globalPos());
+    m_bar_menu->popup(mapToGlobal(position));
 }
 
 [[nodiscard]] QByteArray WideBar::getVisibilityState() const

--- a/launcher/ui/widgets/WideBar.cpp
+++ b/launcher/ui/widgets/WideBar.cpp
@@ -200,4 +200,34 @@ void WideBar::contextMenuEvent(QContextMenuEvent* event)
     m_bar_menu->popup(event->globalPos());
 }
 
+[[nodiscard]] QByteArray WideBar::getVisibilityState() const
+{
+    QByteArray state;
+
+    for (auto const& entry : m_entries) {
+        if (entry.type != BarEntry::Type::Action)
+            continue;
+
+        state.append(entry.bar_action->isVisible() ? '1' : '0');
+    }
+
+    return state;
+}
+
+void WideBar::setVisibilityState(QByteArray&& state)
+{
+    qsizetype i = 0;
+    for (auto& entry : m_entries) {
+        if (entry.type != BarEntry::Type::Action)
+            continue;
+        if (i == state.size())
+            break;
+
+        entry.bar_action->setVisible(state.at(i++) == '1');
+
+        // NOTE: This is needed so that disabled actions get reflected on the button when it is made visible.
+        static_cast<ActionButton*>(widgetForAction(entry.bar_action))->actionChanged();
+    }
+}
+
 #include "WideBar.moc"

--- a/launcher/ui/widgets/WideBar.h
+++ b/launcher/ui/widgets/WideBar.h
@@ -2,9 +2,8 @@
 
 #include <QAction>
 #include <QMap>
+#include <QMenu>
 #include <QToolBar>
-
-class QMenu;
 
 class WideBar : public QToolBar {
     Q_OBJECT
@@ -12,7 +11,7 @@ class WideBar : public QToolBar {
    public:
     explicit WideBar(const QString& title, QWidget* parent = nullptr);
     explicit WideBar(QWidget* parent = nullptr);
-    virtual ~WideBar();
+    ~WideBar() override = default;
 
     void addAction(QAction* action);
     void addSeparator();
@@ -25,10 +24,14 @@ class WideBar : public QToolBar {
     QMenu* createContextMenu(QWidget* parent = nullptr, const QString& title = QString());
 
    private:
-    struct BarEntry;
+    struct BarEntry {
+        enum class Type { None, Action, Separator, Spacer } type = Type::None;
+        QAction* bar_action = nullptr;
+        QAction* menu_action = nullptr;
+    };
 
-    auto getMatching(QAction* act) -> QList<BarEntry*>::iterator;
+    auto getMatching(QAction* act) -> QList<BarEntry>::iterator;
 
    private:
-    QList<BarEntry*> m_entries;
+    QList<BarEntry> m_entries;
 };

--- a/launcher/ui/widgets/WideBar.h
+++ b/launcher/ui/widgets/WideBar.h
@@ -26,6 +26,12 @@ class WideBar : public QToolBar {
     QMenu* createContextMenu(QWidget* parent = nullptr, const QString& title = QString());
     void contextMenuEvent(QContextMenuEvent*) override;
 
+    // Ideally we would use a QBitArray for this, but it doesn't support string conversion,
+    // so using it in settings is very messy.
+
+    [[nodiscard]] QByteArray getVisibilityState() const;
+    void setVisibilityState(QByteArray&&);
+
    private:
     struct BarEntry {
         enum class Type { None, Action, Separator, Spacer } type = Type::None;

--- a/launcher/ui/widgets/WideBar.h
+++ b/launcher/ui/widgets/WideBar.h
@@ -41,6 +41,10 @@ class WideBar : public QToolBar {
 
     auto getMatching(QAction* act) -> QList<BarEntry>::iterator;
 
+    /** Used to distinguish between versions of the WideBar with different actions */
+    [[nodiscard]] QByteArray getHash() const;
+    [[nodiscard]] bool checkHash(QByteArray const&) const;
+
    private:
     QList<BarEntry> m_entries;
 

--- a/launcher/ui/widgets/WideBar.h
+++ b/launcher/ui/widgets/WideBar.h
@@ -5,6 +5,8 @@
 #include <QMenu>
 #include <QToolBar>
 
+#include <memory>
+
 class WideBar : public QToolBar {
     Q_OBJECT
 
@@ -22,6 +24,7 @@ class WideBar : public QToolBar {
     void insertActionAfter(QAction* after, QAction* action);
 
     QMenu* createContextMenu(QWidget* parent = nullptr, const QString& title = QString());
+    void contextMenuEvent(QContextMenuEvent*) override;
 
    private:
     struct BarEntry {
@@ -34,4 +37,8 @@ class WideBar : public QToolBar {
 
    private:
     QList<BarEntry> m_entries;
+
+    // Menu to toggle visibility from buttons in the bar
+    std::unique_ptr<QMenu> m_bar_menu = nullptr;
+    enum class MenuState { Fresh, Dirty } m_menu_state = MenuState::Dirty;
 };

--- a/launcher/ui/widgets/WideBar.h
+++ b/launcher/ui/widgets/WideBar.h
@@ -24,7 +24,7 @@ class WideBar : public QToolBar {
     void insertActionAfter(QAction* after, QAction* action);
 
     QMenu* createContextMenu(QWidget* parent = nullptr, const QString& title = QString());
-    void contextMenuEvent(QContextMenuEvent*) override;
+    void showVisibilityMenu(const QPoint&);
 
     // Ideally we would use a QBitArray for this, but it doesn't support string conversion,
     // so using it in settings is very messy.


### PR DESCRIPTION
This allows the user to use the right-click menu (previously unused) on the WideBar to toggle buttons from appearing on the bar. This setting applies globally, and is remembered between runs.

This is so that less common options can be hidden by the user, but still be available to the people that use them. :>

The right-click menu on the main portion of the page continues to always show all the available actions, so that less common actions can stop cluttering the sidebar, but still be readily available on the menu.