### PR TITLE
Improve usability in BlockedModsDialog

### DIFF
--- a/launcher/ui/dialogs/BlockedModsDialog.cpp
+++ b/launcher/ui/dialogs/BlockedModsDialog.cpp
@@ -236,12 +236,22 @@ void BlockedModsDialog::checkMatchHash(QString hash, QString path)
 /// @return boolean: did the path match the name of a blocked mod?
 bool BlockedModsDialog::checkValidPath(QString path)
 {
-    QFileInfo file = QFileInfo(path);
-    QString filename = file.fileName();
+    const QFileInfo file = QFileInfo(path);
+    const QString filename = file.fileName();
+    QString laxFilename(filename);
+    laxFilename.replace('+', ' ');
+
+    auto compare = [](QString fsfilename, QString metadataFilename) {
+        return metadataFilename.compare(fsfilename, Qt::CaseInsensitive) == 0;
+    };
 
     for (auto& mod : m_mods) {
-        if (mod.name.compare(filename, Qt::CaseInsensitive) == 0) {
+        if (compare(filename, mod.name)) {
             qDebug() << "[Blocked Mods Dialog] Name match found:" << mod.name << "| From path:" << path;
+            return true;
+        }
+        if (compare(laxFilename, mod.name)) {
+            qDebug() << "[Blocked Mods Dialog] Lax name match found:" << mod.name << "| From path:" << path;
             return true;
         }
     }

--- a/launcher/ui/dialogs/BlockedModsDialog.cpp
+++ b/launcher/ui/dialogs/BlockedModsDialog.cpp
@@ -1,3 +1,28 @@
+// SPDX-FileCopyrightText: 2022 Sefa Eyeoglu <contact@scrumplex.net>
+// SPDX-FileCopyrightText: 2022 Rachel Powers <508861+Ryex@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2022 kumquat-ir <66188216+kumquat-ir@users.noreply.github.com>
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022 Rachel Powers <508861+Ryex@users.noreply.github.com>
+ *  Copyright (C) 2022 kumquat-ir <66188216+kumquat-ir@users.noreply.github.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include "BlockedModsDialog.h"
 #include "ui_BlockedModsDialog.h"
 

--- a/launcher/ui/dialogs/BlockedModsDialog.cpp
+++ b/launcher/ui/dialogs/BlockedModsDialog.cpp
@@ -34,15 +34,8 @@ BlockedModsDialog::BlockedModsDialog(QWidget* parent, const QString& title, cons
 
     this->setWindowTitle(title);
     ui->labelDescription->setText(text);
-    ui->labelExplain->setText(
-        QString(tr("Your configured global mods folder and default downloads folder "
-                   "are automatically checked for the downloaded mods and they will be copied to the instance if found.<br/>"
-                   "Optionally, you may drag and drop the downloaded mods onto this dialog or add a folder to watch "
-                   "if you did not download the mods to a default location."))
-            .arg(APPLICATION->settings()->get("CentralModsDir").toString(),
-                 QStandardPaths::writableLocation(QStandardPaths::DownloadLocation)));
 
-    // force all URL handeling as external
+    // force all URL handling as external
     connect(ui->textBrowserWatched, &QTextBrowser::anchorClicked, this, [](const QUrl url) { QDesktopServices::openUrl(url); });
 
     setAcceptDrops(true);

--- a/launcher/ui/dialogs/BlockedModsDialog.h
+++ b/launcher/ui/dialogs/BlockedModsDialog.h
@@ -1,3 +1,28 @@
+// SPDX-FileCopyrightText: 2022 Sefa Eyeoglu <contact@scrumplex.net>
+// SPDX-FileCopyrightText: 2022 Rachel Powers <508861+Ryex@users.noreply.github.com>
+// SPDX-FileCopyrightText: 2022 kumquat-ir <66188216+kumquat-ir@users.noreply.github.com>
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022 Rachel Powers <508861+Ryex@users.noreply.github.com>
+ *  Copyright (C) 2022 kumquat-ir <66188216+kumquat-ir@users.noreply.github.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include <QDialog>

--- a/launcher/ui/dialogs/BlockedModsDialog.h
+++ b/launcher/ui/dialogs/BlockedModsDialog.h
@@ -71,7 +71,7 @@ class BlockedModsDialog : public QDialog {
     shared_qobject_ptr<ConcurrentTask> m_hashing_task;
     QSet<QString> m_pending_hash_paths;
     bool m_rehash_pending;
-    QPushButton *m_openMissingButton;
+    QPushButton* m_openMissingButton;
 
     void openAll(bool missingOnly);
     void addDownloadFolder();

--- a/launcher/ui/dialogs/BlockedModsDialog.h
+++ b/launcher/ui/dialogs/BlockedModsDialog.h
@@ -6,9 +6,9 @@
 
 #include <QFileSystemWatcher>
 
-#include "modplatform/helpers/HashUtils.h"
-
 #include "tasks/ConcurrentTask.h"
+
+class QPushButton;
 
 struct BlockedMod {
     QString name;
@@ -46,8 +46,9 @@ class BlockedModsDialog : public QDialog {
     shared_qobject_ptr<ConcurrentTask> m_hashing_task;
     QSet<QString> m_pending_hash_paths;
     bool m_rehash_pending;
+    QPushButton *m_openMissingButton;
 
-    void openAll();
+    void openAll(bool missingOnly);
     void addDownloadFolder();
     void update();
     void directoryChanged(QString path);

--- a/launcher/ui/dialogs/BlockedModsDialog.ui
+++ b/launcher/ui/dialogs/BlockedModsDialog.ui
@@ -36,7 +36,7 @@
    <item>
     <widget class="QLabel" name="labelExplain">
      <property name="text">
-      <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Your configured global mods folder and default downloads folder are automatically checked for the downloaded mods and they will be copied to the instance if found.&lt;/p&gt;&lt;p&gt;Optionally, you may drag and drop the downloaded mods onto this dialog or add a folder to watch if you did not download the mods to a default location.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Your configured global mods folder and default downloads folder are automatically checked for the downloaded mods and they will be copied to the instance if found.&lt;/p&gt;&lt;p&gt;Optionally, you may drag and drop the downloaded mods onto this dialog or add a folder to watch if you did not download the mods to a default location.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/launcher/ui/dialogs/BlockedModsDialog.ui
+++ b/launcher/ui/dialogs/BlockedModsDialog.ui
@@ -7,17 +7,23 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>455</height>
+    <height>400</height>
    </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>350</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string notr="true">BlockedModsDialog</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,0,3,0,1,0">
    <item>
     <widget class="QLabel" name="labelDescription">
      <property name="text">
-      <string notr="true"/>
+      <string notr="true">Placeholder description</string>
      </property>
      <property name="textFormat">
       <enum>Qt::RichText</enum>
@@ -30,7 +36,7 @@
    <item>
     <widget class="QLabel" name="labelExplain">
      <property name="text">
-      <string/>
+      <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Your configured global mods folder and default downloads folder are automatically checked for the downloaded mods and they will be copied to the instance if found.&lt;/p&gt;&lt;p&gt;Optionally, you may drag and drop the downloaded mods onto this dialog or add a folder to watch if you did not download the mods to a default location.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
@@ -42,12 +48,6 @@
    </item>
    <item>
     <widget class="QTextBrowser" name="textBrowserModsListing">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>165</height>
-      </size>
-     </property>
      <property name="acceptRichText">
       <bool>true</bool>
      </property>
@@ -58,12 +58,6 @@
    </item>
    <item>
     <widget class="QLabel" name="labelWatched">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>1</verstretch>
-      </sizepolicy>
-     </property>
      <property name="text">
       <string>Watched Folders:</string>
      </property>
@@ -71,18 +65,6 @@
    </item>
    <item>
     <widget class="QTextBrowser" name="textBrowserWatched">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>16</height>
-      </size>
-     </property>
      <property name="baseSize">
       <size>
        <width>0</width>


### PR DESCRIPTION
- Improve resize behavior of dialog with proper stretching
- Implement lax filename matching (for now it just treats `+` and ` ` the same)
- Change behavior of Open All to only open missing mods' links
  - Also disable the button if all mods were found