### PR TITLE
fix: use qt 6.4.0 on windows msvc for now

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
             qt_ver: 6
             qt_host: windows
             qt_arch: ''
-            qt_version: '6.4.1'
+            qt_version: '6.4.0'
             qt_modules: 'qt5compat qtimageformats'
             qt_tools: ''
 


### PR DESCRIPTION
qt 6.4.1 has a very bad scaling regression
