### PR TITLE
Make resource buttons work when instance is running

### DIFF
--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -1110,8 +1110,6 @@ std::shared_ptr<ResourcePackFolderModel> MinecraftInstance::resourcePackList() c
     if (!m_resource_pack_list)
     {
         m_resource_pack_list.reset(new ResourcePackFolderModel(resourcePacksDir()));
-        m_resource_pack_list->enableInteraction(!isRunning());
-        connect(this, &BaseInstance::runningStatusChanged, m_resource_pack_list.get(), &ResourcePackFolderModel::disableInteraction);
     }
     return m_resource_pack_list;
 }
@@ -1121,8 +1119,6 @@ std::shared_ptr<TexturePackFolderModel> MinecraftInstance::texturePackList() con
     if (!m_texture_pack_list)
     {
         m_texture_pack_list.reset(new TexturePackFolderModel(texturePacksDir()));
-        m_texture_pack_list->disableInteraction(isRunning());
-        connect(this, &BaseInstance::runningStatusChanged, m_texture_pack_list.get(), &ModFolderModel::disableInteraction);
     }
     return m_texture_pack_list;
 }
@@ -1132,8 +1128,6 @@ std::shared_ptr<ShaderPackFolderModel> MinecraftInstance::shaderPackList() const
     if (!m_shader_pack_list)
     {
         m_shader_pack_list.reset(new ShaderPackFolderModel(shaderPacksDir()));
-        m_shader_pack_list->disableInteraction(isRunning());
-        connect(this, &BaseInstance::runningStatusChanged, m_shader_pack_list.get(), &ModFolderModel::disableInteraction);
     }
     return m_shader_pack_list;
 }

--- a/launcher/ui/pages/instance/ExternalResourcesPage.cpp
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.cpp
@@ -14,8 +14,6 @@ ExternalResourcesPage::ExternalResourcesPage(BaseInstance* instance, std::shared
 {
     ui->setupUi(this);
 
-    ExternalResourcesPage::runningStateChanged(m_instance && m_instance->isRunning());
-
     ui->actionsToolbar->insertSpacer(ui->actionViewConfigs);
 
     m_filterModel = model->createFilterProxyModel(this);
@@ -45,7 +43,6 @@ ExternalResourcesPage::ExternalResourcesPage(BaseInstance* instance, std::shared
     auto selection_model = ui->treeView->selectionModel();
     connect(selection_model, &QItemSelectionModel::currentChanged, this, &ExternalResourcesPage::current);
     connect(ui->filterEdit, &QLineEdit::textChanged, this, &ExternalResourcesPage::filterTextChanged);
-    connect(m_instance, &BaseInstance::runningStatusChanged, this, &ExternalResourcesPage::runningStateChanged);
 }
 
 ExternalResourcesPage::~ExternalResourcesPage()
@@ -95,14 +92,6 @@ void ExternalResourcesPage::filterTextChanged(const QString& newContents)
 {
     m_viewFilter = newContents;
     m_filterModel->setFilterRegularExpression(m_viewFilter);
-}
-
-void ExternalResourcesPage::runningStateChanged(bool running)
-{
-    if (m_controlsEnabled == !running)
-        return;
-    
-    m_controlsEnabled = !running;
 }
 
 bool ExternalResourcesPage::shouldDisplay() const

--- a/launcher/ui/pages/instance/ExternalResourcesPage.h
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.h
@@ -47,7 +47,6 @@ class ExternalResourcesPage : public QMainWindow, public BasePage {
    protected slots:
     void itemActivated(const QModelIndex& index);
     void filterTextChanged(const QString& newContents);
-    virtual void runningStateChanged(bool running);
 
     virtual void addItem();
     virtual void removeItem();

--- a/launcher/ui/pages/instance/ModFolderPage.cpp
+++ b/launcher/ui/pages/instance/ModFolderPage.cpp
@@ -108,13 +108,13 @@ ModFolderPage::ModFolderPage(BaseInstance* inst, std::shared_ptr<ModFolderModel>
             disconnect(mods.get(), &ModFolderModel::updateFinished, this, 0);
         });
 
+        connect(m_instance, &BaseInstance::runningStatusChanged, this, &ModFolderPage::runningStateChanged);
         ModFolderPage::runningStateChanged(m_instance && m_instance->isRunning());
     }
 }
 
 void ModFolderPage::runningStateChanged(bool running)
 {
-    ExternalResourcesPage::runningStateChanged(running);
     ui->actionDownloadItem->setEnabled(!running);
     ui->actionUpdateItem->setEnabled(!running);
     ui->actionAddItem->setEnabled(!running);

--- a/launcher/ui/pages/instance/ModFolderPage.h
+++ b/launcher/ui/pages/instance/ModFolderPage.h
@@ -53,12 +53,12 @@ class ModFolderPage : public ExternalResourcesPage {
     virtual QString helpPage() const override { return "Loader-mods"; }
 
     virtual bool shouldDisplay() const override;
-    void runningStateChanged(bool running) override;
 
    public slots:
     bool onSelectionChanged(const QModelIndex& current, const QModelIndex& previous) override;
 
    private slots:
+    void runningStateChanged(bool running);
     void removeItem() override;
 
     void installMods();


### PR DESCRIPTION
We enabled the buttons for most ExternalResource pages before, but seems like someone forgor removing the code that also prevented the actions from actually doing stuff.
