### PR TITLE
fix: add instance shortcut creation action to menubar

### DIFF
--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -548,8 +548,9 @@ public:
         fileMenu->addAction(actionChangeInstGroup);
         fileMenu->addAction(actionViewSelectedInstFolder);
         fileMenu->addAction(actionExportInstance);
-        fileMenu->addAction(actionDeleteInstance);
         fileMenu->addAction(actionCopyInstance);
+        fileMenu->addAction(actionDeleteInstance);
+        fileMenu->addAction(actionCreateInstanceShortcut);
         fileMenu->addSeparator();
         fileMenu->addAction(actionSettings);
 


### PR DESCRIPTION
also moves deleteinstance to the same place as the instance toolbar
