### PR TITLE
Change mangohud detection and fix mangohud loading

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -125,6 +125,7 @@
 #ifdef Q_OS_LINUX
 #include <dlfcn.h>
 #include "gamemode_client.h"
+#include "MangoHud.h"
 #endif
 
 
@@ -1519,17 +1520,8 @@ void Application::updateCapabilities()
     if (gamemode_query_status() >= 0)
         m_capabilities |= SupportsGameMode;
 
-    {
-        void *dummy = dlopen("libMangoHud_dlsym.so", RTLD_LAZY);
-        // try normal variant as well
-        if (dummy == NULL)
-            dummy = dlopen("libMangoHud.so", RTLD_LAZY);
-
-        if (dummy != NULL) {
-            dlclose(dummy);
-            m_capabilities |= SupportsMangoHud;
-        }
-    }
+    if (!MangoHud::getLibraryString().isEmpty())
+        m_capabilities |= SupportsMangoHud;
 #endif
 }
 

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -90,6 +90,15 @@ set(CORE_SOURCES
     MMCTime.h
     MMCTime.cpp
 )
+if (UNIX AND NOT CYGWIN AND NOT APPLE)
+set(CORE_SOURCES
+    ${CORE_SOURCES}
+
+    # MangoHud
+    MangoHud.h
+    MangoHud.cpp
+    )
+endif()
 
 set(PATHMATCHER_SOURCES
     # Path matchers

--- a/launcher/MangoHud.cpp
+++ b/launcher/MangoHud.cpp
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  PrismLauncher - Minecraft Launcher
+ *  Copyright (C) 2022 Jan Drögehoff <sentrycraft123@gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <QStringList>
+#include <QDir>
+#include <QString>
+#include <QtGlobal>
+
+#include "MangoHud.h"
+#include "FileSystem.h"
+#include "Json.h"
+
+namespace MangoHud {
+
+QString getLibraryString()
+{
+    /*
+     * Check for vulkan layers in this order:
+     *
+     * $VK_LAYER_PATH
+     * $XDG_DATA_DIRS (/usr/local/share/:/usr/share/)
+     * $XDG_DATA_HOME  (~/.local/share)
+     * /etc
+     * $XDG_CONFIG_DIRS (/etc/xdg)
+     * $XDG_CONFIG_HOME (~/.config)
+     */
+
+    QStringList vkLayerList;
+    {
+        QString home = QDir::homePath();
+
+        QString vkLayerPath = qEnvironmentVariable("VK_LAYER_PATH");
+        if (!vkLayerPath.isEmpty()) {
+            vkLayerList << vkLayerPath;
+        }
+
+        QStringList xdgDataDirs = qEnvironmentVariable("XDG_DATA_DIRS", "/usr/local/share/:/usr/share/").split(QLatin1String(":"));
+        for (QString dir : xdgDataDirs) {
+            vkLayerList << FS::PathCombine(dir, "vulkan", "implicit_layer.d");
+        }
+
+        QString xdgDataHome = qEnvironmentVariable("XDG_DATA_HOME");
+        if (xdgDataHome.isEmpty()) {
+            xdgDataHome = FS::PathCombine(home, ".local", "share");
+        }
+        vkLayerList << FS::PathCombine(xdgDataHome, "vulkan", "implicit_layer.d");
+
+        vkLayerList << "/etc";
+
+        QStringList xdgConfigDirs = qEnvironmentVariable("XDG_CONFIG_DIRS", "/etc/xdg").split(QLatin1String(":"));
+        for (QString dir : xdgConfigDirs) {
+            vkLayerList << FS::PathCombine(dir, "vulkan", "implicit_layer.d");
+        }
+
+        QString xdgConfigHome = qEnvironmentVariable("XDG_CONFIG_HOME");
+        if (xdgConfigHome.isEmpty()) {
+            xdgConfigHome = FS::PathCombine(home, ".config");
+        }
+        vkLayerList << FS::PathCombine(xdgConfigHome, "vulkan", "implicit_layer.d");
+    }
+
+    for (QString vkLayer : vkLayerList) {
+        QString filePath = FS::PathCombine(vkLayer, "MangoHud.json");
+        if (!QFile::exists(filePath))
+            continue;
+
+        auto conf = Json::requireDocument(filePath, vkLayer);
+        auto confObject = Json::requireObject(conf, vkLayer);
+        auto layer = Json::ensureObject(confObject, "layer");
+        return Json::ensureString(layer, "library_path");
+    }
+
+    return QString();
+}
+}  // namespace MangoHud

--- a/launcher/MangoHud.h
+++ b/launcher/MangoHud.h
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  PrismLauncher - Minecraft Launcher
+ *  Copyright (C) 2022 Jan Drögehoff <sentrycraft123@gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QString>
+#include <QStringList>
+
+namespace MangoHud {
+
+QString getLibraryString();
+}

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -483,8 +483,11 @@ QProcessEnvironment MinecraftInstance::createLaunchEnvironment()
     if (settings()->get("EnableMangoHud").toBool() && APPLICATION->capabilities() & Application::SupportsMangoHud)
     {
         auto preload = env.value("LD_PRELOAD", "") + ":libMangoHud_dlsym.so:libMangoHud.so";
+        // $LIB/mangohud is a supported lib path by upstream, do not remove
+        auto lib_path = env.value("LD_LIBRARY_PATH", "") + ":/usr/local/$LIB/mangohud/:/usr/$LIB/mangohud/";
 
         env.insert("LD_PRELOAD", preload);
+        env.insert("LD_LIBRARY_PATH", lib_path);
         env.insert("MANGOHUD", "1");
     }
 

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -88,6 +88,10 @@
 #include "minecraft/gameoptions/GameOptions.h"
 #include "minecraft/update/FoldersTask.h"
 
+#ifdef Q_OS_LINUX
+#include "MangoHud.h"
+#endif
+
 #define IBUS "@im=ibus"
 
 // all of this because keeping things compatible with deprecated old settings
@@ -482,12 +486,22 @@ QProcessEnvironment MinecraftInstance::createLaunchEnvironment()
 #ifdef Q_OS_LINUX
     if (settings()->get("EnableMangoHud").toBool() && APPLICATION->capabilities() & Application::SupportsMangoHud)
     {
-        auto preload = env.value("LD_PRELOAD", "") + ":libMangoHud_dlsym.so:libMangoHud.so";
-        // $LIB/mangohud is a supported lib path by upstream, do not remove
-        auto lib_path = env.value("LD_LIBRARY_PATH", "") + ":/usr/local/$LIB/mangohud/:/usr/$LIB/mangohud/";
 
-        env.insert("LD_PRELOAD", preload);
-        env.insert("LD_LIBRARY_PATH", lib_path);
+        auto preloadList = env.value("LD_PRELOAD").split(QLatin1String(":"));
+        auto libPaths = env.value("LD_LIBRARY_PATH").split(QLatin1String(":"));
+
+        auto mangoHudLibString = MangoHud::getLibraryString();
+        if (!mangoHudLibString.isEmpty())
+        {
+            QFileInfo mangoHudLib(mangoHudLibString);
+
+            // dlsym variant is only needed for OpenGL and not included in the vulkan layer
+            preloadList << "libMangoHud_dlsym.so" << mangoHudLib.fileName();
+            libPaths << mangoHudLib.absolutePath();
+        }
+
+        env.insert("LD_PRELOAD", preloadList.join(QLatin1String(":")));
+        env.insert("LD_LIBRARY_PATH", libPaths.join(QLatin1String(":")));
         env.insert("MANGOHUD", "1");
     }
 


### PR DESCRIPTION
Closes #91
Closes #165

In order of commits:
- Re-adds setting LD_LIBARY_PATH to all upstream supported locations
- replaces dlopen method of mangohud detection with a $PATH lookup for the wrapper

getExecutable should probably be offloaded to some sort of utilities class, but I hadn't found a proper location for it.