### PR TITLE
fix(blockedmods): Track and use targetFolder for blocked files

### DIFF
--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -419,6 +419,7 @@ void FlameCreationTask::idResolverSucceeded(QEventLoop& loop)
             blocked_mod.hash = result.hash;
             blocked_mod.matched = false;
             blocked_mod.localPath = "";
+            blocked_mod.targetFolder = result.targetFolder;
 
             blocked_mods.append(blocked_mod);
 
@@ -464,7 +465,7 @@ void FlameCreationTask::copyBlockedMods(QList<BlockedMod> const& blocked_mods)
             continue;
         }
 
-        auto dest_path = FS::PathCombine(m_stagingPath, "minecraft", "mods", mod.name);
+        auto dest_path = FS::PathCombine(m_stagingPath, "minecraft", mod.targetFolder, mod.name);
 
         setStatus(tr("Copying Blocked Mods (%1 out of %2 are done)").arg(QString::number(i), QString::number(total)));
 

--- a/launcher/modplatform/modpacksch/FTBPackInstallTask.cpp
+++ b/launcher/modplatform/modpacksch/FTBPackInstallTask.cpp
@@ -195,6 +195,7 @@ void PackInstallTask::onResolveModsSucceeded()
             blocked_mod.hash = results_file.hash;
             blocked_mod.matched = false;
             blocked_mod.localPath = "";
+            blocked_mod.targetFolder = results_file.targetFolder;
 
             m_blocked_mods.append(blocked_mod);
 
@@ -366,7 +367,7 @@ void PackInstallTask::copyBlockedMods()
             continue;
         }
 
-        auto dest_path = FS::PathCombine(m_stagingPath, ".minecraft", "mods", mod.name);
+        auto dest_path = FS::PathCombine(m_stagingPath, ".minecraft", mod.targetFolder, mod.name);
 
         setStatus(tr("Copying Blocked Mods (%1 out of %2 are done)").arg(QString::number(i), QString::number(total)));
 

--- a/launcher/ui/dialogs/BlockedModsDialog.h
+++ b/launcher/ui/dialogs/BlockedModsDialog.h
@@ -41,6 +41,7 @@ struct BlockedMod {
     QString hash;
     bool matched;
     QString localPath;
+    QString targetFolder;
 };
 
 QT_BEGIN_NAMESPACE


### PR DESCRIPTION
Fixes #570

Simple fix, track and use the targetFolder from the file resolver.
