### PR TITLE
Prevent potental crash if droping non local files in BlockedModsDialog

### DIFF
--- a/launcher/ui/dialogs/BlockedModsDialog.cpp
+++ b/launcher/ui/dialogs/BlockedModsDialog.cpp
@@ -84,7 +84,15 @@ void BlockedModsDialog::dragEnterEvent(QDragEnterEvent* e)
 
 void BlockedModsDialog::dropEvent(QDropEvent* e)
 {
-    for (const QUrl& url : e->mimeData()->urls()) {
+    for (QUrl& url : e->mimeData()->urls()) {
+        if (url.scheme().isEmpty()) { // ensure isLocalFile() works correctly
+            url.setScheme("file");
+        }
+        
+        if (!url.isLocalFile()) { // can't drop external files here.
+            continue;
+        }
+
         QString filePath = url.toLocalFile();
         qDebug() << "[Blocked Mods Dialog] Dropped file:" << filePath;
         addHashTask(filePath);


### PR DESCRIPTION
Saw this check on the import code and realized this was a potential crash.