### PR TITLE
Correct wording on libraries download task

### DIFF
--- a/launcher/minecraft/update/LibrariesTask.cpp
+++ b/launcher/minecraft/update/LibrariesTask.cpp
@@ -12,7 +12,7 @@ LibrariesTask::LibrariesTask(MinecraftInstance * inst)
 
 void LibrariesTask::executeTask()
 {
-    setStatus(tr("Getting the library files from Mojang..."));
+    setStatus(tr("Downloading required library files..."));
     qDebug() << m_inst->name() << ": downloading libraries";
     MinecraftInstance *inst = (MinecraftInstance *)m_inst;
 


### PR DESCRIPTION
This is an utterly trivial change, but this dialog bothers me every time I see it. The thing that takes the longest to download from Mojang, the game assets, have their own individual dialog, and that one's wording is correct.

Most often, when libraries are being downloaded, what's actually being downloaded is a new version of a mod loader or other third-party patch; only during initial install are the libraries truly from Mojang. This misconstrues the origin of libraries and what's really being downloaded.

Not sure what results this will have on translations. PR can get bounced for all I care, but I wanted to bring this up.