### PR TITLE
Fix: Reset stylesheet before setting style

### DIFF
--- a/launcher/ui/themes/ITheme.cpp
+++ b/launcher/ui/themes/ITheme.cpp
@@ -6,19 +6,14 @@
 
 void ITheme::apply(bool)
 {
+    APPLICATION->setStyleSheet(QString());
     QApplication::setStyle(QStyleFactory::create(qtTheme()));
-    if(hasColorScheme())
-    {
+    if (hasColorScheme()) {
         QApplication::setPalette(colorScheme());
     }
-    if(hasStyleSheet())
-    {
+    if (hasStyleSheet())
         APPLICATION->setStyleSheet(appStyleSheet());
-    }
-    else
-    {
-        APPLICATION->setStyleSheet(QString());
-    }
+
     QDir::setSearchPaths("theme", searchPaths());
 }
 


### PR DESCRIPTION
Resolves #510

Having a style sheet applied before calling setStyle will cause the following setStyleSheet call to crash in certain conditions.

This issue is only present after the setup wizard is run, we never actually cleanup the setup wizard so it gets re-themed on style(sheet) changes, and it appears that the wizard or its contents satisfies the conditions to causes the crash. 