### PR TITLE
fix: crash with GTK2 theme due to QProxyStyle in ManagedPackPage

### DIFF
--- a/launcher/ui/pages/instance/ManagedPackPage.cpp
+++ b/launcher/ui/pages/instance/ManagedPackPage.cpp
@@ -7,6 +7,7 @@
 
 #include <QListView>
 #include <QProxyStyle>
+#include <QStyleFactory>
 
 #include <HoeDown.h>
 
@@ -60,7 +61,10 @@ ManagedPackPage::ManagedPackPage(BaseInstance* inst, InstanceWindow* instance_wi
 
     ui->setupUi(this);
 
-    ui->versionsComboBox->setStyle(new NoBigComboBoxStyle(ui->versionsComboBox->style()));
+    // NOTE: GTK2 themes crash with the proxy style.
+    // This seems like an upstream bug, so there's not much else that can be done.
+    if (!QStyleFactory::keys().contains("gtk2"))
+        ui->versionsComboBox->setStyle(new NoBigComboBoxStyle(ui->versionsComboBox->style()));
 
     ui->reloadButton->setVisible(false);
     connect(ui->reloadButton, &QPushButton::clicked, this, [this](bool){


### PR DESCRIPTION
Fixes  #602

bit of a band-aid over the issue, but it seems to be an issue with internal qtstyleplugins stuff, so not much that we can do i guess -m-

Seemingly related issue: https://bugreports.qt.io/browse/QTBUG-49940