### PR TITLE
fix: possible crash in mod and modpack downloaders with images

### DIFF
--- a/launcher/ui/widgets/VariableSizedImageObject.cpp
+++ b/launcher/ui/widgets/VariableSizedImageObject.cpp
@@ -101,7 +101,7 @@ void VariableSizedImageObject::loadImage(QTextDocument* doc, const QUrl& source,
 
     auto full_entry_path = entry->getFullPath();
     auto source_url = source;
-    connect(job, &NetJob::succeeded, [this, doc, full_entry_path, source_url, posInDocument] {
+    connect(job, &NetJob::succeeded, this, [this, doc, full_entry_path, source_url, posInDocument] {
         qDebug() << "Loaded resource at" << full_entry_path;
 
         // If we flushed, don't proceed.


### PR DESCRIPTION
Fixes #590 (Or at least from my testing, involving opening one of the downloaders, selecting an item whose page contains images, and quickly closing the dialog before the image finishes loading. I think they're the same issue.)