### PR TITLE
fix(Inst.Import): don't assert extra data when importing from ZIP

### DIFF
--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -257,20 +257,26 @@ void InstanceImportTask::extractAborted()
 
 void InstanceImportTask::processFlame()
 {
-    auto pack_id_it = m_extra_info.constFind("pack_id");
-    Q_ASSERT(pack_id_it != m_extra_info.constEnd());
-    auto pack_id = pack_id_it.value();
+    FlameCreationTask* inst_creation_task = nullptr;
+    if (!m_extra_info.isEmpty()) {
+        auto pack_id_it = m_extra_info.constFind("pack_id");
+        Q_ASSERT(pack_id_it != m_extra_info.constEnd());
+        auto pack_id = pack_id_it.value();
 
-    auto pack_version_id_it = m_extra_info.constFind("pack_version_id");
-    Q_ASSERT(pack_version_id_it != m_extra_info.constEnd());
-    auto pack_version_id = pack_version_id_it.value();
+        auto pack_version_id_it = m_extra_info.constFind("pack_version_id");
+        Q_ASSERT(pack_version_id_it != m_extra_info.constEnd());
+        auto pack_version_id = pack_version_id_it.value();
 
-    QString original_instance_id;
-    auto original_instance_id_it = m_extra_info.constFind("original_instance_id");
-    if (original_instance_id_it != m_extra_info.constEnd())
-        original_instance_id = original_instance_id_it.value();
+        QString original_instance_id;
+        auto original_instance_id_it = m_extra_info.constFind("original_instance_id");
+        if (original_instance_id_it != m_extra_info.constEnd())
+            original_instance_id = original_instance_id_it.value();
 
-    auto* inst_creation_task = new FlameCreationTask(m_stagingPath, m_globalSettings, m_parent, pack_id, pack_version_id, original_instance_id);
+        inst_creation_task = new FlameCreationTask(m_stagingPath, m_globalSettings, m_parent, pack_id, pack_version_id, original_instance_id);
+    } else {
+        // FIXME: Find a way to get IDs in directly imported ZIPs
+        inst_creation_task = new FlameCreationTask(m_stagingPath, m_globalSettings, m_parent, {}, {});
+    }
 
     inst_creation_task->setName(*this);
     inst_creation_task->setIcon(m_instIcon);
@@ -335,21 +341,33 @@ void InstanceImportTask::processMultiMC()
 
 void InstanceImportTask::processModrinth()
 {
-    auto pack_id_it = m_extra_info.constFind("pack_id");
-    Q_ASSERT(pack_id_it != m_extra_info.constEnd());
-    auto pack_id = pack_id_it.value();
+    ModrinthCreationTask* inst_creation_task = nullptr;
+    if (!m_extra_info.isEmpty()) {
+        auto pack_id_it = m_extra_info.constFind("pack_id");
+        Q_ASSERT(pack_id_it != m_extra_info.constEnd());
+        auto pack_id = pack_id_it.value();
 
-    QString pack_version_id;
-    auto pack_version_id_it = m_extra_info.constFind("pack_version_id");
-    if (pack_version_id_it != m_extra_info.constEnd())
-        pack_version_id = pack_version_id_it.value();
+        QString pack_version_id;
+        auto pack_version_id_it = m_extra_info.constFind("pack_version_id");
+        if (pack_version_id_it != m_extra_info.constEnd())
+            pack_version_id = pack_version_id_it.value();
 
-    QString original_instance_id;
-    auto original_instance_id_it = m_extra_info.constFind("original_instance_id");
-    if (original_instance_id_it != m_extra_info.constEnd())
-        original_instance_id = original_instance_id_it.value();
+        QString original_instance_id;
+        auto original_instance_id_it = m_extra_info.constFind("original_instance_id");
+        if (original_instance_id_it != m_extra_info.constEnd())
+            original_instance_id = original_instance_id_it.value();
 
-    auto* inst_creation_task = new ModrinthCreationTask(m_stagingPath, m_globalSettings, m_parent, pack_id, pack_version_id, original_instance_id);
+        inst_creation_task = new ModrinthCreationTask(m_stagingPath, m_globalSettings, m_parent, pack_id, pack_version_id, original_instance_id);
+    } else {
+        QString pack_id;
+        if (!m_sourceUrl.isEmpty()) {
+            QRegularExpression regex(R"(data\/(.*)\/versions)");
+            pack_id = regex.match(m_sourceUrl.toString()).captured(1);
+        }
+
+        // FIXME: Find a way to get the ID in directly imported ZIPs
+        inst_creation_task = new ModrinthCreationTask(m_stagingPath, m_globalSettings, m_parent, pack_id);
+    }
 
     inst_creation_task->setName(*this);
     inst_creation_task->setIcon(m_instIcon);

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -361,7 +361,9 @@ bool FlameCreationTask::createInstance()
         FS::deletePath(jarmodsPath);
     }
 
-    instance.setManagedPack("flame", m_managed_id, m_pack.name, m_managed_version_id, m_pack.version);
+    // Don't add managed info to packs without an ID (most likely imported from ZIP)
+    if (!m_managed_id.isEmpty())
+        instance.setManagedPack("flame", m_managed_id, m_pack.name, m_managed_version_id, m_pack.version);
     instance.setName(name());
 
     m_mod_id_resolver = new Flame::FileResolvingTask(APPLICATION->network(), m_pack);

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
@@ -217,7 +217,9 @@ bool ModrinthCreationTask::createInstance()
         instance.setIconKey("modrinth");
     }
 
-    instance.setManagedPack("modrinth", m_managed_id, m_managed_name, m_managed_version_id, version());
+    // Don't add managed info to packs without an ID (most likely imported from ZIP)
+    if (!m_managed_id.isEmpty())
+        instance.setManagedPack("modrinth", m_managed_id, m_managed_name, m_managed_version_id, version());
     instance.setName(name());
     instance.saveNow();
 


### PR DESCRIPTION
Fixes #609

ZIPs don't have the necessary data in those cases. This also mean you won't be able to use the managed pack stuff for those, at least for now -m-