### PR TITLE
Safer destructive actions

### DIFF
--- a/launcher/FileSystem.cpp
+++ b/launcher/FileSystem.cpp
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  PolyMC - Minecraft Launcher
+ *  Prism Launcher - Minecraft Launcher
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -226,7 +227,7 @@ bool deletePath(QString path)
     return err.value() == 0;
 }
 
-bool trash(QString path, QString *pathInTrash = nullptr)
+bool trash(QString path, QString *pathInTrash)
 {
 #if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
     return false;

--- a/launcher/FileSystem.h
+++ b/launcher/FileSystem.h
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  PolyMC - Minecraft Launcher
+ *  Prism Launcher - Minecraft Launcher
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -129,7 +130,7 @@ bool deletePath(QString path);
 /**
  * Trash a folder / file
  */
-bool trash(QString path, QString *pathInTrash);
+bool trash(QString path, QString *pathInTrash = nullptr);
 
 QString PathCombine(const QString& path1, const QString& path2);
 QString PathCombine(const QString& path1, const QString& path2, const QString& path3);

--- a/launcher/minecraft/World.cpp
+++ b/launcher/minecraft/World.cpp
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  PolyMC - Minecraft Launcher
+ *  Prism Launcher - Minecraft Launcher
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -545,6 +546,10 @@ bool World::replace(World &with)
 bool World::destroy()
 {
     if(!is_valid) return false;
+
+    if (FS::trash(m_containerFile.filePath()))
+        return true;
+
     if (m_containerFile.isDir())
     {
         QDir d(m_containerFile.filePath());

--- a/launcher/minecraft/mod/Resource.cpp
+++ b/launcher/minecraft/mod/Resource.cpp
@@ -143,5 +143,9 @@ bool Resource::enable(EnableAction action)
 bool Resource::destroy()
 {
     m_type = ResourceType::UNKNOWN;
+
+    if (FS::trash(m_file_info.filePath()))
+        return true;
+
     return FS::deletePath(m_file_info.filePath());
 }

--- a/launcher/ui/GuiUtil.cpp
+++ b/launcher/ui/GuiUtil.cpp
@@ -64,13 +64,12 @@ QString GuiUtil::uploadPaste(const QString &name, const QString &text, QWidget *
             baseUrl = pasteCustomAPIBaseSetting;
 
         if (baseUrl.isValid()) {
-            auto response = CustomMessageBox::selectable(parentWidget, "Confirm Upload",
+            auto response = CustomMessageBox::selectable(parentWidget, QObject::tr("Confirm Upload"),
                                                          QObject::tr("About to upload: %1\n"
                                                                      "Uploading to: %2\n"
                                                                      "You should double-check for personal information.\n\n"
                                                                      "Are you sure?")
-                                                             .arg(name)
-                                                             .arg(baseUrl.host()),
+                                                             .arg(name, baseUrl.host()),
                                                          QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No, QMessageBox::No)
                                 ->exec();
 

--- a/launcher/ui/GuiUtil.cpp
+++ b/launcher/ui/GuiUtil.cpp
@@ -65,8 +65,7 @@ QString GuiUtil::uploadPaste(const QString &name, const QString &text, QWidget *
 
         if (baseUrl.isValid()) {
             auto response = CustomMessageBox::selectable(parentWidget, QObject::tr("Confirm Upload"),
-                                                         QObject::tr("About to upload: %1\n"
-                                                                     "Uploading to: %2\n"
+                                                         QObject::tr("You are about to upload \"%1\" to %2.\n"
                                                                      "You should double-check for personal information.\n\n"
                                                                      "Are you sure?")
                                                              .arg(name, baseUrl.host()),

--- a/launcher/ui/GuiUtil.cpp
+++ b/launcher/ui/GuiUtil.cpp
@@ -50,7 +50,7 @@
 #include <DesktopServices.h>
 #include <BuildConfig.h>
 
-QString GuiUtil::uploadPaste(const QString &name, const QString &text, QWidget *parentWidget)
+std::optional<QString> GuiUtil::uploadPaste(const QString &name, const QString &text, QWidget *parentWidget)
 {
     ProgressDialog dialog(parentWidget);
     auto pasteTypeSetting = static_cast<PasteUpload::PasteType>(APPLICATION->settings()->get("PastebinType").toInt());
@@ -63,7 +63,8 @@ QString GuiUtil::uploadPaste(const QString &name, const QString &text, QWidget *
         else
             baseUrl = pasteCustomAPIBaseSetting;
 
-        if (baseUrl.isValid()) {
+        if (baseUrl.isValid())
+        {
             auto response = CustomMessageBox::selectable(parentWidget, QObject::tr("Confirm Upload"),
                                                          QObject::tr("You are about to upload \"%1\" to %2.\n"
                                                                      "You should double-check for personal information.\n\n"
@@ -73,7 +74,7 @@ QString GuiUtil::uploadPaste(const QString &name, const QString &text, QWidget *
                                 ->exec();
 
             if (response != QMessageBox::Yes)
-                return "canceled";
+                return {};
         }
     }
 

--- a/launcher/ui/GuiUtil.h
+++ b/launcher/ui/GuiUtil.h
@@ -4,7 +4,7 @@
 
 namespace GuiUtil
 {
-QString uploadPaste(const QString &text, QWidget *parentWidget);
+QString uploadPaste(const QString &name, const QString &text, QWidget *parentWidget);
 void setClipboardText(const QString &text);
 QStringList BrowseForFiles(QString context, QString caption, QString filter, QString defaultPath, QWidget *parentWidget);
 QString BrowseForFile(QString context, QString caption, QString filter, QString defaultPath, QWidget *parentWidget);

--- a/launcher/ui/GuiUtil.h
+++ b/launcher/ui/GuiUtil.h
@@ -1,10 +1,11 @@
 #pragma once
 
 #include <QWidget>
+#include <optional>
 
 namespace GuiUtil
 {
-QString uploadPaste(const QString &name, const QString &text, QWidget *parentWidget);
+std::optional<QString> uploadPaste(const QString &name, const QString &text, QWidget *parentWidget);
 void setClipboardText(const QString &text);
 QStringList BrowseForFiles(QString context, QString caption, QString filter, QString defaultPath, QWidget *parentWidget);
 QString BrowseForFile(QString context, QString caption, QString filter, QString defaultPath, QWidget *parentWidget);

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -2094,7 +2094,7 @@ void MainWindow::on_actionDeleteInstance_triggered()
 
     auto id = m_selectedInstance->id();
 
-    auto response = CustomMessageBox::selectable(this, tr("CAREFUL!"),
+    auto response = CustomMessageBox::selectable(this, tr("Confirm Deletion"),
                                                  tr("About to delete: %1\n"
                                                     "This may be permanent and will completely delete the instance.\n\n"
                                                     "Are you sure?")

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -2095,7 +2095,7 @@ void MainWindow::on_actionDeleteInstance_triggered()
     auto id = m_selectedInstance->id();
 
     auto response = CustomMessageBox::selectable(this, tr("Confirm Deletion"),
-                                                 tr("About to delete: %1\n"
+                                                 tr("You are about to delete \"%1\".\n"
                                                     "This may be permanent and will completely delete the instance.\n\n"
                                                     "Are you sure?")
                                                      .arg(m_selectedInstance->name()),

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  PolyMC - Minecraft Launcher
+ *  Prism Launcher - Minecraft Launcher
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -490,7 +491,7 @@ public:
         if (!BuildConfig.BUG_TRACKER_URL.isEmpty()) {
             helpMenu->addAction(actionReportBug);
         }
-        
+
         if(!BuildConfig.MATRIX_URL.isEmpty()) {
             helpMenu->addAction(actionMATRIX);
         }
@@ -2093,21 +2094,23 @@ void MainWindow::on_actionDeleteInstance_triggered()
 
     auto id = m_selectedInstance->id();
 
-    auto response =
-        CustomMessageBox::selectable(this, tr("CAREFUL!"),
-                                     tr("About to delete: %1\nThis may be permanent and will completely delete the instance.\n\nAre you sure?")
-                                         .arg(m_selectedInstance->name()),
-                                     QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No, QMessageBox::No)
-            ->exec();
+    auto response = CustomMessageBox::selectable(this, tr("CAREFUL!"),
+                                                 tr("About to delete: %1\n"
+                                                    "This may be permanent and will completely delete the instance.\n\n"
+                                                    "Are you sure?")
+                                                     .arg(m_selectedInstance->name()),
+                                                 QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No, QMessageBox::No)
+                        ->exec();
 
-    if (response == QMessageBox::Yes) {
-        if (APPLICATION->instances()->trashInstance(id)) {
-            ui->actionUndoTrashInstance->setEnabled(APPLICATION->instances()->trashedSomething());
-            return;
-        }
+    if (response != QMessageBox::Yes)
+        return;
 
-        APPLICATION->instances()->deleteInstance(id);
+    if (APPLICATION->instances()->trashInstance(id)) {
+        ui->actionUndoTrashInstance->setEnabled(APPLICATION->instances()->trashedSomething());
+        return;
     }
+
+    APPLICATION->instances()->deleteInstance(id);
 }
 
 void MainWindow::on_actionExportInstance_triggered()
@@ -2252,7 +2255,7 @@ void MainWindow::on_actionCreateInstanceShortcut_triggered()
         }
 
         QString iconPath = FS::PathCombine(m_selectedInstance->instanceRoot(), "icon.png");
-        
+
         QFile iconFile(iconPath);
         if (!iconFile.open(QFile::WriteOnly))
         {
@@ -2261,7 +2264,7 @@ void MainWindow::on_actionCreateInstanceShortcut_triggered()
         }
         bool success = icon->icon().pixmap(64, 64).save(&iconFile, "PNG");
         iconFile.close();
-        
+
         if (!success)
         {
             iconFile.remove();
@@ -2302,7 +2305,7 @@ void MainWindow::on_actionCreateInstanceShortcut_triggered()
         }
 
         QString iconPath = FS::PathCombine(m_selectedInstance->instanceRoot(), "icon.ico");
-        
+
         // part of fix for weird bug involving the window icon being replaced
         // dunno why it happens, but this 2-line fix seems to be enough, so w/e
         auto appIcon = APPLICATION->getThemedIcon("logo");
@@ -2325,7 +2328,7 @@ void MainWindow::on_actionCreateInstanceShortcut_triggered()
             QMessageBox::critical(this, tr("Create instance shortcut"), tr("Failed to create icon for shortcut."));
             return;
         }
-        
+
         if (FS::createShortcut(FS::PathCombine(desktopPath, m_selectedInstance->name()),
                            QApplication::applicationFilePath(), { "--launch", m_selectedInstance->id() },
                            m_selectedInstance->name(), iconPath)) {

--- a/launcher/ui/pages/instance/ExternalResourcesPage.cpp
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.cpp
@@ -162,7 +162,7 @@ void ExternalResourcesPage::removeItem()
 
     int count = 0;
     bool folder = false;
-    for (auto i : selection.indexes()) {
+    for (auto& i : selection.indexes()) {
         if (i.column() == 0) {
             count++;
 
@@ -172,23 +172,24 @@ void ExternalResourcesPage::removeItem()
         }
     }
 
-    bool enough = count > 1;
+    QString text;
+    bool multiple = count > 1;
 
-    if (enough || folder) {
-        QString text;
-        if (enough)
-            text = tr("About to remove: %1 items\n"
-                      "This may be permanent and they will be gone from the folder.\n\n"
-                      "Are you sure?")
-                       .arg(count);
-        else
-            text = tr("About to remove: %1 (folder)\n"
-                      "This may be permanent and it will be gone from the parent folder.\n\n"
-                      "Are you sure?")
-                       .arg(m_model->at(selection.indexes().at(0).row()).fileinfo().fileName());
+    if (multiple) {
+        text = tr("About to remove: %1 items\n"
+                  "This may be permanent and they will be gone from the folder.\n\n"
+                  "Are you sure?")
+                   .arg(count);
+    } else if (folder) {
+        text = tr("About to remove: %1 (folder)\n"
+                  "This may be permanent and it will be gone from the parent folder.\n\n"
+                  "Are you sure?")
+                   .arg(m_model->at(selection.indexes().at(0).row()).fileinfo().fileName());
+    }
 
-        auto response = CustomMessageBox::selectable(this, tr("CAREFUL!"), text, QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No,
-                                                     QMessageBox::No)
+    if (!text.isEmpty()) {
+        auto response = CustomMessageBox::selectable(this, tr("Confirm Removal"), text, QMessageBox::Warning,
+                                                     QMessageBox::Yes | QMessageBox::No, QMessageBox::No)
                             ->exec();
 
         if (response != QMessageBox::Yes)

--- a/launcher/ui/pages/instance/ExternalResourcesPage.cpp
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.cpp
@@ -1,4 +1,5 @@
 #include "ExternalResourcesPage.h"
+#include "ui/dialogs/CustomMessageBox.h"
 #include "ui_ExternalResourcesPage.h"
 
 #include "DesktopServices.h"
@@ -128,7 +129,7 @@ bool ExternalResourcesPage::eventFilter(QObject* obj, QEvent* ev)
 {
     if (ev->type() != QEvent::KeyPress)
         return QWidget::eventFilter(obj, ev);
-    
+
     QKeyEvent* keyEvent = static_cast<QKeyEvent*>(ev);
     if (obj == ui->treeView)
         return listFilter(keyEvent);
@@ -140,7 +141,6 @@ void ExternalResourcesPage::addItem()
 {
     if (!m_controlsEnabled)
         return;
-    
 
     auto list = GuiUtil::BrowseForFiles(
         helpPage(), tr("Select %1", "Select whatever type of files the page contains. Example: 'Loader Mods'").arg(displayName()),
@@ -157,8 +157,49 @@ void ExternalResourcesPage::removeItem()
 {
     if (!m_controlsEnabled)
         return;
-    
+
     auto selection = m_filterModel->mapSelectionToSource(ui->treeView->selectionModel()->selection());
+
+    int count = 0;
+    bool folder = false;
+    for (auto i : selection.indexes()) {
+        if (i.column() == 0) {
+            count++;
+
+            // if a folder is selected, show the confirmation dialog
+            if (m_model->at(i.row()).fileinfo().isDir())
+                folder = true;
+        }
+    }
+
+    bool enough = count > 1;
+
+    if (enough || folder) {
+        QString text;
+        if (enough)
+            text = tr("About to remove: %1 items\n"
+                      "This may be permanent and they will be gone from the folder.\n\n"
+                      "Are you sure?")
+                       .arg(count);
+        else
+            text = tr("About to remove: %1 (folder)\n"
+                      "This may be permanent and it will be gone from the parent folder.\n\n"
+                      "Are you sure?")
+                       .arg(m_model->at(selection.indexes().at(0).row()).fileinfo().fileName());
+
+        auto response = CustomMessageBox::selectable(this, tr("CAREFUL!"), text, QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No,
+                                                     QMessageBox::No)
+                            ->exec();
+
+        if (response != QMessageBox::Yes)
+            return;
+    }
+
+    removeItems(selection);
+}
+
+void ExternalResourcesPage::removeItems(const QItemSelection& selection)
+{
     m_model->deleteResources(selection.indexes());
 }
 
@@ -209,4 +250,3 @@ bool ExternalResourcesPage::onSelectionChanged(const QModelIndex& current, const
 
     return true;
 }
-

--- a/launcher/ui/pages/instance/ExternalResourcesPage.cpp
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.cpp
@@ -176,12 +176,12 @@ void ExternalResourcesPage::removeItem()
     bool multiple = count > 1;
 
     if (multiple) {
-        text = tr("About to remove: %1 items\n"
+        text = tr("You are about to remove %1 items.\n"
                   "This may be permanent and they will be gone from the folder.\n\n"
                   "Are you sure?")
                    .arg(count);
     } else if (folder) {
-        text = tr("About to remove: %1 (folder)\n"
+        text = tr("You are about to remove the folder \"%1\".\n"
                   "This may be permanent and it will be gone from the parent folder.\n\n"
                   "Are you sure?")
                    .arg(m_model->at(selection.indexes().at(0).row()).fileinfo().fileName());

--- a/launcher/ui/pages/instance/ExternalResourcesPage.h
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.h
@@ -50,7 +50,8 @@ class ExternalResourcesPage : public QMainWindow, public BasePage {
     void filterTextChanged(const QString& newContents);
 
     virtual void addItem();
-    virtual void removeItem();
+    void removeItem();
+    virtual void removeItems(const QItemSelection &selection);
 
     virtual void enableItem();
     virtual void disableItem();

--- a/launcher/ui/pages/instance/LogPage.cpp
+++ b/launcher/ui/pages/instance/LogPage.cpp
@@ -283,16 +283,17 @@ void LogPage::on_btnPaste_clicked()
         )
     );
     auto url = GuiUtil::uploadPaste(tr("Minecraft Log"), m_model->toPlainText(), this);
-    if(url == "canceled")
+    if(!url.has_value())
     {
         m_model->append(MessageLevel::Error, QString("Log upload canceled"));
     }
-    else if(!url.isEmpty())
+    else if (url->isNull())
     {
-        m_model->append(MessageLevel::Launcher, QString("Log uploaded to: %1").arg(url));
-    }
-    else {
         m_model->append(MessageLevel::Error, QString("Log upload failed!"));
+    }
+    else
+    {
+        m_model->append(MessageLevel::Launcher, QString("Log uploaded to: %1").arg(url.value()));
     }
 }
 

--- a/launcher/ui/pages/instance/LogPage.cpp
+++ b/launcher/ui/pages/instance/LogPage.cpp
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  PolyMC - Minecraft Launcher
+ *  Prism Launcher - Minecraft Launcher
  *  Copyright (c) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -277,28 +278,21 @@ void LogPage::on_btnPaste_clicked()
     //FIXME: turn this into a proper task and move the upload logic out of GuiUtil!
     m_model->append(
         MessageLevel::Launcher,
-        QString("%2: Log upload triggered at: %1").arg(
-            QDateTime::currentDateTime().toString(Qt::RFC2822Date),
-            BuildConfig.LAUNCHER_DISPLAYNAME
+        QString("Log upload triggered at: %1").arg(
+            QDateTime::currentDateTime().toString(Qt::RFC2822Date)
         )
     );
-    auto url = GuiUtil::uploadPaste(m_model->toPlainText(), this);
-    if(!url.isEmpty())
+    auto url = GuiUtil::uploadPaste(tr("Minecraft Log"), m_model->toPlainText(), this);
+    if(url == "canceled")
     {
-        m_model->append(
-            MessageLevel::Launcher,
-            QString("%2: Log uploaded to: %1").arg(
-                url,
-                BuildConfig.LAUNCHER_DISPLAYNAME
-            )
-        );
+        m_model->append(MessageLevel::Error, QString("Log upload canceled"));
     }
-    else
+    else if(!url.isEmpty())
     {
-        m_model->append(
-            MessageLevel::Error,
-            QString("%1: Log upload failed!").arg(BuildConfig.LAUNCHER_DISPLAYNAME)
-        );
+        m_model->append(MessageLevel::Launcher, QString("Log uploaded to: %1").arg(url));
+    }
+    else {
+        m_model->append(MessageLevel::Error, QString("Log upload failed!"));
     }
 }
 

--- a/launcher/ui/pages/instance/ModFolderPage.cpp
+++ b/launcher/ui/pages/instance/ModFolderPage.cpp
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  PolyMC - Minecraft Launcher
+ *  Prism Launcher - Minecraft Launcher
  *  Copyright (c) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -139,13 +140,8 @@ bool ModFolderPage::onSelectionChanged(const QModelIndex& current, const QModelI
     return true;
 }
 
-void ModFolderPage::removeItem()
+void ModFolderPage::removeItems(const QItemSelection &selection)
 {
-
-    if (!m_controlsEnabled)
-        return;
-
-    auto selection = m_filterModel->mapSelectionToSource(ui->treeView->selectionModel()->selection());
     m_model->deleteMods(selection.indexes());
 }
 

--- a/launcher/ui/pages/instance/ModFolderPage.h
+++ b/launcher/ui/pages/instance/ModFolderPage.h
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  PolyMC - Minecraft Launcher
+ *  Prism Launcher - Minecraft Launcher
  *  Copyright (c) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -59,7 +60,7 @@ class ModFolderPage : public ExternalResourcesPage {
 
    private slots:
     void runningStateChanged(bool running);
-    void removeItem() override;
+    void removeItems(const QItemSelection &selection) override;
 
     void installMods();
     void updateMods();

--- a/launcher/ui/pages/instance/OtherLogsPage.cpp
+++ b/launcher/ui/pages/instance/OtherLogsPage.cpp
@@ -220,7 +220,7 @@ void OtherLogsPage::on_btnDelete_clicked()
         setControlsEnabled(false);
         return;
     }
-    if (QMessageBox::question(this, tr("CAREFUL!"),
+    if (QMessageBox::question(this, tr("Confirm Deletion"),
                               tr("About to delete: %1\n"
                                  "This may be permanent and it will be gone from the logs folder.\n\n"
                                  "Are you sure?")
@@ -252,7 +252,7 @@ void OtherLogsPage::on_btnClean_clicked()
         return;
     }
     QMessageBox *messageBox = new QMessageBox(this);
-    messageBox->setWindowTitle(tr("CAREFUL!"));
+    messageBox->setWindowTitle(tr("Confirm Cleanup"));
     if(toDelete.size() > 5)
     {
         messageBox->setText(tr("Are you sure you want to delete all log files?"));

--- a/launcher/ui/pages/instance/OtherLogsPage.cpp
+++ b/launcher/ui/pages/instance/OtherLogsPage.cpp
@@ -221,7 +221,7 @@ void OtherLogsPage::on_btnDelete_clicked()
         return;
     }
     if (QMessageBox::question(this, tr("Confirm Deletion"),
-                              tr("About to delete: %1\n"
+                              tr("You are about to delete \"%1\".\n"
                                  "This may be permanent and it will be gone from the logs folder.\n\n"
                                  "Are you sure?")
                                   .arg(m_currentFile),

--- a/launcher/ui/pages/instance/OtherLogsPage.cpp
+++ b/launcher/ui/pages/instance/OtherLogsPage.cpp
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  PolyMC - Minecraft Launcher
+ *  Prism Launcher - Minecraft Launcher
  *  Copyright (c) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
+ *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -204,7 +205,7 @@ void OtherLogsPage::on_btnReload_clicked()
 
 void OtherLogsPage::on_btnPaste_clicked()
 {
-    GuiUtil::uploadPaste(ui->text->toPlainText(), this);
+    GuiUtil::uploadPaste(m_currentFile, ui->text->toPlainText(), this);
 }
 
 void OtherLogsPage::on_btnCopy_clicked()
@@ -219,13 +220,21 @@ void OtherLogsPage::on_btnDelete_clicked()
         setControlsEnabled(false);
         return;
     }
-    if (QMessageBox::question(this, tr("Delete"),
-                              tr("Do you really want to delete %1?").arg(m_currentFile),
-                              QMessageBox::Yes, QMessageBox::No) == QMessageBox::No)
-    {
+    if (QMessageBox::question(this, tr("CAREFUL!"),
+                              tr("About to delete: %1\n"
+                                 "This may be permanent and it will be gone from the logs folder.\n\n"
+                                 "Are you sure?")
+                                  .arg(m_currentFile),
+                              QMessageBox::Yes, QMessageBox::No) == QMessageBox::No) {
         return;
     }
     QFile file(FS::PathCombine(m_path, m_currentFile));
+
+    if (FS::trash(file.fileName()))
+    {
+        return;
+    }
+
     if (!file.remove())
     {
         QMessageBox::critical(this, tr("Error"), tr("Unable to delete %1: %2")
@@ -243,15 +252,15 @@ void OtherLogsPage::on_btnClean_clicked()
         return;
     }
     QMessageBox *messageBox = new QMessageBox(this);
-    messageBox->setWindowTitle(tr("Clean up"));
+    messageBox->setWindowTitle(tr("CAREFUL!"));
     if(toDelete.size() > 5)
     {
-        messageBox->setText(tr("Do you really want to delete all log files?"));
+        messageBox->setText(tr("Are you sure you want to delete all log files?"));
         messageBox->setDetailedText(toDelete.join('\n'));
     }
     else
     {
-        messageBox->setText(tr("Do you really want to delete these files?\n%1").arg(toDelete.join('\n')));
+        messageBox->setText(tr("Are you sure you want to delete all these files?\n%1").arg(toDelete.join('\n')));
     }
     messageBox->setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
     messageBox->setDefaultButton(QMessageBox::Ok);
@@ -267,6 +276,10 @@ void OtherLogsPage::on_btnClean_clicked()
     for(auto item: toDelete)
     {
         QFile file(FS::PathCombine(m_path, item));
+        if (FS::trash(file.fileName()))
+        {
+            continue;
+        }
         if (!file.remove())
         {
             failed.push_back(item);

--- a/launcher/ui/pages/instance/ScreenshotsPage.cpp
+++ b/launcher/ui/pages/instance/ScreenshotsPage.cpp
@@ -526,7 +526,7 @@ void ScreenshotsPage::on_actionDelete_triggered()
                    .arg(count);
 
     auto response =
-        CustomMessageBox::selectable(this, tr("CAREFUL!"), text, QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No)->exec();
+        CustomMessageBox::selectable(this, tr("Confirm Deletion"), text, QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No)->exec();
 
     if (response != QMessageBox::Yes)
         return;

--- a/launcher/ui/pages/instance/ScreenshotsPage.cpp
+++ b/launcher/ui/pages/instance/ScreenshotsPage.cpp
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  PolyMC - Minecraft Launcher
+ *  Prism Launcher - Minecraft Launcher
  *  Copyright (c) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -379,6 +380,24 @@ void ScreenshotsPage::on_actionUpload_triggered()
     if (selection.isEmpty())
         return;
 
+
+    QString text;
+    if (selection.size() > 1)
+        text = tr("About to upload: %1 screenshots\n\n"
+                  "Are you sure?")
+                   .arg(selection.size());
+    else
+        text =
+            tr("About to upload the selected screenshot.\n\n"
+               "Are you sure?");
+
+    auto response = CustomMessageBox::selectable(this, "Confirm Upload", text, QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No,
+                                                 QMessageBox::No)
+                        ->exec();
+
+    if (response != QMessageBox::Yes)
+        return;
+
     QList<ScreenShot::Ptr> uploaded;
     auto job = NetJob::Ptr(new NetJob("Screenshot Upload", APPLICATION->network()));
     if(selection.size() < 2)
@@ -491,17 +510,32 @@ void ScreenshotsPage::on_actionCopy_File_s_triggered()
 
 void ScreenshotsPage::on_actionDelete_triggered()
 {
-    auto mbox = CustomMessageBox::selectable(
-        this, tr("Are you sure?"), tr("This will delete all selected screenshots."),
-        QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No);
-    std::unique_ptr<QMessageBox> box(mbox);
+    auto selected = ui->listView->selectionModel()->selectedIndexes();
 
-    if (box->exec() != QMessageBox::Yes)
+    int count = ui->listView->selectionModel()->selectedRows().size();
+    QString text;
+    if (count > 1)
+        text = tr("About to delete: %1 screenshots\n"
+                  "This may be permanent and they will be gone from the folder.\n\n"
+                  "Are you sure?")
+                   .arg(count);
+    else
+        text = tr("About to delete the selected screenshot.\n"
+                  "This may be permanent and it will be gone from the folder.\n\n"
+                  "Are you sure?")
+                   .arg(count);
+
+    auto response =
+        CustomMessageBox::selectable(this, tr("CAREFUL!"), text, QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No)->exec();
+
+    if (response != QMessageBox::Yes)
         return;
 
-    auto selected = ui->listView->selectionModel()->selectedIndexes();
     for (auto item : selected)
     {
+        if (FS::trash(m_model->filePath(item)))
+            continue;
+
         m_model->remove(item);
     }
 }

--- a/launcher/ui/pages/instance/ScreenshotsPage.cpp
+++ b/launcher/ui/pages/instance/ScreenshotsPage.cpp
@@ -383,12 +383,12 @@ void ScreenshotsPage::on_actionUpload_triggered()
 
     QString text;
     if (selection.size() > 1)
-        text = tr("About to upload: %1 screenshots\n\n"
+        text = tr("You are about to upload %1 screenshots.\n\n"
                   "Are you sure?")
                    .arg(selection.size());
     else
         text =
-            tr("About to upload the selected screenshot.\n\n"
+            tr("You are about to upload the selected screenshot.\n\n"
                "Are you sure?");
 
     auto response = CustomMessageBox::selectable(this, "Confirm Upload", text, QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No,
@@ -515,12 +515,12 @@ void ScreenshotsPage::on_actionDelete_triggered()
     int count = ui->listView->selectionModel()->selectedRows().size();
     QString text;
     if (count > 1)
-        text = tr("About to delete: %1 screenshots\n"
+        text = tr("You are about to delete %1 screenshots.\n"
                   "This may be permanent and they will be gone from the folder.\n\n"
                   "Are you sure?")
                    .arg(count);
     else
-        text = tr("About to delete the selected screenshot.\n"
+        text = tr("You are about to delete the selected screenshot.\n"
                   "This may be permanent and it will be gone from the folder.\n\n"
                   "Are you sure?")
                    .arg(count);

--- a/launcher/ui/pages/instance/ServersPage.cpp
+++ b/launcher/ui/pages/instance/ServersPage.cpp
@@ -801,7 +801,7 @@ void ServersPage::on_actionAdd_triggered()
 
 void ServersPage::on_actionRemove_triggered()
 {
-    auto response = CustomMessageBox::selectable(this, tr("CAREFUL!"),
+    auto response = CustomMessageBox::selectable(this, tr("Confirm Removal"),
                                                  tr("About to remove: %1\n"
                                                     "This is permanent and the server will be gone from your list forever (A LONG TIME).\n\n"
                                                     "Are you sure?")

--- a/launcher/ui/pages/instance/ServersPage.cpp
+++ b/launcher/ui/pages/instance/ServersPage.cpp
@@ -802,7 +802,7 @@ void ServersPage::on_actionAdd_triggered()
 void ServersPage::on_actionRemove_triggered()
 {
     auto response = CustomMessageBox::selectable(this, tr("Confirm Removal"),
-                                                 tr("About to remove: %1\n"
+                                                 tr("You are about to remove \"%1\".\n"
                                                     "This is permanent and the server will be gone from your list forever (A LONG TIME).\n\n"
                                                     "Are you sure?")
                                                      .arg(m_model->at(currentServer)->m_name),

--- a/launcher/ui/pages/instance/ServersPage.cpp
+++ b/launcher/ui/pages/instance/ServersPage.cpp
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  PolyMC - Minecraft Launcher
+ *  Prism Launcher - Minecraft Launcher
  *  Copyright (c) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -35,6 +36,7 @@
  */
 
 #include "ServersPage.h"
+#include "ui/dialogs/CustomMessageBox.h"
 #include "ui_ServersPage.h"
 
 #include <FileSystem.h>
@@ -799,6 +801,17 @@ void ServersPage::on_actionAdd_triggered()
 
 void ServersPage::on_actionRemove_triggered()
 {
+    auto response = CustomMessageBox::selectable(this, tr("CAREFUL!"),
+                                                 tr("About to remove: %1\n"
+                                                    "This is permanent and the server will be gone from your list forever (A LONG TIME).\n\n"
+                                                    "Are you sure?")
+                                                     .arg(m_model->at(currentServer)->m_name),
+                                                 QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No, QMessageBox::No)
+                        ->exec();
+
+    if (response != QMessageBox::Yes)
+        return;
+
     m_model->removeRow(currentServer);
 }
 

--- a/launcher/ui/pages/instance/VersionPage.cpp
+++ b/launcher/ui/pages/instance/VersionPage.cpp
@@ -326,7 +326,7 @@ void VersionPage::on_actionRemove_triggered()
     auto component = m_profile->getComponent(index);
     if (component->isCustom())
     {
-        auto response = CustomMessageBox::selectable(this, tr("CAREFUL!"),
+        auto response = CustomMessageBox::selectable(this, tr("Confirm Removal"),
                                                      tr("About to remove: %1\n"
                                                         "This is permanent and will completely remove the custom component.\n\n"
                                                         "Are you sure?")
@@ -725,7 +725,7 @@ void VersionPage::on_actionRevert_triggered()
     }
     auto component = m_profile->getComponent(version);
 
-    auto response = CustomMessageBox::selectable(this, tr("CAREFUL!"),
+    auto response = CustomMessageBox::selectable(this, tr("Confirm Reversion"),
                                                  tr("About to revert: %1\n"
                                                     "This is permanent and will completely revert your customizations.\n\n"
                                                     "Are you sure?")

--- a/launcher/ui/pages/instance/VersionPage.cpp
+++ b/launcher/ui/pages/instance/VersionPage.cpp
@@ -318,13 +318,29 @@ void VersionPage::on_actionReload_triggered()
 
 void VersionPage::on_actionRemove_triggered()
 {
-    if (ui->packageView->currentIndex().isValid())
+    if (!ui->packageView->currentIndex().isValid())
     {
-        // FIXME: use actual model, not reloading.
-        if (!m_profile->remove(ui->packageView->currentIndex().row()))
-        {
-            QMessageBox::critical(this, tr("Error"), tr("Couldn't remove file"));
-        }
+        return;
+    }
+    int index = ui->packageView->currentIndex().row();
+    auto component = m_profile->getComponent(index);
+    if (component->isCustom())
+    {
+        auto response = CustomMessageBox::selectable(this, tr("CAREFUL!"),
+                                                     tr("About to remove: %1\n"
+                                                        "This is permanent and will completely remove the custom component.\n\n"
+                                                        "Are you sure?")
+                                                         .arg(component->getName()),
+                                                     QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No, QMessageBox::No)
+                            ->exec();
+
+        if (response != QMessageBox::Yes)
+            return;
+    }
+    // FIXME: use actual model, not reloading.
+    if (!m_profile->remove(index))
+    {
+        QMessageBox::critical(this, tr("Error"), tr("Couldn't remove file"));
     }
     updateButtons();
     reloadPackProfile();
@@ -707,6 +723,19 @@ void VersionPage::on_actionRevert_triggered()
     {
         return;
     }
+    auto component = m_profile->getComponent(version);
+
+    auto response = CustomMessageBox::selectable(this, tr("CAREFUL!"),
+                                                 tr("About to revert: %1\n"
+                                                    "This is permanent and will completely revert your customizations.\n\n"
+                                                    "Are you sure?")
+                                                     .arg(component->getName()),
+                                                 QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No, QMessageBox::No)
+                        ->exec();
+
+    if (response != QMessageBox::Yes)
+        return;
+
     if(!m_profile->revertToBase(version))
     {
         // TODO: some error box here

--- a/launcher/ui/pages/instance/VersionPage.cpp
+++ b/launcher/ui/pages/instance/VersionPage.cpp
@@ -327,7 +327,7 @@ void VersionPage::on_actionRemove_triggered()
     if (component->isCustom())
     {
         auto response = CustomMessageBox::selectable(this, tr("Confirm Removal"),
-                                                     tr("About to remove: %1\n"
+                                                     tr("You are about to remove \"%1\".\n"
                                                         "This is permanent and will completely remove the custom component.\n\n"
                                                         "Are you sure?")
                                                          .arg(component->getName()),
@@ -726,7 +726,7 @@ void VersionPage::on_actionRevert_triggered()
     auto component = m_profile->getComponent(version);
 
     auto response = CustomMessageBox::selectable(this, tr("Confirm Reversion"),
-                                                 tr("About to revert: %1\n"
+                                                 tr("You are about to revert \"%1\".\n"
                                                     "This is permanent and will completely revert your customizations.\n\n"
                                                     "Are you sure?")
                                                      .arg(component->getName()),

--- a/launcher/ui/pages/instance/WorldListPage.cpp
+++ b/launcher/ui/pages/instance/WorldListPage.cpp
@@ -194,7 +194,7 @@ void WorldListPage::on_actionRemove_triggered()
     if(!proxiedIndex.isValid())
         return;
 
-    auto result = CustomMessageBox::selectable(this, tr("CAREFUL!"),
+    auto result = CustomMessageBox::selectable(this, tr("Confirm Deletion"),
                                                tr("About to delete: %1\n"
                                                   "The world may be gone forever (A LONG TIME).\n\n"
                                                   "Are you sure?")

--- a/launcher/ui/pages/instance/WorldListPage.cpp
+++ b/launcher/ui/pages/instance/WorldListPage.cpp
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  PolyMC - Minecraft Launcher
+ *  Prism Launcher - Minecraft Launcher
  *  Copyright (c) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -35,6 +36,7 @@
  */
 
 #include "WorldListPage.h"
+#include "ui/dialogs/CustomMessageBox.h"
 #include "ui_WorldListPage.h"
 #include "minecraft/WorldList.h"
 
@@ -192,12 +194,14 @@ void WorldListPage::on_actionRemove_triggered()
     if(!proxiedIndex.isValid())
         return;
 
-    auto result = QMessageBox::question(this,
-                tr("Are you sure?"),
-                tr("This will remove the selected world permenantly.\n"
-                    "The world will be gone forever (A LONG TIME).\n"
-                    "\n"
-                    "Do you want to continue?"));
+    auto result = CustomMessageBox::selectable(this, tr("CAREFUL!"),
+                                               tr("About to delete: %1\n"
+                                                  "The world may be gone forever (A LONG TIME).\n\n"
+                                                  "Are you sure?")
+                                                   .arg(m_worlds->allWorlds().at(proxiedIndex.row()).name()),
+                                               QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No, QMessageBox::No)
+                      ->exec();
+
     if(result != QMessageBox::Yes)
     {
         return;

--- a/launcher/ui/pages/instance/WorldListPage.cpp
+++ b/launcher/ui/pages/instance/WorldListPage.cpp
@@ -195,7 +195,7 @@ void WorldListPage::on_actionRemove_triggered()
         return;
 
     auto result = CustomMessageBox::selectable(this, tr("Confirm Deletion"),
-                                               tr("About to delete: %1\n"
+                                               tr("You are about to delete \"%1\".\n"
                                                   "The world may be gone forever (A LONG TIME).\n\n"
                                                   "Are you sure?")
                                                    .arg(m_worlds->allWorlds().at(proxiedIndex.row()).name()),

--- a/launcher/ui/pages/instance/WorldListPage.ui
+++ b/launcher/ui/pages/instance/WorldListPage.ui
@@ -109,7 +109,7 @@
   </action>
   <action name="actionRemove">
    <property name="text">
-    <string>Remove</string>
+    <string>Delete</string>
    </property>
   </action>
   <action name="actionMCEdit">


### PR DESCRIPTION
Fixes #298 
Fixes https://github.com/PolyMC/PolyMC/issues/948. Well, it obviously won't actually close the issue. I went further though - some may say it's too hard to do dumb things now.

- Confirmation when deleting multiple resources (mods, resource packs, etc.), or if they are folders.
- Confirmation when deleting servers. Since servers are nothing much more than IP addresses maybe this should only show if it's an IP address rather than a domain.
- Confirmation when uploading logs and screenshots.
- Confirmation for removing component customisations either by pressing remove or revert. Some may say this isn't very useful since there's no multi-select.
- Move a lot of things to trash instead of completely deleting them.
- Improved consistency.

Unfortunately it still says "may be permanent" which in my opinion is not really great. Perhaps it could be adapted to whether Flatpak is being used, and perhaps the whole dialog logic could be moved into a utility since it's now used a lot.

![image](https://user-images.githubusercontent.com/57493648/207644508-8c1bc6b6-24ea-4803-8e02-c2103dc0710a.png)

![image](https://user-images.githubusercontent.com/57493648/207644656-195fdecf-f6b3-4e27-9ac8-34576844f61a.png)

![image](https://user-images.githubusercontent.com/57493648/207644291-8dc0e15f-1355-4072-9ffe-90fa966c6e31.png)
