### PR TITLE
ApplicationMessage: Use QHash instead of QMap

### DIFF
--- a/launcher/ApplicationMessage.cpp
+++ b/launcher/ApplicationMessage.cpp
@@ -47,8 +47,8 @@ void ApplicationMessage::parse(const QByteArray & input) {
     args.clear();
 
     auto parsedArgs = root.value("args").toObject();
-    for(auto iter = parsedArgs.begin(); iter != parsedArgs.end(); iter++) {
-        args[iter.key()] = iter.value().toString();
+    for(auto iter = parsedArgs.constBegin(); iter != parsedArgs.constEnd(); iter++) {
+        args.insert(iter.key(), iter.value().toString());
     }
 }
 
@@ -56,8 +56,8 @@ QByteArray ApplicationMessage::serialize() {
     QJsonObject root;
     root.insert("command", command);
     QJsonObject outArgs;
-    for (auto iter = args.begin(); iter != args.end(); iter++) {
-        outArgs[iter.key()] = iter.value();
+    for (auto iter = args.constBegin(); iter != args.constEnd(); iter++) {
+        outArgs.insert(iter.key(), iter.value());
     }
     root.insert("args", outArgs);
 

--- a/launcher/ApplicationMessage.h
+++ b/launcher/ApplicationMessage.h
@@ -1,12 +1,12 @@
 #pragma once
 
 #include <QString>
-#include <QMap>
+#include <QHash>
 #include <QByteArray>
 
 struct ApplicationMessage {
     QString command;
-    QMap<QString, QString> args;
+    QHash<QString, QString> args;
 
     QByteArray serialize();
     void parse(const QByteArray & input);


### PR DESCRIPTION
QHash provides faster lookup times than QMap because it uses a hash table to store the elements, while QMap uses a self-balancing binary tree.

Signed-off-by: Edgars Cīrulis <edgarsscirulis@gmail.com>