### PR TITLE
Replace NDEBUG checks with AUTH_DEBUG for security

### DIFF
--- a/launcher/minecraft/auth/Parsers.cpp
+++ b/launcher/minecraft/auth/Parsers.cpp
@@ -75,7 +75,7 @@ bool getBool(QJsonValue value, bool & out) {
 
 bool parseXTokenResponse(QByteArray & data, Katabasis::Token &output, QString name) {
     qDebug() << "Parsing" << name <<":";
-#ifndef NDEBUG
+#ifdef AUTH_DEBUG
     qDebug() << data;
 #endif
     QJsonParseError jsonError;
@@ -137,7 +137,7 @@ bool parseXTokenResponse(QByteArray & data, Katabasis::Token &output, QString na
 
 bool parseMinecraftProfile(QByteArray & data, MinecraftProfile &output) {
     qDebug() << "Parsing Minecraft profile...";
-#ifndef NDEBUG
+#ifdef AUTH_DEBUG
     qDebug() << data;
 #endif
 
@@ -275,7 +275,7 @@ decoded base64 "value":
 
 bool parseMinecraftProfileMojang(QByteArray & data, MinecraftProfile &output) {
     qDebug() << "Parsing Minecraft profile...";
-#ifndef NDEBUG
+#ifdef AUTH_DEBUG
     qDebug() << data;
 #endif
 
@@ -389,7 +389,7 @@ bool parseMinecraftProfileMojang(QByteArray & data, MinecraftProfile &output) {
 
 bool parseMinecraftEntitlements(QByteArray & data, MinecraftEntitlement &output) {
     qDebug() << "Parsing Minecraft entitlements...";
-#ifndef NDEBUG
+#ifdef AUTH_DEBUG
     qDebug() << data;
 #endif
 
@@ -424,7 +424,7 @@ bool parseMinecraftEntitlements(QByteArray & data, MinecraftEntitlement &output)
 
 bool parseRolloutResponse(QByteArray & data, bool& result) {
     qDebug() << "Parsing Rollout response...";
-#ifndef NDEBUG
+#ifdef AUTH_DEBUG
     qDebug() << data;
 #endif
 
@@ -455,7 +455,7 @@ bool parseRolloutResponse(QByteArray & data, bool& result) {
 bool parseMojangResponse(QByteArray & data, Katabasis::Token &output) {
     QJsonParseError jsonError;
     qDebug() << "Parsing Mojang response...";
-#ifndef NDEBUG
+#ifdef AUTH_DEBUG
     qDebug() << data;
 #endif
     QJsonDocument doc = QJsonDocument::fromJson(data, &jsonError);

--- a/launcher/minecraft/auth/steps/EntitlementsStep.cpp
+++ b/launcher/minecraft/auth/steps/EntitlementsStep.cpp
@@ -41,7 +41,7 @@ void EntitlementsStep::onRequestDone(
     auto requestor = qobject_cast<AuthRequest *>(QObject::sender());
     requestor->deleteLater();
 
-#ifndef NDEBUG
+#ifdef AUTH_DEBUG
     qDebug() << data;
 #endif
 

--- a/launcher/minecraft/auth/steps/LauncherLoginStep.cpp
+++ b/launcher/minecraft/auth/steps/LauncherLoginStep.cpp
@@ -51,12 +51,12 @@ void LauncherLoginStep::onRequestDone(
     auto requestor = qobject_cast<AuthRequest *>(QObject::sender());
     requestor->deleteLater();
 
-#ifndef NDEBUG
+#ifdef AUTH_DEBUG
     qDebug() << data;
 #endif
     if (error != QNetworkReply::NoError) {
         qWarning() << "Reply error:" << error;
-#ifndef NDEBUG
+#ifdef AUTH_DEBUG
         qDebug() << data;
 #endif
         if (Net::isApplicationError(error)) {
@@ -76,7 +76,7 @@ void LauncherLoginStep::onRequestDone(
 
     if(!Parsers::parseMojangResponse(data, m_data->yggdrasilToken)) {
         qWarning() << "Could not parse login_with_xbox response...";
-#ifndef NDEBUG
+#ifdef AUTH_DEBUG
         qDebug() << data;
 #endif
         emit finished(

--- a/launcher/minecraft/auth/steps/MSAStep.cpp
+++ b/launcher/minecraft/auth/steps/MSAStep.cpp
@@ -117,7 +117,7 @@ void MSAStep::onOAuthActivityChanged(Katabasis::Activity activity) {
             // Succeeded or did not invalidate tokens
             emit hideVerificationUriAndCode();
             QVariantMap extraTokens = m_oauth2->extraTokens();
-#ifndef NDEBUG
+#ifdef AUTH_DEBUG
             if (!extraTokens.isEmpty()) {
                 qDebug() << "Extra tokens in response:";
                 foreach (QString key, extraTokens.keys()) {

--- a/launcher/minecraft/auth/steps/MinecraftProfileStep.cpp
+++ b/launcher/minecraft/auth/steps/MinecraftProfileStep.cpp
@@ -40,7 +40,7 @@ void MinecraftProfileStep::onRequestDone(
     auto requestor = qobject_cast<AuthRequest *>(QObject::sender());
     requestor->deleteLater();
 
-#ifndef NDEBUG
+#ifdef AUTH_DEBUG
     qDebug() << data;
 #endif
     if (error == QNetworkReply::ContentNotFoundError) {

--- a/launcher/minecraft/auth/steps/MinecraftProfileStepMojang.cpp
+++ b/launcher/minecraft/auth/steps/MinecraftProfileStepMojang.cpp
@@ -43,7 +43,7 @@ void MinecraftProfileStepMojang::onRequestDone(
     auto requestor = qobject_cast<AuthRequest *>(QObject::sender());
     requestor->deleteLater();
 
-#ifndef NDEBUG
+#ifdef AUTH_DEBUG
     qDebug() << data;
 #endif
     if (error == QNetworkReply::ContentNotFoundError) {

--- a/launcher/minecraft/auth/steps/XboxAuthorizationStep.cpp
+++ b/launcher/minecraft/auth/steps/XboxAuthorizationStep.cpp
@@ -58,7 +58,7 @@ void XboxAuthorizationStep::onRequestDone(
     auto requestor = qobject_cast<AuthRequest *>(QObject::sender());
     requestor->deleteLater();
 
-#ifndef NDEBUG
+#ifdef AUTH_DEBUG
     qDebug() << data;
 #endif
     if (error != QNetworkReply::NoError) {

--- a/launcher/minecraft/auth/steps/XboxProfileStep.cpp
+++ b/launcher/minecraft/auth/steps/XboxProfileStep.cpp
@@ -56,7 +56,7 @@ void XboxProfileStep::onRequestDone(
 
     if (error != QNetworkReply::NoError) {
         qWarning() << "Reply error:" << error;
-#ifndef NDEBUG
+#ifdef AUTH_DEBUG
         qDebug() << data;
 #endif
         if (Net::isApplicationError(error)) {
@@ -74,7 +74,7 @@ void XboxProfileStep::onRequestDone(
         return;
     }
 
-#ifndef NDEBUG
+#ifdef AUTH_DEBUG
     qDebug() << "XBox profile: " << data;
 #endif
 

--- a/libraries/katabasis/src/DeviceFlow.cpp
+++ b/libraries/katabasis/src/DeviceFlow.cpp
@@ -333,7 +333,7 @@ QString DeviceFlow::refreshToken() {
 }
 
 void DeviceFlow::setRefreshToken(const QString &v) {
-#ifndef NDEBUG
+#ifdef AUTH_DEBUG
     qDebug() << "DeviceFlow::setRefreshToken" << v << "...";
 #endif
     token_.refresh_token = v;


### PR DESCRIPTION
This seems like a silly change, but I've seen examples in the past of why it may be needed (I don't want to be too specific). This makes the debugging messages for authentication opt-in with AUTH_DEBUG.