### PR TITLE
improve msvc build flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,19 +28,23 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_C_STANDARD 11)
 include(GenerateExportHeader)
 if(MSVC)
-    # Use /W4 as /Wall includes unnesserey warnings such as added padding to structs
+    # /GL enables whole program optimizations
+    # /Gw helps reduce binary size
+    # /Gy allows the compiler to package individual functions
+    # /guard:cf enables control flow guard
     # /permissive- specify standards-conforming compiler behavior, also enabled by Qt6, default on with std:c++20
-    # /GS Adds buffer security checks, default on but incuded anyway to mirror gcc's fstack-protector flag
-    set(CMAKE_CXX_FLAGS "/W4 /permissive- /GS ${CMAKE_CXX_FLAGS}")
+    # Use /W4 as /Wall includes unnesserey warnings such as added padding to structs
+    set(CMAKE_CXX_FLAGS "/GL /Gw /Gy /guard:cf /permissive- /W4 ${CMAKE_CXX_FLAGS}")
 
     # LINK accepts /SUBSYSTEM whics sets if we are a WINDOWS (gui) or a CONSOLE programs
     # This implicitly selects an entrypoint specific to the subsystem selected
     # qtmain/QtEntryPointLib provides the correct entrypoint (wWinMain) for gui programs
     # Additinaly LINK autodetects we use a GUI so we can omit /SUBSYSTEM
     # This allows tests to still use have console without using seperate linker flags
+    # /LTCG allows for linking wholy optimizated programs
     # /MANIFEST:NO disables generating a manifest file, we instead provide our own
     # /STACK sets the stack reserve size, ATL's pack list needs 3-4 MiB as of November 2022, provide 8 MiB
-    set(CMAKE_EXE_LINKER_FLAGS "/MANIFEST:NO /STACK:8388608 ${CMAKE_EXE_LINKER_FLAGS}")
+    set(CMAKE_EXE_LINKER_FLAGS "/LTCG /MANIFEST:NO /STACK:8388608 ${CMAKE_EXE_LINKER_FLAGS}")
 
     # See https://github.com/ccache/ccache/issues/1040
     # Note, CMake 3.25 replaces this with CMAKE_MSVC_DEBUG_INFORMATION_FORMAT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,13 +28,10 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_C_STANDARD 11)
 include(GenerateExportHeader)
 if(MSVC)
-    # /GL enables whole program optimizations
-    # /Gw helps reduce binary size
-    # /Gy allows the compiler to package individual functions
-    # /guard:cf enables control flow guard
+    # /GS Adds buffer security checks, default on but incuded anyway to mirror gcc's fstack-protector flag
     # /permissive- specify standards-conforming compiler behavior, also enabled by Qt6, default on with std:c++20
     # Use /W4 as /Wall includes unnesserey warnings such as added padding to structs
-    set(CMAKE_CXX_FLAGS "/GL /Gw /Gy /guard:cf /permissive- /W4 ${CMAKE_CXX_FLAGS}")
+    set(CMAKE_CXX_FLAGS "/GS /permissive- /W4 ${CMAKE_CXX_FLAGS}")
 
     # LINK accepts /SUBSYSTEM whics sets if we are a WINDOWS (gui) or a CONSOLE programs
     # This implicitly selects an entrypoint specific to the subsystem selected
@@ -45,6 +42,14 @@ if(MSVC)
     # /MANIFEST:NO disables generating a manifest file, we instead provide our own
     # /STACK sets the stack reserve size, ATL's pack list needs 3-4 MiB as of November 2022, provide 8 MiB
     set(CMAKE_EXE_LINKER_FLAGS "/LTCG /MANIFEST:NO /STACK:8388608 ${CMAKE_EXE_LINKER_FLAGS}")
+
+    # /GL enables whole program optimizations
+    # /Gw helps reduce binary size
+    # /Gy allows the compiler to package individual functions
+    # /guard:cf enables control flow guard
+    foreach(lang C CXX)
+        set("CMAKE_${lang}_FLAGS_RELEASE" "/GL /Gw /Gy /guard:cf")
+    endforeach()
 
     # See https://github.com/ccache/ccache/issues/1040
     # Note, CMake 3.25 replaces this with CMAKE_MSVC_DEBUG_INFORMATION_FORMAT


### PR DESCRIPTION
recently i've noticed the current msvc flags aren't as well optimized as they could be, which is standard for other platforms like Linux - since setting better flags is handled by distributions/packagers - but considering our builds are the primary source for users on windows, i think we should be a bit more aggressive than usual.  

so in summary, for release builds this:
- adds /GL, /Gy, and /LTCG for better optimizations for
- adds /Gw for a smaller binary size for
- adds /guard:cf for added security at runtime
- ~~removes unneeded /GS flag as that's already enabled by [default](https://learn.microsoft.com/en-us/cpp/build/reference/gs-buffer-security-check?view=msvc-170)~~

the options /GL and /LTCG allow for better optimizations by [taking into account all modules](https://learn.microsoft.com/en-us/cpp/build/reference/gl-whole-program-optimization?view=msvc-170) (/LTCG is just adding linker support for this), and /Gw works in conjunction with these flags to reach a smaller binary size and give highly detailed information to the linker by packaging individual functions into COMDATs (good write up about it [here](https://devblogs.microsoft.com/cppblog/introducing-gw-compiler-switch/))

/guard:cfg also enables windows' [control flow guard](https://learn.microsoft.com/en-us/windows/win32/secbp/control-flow-guard), which helps mitigate issues involving memory corruption with little to no performance hit (you can read more [here](https://learn.microsoft.com/en-us/windows/win32/secbp/control-flow-guard)). on versions of windows that don't support CFG (< 8.1), it seems the feature is just ignored

Signed-off-by: seth <getchoo@tuta.io>
