### PR TITLE
fix: exclude unused tls backends

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -1166,6 +1166,8 @@ if(INSTALL_BUNDLE STREQUAL "full")
             CONFIGURATIONS Debug RelWithDebInfo ""
             DESTINATION ${PLUGIN_DEST_DIR}
             COMPONENT Runtime
+            PATTERN "*qopensslbackend*" EXCLUDE
+            PATTERN "*qcertonlybackend*" EXCLUDE
         )
         install(
             DIRECTORY "${QT_PLUGINS_DIR}/tls"
@@ -1175,6 +1177,8 @@ if(INSTALL_BUNDLE STREQUAL "full")
             REGEX "dd\\." EXCLUDE
             REGEX "_debug\\." EXCLUDE
             REGEX "\\.dSYM" EXCLUDE
+            PATTERN "*qopensslbackend*" EXCLUDE
+            PATTERN "*qcertonlybackend*" EXCLUDE
         )
     endif()
     configure_file(


### PR DESCRIPTION
makes bundles slightly smaller on windows and macos:

- qopensslbackend will not be used neither on macos nor on qt6 windows, so let's just not copy it
- qcertonlybackend won't be used and wouldn't work for prism anyways as it doesn't support some features we use

