### PR TITLE
Update installers-regex for winget releaser again

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -11,5 +11,5 @@ jobs:
         with:
           identifier: PrismLauncher.PrismLauncher
           version: ${{ github.event.release.tag_name }}
-          installers-regex: 'PrismLauncher-Windows-MSVC(:?-arm64)?-Setup-.+\.exe$'
+          installers-regex: 'PrismLauncher-Windows-MSVC(:?-arm64|-Legacy)?-Setup-.+\.exe$'
           token: ${{ secrets.WINGET_TOKEN }}


### PR DESCRIPTION
This one should match all files we need.

![preview](https://scrumplex.rocks/img/1671463386_Bi9thi.png)

Last WinGet yaml:
```yaml
# Created with YamlCreate.ps1 v2.2.1 using InputObject 🤖 $debug=QUSU.CRLF.7-2-7
# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.2.0.schema.json

PackageIdentifier: PrismLauncher.PrismLauncher
PackageVersion: "6.0"
MinimumOSVersion: 10.0.0.0
InstallerType: nullsoft
InstallModes:
- interactive
- silent
- silentWithProgress
UpgradeBehavior: install
ReleaseDate: 2022-12-12
Installers:
- Architecture: x64
  InstallerUrl: https://github.com/PrismLauncher/PrismLauncher/releases/download/6.0/PrismLauncher-Windows-MSVC-Setup-6.0.exe
  InstallerSha256: e68fe6053a2e837ffa6df09cdbccdb0bd8e6c3d31bcdba0074e587d0f283c575
  Dependencies:
    PackageDependencies:
    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
- Architecture: x86
  InstallerUrl: https://github.com/PrismLauncher/PrismLauncher/releases/download/6.0/PrismLauncher-Windows-MSVC-Legacy-Setup-6.0.exe
  InstallerSha256: 3b1a48e667aaa6c254f9cc9315db9c4f860a2f8d983bd51a056dda2cec73ad22
  Dependencies:
    PackageDependencies:
    - PackageIdentifier: Microsoft.VCRedist.2015+.x86
- Architecture: arm64
  InstallerUrl: https://github.com/PrismLauncher/PrismLauncher/releases/download/6.0/PrismLauncher-Windows-MSVC-arm64-Setup-6.0.exe
  InstallerSha256: 8515e7782011812ebc6ef45206e4bfb1eec924c70787c4b8f41284e7a2cdd1bc
  Dependencies:
    PackageDependencies:
    - PackageIdentifier: Microsoft.VCRedist.2022.arm64
ManifestType: installer
ManifestVersion: 1.2.0
```