### PR TITLE
LocalPeer: Fix warning

### DIFF
--- a/libraries/LocalPeer/src/LocalPeer.cpp
+++ b/libraries/LocalPeer/src/LocalPeer.cpp
@@ -122,6 +122,14 @@ LocalPeer::LocalPeer(QObject * parent, const ApplicationId &appId)
     QString lockName = QDir(QDir::tempPath()).absolutePath() + QLatin1Char('/') + socketName + QLatin1String("-lockfile");
     lockFile.reset(new LockedFile(lockName));
     lockFile->open(QIODevice::ReadWrite);
+
+    if (!server->isListening())
+    {
+        if (!server->listen(socketName))
+        {
+            // handle warning
+        }
+    }
 }
 
 LocalPeer::~LocalPeer()


### PR DESCRIPTION
This will check if the QLocalServer object is already listening for connections before trying to start it again, and will only start it if it is not already listening.

This should fix the "QLocalSocket::setServerName() called while not in unconnected state" warning.

Signed-off-by: Edgars Cīrulis <edgarsscirulis@gmail.com>