### PR TITLE
Use Qt logging facilities instead of our own

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -425,7 +425,6 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
         }
         qInstallMessageHandler(appDebugOutput);
 
-        // TODO: Set filter rules based on CLI arguments
         qSetMessagePattern(
                 "%{time process}" " "
                 "%{if-debug}D%{endif}" "%{if-info}I%{endif}" "%{if-warning}W%{endif}" "%{if-critical}C%{endif}" "%{if-fatal}F%{endif}"

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -146,19 +146,12 @@ static const QLatin1String liveCheckFile("live.check");
 PixmapCache* PixmapCache::s_instance = nullptr;
 
 namespace {
+
+/** This is used so that we can output to the log file in addition to the CLI. */
 void appDebugOutput(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {
-    const char *levels = "DWCFIS";
-    const QString format("%1 %2 %3\n");
-
-    qint64 msecstotal = APPLICATION->timeSinceStart();
-    qint64 seconds = msecstotal / 1000;
-    qint64 msecs = msecstotal % 1000;
-    QString foo;
-    char buf[1025] = {0};
-    ::snprintf(buf, 1024, "%5lld.%03lld", seconds, msecs);
-
-    QString out = format.arg(buf).arg(levels[type]).arg(msg);
+    QString out = qFormatLogMessage(type, context, msg);
+    out += QChar::LineFeed;
 
     APPLICATION->logFile->write(out.toUtf8());
     APPLICATION->logFile->flush();
@@ -431,6 +424,15 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
             return;
         }
         qInstallMessageHandler(appDebugOutput);
+
+        // TODO: Set filter rules based on CLI arguments
+        qSetMessagePattern(
+                "%{time process}" " "
+                "%{if-debug}D%{endif}" "%{if-info}I%{endif}" "%{if-warning}W%{endif}" "%{if-critical}C%{endif}" "%{if-fatal}F%{endif}"
+                " " "|" " "
+                "%{if-category}[%{category}]: %{endif}"
+                "%{message}");
+
         qDebug() << "<> Log initialized.";
     }
 

--- a/program_info/prismlauncher.6.scd
+++ b/program_info/prismlauncher.6.scd
@@ -41,6 +41,24 @@ Here are the current features of Prism Launcher.
 *-a, --profile*=PROFILE
 	Use the account specified by PROFILE (only valid in combination with --launch).
 
+# ENVIRONMENT
+
+The behavior of the launcher can be customized by the following environment
+variables, besides other common Qt variables:
+
+*QT_LOGGING_RULES*
+	Specifies which logging categories are shown in the logs. One can
+	enable/disable multiple categories by separating them with a semicolon (;).
+
+	The specific syntax, and alternatives to this setting, can be found at
+	https://doc.qt.io/qt-6/qloggingcategory.html#configuring-categories.
+
+*QT_MESSAGE_PATTERN*
+	Specifies the format in which the console output will be shown.
+
+	Available options, as well as syntax, can be viewed at
+	https://doc.qt.io/qt-6/qtglobal.html#qSetMessagePattern.
+
 # EXIT STATUS
 
 *0*


### PR DESCRIPTION
This allows changing the behavior of the logger at runtime via environment variables that Qt takes care of for us. More specifically, it allows people to set their own log format, with more or less information per line, or enable/disable categories. It also shows up the categories of logs from Qt itself.

The default log is very similar to the old one, only adding a category thing when those exist (like in Qt internal prints) and an extra '|' to better separate the date / type from the actual message :>

old default:
![old default logging](https://user-images.githubusercontent.com/9145768/209245156-5b214b69-e5e0-4f58-9443-ead918e09f25.png)
new default:
![new default logging](https://user-images.githubusercontent.com/9145768/209245240-d85fd2e9-f067-4638-9051-c27ca31077f1.png)