### PR TITLE
Remove commit hash from builds where git wasn't installed at build time

### DIFF
--- a/buildconfig/BuildConfig.cpp.in
+++ b/buildconfig/BuildConfig.cpp.in
@@ -76,7 +76,8 @@ Config::Config()
 
     // Assume that builds outside of Git repos are "stable"
     if (GIT_REFSPEC == QStringLiteral("GITDIR-NOTFOUND")
-        || GIT_TAG == QStringLiteral("GITDIR-NOTFOUND"))
+        || GIT_TAG == QStringLiteral("GITDIR-NOTFOUND")
+        || GIT_TAG == QStringLiteral("GIT-NOTFOUND"))
     {
         GIT_REFSPEC = "refs/heads/stable";
         GIT_TAG = versionString();

--- a/buildconfig/BuildConfig.cpp.in
+++ b/buildconfig/BuildConfig.cpp.in
@@ -77,6 +77,7 @@ Config::Config()
     // Assume that builds outside of Git repos are "stable"
     if (GIT_REFSPEC == QStringLiteral("GITDIR-NOTFOUND")
         || GIT_TAG == QStringLiteral("GITDIR-NOTFOUND")
+        || GIT_REFSPEC == QStringLiteral("")
         || GIT_TAG == QStringLiteral("GIT-NOTFOUND"))
     {
         GIT_REFSPEC = "refs/heads/stable";


### PR DESCRIPTION
since builds are already assumed to be stable when outside of a git repo, i think it would be okay to assume their stable when `git` isn't found either. this would fix issues with current packages that build from the vendor tarball displaying the commit hash in the title bar (mine :trollface: and maybe some others out there as well) and not force `git` to be a build dependency when it really isn't needed outside of this.

Signed-off-by: seth <getchoo@tuta.io>
