### PR TITLE
store logs in seperate directory

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -394,7 +394,11 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
 
     // init the logger
     {
-        static const QString logBase = BuildConfig.LAUNCHER_NAME + "-%0.log";
+        static const QString logBase = "logs/"+BuildConfig.LAUNCHER_NAME + "-%0.log";
+        QDir logDir = QDir(dataPath);
+        if(!logDir.exists("logs")) {
+            logDir.mkpath("logs"); //this can fail, but there is no need to throw an error *yet*, since it also triggers the error message below!
+        }
         auto moveFile = [](const QString &oldName, const QString &newName)
         {
             QFile::remove(newName);
@@ -415,11 +419,11 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
                 QString(
                     "The launcher couldn't create a log file - the data folder is not writable.\n"
                     "\n"
-                    "Make sure you have write permissions to the data folder.\n"
+                    "Make sure you have write permissions to the logs folder.\n"
                     "(%1)\n"
                     "\n"
                     "The launcher cannot continue until you fix this problem."
-                ).arg(dataPath)
+                ).arg(dataPath+"/logs")
             );
             return;
         }
@@ -1666,6 +1670,7 @@ bool Application::handleDataMigration(const QString& currentData,
         matcher->add(std::make_shared<SimplePrefixMatcher>(configFile));
         matcher->add(std::make_shared<SimplePrefixMatcher>(
             BuildConfig.LAUNCHER_CONFIGFILE));  // it's possible that we already used that directory before
+        matcher->add(std::make_shared<SimplePrefixMatcher>("logs/"));
         matcher->add(std::make_shared<SimplePrefixMatcher>("accounts.json"));
         matcher->add(std::make_shared<SimplePrefixMatcher>("accounts/"));
         matcher->add(std::make_shared<SimplePrefixMatcher>("assets/"));


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
This simple pull request makes it so that all logs from now on are stored in a seperate directory, that way the root folder won't get too messy!

Now the file structure of the data folder (fresh install that got launched once) looks like this:
![grafik](https://user-images.githubusercontent.com/95762086/209483808-9c865897-0e7b-4895-ae65-84c8afdd1fa5.png)


See issue #136 

How to test:

1. Compile the branch
2. launch the programm at least once
3. verify that the log file is now in the logs directory