### PR TITLE
feat: recreate dependencies when they conflict

### DIFF
--- a/launcher/minecraft/ComponentUpdateTask.cpp
+++ b/launcher/minecraft/ComponentUpdateTask.cpp
@@ -265,7 +265,7 @@ void ComponentUpdateTask::loadComponents(bool firstRun)
         case LoadResult::LoadedLocal:
         {
             // Everything got loaded. Advance to dependency resolution.
-            resolveDependencies(firstRun, d->mode == Mode::Launch || d->netmode == Net::Mode::Offline);
+            resolveDependencies(d->mode == Mode::Launch || d->netmode == Net::Mode::Offline, firstRun);
             break;
         }
         case LoadResult::RequiresRemote:
@@ -403,9 +403,9 @@ static void getTrivialRemovals(const ComponentContainer & components, const Requ
         if(iter == reqs.cend())
         {
             toRemove.append(component->m_uid);
-        } else if (greedyRemove) {
+        } else if (greedyRemove && !component->isCustom()) {
 // ############################################################################################################
-// HACK HACK HACK HACK FIXME: this is a placeholder for removing intermediary to be added back later
+// HACK HACK HACK HACK FIXME: this is a placeholder for removing intermediaries to be added back later
             if (component->m_uid == "net.fabricmc.intermediary" || component->m_uid == "org.quiltmc.hashed")
             {
                 toRemove.append(component->m_uid);
@@ -515,7 +515,7 @@ static bool getTrivialComponentChanges(const ComponentIndex & index, const Requi
 // FIXME, TODO: decouple dependency resolution from loading
 // FIXME: This works directly with the PackProfile internals. It shouldn't! It needs richer data types than PackProfile uses.
 // FIXME: throw all this away and use a graph
-void ComponentUpdateTask::resolveDependencies(bool firstRun, bool checkOnly)
+void ComponentUpdateTask::resolveDependencies(bool checkOnly, bool firstRun)
 {
     qDebug() << "Resolving dependencies";
     /*
@@ -702,7 +702,7 @@ void ComponentUpdateTask::checkIfAllFinished(bool firstRun)
     {
         // nothing bad happened... clear the temp load status and proceed with looking at dependencies
         d->remoteLoadStatusList.clear();
-        resolveDependencies(firstRun, d->mode == Mode::Launch);
+        resolveDependencies(d->mode == Mode::Launch, firstRun);
     }
     else
     {

--- a/launcher/minecraft/ComponentUpdateTask.h
+++ b/launcher/minecraft/ComponentUpdateTask.h
@@ -25,12 +25,12 @@ protected:
     void executeTask();
 
 private:
-    void loadComponents();
-    void resolveDependencies(bool checkOnly);
+    void loadComponents(bool firstRun);
+    void resolveDependencies(bool firstRun, bool checkOnly);
 
-    void remoteLoadSucceeded(size_t index);
-    void remoteLoadFailed(size_t index, const QString &msg);
-    void checkIfAllFinished();
+    void remoteLoadSucceeded(size_t index, bool firstRun);
+    void remoteLoadFailed(size_t index, const QString &msg, bool firstRun);
+    void checkIfAllFinished(bool firstRun);
 
 private:
     std::unique_ptr<ComponentUpdateTaskData> d;

--- a/launcher/minecraft/ComponentUpdateTask.h
+++ b/launcher/minecraft/ComponentUpdateTask.h
@@ -26,7 +26,7 @@ protected:
 
 private:
     void loadComponents(bool firstRun);
-    void resolveDependencies(bool firstRun, bool checkOnly);
+    void resolveDependencies(bool checkOnly, bool firstRun);
 
     void remoteLoadSucceeded(size_t index, bool firstRun);
     void remoteLoadFailed(size_t index, const QString &msg, bool firstRun);


### PR DESCRIPTION
This changes the behaviour of ComponentUpdateTask to remove intermediaries so that they will be resolved again later.

This is kinda ugly, but this should be a better place to do this than doing it directly in PackProfile.

We really need to rewrite this logic.

Related #577