### PR TITLE
Skip HTML in markdown rendering

### DIFF
--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -428,6 +428,10 @@ void ModPage::updateUi()
     text += "<hr>";
 
     HoeDown h;
+
+    // hoedown bug: it doesn't handle markdown surrounded by block tags (like center, div) so strip them
+    current.extraData.body.remove(QRegularExpression("<[^>]*(?:center|div)\\W*>"));
+
     ui->packDescription->setHtml(text + (current.extraData.body.isEmpty() ? current.description : h.process(current.extraData.body.toUtf8())));
     ui->packDescription->flush();
 }


### PR DESCRIPTION
Some mod pages use HTML for centering purposes, but this trips up hoedown - so let's skip HTML for now. I use [Zoomify](https://github.com/isXander/Zoomify/blob/1.19.3/README.md?plain=1#L1) for my example since they place a `<div align=center">` tag to center some of their images.

## Before 

![image](https://user-images.githubusercontent.com/54911369/211051344-f869276e-ca74-421a-9db0-6efdbe63b684.png)

## After

![image](https://user-images.githubusercontent.com/54911369/211051333-632653e9-136f-4801-a925-bc1f2ad49731.png)

## Explanation

Before, we set the flags for the hoedown HTML renderer to 0 (I have no idea how it parses this? no flags?) but it seems to trip up their markdown renderer whenever it gets snagged on a HTML tag. Since some mods use some HTML for innocous purposes like centering logos and badges, it's pretty annoying to have a big glob of markdown find it's way into the mod description. This patch just tells hoedown to ignore HTML and now everything should render fine. 

There's also no way AFAIK to get hoedown to just, give us the HTML and let Qt handle it. There's an "escape" mode but that is a literal escape - as in it renders the HTML tags it finds as regular text.