### PR TITLE
chore: update windows msvc to qt 6.4.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
             qt_ver: 6
             qt_host: windows
             qt_arch: ''
-            qt_version: '6.4.0'
+            qt_version: '6.4.2'
             qt_modules: 'qt5compat qtimageformats'
             qt_tools: ''
 
@@ -73,7 +73,7 @@ jobs:
             qt_ver: 6
             qt_host: windows
             qt_arch: 'win64_msvc2019_arm64'
-            qt_version: '6.4.0'
+            qt_version: '6.4.2'
             qt_modules: 'qt5compat qtimageformats'
             qt_tools: ''
 


### PR DESCRIPTION
closes https://github.com/PrismLauncher/PrismLauncher/issues/288

the scaling regression is fixed so we can update just fine now