### PR TITLE
fix: just use github runner's openssl 1.1 instead of installing 3 on …

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -342,9 +342,8 @@ jobs:
         if: matrix.name == 'macOS'
         run: |
           if [ '${{ secrets.SPARKLE_ED25519_KEY }}' != '' ]; then
-            brew install openssl@3
             echo '${{ secrets.SPARKLE_ED25519_KEY }}' > ed25519-priv.pem
-            signature=$(/usr/local/opt/openssl@3/bin/openssl pkeyutl -sign -rawin -in ${{ github.workspace }}/PrismLauncher.tar.gz -inkey ed25519-priv.pem | openssl base64 | tr -d \\n)
+            signature=$(openssl pkeyutl -sign -rawin -in ${{ github.workspace }}/PrismLauncher.tar.gz -inkey ed25519-priv.pem | openssl base64 | tr -d \\n)
             rm ed25519-priv.pem
             cat >> $GITHUB_STEP_SUMMARY << EOF
           ### Artifact Information :information_source:


### PR DESCRIPTION
…macos signing


should fix macos signing step and make it not fail (https://github.com/PrismLauncher/PrismLauncher/actions/runs/3881263498/jobs/6622083524#step:30:519)