### PR TITLE
Fix random ResourceFolderModel test failures on some Windows builds

### DIFF
--- a/launcher/FileSystem.cpp
+++ b/launcher/FileSystem.cpp
@@ -57,6 +57,7 @@
 #include <shlobj.h>
 #include <shobjidl.h>
 #include <sys/utime.h>
+#include <versionhelpers.h>
 #include <windows.h>
 #include <winnls.h>
 #include <string>
@@ -251,6 +252,10 @@ bool trash(QString path, QString *pathInTrash)
     // FIXME: Figure out trash in Flatpak. Qt seemingly doesn't use the Trash portal
     if (DesktopServices::isFlatpak())
         return false;
+#if defined Q_OS_WIN32
+    if (IsWindowsServer())
+        return false;
+#endif
     return QFile::moveToTrash(path, pathInTrash);
 #endif
 }


### PR DESCRIPTION
Based on my ~not so through and not very scientific~ testing, it seems like trashing on Windows Server (used by the CI runner) is borked :)

The tests started failing after the PR that added confirmation on deletion was added, and ever since, when the test didn't outright fail, it took seconds to complete, particularly on the MSVC Legacy builds. With this patch, it _seems_ to be back to normal.

Anyway, we don't really need to trash the files on the tests for them to test what they do, so :woman_shrugging: 