### PR TITLE
Add button to import component JSONs

### DIFF
--- a/launcher/minecraft/PackProfile.cpp
+++ b/launcher/minecraft/PackProfile.cpp
@@ -1,7 +1,10 @@
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2022-2023 Sefa Eyeoglu <contact@scrumplex.net>
+//
+// SPDX-License-Identifier: GPL-3.0-only AND Apache-2.0
+
 /*
  *  Prism Launcher - Minecraft Launcher
- *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022-2023 Sefa Eyeoglu <contact@scrumplex.net>
  *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *
  *  This program is free software: you can redistribute it and/or modify

--- a/launcher/minecraft/PackProfile.h
+++ b/launcher/minecraft/PackProfile.h
@@ -86,6 +86,9 @@ public:
     /// install a jar/zip as a replacement for the main jar
     void installCustomJar(QString selectedFile);
 
+    /// install MMC/Prism component files
+    void installComponents(QStringList selectedFiles);
+
     /// install Java agent files
     void installAgents(QStringList selectedFiles);
 
@@ -171,6 +174,7 @@ private:
     bool load();
     bool installJarMods_internal(QStringList filepaths);
     bool installCustomJar_internal(QString filepath);
+    bool installComponents_internal(QStringList filepaths);
     bool installAgents_internal(QStringList filepaths);
     bool removeComponent_internal(ComponentPtr patch);
 

--- a/launcher/minecraft/PackProfile.h
+++ b/launcher/minecraft/PackProfile.h
@@ -1,7 +1,10 @@
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2022-2023 Sefa Eyeoglu <contact@scrumplex.net>
+//
+// SPDX-License-Identifier: GPL-3.0-only AND Apache-2.0
+
 /*
  *  Prism Launcher - Minecraft Launcher
- *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022-2023 Sefa Eyeoglu <contact@scrumplex.net>
  *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *
  *  This program is free software: you can redistribute it and/or modify

--- a/launcher/minecraft/PackProfile.h
+++ b/launcher/minecraft/PackProfile.h
@@ -90,7 +90,7 @@ public:
     void installCustomJar(QString selectedFile);
 
     /// install MMC/Prism component files
-    void installComponents(QStringList selectedFiles);
+    bool installComponents(QStringList selectedFiles);
 
     /// install Java agent files
     void installAgents(QStringList selectedFiles);
@@ -177,7 +177,6 @@ private:
     bool load();
     bool installJarMods_internal(QStringList filepaths);
     bool installCustomJar_internal(QString filepath);
-    bool installComponents_internal(QStringList filepaths);
     bool installAgents_internal(QStringList filepaths);
     bool removeComponent_internal(ComponentPtr patch);
 

--- a/launcher/ui/pages/instance/VersionPage.cpp
+++ b/launcher/ui/pages/instance/VersionPage.cpp
@@ -1,8 +1,11 @@
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2022-2023 Sefa Eyeoglu <contact@scrumplex.net>
+//
+// SPDX-License-Identifier: GPL-3.0-only AND Apache-2.0
+
 /*
  *  Prism Launcher - Minecraft Launcher
  *  Copyright (c) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
- *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022-2023 Sefa Eyeoglu <contact@scrumplex.net>
  *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *
  *  This program is free software: you can redistribute it and/or modify

--- a/launcher/ui/pages/instance/VersionPage.cpp
+++ b/launcher/ui/pages/instance/VersionPage.cpp
@@ -384,8 +384,12 @@ void VersionPage::on_actionImport_Components_triggered()
     QStringList list = GuiUtil::BrowseForFiles("component", tr("Select components"), tr("Components (*.json)"),
                                                APPLICATION->settings()->get("CentralModsDir").toString(), this->parentWidget());
 
-    if (!list.isEmpty())
-        m_profile->installComponents(list);
+    if (!list.isEmpty()) {
+        if (!m_profile->installComponents(list)) {
+            QMessageBox::warning(this, tr("Failed to import components"),
+                                 tr("Some components could not be imported. Check logs for details"));
+        }
+    }
 
     updateButtons();
 }

--- a/launcher/ui/pages/instance/VersionPage.cpp
+++ b/launcher/ui/pages/instance/VersionPage.cpp
@@ -282,6 +282,7 @@ void VersionPage::updateButtons(int row)
     ui->actionRevert->setEnabled(controlsEnabled && patch && patch->isRevertible());
     ui->actionDownload_All->setEnabled(controlsEnabled);
     ui->actionAdd_Empty->setEnabled(controlsEnabled);
+    ui->actionImport_Components->setEnabled(controlsEnabled);
     ui->actionReload->setEnabled(controlsEnabled);
     ui->actionInstall_mods->setEnabled(controlsEnabled);
     ui->actionReplace_Minecraft_jar->setEnabled(controlsEnabled);
@@ -375,6 +376,16 @@ void VersionPage::on_actionReplace_Minecraft_jar_triggered()
     updateButtons();
 }
 
+void VersionPage::on_actionImport_Components_triggered()
+{
+    QStringList list = GuiUtil::BrowseForFiles("component", tr("Select components"), tr("Components (*.json)"),
+                                               APPLICATION->settings()->get("CentralModsDir").toString(), this->parentWidget());
+
+    if (!list.isEmpty())
+        m_profile->installComponents(list);
+
+    updateButtons();
+}
 
 void VersionPage::on_actionAdd_Agents_triggered()
 {

--- a/launcher/ui/pages/instance/VersionPage.h
+++ b/launcher/ui/pages/instance/VersionPage.h
@@ -1,7 +1,11 @@
-// SPDX-License-Identifier: GPL-3.0-only
+// SPDX-FileCopyrightText: 2022-2023 Sefa Eyeoglu <contact@scrumplex.net>
+//
+// SPDX-License-Identifier: GPL-3.0-only AND Apache-2.0
+
 /*
  *  Prism Launcher - Minecraft Launcher
  *  Copyright (c) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
+ *  Copyright (C) 2022-2023 Sefa Eyeoglu <contact@scrumplex.net>
  *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *
  *  This program is free software: you can redistribute it and/or modify

--- a/launcher/ui/pages/instance/VersionPage.h
+++ b/launcher/ui/pages/instance/VersionPage.h
@@ -86,6 +86,7 @@ private slots:
     void on_actionMove_down_triggered();
     void on_actionAdd_to_Minecraft_jar_triggered();
     void on_actionReplace_Minecraft_jar_triggered();
+    void on_actionImport_Components_triggered();
     void on_actionAdd_Agents_triggered();
     void on_actionRevert_triggered();
     void on_actionEdit_triggered();

--- a/launcher/ui/pages/instance/VersionPage.ui
+++ b/launcher/ui/pages/instance/VersionPage.ui
@@ -108,6 +108,7 @@
    <addaction name="actionReplace_Minecraft_jar"/>
    <addaction name="actionAdd_Agents"/>
    <addaction name="actionAdd_Empty"/>
+   <addaction name="actionImport_Components"/>
    <addaction name="separator"/>
    <addaction name="actionMinecraftFolder"/>
    <addaction name="actionLibrariesFolder"/>
@@ -226,10 +227,10 @@
   </action>
   <action name="actionAdd_Agents">
    <property name="text">
-	<string>Add Agents</string>
+    <string>Add Agents</string>
    </property>
    <property name="toolTip">
-	<string>Add Java agents.</string>
+    <string>Add Java agents.</string>
    </property>
   </action>
   <action name="actionAdd_Empty">
@@ -270,6 +271,14 @@
    </property>
    <property name="toolTip">
     <string>Open the instance's local libraries folder.</string>
+   </property>
+  </action>
+  <action name="actionImport_Components">
+   <property name="text">
+    <string>Import Components</string>
+   </property>
+   <property name="toolTip">
+    <string>Import existing component JSON files.</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This is useful for adding generic components to an instance.

One use case for this is to add [BetaCraft's LegacyFix](https://github.com/betacraftuk/legacyfix) java agent using just a JSON file.

Sample JSON file:

```json
{
    "+agents": [
        {
            "name": "uk.betacraft:legacyfix:nightly-7ff1a85",
            "url": "https://files.prismlauncher.org/maven"
        }
    ],
    "+jvmArgs": [
        "-Dlf.deAWT=true"
    ],
    "formatVersion": 1,
    "name": "BetaCraft LegacyFix",
    "uid": "uk.betacraft.legacyfix"
}

```