### PR TITLE
Don't fail mod parsing when encountering invalid modListVersion

### DIFF
--- a/launcher/minecraft/mod/tasks/LocalModParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalModParseTask.cpp
@@ -17,7 +17,7 @@
 namespace ModUtils {
 
 // NEW format
-// https://github.com/MinecraftForge/FML/wiki/FML-mod-information-file/6f62b37cea040daf350dc253eae6326dd9c822c3
+// https://github.com/MinecraftForge/FML/wiki/FML-mod-information-file/c8d8f1929aff9979e322af79a59ce81f3e02db6a
 
 // OLD format:
 // https://github.com/MinecraftForge/FML/wiki/FML-mod-information-file/5bf6a2d05145ec79387acc0d45c958642fb049fc
@@ -74,10 +74,11 @@ ModDetails ReadMCModInfo(QByteArray contents)
             version = Json::ensureString(val, "").toInt();
 
         if (version != 2) {
-            qCritical() << "BAD stuff happened to mod json:";
-            qCritical() << contents;
-            return {};
+            qWarning() << QString(R"(The value of 'modListVersion' is "%1" (expected "2")! The file may be corrupted.)").arg(version);
+            qWarning() << "The contents of 'mcmod.info' are as follows:";
+            qWarning() << contents;
         }
+
         auto arrVal = jsonDoc.object().value("modlist");
         if (arrVal.isUndefined()) {
             arrVal = jsonDoc.object().value("modList");


### PR DESCRIPTION
This allows parsing of some non-conforming mods, like <https://www.curseforge.com/minecraft/mc-mods/aether-ii/files/2273367>, giving only a warning instead of hard-failing.