### PR TITLE
Allow launching an instance while its already running

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -1163,12 +1163,25 @@ bool Application::launch(
         MinecraftServerTargetPtr serverToJoin,
         MinecraftAccountPtr accountToUse
 ) {
+    //This can cause the instance to become corrupted
     if(m_updateRunning)
     {
         qDebug() << "Cannot launch instances while an update is running. Please try again when updates are completed.";
     }
     else if(instance->canLaunch())
     {
+        //This can cause the instance to become corrupted, but the default Minecraft launcher allows it :^)
+        if (instance->isRunning())
+        {
+            auto reply = QMessageBox::question(nullptr, tr("Warning"), tr("Are you sure you want to launch this instance again? Launching the same instance multiple times could corrupt it!"), QMessageBox::Yes | QMessageBox::No);
+            if(reply != QMessageBox::Yes)
+            {
+                return false;
+            }
+
+            qDebug() << "Launching an instance that was already running.";
+        }
+
         auto & extras = m_instanceExtras[instance->id()];
         auto & window = extras.window;
         if(window)

--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -298,7 +298,7 @@ SettingsObjectPtr BaseInstance::settings()
 
 bool BaseInstance::canLaunch() const
 {
-    return (!hasVersionBroken() && !isRunning());
+    return (!hasVersionBroken());
 }
 
 bool BaseInstance::reloadSettings()

--- a/launcher/minecraft/launch/ExtractNatives.cpp
+++ b/launcher/minecraft/launch/ExtractNatives.cpp
@@ -66,8 +66,9 @@ static bool unzipNatives(QString source, QString targetFolder, bool applyJnilibH
         {
             name = replaceSuffix(name, ".jnilib", ".dylib");
         }
+
         QString absFilePath = directory.absoluteFilePath(name);
-        if (!JlCompress::extractFile(&zip, "", absFilePath))
+        if (!QFile::exists(absFilePath) && !JlCompress::extractFile(&zip, "", absFilePath))
         {
             return false;
         }

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -1232,11 +1232,9 @@ void MainWindow::updateToolsMenu()
 {
     QToolButton *launchButton = dynamic_cast<QToolButton*>(ui->instanceToolBar->widgetForAction(ui->actionLaunchInstance));
 
-    bool currentInstanceRunning = m_selectedInstance && m_selectedInstance->isRunning();
-
-    ui->actionLaunchInstance->setDisabled(!m_selectedInstance || currentInstanceRunning);
-    ui->actionLaunchInstanceOffline->setDisabled(!m_selectedInstance || currentInstanceRunning);
-    ui->actionLaunchInstanceDemo->setDisabled(!m_selectedInstance || currentInstanceRunning);
+    ui->actionLaunchInstance->setDisabled(!m_selectedInstance);
+    ui->actionLaunchInstanceOffline->setDisabled(!m_selectedInstance);
+    ui->actionLaunchInstanceDemo->setDisabled(!m_selectedInstance);
 
     QMenu *launchMenu = ui->actionLaunchInstance->menu();
     launchButton->setPopupMode(QToolButton::MenuButtonPopup);
@@ -2171,7 +2169,7 @@ void MainWindow::instanceActivated(QModelIndex index)
 
 void MainWindow::on_actionLaunchInstance_triggered()
 {
-    if(m_selectedInstance && !m_selectedInstance->isRunning())
+    if(m_selectedInstance)
     {
         APPLICATION->launch(m_selectedInstance);
     }


### PR DESCRIPTION
We now mimic the functionality of the official Minecraft launcher and we provide a warning message when this is done (as it could in some cases lead to file corruption).

This is a first "just-works" implementation as at the moment the codebase doesn't really understand having multiple processes of the same instance.

I still believe this is worth it as many people initially expect this behaviour on a Minecraft launcher (including me), and the community has started to find weird but functional workarounds to fix the previously missing behaviour:

https://www.reddit.com/r/PrismLauncher/comments/zx983n/any_way_to_open_multiple_games_from_same_instance/

So I believe we should just provide this expected functionality while being clear of the "risks" involved :)

Related #250

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
