### PR TITLE
BaseInstance: fix unnecessary setting saves

### DIFF
--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -313,15 +313,13 @@ qint64 BaseInstance::lastLaunch() const
 
 void BaseInstance::setLastLaunch(qint64 val)
 {
-    //FIXME: if no change, do not set. setting involves saving a file.
-    m_settings->set("lastLaunchTime", val);
+    setSetting("lastLaunchTime", val);
     emit propertiesChanged(this);
 }
 
 void BaseInstance::setNotes(QString val)
 {
-    //FIXME: if no change, do not set. setting involves saving a file.
-    m_settings->set("notes", val);
+    setSetting("notes", val);
 }
 
 QString BaseInstance::notes() const
@@ -331,8 +329,7 @@ QString BaseInstance::notes() const
 
 void BaseInstance::setIconKey(QString val)
 {
-    //FIXME: if no change, do not set. setting involves saving a file.
-    m_settings->set("iconKey", val);
+    setSetting("iconKey", val);
     emit propertiesChanged(this);
 }
 
@@ -343,8 +340,7 @@ QString BaseInstance::iconKey() const
 
 void BaseInstance::setName(QString val)
 {
-    //FIXME: if no change, do not set. setting involves saving a file.
-    m_settings->set("name", val);
+    setSetting("name", val);
     emit propertiesChanged(this);
 }
 
@@ -367,6 +363,13 @@ QStringList BaseInstance::extraArguments()
 shared_qobject_ptr<LaunchTask> BaseInstance::getLaunchTask()
 {
     return m_launchProcess;
+}
+
+void BaseInstance::setSetting(const QString& key, const QVariant& value)
+{
+    if (m_settings->get(key) != value) {
+        m_settings->set(key, value);
+    }
 }
 
 void BaseInstance::updateRuntimeContext()

--- a/launcher/BaseInstance.h
+++ b/launcher/BaseInstance.h
@@ -128,6 +128,8 @@ public:
     QString name() const;
     void setName(QString val);
 
+    void setSetting(const QString& key, const QVariant& value);
+
     /// Value used for instance window titles
     QString windowTitle() const;
 


### PR DESCRIPTION
This pull request addresses the "FIXME" comment in the BaseInstance class regarding unnecessary calls to the save function for settings that do not change. The changes made include adding a check to ensure that settings are only changed if their value is different from the current value. This reduces the number of unnecessary file saves and improves the performance of the code.

Please review the changes and let me know if there are any issues or if any further changes are needed.

Signed-off-by: Edgars Cīrulis <edgarsscirulis@gmail.com>