### PR TITLE
make MainWindow cat update instantly

### DIFF
--- a/launcher/Application.h
+++ b/launcher/Application.h
@@ -208,6 +208,7 @@ signals:
     void updateAllowedChanged(bool status);
     void globalSettingsAboutToOpen();
     void globalSettingsClosed();
+    int currentCatChanged(int index);
 
 #ifdef Q_OS_MACOS
     void clickedOnDock();

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -974,6 +974,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new MainWindow
         ui->actionCAT->setChecked(cat_enable);
         // NOTE: calling the operator like that is an ugly hack to appease ancient gcc...
         connect(ui->actionCAT.operator->(), SIGNAL(toggled(bool)), SLOT(onCatToggled(bool)));
+        connect(APPLICATION, &Application::currentCatChanged, this, &MainWindow::onCatChanged);
         setCatBackground(cat_enable);
     }
 
@@ -2074,6 +2075,10 @@ void MainWindow::newsButtonClicked()
     NewsDialog news_dialog(entries, this);
     news_dialog.toggleArticleList();
     news_dialog.exec();
+}
+
+void MainWindow::onCatChanged(int) {
+    setCatBackground(APPLICATION->settings()->get("TheCat").toBool());
 }
 
 void MainWindow::on_actionAbout_triggered()

--- a/launcher/ui/MainWindow.h
+++ b/launcher/ui/MainWindow.h
@@ -90,6 +90,8 @@ protected:
 private slots:
     void onCatToggled(bool);
 
+    void onCatChanged(int);
+
     void on_actionAbout_triggered();
 
     void on_actionAddInstance_triggered();

--- a/launcher/ui/pages/global/LauncherPage.cpp
+++ b/launcher/ui/pages/global/LauncherPage.cpp
@@ -106,6 +106,8 @@ LauncherPage::LauncherPage(QWidget *parent) : QWidget(parent), ui(new Ui::Launch
     }
     connect(ui->fontSizeBox, SIGNAL(valueChanged(int)), SLOT(refreshFontPreview()));
     connect(ui->consoleFont, SIGNAL(currentFontChanged(QFont)), SLOT(refreshFontPreview()));
+
+    connect(ui->themeCustomizationWidget, &ThemeCustomizationWidget::currentCatChanged, APPLICATION, &Application::currentCatChanged);
 }
 
 LauncherPage::~LauncherPage()


### PR DESCRIPTION
closes https://github.com/PrismLauncher/PrismLauncher/issues/763

this introduces a signal/slot chain from ThemeCustomizationWidget via LauncherPage and Application to MainWindow. 
Maybe there is a better way to go from that widget to the MainWindow, I'm always up for any suggestions!