### PR TITLE
Fix: zlib fallback not working

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,8 +208,14 @@ set(Launcher_BUILD_TIMESTAMP "${TODAY}")
 
 ################################ 3rd Party Libs ################################
 
-if(NOT Launcher_FORCE_BUNDLED_LIBS)
+# Successive configurations of cmake without cleaning the build dir will cause zlib fallback to fail due to cached values
+# Record when fallback triggered and skip this find_package
+if(NOT Launcher_FORCE_BUNDLED_LIBS AND NOT FORCE_BUNDLED_ZLIB)
     find_package(ZLIB QUIET)
+endif()
+if(NOT ZLIB_FOUND)
+    set(FORCE_BUNDLED_ZLIB TRUE CACHE BOOL "")
+    mark_as_advanced(FORCE_BUNDLED_ZLIB)
 endif()
 
 # Find the required Qt parts
@@ -379,13 +385,14 @@ add_subdirectory(libraries/libnbtplusplus)
 add_subdirectory(libraries/systeminfo) # system information library
 add_subdirectory(libraries/launcher) # java based launcher part for Minecraft
 add_subdirectory(libraries/javacheck) # java compatibility checker
-if(NOT ZLIB_FOUND)
+if(FORCE_BUNDLED_ZLIB)
     message(STATUS "Using bundled zlib")
+
     set(CMAKE_POLICY_DEFAULT_CMP0069 NEW) # Suppress cmake warnings and allow INTERPROCEDURAL_OPTIMIZATION for zlib
     set(SKIP_INSTALL_ALL ON)
     add_subdirectory(libraries/zlib EXCLUDE_FROM_ALL)
     
-    set(ZLIB_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/libraries/zlib" "${CMAKE_CURRENT_BINARY_DIR}/libraries/zlib" CACHE STRING "")
+    set(ZLIB_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/libraries/zlib" "${CMAKE_CURRENT_BINARY_DIR}/libraries/zlib" CACHE STRING "" FORCE)
     set_target_properties(zlibstatic PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${ZLIB_INCLUDE_DIR}")
     add_library(ZLIB::ZLIB ALIAS zlibstatic)
     set(ZLIB_LIBRARY ZLIB::ZLIB CACHE STRING "zlib library name")


### PR DESCRIPTION
### Description of Changes

When `Launcher_FORCE_BUNDLED_LIBS` is not defined, the zlib submodule will fail to load due to the nature of cached values and find_package.

This can be fixed by forcing `ZLIB_INCLUDE_DIR`, however subsequent configurations will cause builds to fail as the first find_package will succeed due to cached variables.

Add a new cmake cached variable `FORCE_BUNDLED_ZLIB` which gets set when bundled zlib is required, which is checked on subsequent configurations to ensure the zlib submodule is correctly loaded.

### Suggested Testing Steps

Test cmake configuration & build without a system installed zlib, and without `Launcher_FORCE_BUNDLED_LIBS`.
Reconfigure cmake & build to ensure subsequent configurations still function.
Check CI.