### PR TITLE
fix: Undo zlibs file rename when using bundled zlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -391,8 +391,18 @@ if(FORCE_BUNDLED_ZLIB)
     set(CMAKE_POLICY_DEFAULT_CMP0069 NEW) # Suppress cmake warnings and allow INTERPROCEDURAL_OPTIMIZATION for zlib
     set(SKIP_INSTALL_ALL ON)
     add_subdirectory(libraries/zlib EXCLUDE_FROM_ALL)
-    
-    set(ZLIB_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/libraries/zlib" "${CMAKE_CURRENT_BINARY_DIR}/libraries/zlib" CACHE STRING "" FORCE)
+
+    # On OS where unistd.h exists, zlib's generated header defines `Z_HAVE_UNISTD_H`, while the included header does not. 
+    # We cannot safely undo the rename on those systems, and they generally have packages for zlib anyway.
+    check_include_file(unistd.h NEED_GENERATED_ZCONF)
+    if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/libraries/zlib/zconf.h.included" AND NOT NEED_GENERATED_ZCONF)
+        # zlib's cmake script renames a file, dirtying the submodule, see https://github.com/madler/zlib/issues/162
+        message(STATUS "Undoing Rename")
+        message(STATUS "    ${CMAKE_CURRENT_SOURCE_DIR}/libraries/zlib/zconf.h")
+        file(RENAME "${CMAKE_CURRENT_SOURCE_DIR}/libraries/zlib/zconf.h.included" "${CMAKE_CURRENT_SOURCE_DIR}/libraries/zlib/zconf.h")
+    endif()
+
+    set(ZLIB_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/libraries/zlib" "${CMAKE_CURRENT_SOURCE_DIR}/libraries/zlib" CACHE STRING "" FORCE)
     set_target_properties(zlibstatic PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${ZLIB_INCLUDE_DIR}")
     add_library(ZLIB::ZLIB ALIAS zlibstatic)
     set(ZLIB_LIBRARY ZLIB::ZLIB CACHE STRING "zlib library name")


### PR DESCRIPTION
zlib's cmake script renames `zconf.h`, dirtying the submodule.
It does this to avoid conflicts with the generated `zconf.h` in the binary directory.

This is annoying as you have to revert this when dealing with git.

Lets undo this renaming with our cmake script.

I reordered our zlib include paths trying to pick the generated `zconf.h`, however, the included header is still picked.

With MSVC, this doesn't matter, as the generated header is effectively the same as the included one.
Other platforms may have issues, so I've added a condition to prevent undoing the rename, we shouldn't need the bundled zlib on those platforms anyway.