### PR TITLE
fix: let jars be found from inside build dir for debug builds

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -1547,7 +1547,10 @@ QString Application::getJarPath(QString jarFile)
         FS::PathCombine(m_rootPath, "share/" + BuildConfig.LAUNCHER_APP_BINARY_NAME),
 #endif
         FS::PathCombine(m_rootPath, "jars"),
-        FS::PathCombine(applicationDirPath(), "jars")
+        FS::PathCombine(applicationDirPath(), "jars"),
+#if !defined(NDEBUG)
+        FS::PathCombine(applicationDirPath(), "..", "jars") // from inside build dir , for debuging
+#endif
     };
     for(QString p : potentialPaths)
     {

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -1548,7 +1548,7 @@ QString Application::getJarPath(QString jarFile)
 #endif
         FS::PathCombine(m_rootPath, "jars"),
         FS::PathCombine(applicationDirPath(), "jars"),
-        FS::PathCombine(applicationDirPath(), "..", "jars") // from inside build dir , for debuging
+        FS::PathCombine(applicationDirPath(), "..", "jars") // from inside build dir, for debuging
     };
     for(QString p : potentialPaths)
     {

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -1548,9 +1548,7 @@ QString Application::getJarPath(QString jarFile)
 #endif
         FS::PathCombine(m_rootPath, "jars"),
         FS::PathCombine(applicationDirPath(), "jars"),
-#if !defined(NDEBUG)
         FS::PathCombine(applicationDirPath(), "..", "jars") // from inside build dir , for debuging
-#endif
     };
     for(QString p : potentialPaths)
     {


### PR DESCRIPTION
debug builds run form inside the build dir before they are bundled can't find the jars. this fixes that.
