### PR TITLE
Don't create two smart pointers for the same raw pointer in ResourceFolderModel

### DIFF
--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -260,7 +260,7 @@ void ResourceFolderModel::resolveResource(Resource* res)
         return;
     }
 
-    auto task = createParseTask(*res);
+    Task::Ptr task{ createParseTask(*res) };
     if (!task)
         return;
 
@@ -270,11 +270,11 @@ void ResourceFolderModel::resolveResource(Resource* res)
     m_active_parse_tasks.insert(ticket, task);
 
     connect(
-        task, &Task::succeeded, this, [=] { onParseSucceeded(ticket, res->internal_id()); }, Qt::ConnectionType::QueuedConnection);
+        task.get(), &Task::succeeded, this, [=] { onParseSucceeded(ticket, res->internal_id()); }, Qt::ConnectionType::QueuedConnection);
     connect(
-        task, &Task::failed, this, [=] { onParseFailed(ticket, res->internal_id()); }, Qt::ConnectionType::QueuedConnection);
+        task.get(), &Task::failed, this, [=] { onParseFailed(ticket, res->internal_id()); }, Qt::ConnectionType::QueuedConnection);
     connect(
-        task, &Task::finished, this, [=] { m_active_parse_tasks.remove(ticket); }, Qt::ConnectionType::QueuedConnection);
+        task.get(), &Task::finished, this, [=] { m_active_parse_tasks.remove(ticket); }, Qt::ConnectionType::QueuedConnection);
 
     m_helper_thread_task.addTask(task);
 

--- a/launcher/tasks/ConcurrentTask.cpp
+++ b/launcher/tasks/ConcurrentTask.cpp
@@ -115,7 +115,7 @@ void ConcurrentTask::startNext()
     QMetaObject::invokeMethod(next.get(), &Task::start, Qt::QueuedConnection);
 
     // Allow going up the number of concurrent tasks in case of tasks being added in the middle of a running task.
-    int num_starts = m_total_max_size - m_doing.size();
+    int num_starts = qMin(m_queue.size(), m_total_max_size - m_doing.size());
     for (int i = 0; i < num_starts; i++)
         QMetaObject::invokeMethod(this, &ConcurrentTask::startNext, Qt::QueuedConnection);
 }


### PR DESCRIPTION
i'm working on making the `shared_qobject_ptr` constructors explicit to catch this kind of error at compile-time in the future, but since that's a lot more changes in the codebase, it should probably go into 7.0. So, this just fixes the current issue for 6.2, "introduced" in #758 (the issue already existed, but the change in there made it much more prevalent).