### PR TITLE
Make `shared_qobject_ptr`'s constructor explicit

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -679,7 +679,7 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
 
     // initialize network access and proxy setup
     {
-        m_network = new QNetworkAccessManager();
+        m_network.reset(new QNetworkAccessManager());
         QString proxyTypeStr = settings()->get("ProxyType").toString();
         QString addr = settings()->get("ProxyAddr").toString();
         int port = settings()->get("ProxyPort").value<qint16>();

--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -88,7 +88,7 @@ void InstanceImportTask::executeTask()
         entry->setStale(true);
         m_archivePath = entry->getFullPath();
 
-        m_filesNetJob = new NetJob(tr("Modpack download"), APPLICATION->network());
+        m_filesNetJob.reset(new NetJob(tr("Modpack download"), APPLICATION->network()));
         m_filesNetJob->addNetAction(Net::Download::makeCached(m_sourceUrl, entry));
 
         connect(m_filesNetJob.get(), &NetJob::succeeded, this, &InstanceImportTask::downloadSucceeded);
@@ -301,7 +301,7 @@ void InstanceImportTask::processFlame()
 
 void InstanceImportTask::processTechnic()
 {
-    shared_qobject_ptr<Technic::TechnicPackProcessor> packProcessor = new Technic::TechnicPackProcessor();
+    shared_qobject_ptr<Technic::TechnicPackProcessor> packProcessor{ new Technic::TechnicPackProcessor };
     connect(packProcessor.get(), &Technic::TechnicPackProcessor::succeeded, this, &InstanceImportTask::emitSucceeded);
     connect(packProcessor.get(), &Technic::TechnicPackProcessor::failed, this, &InstanceImportTask::emitFailed);
     packProcessor->run(m_globalSettings, name(), m_instIcon, m_stagingPath);

--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -382,15 +382,15 @@ void LaunchController::launchInstance()
             }
             resolved_servers = resolved_servers + "]\n\n";
         }
-        m_launcher->prependStep(new TextPrint(m_launcher.get(), resolved_servers, MessageLevel::Launcher));
+        m_launcher->prependStep(makeShared<TextPrint>(m_launcher.get(), resolved_servers, MessageLevel::Launcher));
     } else {
         online_mode = m_demo ? "demo" : "offline";
     }
 
-    m_launcher->prependStep(new TextPrint(m_launcher.get(), "Launched instance in " + online_mode + " mode\n", MessageLevel::Launcher));
+    m_launcher->prependStep(makeShared<TextPrint>(m_launcher.get(), "Launched instance in " + online_mode + " mode\n", MessageLevel::Launcher));
 
     // Prepend Version
-    m_launcher->prependStep(new TextPrint(m_launcher.get(), BuildConfig.LAUNCHER_DISPLAYNAME + " version: " + BuildConfig.printableVersionString() + "\n\n", MessageLevel::Launcher));
+    m_launcher->prependStep(makeShared<TextPrint>(m_launcher.get(), BuildConfig.LAUNCHER_DISPLAYNAME + " version: " + BuildConfig.printableVersionString() + "\n\n", MessageLevel::Launcher));
     m_launcher->start();
 }
 

--- a/launcher/QObjectPtr.h
+++ b/launcher/QObjectPtr.h
@@ -20,8 +20,8 @@ using unique_qobject_ptr = QScopedPointer<T, QScopedPointerDeleteLater>;
 template <typename T>
 class shared_qobject_ptr : public QSharedPointer<T> {
    public:
-    constexpr shared_qobject_ptr() : QSharedPointer<T>() {}
-    constexpr shared_qobject_ptr(T* ptr) : QSharedPointer<T>(ptr, &QObject::deleteLater) {}
+    constexpr explicit shared_qobject_ptr() : QSharedPointer<T>() {}
+    constexpr explicit shared_qobject_ptr(T* ptr) : QSharedPointer<T>(ptr, &QObject::deleteLater) {}
     constexpr shared_qobject_ptr(std::nullptr_t null_ptr) : QSharedPointer<T>(null_ptr, &QObject::deleteLater) {}
 
     template <typename Derived>
@@ -33,9 +33,21 @@ class shared_qobject_ptr : public QSharedPointer<T> {
     {}
 
     void reset() { QSharedPointer<T>::reset(); }
+    void reset(T*&& other)
+    {
+        shared_qobject_ptr<T> t(other);
+        this->swap(t);
+    }
     void reset(const shared_qobject_ptr<T>& other)
     {
         shared_qobject_ptr<T> t(other);
         this->swap(t);
     }
 };
+
+template <typename T, typename... Args>
+shared_qobject_ptr<T> makeShared(Args... args)
+{
+    auto obj = new T(args...);
+    return shared_qobject_ptr<T>(obj);
+}

--- a/launcher/java/JavaInstallList.cpp
+++ b/launcher/java/JavaInstallList.cpp
@@ -67,7 +67,7 @@ void JavaInstallList::load()
     if(m_status != Status::InProgress)
     {
         m_status = Status::InProgress;
-        m_loadTask = new JavaListLoadTask(this);
+        m_loadTask.reset(new JavaListLoadTask(this));
         m_loadTask->start();
     }
 }
@@ -167,7 +167,7 @@ void JavaListLoadTask::executeTask()
     JavaUtils ju;
     QList<QString> candidate_paths = ju.FindJavaPaths();
 
-    m_job = new JavaCheckerJob("Java detection");
+    m_job.reset(new JavaCheckerJob("Java detection"));
     connect(m_job.get(), &Task::finished, this, &JavaListLoadTask::javaCheckerFinished);
     connect(m_job.get(), &Task::progress, this, &Task::setProgress);
 

--- a/launcher/launch/steps/CheckJava.cpp
+++ b/launcher/launch/steps/CheckJava.cpp
@@ -93,7 +93,7 @@ void CheckJava::executeTask()
         || storedArchitecture.size() == 0 || storedRealArchitecture.size() == 0
         || storedVendor.size() == 0)
     {
-        m_JavaChecker = new JavaChecker();
+        m_JavaChecker.reset(new JavaChecker);
         emit logLine(QString("Checking Java version..."), MessageLevel::Launcher);
         connect(m_JavaChecker.get(), &JavaChecker::checkFinished, this, &CheckJava::checkJavaFinished);
         m_JavaChecker->m_path = realJavaPath;

--- a/launcher/meta/BaseEntity.cpp
+++ b/launcher/meta/BaseEntity.cpp
@@ -126,7 +126,7 @@ void Meta::BaseEntity::load(Net::Mode loadType)
     {
         return;
     }
-    m_updateTask = new NetJob(QObject::tr("Download of meta file %1").arg(localFilename()), APPLICATION->network());
+    m_updateTask.reset(new NetJob(QObject::tr("Download of meta file %1").arg(localFilename()), APPLICATION->network()));
     auto url = this->url();
     auto entry = APPLICATION->metacache()->resolveEntry("meta", localFilename());
     entry->setStale(true);

--- a/launcher/minecraft/AssetsUtils.cpp
+++ b/launcher/minecraft/AssetsUtils.cpp
@@ -340,7 +340,7 @@ QString AssetObject::getRelPath()
 
 NetJob::Ptr AssetsIndex::getDownloadJob()
 {
-    auto job = new NetJob(QObject::tr("Assets for %1").arg(id), APPLICATION->network());
+    auto job = makeShared<NetJob>(QObject::tr("Assets for %1").arg(id), APPLICATION->network());
     for (auto &object : objects.values())
     {
         auto dl = object.getDownloadAction();

--- a/launcher/minecraft/ComponentUpdateTask.cpp
+++ b/launcher/minecraft/ComponentUpdateTask.cpp
@@ -572,7 +572,7 @@ void ComponentUpdateTask::resolveDependencies(bool checkOnly)
         // add stuff...
         for(auto &add: toAdd)
         {
-            ComponentPtr component = new Component(d->m_list, add.uid);
+            auto component = makeShared<Component>(d->m_list, add.uid);
             if(!add.equalsVersion.isEmpty())
             {
                 // exact version

--- a/launcher/minecraft/MinecraftUpdate.cpp
+++ b/launcher/minecraft/MinecraftUpdate.cpp
@@ -43,7 +43,7 @@ void MinecraftUpdate::executeTask()
     m_tasks.clear();
     // create folders
     {
-        m_tasks.append(new FoldersTask(m_inst));
+        m_tasks.append(makeShared<FoldersTask>(m_inst));
     }
 
     // add metadata update task if necessary
@@ -59,17 +59,17 @@ void MinecraftUpdate::executeTask()
 
     // libraries download
     {
-        m_tasks.append(new LibrariesTask(m_inst));
+        m_tasks.append(makeShared<LibrariesTask>(m_inst));
     }
 
     // FML libraries download and copy into the instance
     {
-        m_tasks.append(new FMLLibrariesTask(m_inst));
+        m_tasks.append(makeShared<FMLLibrariesTask>(m_inst));
     }
 
     // assets update
     {
-        m_tasks.append(new AssetUpdateTask(m_inst));
+        m_tasks.append(makeShared<AssetUpdateTask>(m_inst));
     }
 
     if(!m_preFailure.isEmpty())

--- a/launcher/minecraft/PackProfile.cpp
+++ b/launcher/minecraft/PackProfile.cpp
@@ -130,7 +130,7 @@ static ComponentPtr componentFromJsonV1(PackProfile * parent, const QString & co
     // critical
     auto uid = Json::requireString(obj.value("uid"));
     auto filePath = componentJsonPattern.arg(uid);
-    auto component = new Component(parent, uid);
+    auto component = makeShared<Component>(parent, uid);
     component->m_version = Json::ensureString(obj.value("version"));
     component->m_dependencyOnly = Json::ensureBoolean(obj.value("dependencyOnly"), false);
     component->m_important = Json::ensureBoolean(obj.value("important"), false);
@@ -518,23 +518,23 @@ bool PackProfile::revertToBase(int index)
     return true;
 }
 
-Component * PackProfile::getComponent(const QString &id)
+ComponentPtr PackProfile::getComponent(const QString &id)
 {
     auto iter = d->componentIndex.find(id);
     if (iter == d->componentIndex.end())
     {
         return nullptr;
     }
-    return (*iter).get();
+    return (*iter);
 }
 
-Component * PackProfile::getComponent(int index)
+ComponentPtr PackProfile::getComponent(int index)
 {
     if(index < 0 || index >= d->components.size())
     {
         return nullptr;
     }
-    return d->components[index].get();
+    return d->components[index];
 }
 
 QVariant PackProfile::data(const QModelIndex &index, int role) const
@@ -765,7 +765,7 @@ bool PackProfile::installEmpty(const QString& uid, const QString& name)
     file.write(OneSixVersionFormat::versionFileToJson(f).toJson());
     file.close();
 
-    appendComponent(new Component(this, f->uid, f));
+    appendComponent(makeShared<Component>(this, f->uid, f));
     scheduleSave();
     invalidateLaunchProfile();
     return true;
@@ -872,7 +872,7 @@ bool PackProfile::installJarMods_internal(QStringList filepaths)
         file.write(OneSixVersionFormat::versionFileToJson(f).toJson());
         file.close();
 
-        appendComponent(new Component(this, f->uid, f));
+        appendComponent(makeShared<Component>(this, f->uid, f));
     }
     scheduleSave();
     invalidateLaunchProfile();
@@ -933,7 +933,7 @@ bool PackProfile::installCustomJar_internal(QString filepath)
     file.write(OneSixVersionFormat::versionFileToJson(f).toJson());
     file.close();
 
-    appendComponent(new Component(this, f->uid, f));
+    appendComponent(makeShared<Component>(this, f->uid, f));
 
     scheduleSave();
     invalidateLaunchProfile();
@@ -989,7 +989,7 @@ bool PackProfile::installAgents_internal(QStringList filepaths)
         patchFile.write(OneSixVersionFormat::versionFileToJson(versionFile).toJson());
         patchFile.close();
 
-        appendComponent(new Component(this, versionFile->uid, versionFile));
+        appendComponent(makeShared<Component>(this, versionFile->uid, versionFile));
     }
 
     scheduleSave();
@@ -1038,7 +1038,7 @@ bool PackProfile::setComponentVersion(const QString& uid, const QString& version
     else
     {
         // add new
-        auto component = new Component(this, uid);
+        auto component = makeShared<Component>(this, uid);
         component->m_version = version;
         component->m_important = important;
         appendComponent(component);

--- a/launcher/minecraft/PackProfile.h
+++ b/launcher/minecraft/PackProfile.h
@@ -136,10 +136,10 @@ signals:
 
 public:
     /// get the profile component by id
-    Component * getComponent(const QString &id);
+    ComponentPtr getComponent(const QString &id);
 
     /// get the profile component by index
-    Component * getComponent(int index);
+    ComponentPtr getComponent(int index);
 
     /// Add the component to the internal list of patches
     // todo(merged): is this the best approach

--- a/launcher/minecraft/auth/MinecraftAccount.cpp
+++ b/launcher/minecraft/auth/MinecraftAccount.cpp
@@ -75,7 +75,7 @@ MinecraftAccountPtr MinecraftAccount::loadFromJsonV3(const QJsonObject& json) {
 
 MinecraftAccountPtr MinecraftAccount::createFromUsername(const QString &username)
 {
-    MinecraftAccountPtr account = new MinecraftAccount();
+    auto account = makeShared<MinecraftAccount>();
     account->data.type = AccountType::Mojang;
     account->data.yggdrasilToken.extra["userName"] = username;
     account->data.yggdrasilToken.extra["clientToken"] = QUuid::createUuid().toString().remove(QRegularExpression("[{}-]"));
@@ -91,7 +91,7 @@ MinecraftAccountPtr MinecraftAccount::createBlankMSA()
 
 MinecraftAccountPtr MinecraftAccount::createOffline(const QString &username)
 {
-    MinecraftAccountPtr account = new MinecraftAccount();
+    auto account = makeShared<MinecraftAccount>();
     account->data.type = AccountType::Offline;
     account->data.yggdrasilToken.token = "offline";
     account->data.yggdrasilToken.validity = Katabasis::Validity::Certain;

--- a/launcher/minecraft/auth/flows/MSA.cpp
+++ b/launcher/minecraft/auth/flows/MSA.cpp
@@ -10,28 +10,28 @@
 #include "minecraft/auth/steps/GetSkinStep.h"
 
 MSASilent::MSASilent(AccountData* data, QObject* parent) : AuthFlow(data, parent) {
-    m_steps.append(new MSAStep(m_data, MSAStep::Action::Refresh));
-    m_steps.append(new XboxUserStep(m_data));
-    m_steps.append(new XboxAuthorizationStep(m_data, &m_data->xboxApiToken, "http://xboxlive.com", "Xbox"));
-    m_steps.append(new XboxAuthorizationStep(m_data, &m_data->mojangservicesToken, "rp://api.minecraftservices.com/", "Mojang"));
-    m_steps.append(new LauncherLoginStep(m_data));
-    m_steps.append(new XboxProfileStep(m_data));
-    m_steps.append(new EntitlementsStep(m_data));
-    m_steps.append(new MinecraftProfileStep(m_data));
-    m_steps.append(new GetSkinStep(m_data));
+    m_steps.append(makeShared<MSAStep>(m_data, MSAStep::Action::Refresh));
+    m_steps.append(makeShared<XboxUserStep>(m_data));
+    m_steps.append(makeShared<XboxAuthorizationStep>(m_data, &m_data->xboxApiToken, "http://xboxlive.com", "Xbox"));
+    m_steps.append(makeShared<XboxAuthorizationStep>(m_data, &m_data->mojangservicesToken, "rp://api.minecraftservices.com/", "Mojang"));
+    m_steps.append(makeShared<LauncherLoginStep>(m_data));
+    m_steps.append(makeShared<XboxProfileStep>(m_data));
+    m_steps.append(makeShared<EntitlementsStep>(m_data));
+    m_steps.append(makeShared<MinecraftProfileStep>(m_data));
+    m_steps.append(makeShared<GetSkinStep>(m_data));
 }
 
 MSAInteractive::MSAInteractive(
     AccountData* data,
     QObject* parent
 ) : AuthFlow(data, parent) {
-    m_steps.append(new MSAStep(m_data, MSAStep::Action::Login));
-    m_steps.append(new XboxUserStep(m_data));
-    m_steps.append(new XboxAuthorizationStep(m_data, &m_data->xboxApiToken, "http://xboxlive.com", "Xbox"));
-    m_steps.append(new XboxAuthorizationStep(m_data, &m_data->mojangservicesToken, "rp://api.minecraftservices.com/", "Mojang"));
-    m_steps.append(new LauncherLoginStep(m_data));
-    m_steps.append(new XboxProfileStep(m_data));
-    m_steps.append(new EntitlementsStep(m_data));
-    m_steps.append(new MinecraftProfileStep(m_data));
-    m_steps.append(new GetSkinStep(m_data));
+    m_steps.append(makeShared<MSAStep>(m_data, MSAStep::Action::Login));
+    m_steps.append(makeShared<XboxUserStep>(m_data));
+    m_steps.append(makeShared<XboxAuthorizationStep>(m_data, &m_data->xboxApiToken, "http://xboxlive.com", "Xbox"));
+    m_steps.append(makeShared<XboxAuthorizationStep>(m_data, &m_data->mojangservicesToken, "rp://api.minecraftservices.com/", "Mojang"));
+    m_steps.append(makeShared<LauncherLoginStep>(m_data));
+    m_steps.append(makeShared<XboxProfileStep>(m_data));
+    m_steps.append(makeShared<EntitlementsStep>(m_data));
+    m_steps.append(makeShared<MinecraftProfileStep>(m_data));
+    m_steps.append(makeShared<GetSkinStep>(m_data));
 }

--- a/launcher/minecraft/auth/flows/Mojang.cpp
+++ b/launcher/minecraft/auth/flows/Mojang.cpp
@@ -9,10 +9,10 @@ MojangRefresh::MojangRefresh(
     AccountData *data,
     QObject *parent
 ) : AuthFlow(data, parent) {
-    m_steps.append(new YggdrasilStep(m_data, QString()));
-    m_steps.append(new MinecraftProfileStepMojang(m_data));
-    m_steps.append(new MigrationEligibilityStep(m_data));
-    m_steps.append(new GetSkinStep(m_data));
+    m_steps.append(makeShared<YggdrasilStep>(m_data, QString()));
+    m_steps.append(makeShared<MinecraftProfileStepMojang>(m_data));
+    m_steps.append(makeShared<MigrationEligibilityStep>(m_data));
+    m_steps.append(makeShared<GetSkinStep>(m_data));
 }
 
 MojangLogin::MojangLogin(
@@ -20,8 +20,8 @@ MojangLogin::MojangLogin(
     QString password,
     QObject *parent
 ): AuthFlow(data, parent), m_password(password) {
-    m_steps.append(new YggdrasilStep(m_data, m_password));
-    m_steps.append(new MinecraftProfileStepMojang(m_data));
-    m_steps.append(new MigrationEligibilityStep(m_data));
-    m_steps.append(new GetSkinStep(m_data));
+    m_steps.append(makeShared<YggdrasilStep>(m_data, m_password));
+    m_steps.append(makeShared<MinecraftProfileStepMojang>(m_data));
+    m_steps.append(makeShared<MigrationEligibilityStep>(m_data));
+    m_steps.append(makeShared<GetSkinStep>(m_data));
 }

--- a/launcher/minecraft/auth/flows/Offline.cpp
+++ b/launcher/minecraft/auth/flows/Offline.cpp
@@ -6,12 +6,12 @@ OfflineRefresh::OfflineRefresh(
     AccountData *data,
     QObject *parent
 ) : AuthFlow(data, parent) {
-    m_steps.append(new OfflineStep(m_data));
+    m_steps.append(makeShared<OfflineStep>(m_data));
 }
 
 OfflineLogin::OfflineLogin(
     AccountData *data,
     QObject *parent
 ) : AuthFlow(data, parent) {
-    m_steps.append(new OfflineStep(m_data));
+    m_steps.append(makeShared<OfflineStep>(m_data));
 }

--- a/launcher/minecraft/mod/ResourcePackFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourcePackFolderModel.cpp
@@ -142,7 +142,7 @@ int ResourcePackFolderModel::columnCount(const QModelIndex& parent) const
 
 Task* ResourcePackFolderModel::createUpdateTask()
 {
-    return new BasicFolderLoadTask(m_dir, [](QFileInfo const& entry) { return new ResourcePack(entry); });
+    return new BasicFolderLoadTask(m_dir, [](QFileInfo const& entry) { return makeShared<ResourcePack>(entry); });
 }
 
 Task* ResourcePackFolderModel::createParseTask(Resource& resource)

--- a/launcher/minecraft/mod/TexturePackFolderModel.cpp
+++ b/launcher/minecraft/mod/TexturePackFolderModel.cpp
@@ -43,7 +43,7 @@ TexturePackFolderModel::TexturePackFolderModel(const QString &dir) : ResourceFol
 
 Task* TexturePackFolderModel::createUpdateTask()
 {
-    return new BasicFolderLoadTask(m_dir, [](QFileInfo const& entry) { return new TexturePack(entry); });
+    return new BasicFolderLoadTask(m_dir, [](QFileInfo const& entry) { return makeShared<TexturePack>(entry); });
 }
 
 Task* TexturePackFolderModel::createParseTask(Resource& resource)

--- a/launcher/minecraft/mod/tasks/BasicFolderLoadTask.h
+++ b/launcher/minecraft/mod/tasks/BasicFolderLoadTask.h
@@ -26,11 +26,11 @@ class BasicFolderLoadTask : public Task {
    public:
     BasicFolderLoadTask(QDir dir) : Task(nullptr, false), m_dir(dir), m_result(new Result), m_thread_to_spawn_into(thread())
     {
-        m_create_func = [](QFileInfo const& entry) -> Resource* {
-                return new Resource(entry);
+        m_create_func = [](QFileInfo const& entry) -> Resource::Ptr {
+                return makeShared<Resource>(entry);
             };
     }
-    BasicFolderLoadTask(QDir dir, std::function<Resource*(QFileInfo const&)> create_function)
+    BasicFolderLoadTask(QDir dir, std::function<Resource::Ptr(QFileInfo const&)> create_function)
         : Task(nullptr, false), m_dir(dir), m_result(new Result), m_create_func(std::move(create_function)), m_thread_to_spawn_into(thread())
     {}
 
@@ -65,7 +65,7 @@ private:
 
     std::atomic<bool> m_aborted = false;
 
-    std::function<Resource*(QFileInfo const&)> m_create_func;
+    std::function<Resource::Ptr(QFileInfo const&)> m_create_func;
 
     /** This is the thread in which we should put new mod objects */
     QThread* m_thread_to_spawn_into;

--- a/launcher/minecraft/mod/tasks/ModFolderLoadTask.cpp
+++ b/launcher/minecraft/mod/tasks/ModFolderLoadTask.cpp
@@ -72,14 +72,14 @@ void ModFolderLoadTask::executeTask()
                 delete mod;
             }
             else {
-                m_result->mods[mod->internal_id()] = mod;
+                m_result->mods[mod->internal_id()].reset(std::move(mod));
                 m_result->mods[mod->internal_id()]->setStatus(ModStatus::NoMetadata);
             }
         }
         else { 
             QString chopped_id = mod->internal_id().chopped(9);
             if (m_result->mods.contains(chopped_id)) {
-                m_result->mods[mod->internal_id()] = mod;
+                m_result->mods[mod->internal_id()].reset(std::move(mod));
 
                 auto metadata = m_result->mods[chopped_id]->metadata();
                 if (metadata) {
@@ -90,7 +90,7 @@ void ModFolderLoadTask::executeTask()
                 }
             }
             else {
-                m_result->mods[mod->internal_id()] = mod;
+                m_result->mods[mod->internal_id()].reset(std::move(mod));
                 m_result->mods[mod->internal_id()]->setStatus(ModStatus::NoMetadata);
             }
         }
@@ -130,6 +130,6 @@ void ModFolderLoadTask::getFromMetadata()
 
         auto* mod = new Mod(m_mods_dir, metadata);
         mod->setStatus(ModStatus::NotInstalled);
-        m_result->mods[mod->internal_id()] = mod;
+        m_result->mods[mod->internal_id()].reset(std::move(mod));
     }
 }

--- a/launcher/minecraft/update/AssetUpdateTask.cpp
+++ b/launcher/minecraft/update/AssetUpdateTask.cpp
@@ -24,7 +24,7 @@ void AssetUpdateTask::executeTask()
     auto assets = profile->getMinecraftAssets();
     QUrl indexUrl = assets->url;
     QString localPath = assets->id + ".json";
-    auto job = new NetJob(
+    auto job = makeShared<NetJob>(
         tr("Asset index for %1").arg(m_inst->name()),
         APPLICATION->network()
     );

--- a/launcher/minecraft/update/FMLLibrariesTask.cpp
+++ b/launcher/minecraft/update/FMLLibrariesTask.cpp
@@ -61,7 +61,7 @@ void FMLLibrariesTask::executeTask()
 
     // download missing libs to our place
     setStatus(tr("Downloading FML libraries..."));
-    auto dljob = new NetJob("FML libraries", APPLICATION->network());
+    NetJob::Ptr dljob{ new NetJob("FML libraries", APPLICATION->network()) };
     auto metacache = APPLICATION->metacache();
     Net::Download::Options options = Net::Download::Option::MakeEternal;
     for (auto &lib : fmlLibsToProcess)
@@ -71,10 +71,10 @@ void FMLLibrariesTask::executeTask()
         dljob->addNetAction(Net::Download::makeCached(QUrl(urlString), entry, options));
     }
 
-    connect(dljob, &NetJob::succeeded, this, &FMLLibrariesTask::fmllibsFinished);
-    connect(dljob, &NetJob::failed, this, &FMLLibrariesTask::fmllibsFailed);
-    connect(dljob, &NetJob::aborted, this, [this]{ emitFailed(tr("Aborted")); });
-    connect(dljob, &NetJob::progress, this, &FMLLibrariesTask::progress);
+    connect(dljob.get(), &NetJob::succeeded, this, &FMLLibrariesTask::fmllibsFinished);
+    connect(dljob.get(), &NetJob::failed, this, &FMLLibrariesTask::fmllibsFailed);
+    connect(dljob.get(), &NetJob::aborted, this, [this]{ emitFailed(tr("Aborted")); });
+    connect(dljob.get(), &NetJob::progress, this, &FMLLibrariesTask::progress);
     downloadJob.reset(dljob);
     downloadJob->start();
 }

--- a/launcher/minecraft/update/LibrariesTask.cpp
+++ b/launcher/minecraft/update/LibrariesTask.cpp
@@ -20,7 +20,7 @@ void LibrariesTask::executeTask()
     auto components = inst->getPackProfile();
     auto profile = components->getProfile();
 
-    auto job = new NetJob(tr("Libraries for instance %1").arg(inst->name()), APPLICATION->network());
+    NetJob::Ptr job{ new NetJob(tr("Libraries for instance %1").arg(inst->name()), APPLICATION->network()) };
     downloadJob.reset(job);
 
     auto metacache = APPLICATION->metacache();

--- a/launcher/modplatform/CheckUpdateTask.h
+++ b/launcher/modplatform/CheckUpdateTask.h
@@ -22,10 +22,10 @@ class CheckUpdateTask : public Task {
         QString new_version;
         QString changelog;
         ModPlatform::ResourceProvider provider;
-        ResourceDownloadTask* download;
+        shared_qobject_ptr<ResourceDownloadTask> download;
 
        public:
-        UpdatableMod(QString name, QString old_h, QString old_v, QString new_v, QString changelog, ModPlatform::ResourceProvider p, ResourceDownloadTask* t)
+        UpdatableMod(QString name, QString old_h, QString old_v, QString new_v, QString changelog, ModPlatform::ResourceProvider p, shared_qobject_ptr<ResourceDownloadTask> t)
             : name(name), old_hash(old_h), old_version(old_v), new_version(new_v), changelog(changelog), provider(p), download(t)
         {}
     };

--- a/launcher/modplatform/EnsureMetadataTask.cpp
+++ b/launcher/modplatform/EnsureMetadataTask.cpp
@@ -32,7 +32,7 @@ EnsureMetadataTask::EnsureMetadataTask(Mod* mod, QDir dir, ModPlatform::Resource
 EnsureMetadataTask::EnsureMetadataTask(QList<Mod*>& mods, QDir dir, ModPlatform::ResourceProvider prov)
     : Task(nullptr), m_index_dir(dir), m_provider(prov), m_current_task(nullptr)
 {
-    m_hashing_task = new ConcurrentTask(this, "MakeHashesTask", 10);
+    m_hashing_task.reset(new ConcurrentTask(this, "MakeHashesTask", 10));
     for (auto* mod : mods) {
         auto hash_task = createNewHash(mod);
         if (!hash_task)
@@ -217,7 +217,7 @@ Task::Ptr EnsureMetadataTask::modrinthVersionsTask()
 
     // Prevents unfortunate timings when aborting the task
     if (!ver_task)
-        return {};
+        return Task::Ptr{nullptr};
 
     connect(ver_task.get(), &Task::succeeded, this, [this, response] {
         QJsonParseError parse_error{};
@@ -277,7 +277,7 @@ Task::Ptr EnsureMetadataTask::modrinthProjectsTask()
 
     // Prevents unfortunate timings when aborting the task
     if (!proj_task)
-        return {};
+        return Task::Ptr{nullptr};
 
     connect(proj_task.get(), &Task::succeeded, this, [this, response, addonIds] {
         QJsonParseError parse_error{};
@@ -434,7 +434,7 @@ Task::Ptr EnsureMetadataTask::flameProjectsTask()
 
     // Prevents unfortunate timings when aborting the task
     if (!proj_task)
-        return {};
+        return Task::Ptr{nullptr};
 
     connect(proj_task.get(), &Task::succeeded, this, [this, response, addonIds] {
         QJsonParseError parse_error{};

--- a/launcher/modplatform/EnsureMetadataTask.h
+++ b/launcher/modplatform/EnsureMetadataTask.h
@@ -60,6 +60,6 @@ class EnsureMetadataTask : public Task {
     ModPlatform::ResourceProvider m_provider;
 
     QHash<QString, ModPlatform::IndexedVersion> m_temp_versions;
-    ConcurrentTask* m_hashing_task;
+    ConcurrentTask::Ptr m_hashing_task;
     Task::Ptr m_current_task;
 };

--- a/launcher/modplatform/flame/FileResolvingTask.cpp
+++ b/launcher/modplatform/flame/FileResolvingTask.cpp
@@ -23,7 +23,7 @@ void Flame::FileResolvingTask::executeTask()
 {
     setStatus(tr("Resolving mod IDs..."));
     setProgress(0, 3);
-    m_dljob = new NetJob("Mod id resolver", m_network);
+    m_dljob.reset(new NetJob("Mod id resolver", m_network));
     result.reset(new QByteArray());
     //build json data to send
     QJsonObject object;
@@ -43,7 +43,7 @@ void Flame::FileResolvingTask::netJobFinished()
 {
     setProgress(1, 3);
     // job to check modrinth for blocked projects
-    m_checkJob = new NetJob("Modrinth check", m_network);
+    m_checkJob.reset(new NetJob("Modrinth check", m_network));
     blockedProjects = QMap<File *,QByteArray *>();
 
     QJsonDocument doc;

--- a/launcher/modplatform/flame/FlameAPI.cpp
+++ b/launcher/modplatform/flame/FlameAPI.cpp
@@ -13,7 +13,7 @@
 
 Task::Ptr FlameAPI::matchFingerprints(const QList<uint>& fingerprints, QByteArray* response)
 {
-    auto* netJob = new NetJob(QString("Flame::MatchFingerprints"), APPLICATION->network());
+    auto netJob = makeShared<NetJob>(QString("Flame::MatchFingerprints"), APPLICATION->network());
 
     QJsonObject body_obj;
     QJsonArray fingerprints_arr;
@@ -28,7 +28,7 @@ Task::Ptr FlameAPI::matchFingerprints(const QList<uint>& fingerprints, QByteArra
 
     netJob->addNetAction(Net::Upload::makeByteArray(QString("https://api.curseforge.com/v1/fingerprints"), response, body_raw));
 
-    QObject::connect(netJob, &NetJob::finished, [response] { delete response; });
+    QObject::connect(netJob.get(), &NetJob::finished, [response] { delete response; });
 
     return netJob;
 }
@@ -173,7 +173,7 @@ auto FlameAPI::getLatestVersion(VersionSearchArgs&& args) -> ModPlatform::Indexe
 
 Task::Ptr FlameAPI::getProjects(QStringList addonIds, QByteArray* response) const
 {
-    auto* netJob = new NetJob(QString("Flame::GetProjects"), APPLICATION->network());
+    auto netJob = makeShared<NetJob>(QString("Flame::GetProjects"), APPLICATION->network());
 
     QJsonObject body_obj;
     QJsonArray addons_arr;
@@ -188,15 +188,15 @@ Task::Ptr FlameAPI::getProjects(QStringList addonIds, QByteArray* response) cons
 
     netJob->addNetAction(Net::Upload::makeByteArray(QString("https://api.curseforge.com/v1/mods"), response, body_raw));
 
-    QObject::connect(netJob, &NetJob::finished, [response] { delete response; });
-    QObject::connect(netJob, &NetJob::failed, [body_raw] { qDebug() << body_raw; });
+    QObject::connect(netJob.get(), &NetJob::finished, [response] { delete response; });
+    QObject::connect(netJob.get(), &NetJob::failed, [body_raw] { qDebug() << body_raw; });
 
     return netJob;
 }
 
 Task::Ptr FlameAPI::getFiles(const QStringList& fileIds, QByteArray* response) const
 {
-    auto* netJob = new NetJob(QString("Flame::GetFiles"), APPLICATION->network());
+    auto netJob = makeShared<NetJob>(QString("Flame::GetFiles"), APPLICATION->network());
 
     QJsonObject body_obj;
     QJsonArray files_arr;
@@ -211,8 +211,8 @@ Task::Ptr FlameAPI::getFiles(const QStringList& fileIds, QByteArray* response) c
 
     netJob->addNetAction(Net::Upload::makeByteArray(QString("https://api.curseforge.com/v1/mods/files"), response, body_raw));
 
-    QObject::connect(netJob, &NetJob::finished, [response] { delete response; });
-    QObject::connect(netJob, &NetJob::failed, [body_raw] { qDebug() << body_raw; });
+    QObject::connect(netJob.get(), &NetJob::finished, [response] { delete response; });
+    QObject::connect(netJob.get(), &NetJob::failed, [body_raw] { qDebug() << body_raw; });
 
     return netJob;
 }

--- a/launcher/modplatform/flame/FlameCheckUpdate.cpp
+++ b/launcher/modplatform/flame/FlameCheckUpdate.cpp
@@ -172,7 +172,7 @@ void FlameCheckUpdate::executeTask()
                 old_version = current_ver.version;
             }
 
-            auto download_task = new ResourceDownloadTask(pack, latest_ver, m_mods_folder);
+            auto download_task = makeShared<ResourceDownloadTask>(pack, latest_ver, m_mods_folder);
             m_updatable.emplace_back(pack.name, mod->metadata()->hash, old_version, latest_ver.version,
                                      api.getModFileChangelog(latest_ver.addonId.toInt(), latest_ver.fileId.toInt()),
                                      ModPlatform::ResourceProvider::FLAME, download_task);

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -373,7 +373,7 @@ bool FlameCreationTask::createInstance()
         instance.setManagedPack("flame", m_managed_id, m_pack.name, m_managed_version_id, m_pack.version);
     instance.setName(name());
 
-    m_mod_id_resolver = new Flame::FileResolvingTask(APPLICATION->network(), m_pack);
+    m_mod_id_resolver.reset(new Flame::FileResolvingTask(APPLICATION->network(), m_pack));
     connect(m_mod_id_resolver.get(), &Flame::FileResolvingTask::succeeded, this, [this, &loop] { idResolverSucceeded(loop); });
     connect(m_mod_id_resolver.get(), &Flame::FileResolvingTask::failed, [&](QString reason) {
         m_mod_id_resolver.reset();
@@ -452,7 +452,7 @@ void FlameCreationTask::idResolverSucceeded(QEventLoop& loop)
 
 void FlameCreationTask::setupDownloadJob(QEventLoop& loop)
 {
-    m_files_job = new NetJob(tr("Mod download"), APPLICATION->network());
+    m_files_job.reset(new NetJob(tr("Mod download"), APPLICATION->network()));
     for (const auto& result : m_mod_id_resolver->getResults().files) {
         QString filename = result.fileName;
         if (!result.required) {

--- a/launcher/modplatform/helpers/HashUtils.cpp
+++ b/launcher/modplatform/helpers/HashUtils.cpp
@@ -28,22 +28,22 @@ Hasher::Ptr createHasher(QString file_path, ModPlatform::ResourceProvider provid
 
 Hasher::Ptr createModrinthHasher(QString file_path)
 {
-    return new ModrinthHasher(file_path);
+    return makeShared<ModrinthHasher>(file_path);
 }
 
 Hasher::Ptr createFlameHasher(QString file_path)
 {
-    return new FlameHasher(file_path);
+    return makeShared<FlameHasher>(file_path);
 }
 
 Hasher::Ptr createBlockedModHasher(QString file_path, ModPlatform::ResourceProvider provider)
 {
-    return new BlockedModHasher(file_path, provider);
+    return makeShared<BlockedModHasher>(file_path, provider);
 }
 
 Hasher::Ptr createBlockedModHasher(QString file_path, ModPlatform::ResourceProvider provider, QString type)
 {
-    auto hasher = new BlockedModHasher(file_path, provider);
+    auto hasher = makeShared<BlockedModHasher>(file_path, provider);
     hasher->useHashType(type);
     return hasher;
 }

--- a/launcher/modplatform/legacy_ftb/PackFetchTask.cpp
+++ b/launcher/modplatform/legacy_ftb/PackFetchTask.cpp
@@ -47,7 +47,7 @@ void PackFetchTask::fetch()
     publicPacks.clear();
     thirdPartyPacks.clear();
 
-    jobPtr = new NetJob("LegacyFTB::ModpackFetch", m_network);
+    jobPtr.reset(new NetJob("LegacyFTB::ModpackFetch", m_network));
 
     QUrl publicPacksUrl = QUrl(BuildConfig.LEGACY_FTB_CDN_BASE_URL + "static/modpacks.xml");
     qDebug() << "Downloading public version info from" << publicPacksUrl.toString();

--- a/launcher/modplatform/legacy_ftb/PackInstallTask.cpp
+++ b/launcher/modplatform/legacy_ftb/PackInstallTask.cpp
@@ -69,7 +69,7 @@ void PackInstallTask::downloadPack()
 
     archivePath = QString("%1/%2/%3").arg(m_pack.dir, m_version.replace(".", "_"), m_pack.file);
 
-    netJobContainer = new NetJob("Download FTB Pack", m_network);
+    netJobContainer.reset(new NetJob("Download FTB Pack", m_network));
     QString url;
     if (m_pack.type == PackType::Private) {
         url = QString(BuildConfig.LEGACY_FTB_CDN_BASE_URL + "privatepacks/%1").arg(archivePath);

--- a/launcher/modplatform/modrinth/ModrinthAPI.cpp
+++ b/launcher/modplatform/modrinth/ModrinthAPI.cpp
@@ -11,19 +11,19 @@
 
 Task::Ptr ModrinthAPI::currentVersion(QString hash, QString hash_format, QByteArray* response)
 {
-    auto* netJob = new NetJob(QString("Modrinth::GetCurrentVersion"), APPLICATION->network());
+    auto netJob = makeShared<NetJob>(QString("Modrinth::GetCurrentVersion"), APPLICATION->network());
 
     netJob->addNetAction(Net::Download::makeByteArray(
         QString(BuildConfig.MODRINTH_PROD_URL + "/version_file/%1?algorithm=%2").arg(hash, hash_format), response));
 
-    QObject::connect(netJob, &NetJob::finished, [response] { delete response; });
+    QObject::connect(netJob.get(), &NetJob::finished, [response] { delete response; });
 
     return netJob;
 }
 
 Task::Ptr ModrinthAPI::currentVersions(const QStringList& hashes, QString hash_format, QByteArray* response)
 {
-    auto* netJob = new NetJob(QString("Modrinth::GetCurrentVersions"), APPLICATION->network());
+    auto netJob = makeShared<NetJob>(QString("Modrinth::GetCurrentVersions"), APPLICATION->network());
 
     QJsonObject body_obj;
 
@@ -35,7 +35,7 @@ Task::Ptr ModrinthAPI::currentVersions(const QStringList& hashes, QString hash_f
 
     netJob->addNetAction(Net::Upload::makeByteArray(QString(BuildConfig.MODRINTH_PROD_URL + "/version_files"), response, body_raw));
 
-    QObject::connect(netJob, &NetJob::finished, [response] { delete response; });
+    QObject::connect(netJob.get(), &NetJob::finished, [response] { delete response; });
 
     return netJob;
 }
@@ -46,7 +46,7 @@ Task::Ptr ModrinthAPI::latestVersion(QString hash,
                                      std::optional<ModLoaderTypes> loaders,
                                      QByteArray* response)
 {
-    auto* netJob = new NetJob(QString("Modrinth::GetLatestVersion"), APPLICATION->network());
+    auto netJob = makeShared<NetJob>(QString("Modrinth::GetLatestVersion"), APPLICATION->network());
 
     QJsonObject body_obj;
 
@@ -67,7 +67,7 @@ Task::Ptr ModrinthAPI::latestVersion(QString hash,
     netJob->addNetAction(Net::Upload::makeByteArray(
         QString(BuildConfig.MODRINTH_PROD_URL + "/version_file/%1/update?algorithm=%2").arg(hash, hash_format), response, body_raw));
 
-    QObject::connect(netJob, &NetJob::finished, [response] { delete response; });
+    QObject::connect(netJob.get(), &NetJob::finished, [response] { delete response; });
 
     return netJob;
 }
@@ -78,7 +78,7 @@ Task::Ptr ModrinthAPI::latestVersions(const QStringList& hashes,
                                       std::optional<ModLoaderTypes> loaders,
                                       QByteArray* response)
 {
-    auto* netJob = new NetJob(QString("Modrinth::GetLatestVersions"), APPLICATION->network());
+    auto netJob = makeShared<NetJob>(QString("Modrinth::GetLatestVersions"), APPLICATION->network());
 
     QJsonObject body_obj;
 
@@ -101,21 +101,20 @@ Task::Ptr ModrinthAPI::latestVersions(const QStringList& hashes,
 
     netJob->addNetAction(Net::Upload::makeByteArray(QString(BuildConfig.MODRINTH_PROD_URL + "/version_files/update"), response, body_raw));
 
-    QObject::connect(netJob, &NetJob::finished, [response] { delete response; });
+    QObject::connect(netJob.get(), &NetJob::finished, [response] { delete response; });
 
     return netJob;
 }
 
 Task::Ptr ModrinthAPI::getProjects(QStringList addonIds, QByteArray* response) const
 {
-    auto netJob = new NetJob(QString("Modrinth::GetProjects"), APPLICATION->network());
+    auto netJob = makeShared<NetJob>(QString("Modrinth::GetProjects"), APPLICATION->network());
     auto searchUrl = getMultipleModInfoURL(addonIds);
 
     netJob->addNetAction(Net::Download::makeByteArray(QUrl(searchUrl), response));
 
-    QObject::connect(netJob, &NetJob::finished, [response, netJob] {
+    QObject::connect(netJob.get(), &NetJob::finished, [response, netJob] {
         delete response;
-        netJob->deleteLater();
     });
 
     return netJob;

--- a/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
+++ b/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
@@ -159,7 +159,7 @@ void ModrinthCheckUpdate::executeTask()
                     pack.description = mod->description();
                     pack.provider = ModPlatform::ResourceProvider::MODRINTH;
 
-                    auto download_task = new ResourceDownloadTask(pack, project_ver, m_mods_folder);
+                    auto download_task = makeShared<ResourceDownloadTask>(pack, project_ver, m_mods_folder);
 
                     m_updatable.emplace_back(pack.name, hash, mod->version(), project_ver.version_number, project_ver.changelog,
                                              ModPlatform::ResourceProvider::MODRINTH, download_task);

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
@@ -223,7 +223,7 @@ bool ModrinthCreationTask::createInstance()
     instance.setName(name());
     instance.saveNow();
 
-    m_files_job = new NetJob(tr("Mod download"), APPLICATION->network());
+    m_files_job.reset(new NetJob(tr("Mod download"), APPLICATION->network()));
 
     for (auto file : m_files) {
         auto path = FS::PathCombine(m_stagingPath, ".minecraft", file.path);

--- a/launcher/modplatform/technic/SingleZipPackInstallTask.cpp
+++ b/launcher/modplatform/technic/SingleZipPackInstallTask.cpp
@@ -44,7 +44,7 @@ void Technic::SingleZipPackInstallTask::executeTask()
     const QString path = m_sourceUrl.host() + '/' + m_sourceUrl.path();
     auto entry = APPLICATION->metacache()->resolveEntry("general", path);
     entry->setStale(true);
-    m_filesNetJob = new NetJob(tr("Modpack download"), APPLICATION->network());
+    m_filesNetJob.reset(new NetJob(tr("Modpack download"), APPLICATION->network()));
     m_filesNetJob->addNetAction(Net::Download::makeCached(m_sourceUrl, entry));
     m_archivePath = entry->getFullPath();
     auto job = m_filesNetJob.get();
@@ -130,7 +130,7 @@ void Technic::SingleZipPackInstallTask::extractFinished()
         }
     }
 
-    shared_qobject_ptr<Technic::TechnicPackProcessor> packProcessor = new Technic::TechnicPackProcessor();
+    auto packProcessor = makeShared<Technic::TechnicPackProcessor>();
     connect(packProcessor.get(), &Technic::TechnicPackProcessor::succeeded, this, &Technic::SingleZipPackInstallTask::emitSucceeded);
     connect(packProcessor.get(), &Technic::TechnicPackProcessor::failed, this, &Technic::SingleZipPackInstallTask::emitFailed);
     packProcessor->run(m_globalSettings, name(), m_instIcon, m_stagingPath, m_minecraftVersion);

--- a/launcher/modplatform/technic/SolderPackInstallTask.cpp
+++ b/launcher/modplatform/technic/SolderPackInstallTask.cpp
@@ -70,7 +70,7 @@ void Technic::SolderPackInstallTask::executeTask()
 {
     setStatus(tr("Resolving modpack files"));
 
-    m_filesNetJob = new NetJob(tr("Resolving modpack files"), m_network);
+    m_filesNetJob.reset(new NetJob(tr("Resolving modpack files"), m_network));
     auto sourceUrl = QString("%1/modpack/%2/%3").arg(m_solderUrl.toString(), m_pack, m_version);
     m_filesNetJob->addNetAction(Net::Download::makeByteArray(sourceUrl, &m_response));
 
@@ -107,7 +107,7 @@ void Technic::SolderPackInstallTask::fileListSucceeded()
     if (!build.minecraft.isEmpty())
         m_minecraftVersion = build.minecraft;
 
-    m_filesNetJob = new NetJob(tr("Downloading modpack"), m_network);
+    m_filesNetJob.reset(new NetJob(tr("Downloading modpack"), m_network));
 
     int i = 0;
     for (const auto &mod : build.mods) {
@@ -219,7 +219,7 @@ void Technic::SolderPackInstallTask::extractFinished()
         }
     }
 
-    shared_qobject_ptr<Technic::TechnicPackProcessor> packProcessor = new Technic::TechnicPackProcessor();
+    auto packProcessor = makeShared<Technic::TechnicPackProcessor>();
     connect(packProcessor.get(), &Technic::TechnicPackProcessor::succeeded, this, &Technic::SolderPackInstallTask::emitSucceeded);
     connect(packProcessor.get(), &Technic::TechnicPackProcessor::failed, this, &Technic::SolderPackInstallTask::emitFailed);
     packProcessor->run(m_globalSettings, name(), m_instIcon, m_stagingPath, m_minecraftVersion, true);

--- a/launcher/net/Download.cpp
+++ b/launcher/net/Download.cpp
@@ -49,14 +49,9 @@
 
 namespace Net {
 
-Download::Download() : NetAction()
-{
-    m_state = State::Inactive;
-}
-
 auto Download::makeCached(QUrl url, MetaEntryPtr entry, Options options) -> Download::Ptr
 {
-    auto* dl = new Download();
+    auto dl = makeShared<Download>();
     dl->m_url = url;
     dl->m_options = options;
     auto md5Node = new ChecksumValidator(QCryptographicHash::Md5);
@@ -67,7 +62,7 @@ auto Download::makeCached(QUrl url, MetaEntryPtr entry, Options options) -> Down
 
 auto Download::makeByteArray(QUrl url, QByteArray* output, Options options) -> Download::Ptr
 {
-    auto* dl = new Download();
+    auto dl = makeShared<Download>();
     dl->m_url = url;
     dl->m_options = options;
     dl->m_sink.reset(new ByteArraySink(output));
@@ -76,7 +71,7 @@ auto Download::makeByteArray(QUrl url, QByteArray* output, Options options) -> D
 
 auto Download::makeFile(QUrl url, QString path, Options options) -> Download::Ptr
 {
-    auto* dl = new Download();
+    auto dl = makeShared<Download>();
     dl->m_url = url;
     dl->m_options = options;
     dl->m_sink.reset(new FileSink(path));

--- a/launcher/net/Download.h
+++ b/launcher/net/Download.h
@@ -52,9 +52,6 @@ class Download : public NetAction {
     enum class Option { NoOptions = 0, AcceptLocalFiles = 1, MakeEternal = 2 };
     Q_DECLARE_FLAGS(Options, Option)
 
-   protected:
-    explicit Download();
-
    public:
     ~Download() override = default;
 

--- a/launcher/net/Upload.cpp
+++ b/launcher/net/Upload.cpp
@@ -233,7 +233,7 @@ namespace Net {
     }
 
     Upload::Ptr Upload::makeByteArray(QUrl url, QByteArray *output, QByteArray m_post_data) {
-        auto* up = new Upload();
+        auto up = makeShared<Upload>();
         up->m_url = std::move(url);
         up->m_sink.reset(new ByteArraySink(output));
         up->m_post_data = std::move(m_post_data);

--- a/launcher/net/Upload.h
+++ b/launcher/net/Upload.h
@@ -45,6 +45,8 @@ namespace Net {
         Q_OBJECT
 
     public:
+        using Ptr = shared_qobject_ptr<Upload>;
+
         static Upload::Ptr makeByteArray(QUrl url, QByteArray *output, QByteArray m_post_data);
         auto abort() -> bool override;
         auto canAbort() const -> bool override { return true; };

--- a/launcher/news/NewsChecker.cpp
+++ b/launcher/news/NewsChecker.cpp
@@ -57,10 +57,10 @@ void NewsChecker::reloadNews()
 
     qDebug() << "Reloading news.";
 
-    NetJob* job = new NetJob("News RSS Feed", m_network);
+    NetJob::Ptr job{ new NetJob("News RSS Feed", m_network) };
     job->addNetAction(Net::Download::makeByteArray(m_feedUrl, &newsData));
-    QObject::connect(job, &NetJob::succeeded, this, &NewsChecker::rssDownloadFinished);
-    QObject::connect(job, &NetJob::failed, this, &NewsChecker::rssDownloadFailed);
+    QObject::connect(job.get(), &NetJob::succeeded, this, &NewsChecker::rssDownloadFinished);
+    QObject::connect(job.get(), &NetJob::failed, this, &NewsChecker::rssDownloadFailed);
     m_newsNetJob.reset(job);
     job->start();
 }

--- a/launcher/tasks/ConcurrentTask.h
+++ b/launcher/tasks/ConcurrentTask.h
@@ -8,6 +8,8 @@
 class ConcurrentTask : public Task {
     Q_OBJECT
 public:
+    using Ptr = shared_qobject_ptr<ConcurrentTask>;
+
     explicit ConcurrentTask(QObject* parent = nullptr, QString task_name = "", int max_concurrent = 6);
     ~ConcurrentTask() override;
 

--- a/launcher/translations/TranslationsModel.cpp
+++ b/launcher/translations/TranslationsModel.cpp
@@ -670,7 +670,7 @@ void TranslationsModel::downloadIndex()
         return;
     }
     qDebug() << "Downloading Translations Index...";
-    d->m_index_job = new NetJob("Translations Index", APPLICATION->network());
+    d->m_index_job.reset(new NetJob("Translations Index", APPLICATION->network()));
     MetaEntryPtr entry = APPLICATION->metacache()->resolveEntry("translations", "index_v2.json");
     entry->setStale(true);
     d->m_index_task = Net::Download::makeCached(QUrl(BuildConfig.TRANSLATIONS_BASE_URL + "index_v2.json"), entry);
@@ -722,7 +722,7 @@ void TranslationsModel::downloadTranslation(QString key)
     dl->addValidator(new Net::ChecksumValidator(QCryptographicHash::Sha1, rawHash));
     dl->setProgress(dl->getProgress(), lang->file_size);
 
-    d->m_dl_job = new NetJob("Translation for " + key, APPLICATION->network());
+    d->m_dl_job.reset(new NetJob("Translation for " + key, APPLICATION->network()));
     d->m_dl_job->addNetAction(dl);
 
     connect(d->m_dl_job.get(), &NetJob::succeeded, this, &TranslationsModel::dlGood);

--- a/launcher/ui/dialogs/ModUpdateDialog.h
+++ b/launcher/ui/dialogs/ModUpdateDialog.h
@@ -25,7 +25,7 @@ class ModUpdateDialog final : public ReviewMessageBox {
 
     void appendMod(const CheckUpdateTask::UpdatableMod& info);
 
-    const QList<ResourceDownloadTask*> getTasks();
+    const QList<ResourceDownloadTask::Ptr> getTasks();
     auto indexDir() const -> QDir { return m_mod_model->indexDir(); }
 
     auto noUpdates() const -> bool { return m_no_updates; };
@@ -41,8 +41,8 @@ class ModUpdateDialog final : public ReviewMessageBox {
    private:
     QWidget* m_parent;
 
-    ModrinthCheckUpdate* m_modrinth_check_task = nullptr;
-    FlameCheckUpdate* m_flame_check_task = nullptr;
+    shared_qobject_ptr<ModrinthCheckUpdate> m_modrinth_check_task;
+    shared_qobject_ptr<FlameCheckUpdate> m_flame_check_task;
 
     const std::shared_ptr<ModFolderModel> m_mod_model;
 
@@ -50,11 +50,11 @@ class ModUpdateDialog final : public ReviewMessageBox {
     QList<Mod*> m_modrinth_to_update;
     QList<Mod*> m_flame_to_update;
 
-    ConcurrentTask* m_second_try_metadata;
+    ConcurrentTask::Ptr m_second_try_metadata;
     QList<std::tuple<Mod*, QString>> m_failed_metadata;
     QList<std::tuple<Mod*, QString, QUrl>> m_failed_check_update;
 
-    QHash<QString, ResourceDownloadTask*> m_tasks;
+    QHash<QString, ResourceDownloadTask::Ptr> m_tasks;
     BaseInstance* m_instance;
 
     bool m_no_updates = false;

--- a/launcher/ui/dialogs/ResourceDownloadDialog.cpp
+++ b/launcher/ui/dialogs/ResourceDownloadDialog.cpp
@@ -147,7 +147,7 @@ void ResourceDownloadDialog::addResource(ModPlatform::IndexedPack& pack, ModPlat
     removeResource(pack, ver);
 
     ver.is_currently_selected = true;
-    m_selected.insert(pack.name, new ResourceDownloadTask(pack, ver, getBaseModel(), is_indexed));
+    m_selected.insert(pack.name, makeShared<ResourceDownloadTask>(pack, ver, getBaseModel(), is_indexed));
 
     m_buttons.button(QDialogButtonBox::Ok)->setEnabled(!m_selected.isEmpty());
 }

--- a/launcher/ui/pages/instance/VersionPage.cpp
+++ b/launcher/ui/pages/instance/VersionPage.cpp
@@ -660,7 +660,7 @@ void VersionPage::onGameUpdateError(QString error)
     CustomMessageBox::selectable(this, tr("Error updating instance"), error, QMessageBox::Warning)->show();
 }
 
-Component * VersionPage::current()
+ComponentPtr VersionPage::current()
 {
     auto row = currentRow();
     if(row < 0)

--- a/launcher/ui/pages/instance/VersionPage.h
+++ b/launcher/ui/pages/instance/VersionPage.h
@@ -99,7 +99,7 @@ private slots:
     void updateVersionControls();
 
 private:
-    Component * current();
+    ComponentPtr current();
     int currentRow();
     void updateButtons(int row = -1);
     void preselect(int row = 0);

--- a/launcher/ui/pages/modplatform/ResourceModel.cpp
+++ b/launcher/ui/pages/modplatform/ResourceModel.cpp
@@ -265,7 +265,7 @@ std::optional<QIcon> ResourceModel::getIcon(QModelIndex& index, const QUrl& url)
         return { pixmap };
 
     if (!m_current_icon_job)
-        m_current_icon_job = new NetJob("IconJob", APPLICATION->network());
+        m_current_icon_job.reset(new NetJob("IconJob", APPLICATION->network()));
 
     if (m_currently_running_icon_actions.contains(url))
         return {};

--- a/launcher/ui/pages/modplatform/atlauncher/AtlListModel.cpp
+++ b/launcher/ui/pages/modplatform/atlauncher/AtlListModel.cpp
@@ -86,14 +86,14 @@ void ListModel::request()
     modpacks.clear();
     endResetModel();
 
-    auto *netJob = new NetJob("Atl::Request", APPLICATION->network());
+    auto netJob = makeShared<NetJob>("Atl::Request", APPLICATION->network());
     auto url = QString(BuildConfig.ATL_DOWNLOAD_SERVER_URL + "launcher/json/packsnew.json");
     netJob->addNetAction(Net::Download::makeByteArray(QUrl(url), &response));
     jobPtr = netJob;
     jobPtr->start();
 
-    QObject::connect(netJob, &NetJob::succeeded, this, &ListModel::requestFinished);
-    QObject::connect(netJob, &NetJob::failed, this, &ListModel::requestFailed);
+    QObject::connect(netJob.get(), &NetJob::succeeded, this, &ListModel::requestFinished);
+    QObject::connect(netJob.get(), &NetJob::failed, this, &ListModel::requestFailed);
 }
 
 void ListModel::requestFinished()

--- a/launcher/ui/pages/modplatform/flame/FlameModel.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameModel.cpp
@@ -155,7 +155,7 @@ void ListModel::fetchMore(const QModelIndex& parent)
 
 void ListModel::performPaginatedSearch()
 {
-    NetJob* netJob = new NetJob("Flame::Search", APPLICATION->network());
+    auto netJob = makeShared<NetJob>("Flame::Search", APPLICATION->network());
     auto searchUrl = QString(
                          "https://api.curseforge.com/v1/mods/search?"
                          "gameId=432&"
@@ -172,8 +172,8 @@ void ListModel::performPaginatedSearch()
     netJob->addNetAction(Net::Download::makeByteArray(QUrl(searchUrl), &response));
     jobPtr = netJob;
     jobPtr->start();
-    QObject::connect(netJob, &NetJob::succeeded, this, &ListModel::searchRequestFinished);
-    QObject::connect(netJob, &NetJob::failed, this, &ListModel::searchRequestFailed);
+    QObject::connect(netJob.get(), &NetJob::succeeded, this, &ListModel::searchRequestFinished);
+    QObject::connect(netJob.get(), &NetJob::failed, this, &ListModel::searchRequestFailed);
 }
 
 void ListModel::searchWithTerm(const QString& term, int sort)

--- a/launcher/ui/pages/modplatform/ftb/FtbListModel.cpp
+++ b/launcher/ui/pages/modplatform/ftb/FtbListModel.cpp
@@ -109,14 +109,14 @@ void ListModel::request()
     modpacks.clear();
     endResetModel();
 
-    auto *netJob = new NetJob("Ftb::Request", APPLICATION->network());
+    auto netJob = makeShared<NetJob>("Ftb::Request", APPLICATION->network());
     auto url = QString(BuildConfig.MODPACKSCH_API_BASE_URL + "public/modpack/all");
     netJob->addNetAction(Net::Download::makeByteArray(QUrl(url), &response));
     jobPtr = netJob;
     jobPtr->start();
 
-    QObject::connect(netJob, &NetJob::succeeded, this, &ListModel::requestFinished);
-    QObject::connect(netJob, &NetJob::failed, this, &ListModel::requestFailed);
+    QObject::connect(netJob.get(), &NetJob::succeeded, this, &ListModel::requestFinished);
+    QObject::connect(netJob.get(), &NetJob::failed, this, &ListModel::requestFailed);
 }
 
 void ListModel::abortRequest()
@@ -158,14 +158,14 @@ void ListModel::requestFailed(QString reason)
 
 void ListModel::requestPack()
 {
-    auto *netJob = new NetJob("Ftb::Search", APPLICATION->network());
+    auto netJob = makeShared<NetJob>("Ftb::Search", APPLICATION->network());
     auto searchUrl = QString(BuildConfig.MODPACKSCH_API_BASE_URL + "public/modpack/%1").arg(currentPack);
     netJob->addNetAction(Net::Download::makeByteArray(QUrl(searchUrl), &response));
     jobPtr = netJob;
     jobPtr->start();
 
-    QObject::connect(netJob, &NetJob::succeeded, this, &ListModel::packRequestFinished);
-    QObject::connect(netJob, &NetJob::failed, this, &ListModel::packRequestFailed);
+    QObject::connect(netJob.get(), &NetJob::succeeded, this, &ListModel::packRequestFinished);
+    QObject::connect(netJob.get(), &NetJob::failed, this, &ListModel::packRequestFailed);
 }
 
 void ListModel::packRequestFinished()
@@ -281,16 +281,16 @@ void ListModel::requestLogo(QString logo, QString url)
 
     bool stale = entry->isStale();
 
-    NetJob *job = new NetJob(QString("ModpacksCH Icon Download %1").arg(logo), APPLICATION->network());
+    auto job = makeShared<NetJob>(QString("ModpacksCH Icon Download %1").arg(logo), APPLICATION->network());
     job->addNetAction(Net::Download::makeCached(QUrl(url), entry));
 
     auto fullPath = entry->getFullPath();
-    QObject::connect(job, &NetJob::finished, this, [this, logo, fullPath, stale]
+    QObject::connect(job.get(), &NetJob::finished, this, [this, logo, fullPath, stale]
     {
         logoLoaded(logo, stale);
     });
 
-    QObject::connect(job, &NetJob::failed, this, [this, logo]
+    QObject::connect(job.get(), &NetJob::failed, this, [this, logo]
     {
         logoFailed(logo);
     });

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
@@ -127,7 +127,7 @@ bool ModpackListModel::setData(const QModelIndex &index, const QVariant &value, 
 void ModpackListModel::performPaginatedSearch()
 {
     // TODO: Move to standalone API
-    NetJob* netJob = new NetJob("Modrinth::SearchModpack", APPLICATION->network());
+    auto netJob = makeShared<NetJob>("Modrinth::SearchModpack", APPLICATION->network());
     auto searchAllUrl = QString(BuildConfig.MODRINTH_PROD_URL +
                             "/search?"
                             "offset=%1&"
@@ -142,7 +142,7 @@ void ModpackListModel::performPaginatedSearch()
 
     netJob->addNetAction(Net::Download::makeByteArray(QUrl(searchAllUrl), &m_all_response));
 
-    QObject::connect(netJob, &NetJob::succeeded, this, [this] {
+    QObject::connect(netJob.get(), &NetJob::succeeded, this, [this] {
         QJsonParseError parse_error_all{};
 
         QJsonDocument doc_all = QJsonDocument::fromJson(m_all_response, &parse_error_all);
@@ -155,7 +155,7 @@ void ModpackListModel::performPaginatedSearch()
 
         searchRequestFinished(doc_all);
     });
-    QObject::connect(netJob, &NetJob::failed, this, &ModpackListModel::searchRequestFailed);
+    QObject::connect(netJob.get(), &NetJob::failed, this, &ModpackListModel::searchRequestFailed);
 
     jobPtr = netJob;
     jobPtr->start();

--- a/launcher/ui/pages/modplatform/technic/TechnicModel.cpp
+++ b/launcher/ui/pages/modplatform/technic/TechnicModel.cpp
@@ -112,7 +112,7 @@ void Technic::ListModel::searchWithTerm(const QString& term)
 
 void Technic::ListModel::performSearch()
 {
-    NetJob *netJob = new NetJob("Technic::Search", APPLICATION->network());
+    auto netJob = makeShared<NetJob>("Technic::Search", APPLICATION->network());
     QString searchUrl = "";
     if (currentSearchTerm.isEmpty()) {
         searchUrl = QString("%1trending?build=%2")
@@ -137,8 +137,8 @@ void Technic::ListModel::performSearch()
     netJob->addNetAction(Net::Download::makeByteArray(QUrl(searchUrl), &response));
     jobPtr = netJob;
     jobPtr->start();
-    QObject::connect(netJob, &NetJob::succeeded, this, &ListModel::searchRequestFinished);
-    QObject::connect(netJob, &NetJob::failed, this, &ListModel::searchRequestFailed);
+    QObject::connect(netJob.get(), &NetJob::succeeded, this, &ListModel::searchRequestFinished);
+    QObject::connect(netJob.get(), &NetJob::failed, this, &ListModel::searchRequestFailed);
 }
 
 void Technic::ListModel::searchRequestFinished()

--- a/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
+++ b/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
@@ -141,10 +141,10 @@ void TechnicPage::suggestCurrent()
         return;
     }
 
-    NetJob *netJob = new NetJob(QString("Technic::PackMeta(%1)").arg(current.name), APPLICATION->network());
+    auto netJob = makeShared<NetJob>(QString("Technic::PackMeta(%1)").arg(current.name), APPLICATION->network());
     QString slug = current.slug;
     netJob->addNetAction(Net::Download::makeByteArray(QString("%1modpack/%2?build=%3").arg(BuildConfig.TECHNIC_API_BASE_URL, slug, BuildConfig.TECHNIC_API_BUILD), &response));
-    QObject::connect(netJob, &NetJob::succeeded, this, [this, slug]
+    QObject::connect(netJob.get(), &NetJob::succeeded, this, [this, slug]
     {
         jobPtr.reset();
 
@@ -247,11 +247,11 @@ void TechnicPage::metadataLoaded()
         // version so we can display something quicker
         ui->versionSelectionBox->addItem(current.currentVersion);
 
-        auto* netJob = new NetJob(QString("Technic::SolderMeta(%1)").arg(current.name), APPLICATION->network());
+        auto netJob = makeShared<NetJob>(QString("Technic::SolderMeta(%1)").arg(current.name), APPLICATION->network());
         auto url = QString("%1/modpack/%2").arg(current.url, current.slug);
         netJob->addNetAction(Net::Download::makeByteArray(QUrl(url), &response));
 
-        QObject::connect(netJob, &NetJob::succeeded, this, &TechnicPage::onSolderLoaded);
+        QObject::connect(netJob.get(), &NetJob::succeeded, this, &TechnicPage::onSolderLoaded);
 
         jobPtr = netJob;
         jobPtr->start();

--- a/tests/DummyResourceAPI.h
+++ b/tests/DummyResourceAPI.h
@@ -36,12 +36,11 @@ class DummyResourceAPI : public ResourceAPI {
 
     [[nodiscard]] Task::Ptr searchProjects(SearchArgs&&, SearchCallbacks&& callbacks) const override
     {
-        auto task = new SearchTask;
-        QObject::connect(task, &Task::succeeded, [=] {
+        auto task = makeShared<SearchTask>();
+        QObject::connect(task.get(), &Task::succeeded, [=] {
             auto json = searchRequestResult();
             callbacks.on_succeed(json);
         });
-        QObject::connect(task, &Task::finished, task, &Task::deleteLater);
         return task;
     }
 };

--- a/tests/Task_test.cpp
+++ b/tests/Task_test.cpp
@@ -49,10 +49,10 @@ class BigConcurrentTask : public QThread {
 
         // NOTE: Arbitrary value that manages to trigger a problem when there is one.
         static const unsigned s_num_tasks = 1 << 14;
-        auto sub_tasks = new BasicTask*[s_num_tasks];
+        auto sub_tasks = new BasicTask::Ptr[s_num_tasks];
 
         for (unsigned i = 0; i < s_num_tasks; i++) {
-            sub_tasks[i] = new BasicTask(false);
+            sub_tasks[i] = makeShared<BasicTask>(false);
             big_task.addTask(sub_tasks[i]);
         }
 
@@ -119,21 +119,21 @@ class TaskTest : public QObject {
     }
 
     void test_basicConcurrentRun(){
-        BasicTask t1;
-        BasicTask t2;
-        BasicTask t3;
+        auto t1 = makeShared<BasicTask>();
+        auto t2 = makeShared<BasicTask>();
+        auto t3 = makeShared<BasicTask>();
 
         ConcurrentTask t;
 
-        t.addTask(&t1);
-        t.addTask(&t2);
-        t.addTask(&t3);
+        t.addTask(t1);
+        t.addTask(t2);
+        t.addTask(t3);
 
         QObject::connect(&t, &Task::finished, [&]{
                 QVERIFY2(t.wasSuccessful(), "Task finished but was not successful when it should have been.");
-                QVERIFY(t1.wasSuccessful());
-                QVERIFY(t2.wasSuccessful());
-                QVERIFY(t3.wasSuccessful());
+                QVERIFY(t1->wasSuccessful());
+                QVERIFY(t2->wasSuccessful());
+                QVERIFY(t3->wasSuccessful());
         });
 
         t.start();
@@ -144,31 +144,39 @@ class TaskTest : public QObject {
 
     // Tests if starting new tasks after the 6 initial ones is working
     void test_moreConcurrentRun(){
-        BasicTask t1, t2, t3, t4, t5, t6, t7, t8, t9;
+        auto t1 = makeShared<BasicTask>();
+        auto t2 = makeShared<BasicTask>();
+        auto t3 = makeShared<BasicTask>();
+        auto t4 = makeShared<BasicTask>();
+        auto t5 = makeShared<BasicTask>();
+        auto t6 = makeShared<BasicTask>();
+        auto t7 = makeShared<BasicTask>();
+        auto t8 = makeShared<BasicTask>();
+        auto t9 = makeShared<BasicTask>();
 
         ConcurrentTask t;
 
-        t.addTask(&t1);
-        t.addTask(&t2);
-        t.addTask(&t3);
-        t.addTask(&t4);
-        t.addTask(&t5);
-        t.addTask(&t6);
-        t.addTask(&t7);
-        t.addTask(&t8);
-        t.addTask(&t9);
+        t.addTask(t1);
+        t.addTask(t2);
+        t.addTask(t3);
+        t.addTask(t4);
+        t.addTask(t5);
+        t.addTask(t6);
+        t.addTask(t7);
+        t.addTask(t8);
+        t.addTask(t9);
 
         QObject::connect(&t, &Task::finished, [&]{
                 QVERIFY2(t.wasSuccessful(), "Task finished but was not successful when it should have been.");
-                QVERIFY(t1.wasSuccessful());
-                QVERIFY(t2.wasSuccessful());
-                QVERIFY(t3.wasSuccessful());
-                QVERIFY(t4.wasSuccessful());
-                QVERIFY(t5.wasSuccessful());
-                QVERIFY(t6.wasSuccessful());
-                QVERIFY(t7.wasSuccessful());
-                QVERIFY(t8.wasSuccessful());
-                QVERIFY(t9.wasSuccessful());
+                QVERIFY(t1->wasSuccessful());
+                QVERIFY(t2->wasSuccessful());
+                QVERIFY(t3->wasSuccessful());
+                QVERIFY(t4->wasSuccessful());
+                QVERIFY(t5->wasSuccessful());
+                QVERIFY(t6->wasSuccessful());
+                QVERIFY(t7->wasSuccessful());
+                QVERIFY(t8->wasSuccessful());
+                QVERIFY(t9->wasSuccessful());
         });
 
         t.start();
@@ -178,21 +186,21 @@ class TaskTest : public QObject {
     }
 
     void test_basicSequentialRun(){
-        BasicTask t1;
-        BasicTask t2;
-        BasicTask t3;
+        auto t1 = makeShared<BasicTask>();
+        auto t2 = makeShared<BasicTask>();
+        auto t3 = makeShared<BasicTask>();
 
         SequentialTask t;
 
-        t.addTask(&t1);
-        t.addTask(&t2);
-        t.addTask(&t3);
+        t.addTask(t1);
+        t.addTask(t2);
+        t.addTask(t3);
 
         QObject::connect(&t, &Task::finished, [&]{
                 QVERIFY2(t.wasSuccessful(), "Task finished but was not successful when it should have been.");
-                QVERIFY(t1.wasSuccessful());
-                QVERIFY(t2.wasSuccessful());
-                QVERIFY(t3.wasSuccessful());
+                QVERIFY(t1->wasSuccessful());
+                QVERIFY(t2->wasSuccessful());
+                QVERIFY(t3->wasSuccessful());
         });
 
         t.start();
@@ -202,21 +210,21 @@ class TaskTest : public QObject {
     }
 
     void test_basicMultipleOptionsRun(){
-        BasicTask t1;
-        BasicTask t2;
-        BasicTask t3;
+        auto t1 = makeShared<BasicTask>();
+        auto t2 = makeShared<BasicTask>();
+        auto t3 = makeShared<BasicTask>();
 
         MultipleOptionsTask t;
 
-        t.addTask(&t1);
-        t.addTask(&t2);
-        t.addTask(&t3);
+        t.addTask(t1);
+        t.addTask(t2);
+        t.addTask(t3);
 
         QObject::connect(&t, &Task::finished, [&]{
                 QVERIFY2(t.wasSuccessful(), "Task finished but was not successful when it should have been.");
-                QVERIFY(t1.wasSuccessful());
-                QVERIFY(!t2.wasSuccessful());
-                QVERIFY(!t3.wasSuccessful());
+                QVERIFY(t1->wasSuccessful());
+                QVERIFY(!t2->wasSuccessful());
+                QVERIFY(!t3->wasSuccessful());
         });
 
         t.start();


### PR DESCRIPTION
This makes issues like #784 and [this old fella](https://github.com/PolyMC/PolyMC/issues/1136) much more difficult to happen by accident. I've kept the `nullptr_t` ctor implicit so that we can do `thing = nullptr` in places, as that is very handy and isn't able to cause a lot of issues afaict. 