### PR TITLE
Fix: fix some regressions in the main window

### DIFF
--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -192,7 +192,9 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
         foldersMenuButton->setPopupMode(QToolButton::InstantPopup);
 
         helpMenuButton = dynamic_cast<QToolButton*>(ui->mainToolBar->widgetForAction(ui->actionHelpButton));
-        ui->actionHelpButton->setMenu(ui->helpMenu);
+        ui->actionHelpButton->setMenu(new QMenu(this));
+        ui->actionHelpButton->menu()->addActions(ui->helpMenu->actions());
+        ui->actionHelpButton->menu()->removeAction(ui->actionCheckUpdate);
         helpMenuButton->setPopupMode(QToolButton::InstantPopup);
 
         auto accountMenuButton = dynamic_cast<QToolButton*>(ui->mainToolBar->widgetForAction(ui->actionAccountsButton));

--- a/launcher/ui/MainWindow.ui
+++ b/launcher/ui/MainWindow.ui
@@ -621,9 +621,6 @@
    </property>
   </action>
   <action name="actionAddToPATH">
-   <property name="enabled">
-    <bool>false</bool>
-   </property>
    <property name="icon">
     <iconset theme="custom-commands">
      <normaloff>.</normaloff>.</iconset>
@@ -633,9 +630,6 @@
    </property>
    <property name="toolTip">
     <string>Install a %1 symlink to /usr/local/bin</string>
-   </property>
-   <property name="visible">
-    <bool>false</bool>
    </property>
   </action>
   <action name="actionFoldersButton">


### PR DESCRIPTION
this removes the update action from the help button 
and fixes the add to path action not showing on macos

closes #792