### PR TITLE
Make the logger thread-safe

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -77,6 +77,7 @@
 #include "ApplicationMessage.h"
 
 #include <iostream>
+#include <mutex>
 
 #include <QAccessible>
 #include <QCommandLineParser>
@@ -150,7 +151,8 @@ namespace {
 /** This is used so that we can output to the log file in addition to the CLI. */
 void appDebugOutput(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {
-    const std::lock_guard<std::mutex> lock(APPLICATION->loggerMutex); // synchronized, QFile logFile is not thread-safe
+    static std::mutex loggerMutex;
+    const std::lock_guard<std::mutex> lock(loggerMutex); // synchronized, QFile logFile is not thread-safe
 
     QString out = qFormatLogMessage(type, context, msg);
     out += QChar::LineFeed;

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -150,6 +150,8 @@ namespace {
 /** This is used so that we can output to the log file in addition to the CLI. */
 void appDebugOutput(QtMsgType type, const QMessageLogContext &context, const QString &msg)
 {
+    const std::lock_guard<std::mutex> lock(APPLICATION->loggerMutex); // synchronized, QFile logFile is not thread-safe
+
     QString out = qFormatLogMessage(type, context, msg);
     out += QChar::LineFeed;
 

--- a/launcher/Application.h
+++ b/launcher/Application.h
@@ -45,6 +45,7 @@
 #include <QUrl>
 
 #include <BaseInstance.h>
+#include <mutex>
 
 #include "minecraft/launch/MinecraftServerTarget.h"
 
@@ -310,4 +311,5 @@ public:
     QList<QUrl> m_zipsToImport;
     QString m_instanceIdToShowWindowOf;
     std::unique_ptr<QFile> logFile;
+    std::mutex loggerMutex;
 };

--- a/launcher/Application.h
+++ b/launcher/Application.h
@@ -45,7 +45,6 @@
 #include <QUrl>
 
 #include <BaseInstance.h>
-#include <mutex>
 
 #include "minecraft/launch/MinecraftServerTarget.h"
 
@@ -311,5 +310,4 @@ public:
     QList<QUrl> m_zipsToImport;
     QString m_instanceIdToShowWindowOf;
     std::unique_ptr<QFile> logFile;
-    std::mutex loggerMutex;
 };


### PR DESCRIPTION
use a mutex to make appDebugOutput thread-safe, fixing `ringbuffer "bytes <= bufferSize"` when flushing logFile (what is not thread-safe)   

Also, potentially fixing some crashes.  


Signed-off-by: KosmX <kosmx.mc@gmail.com>


