### PR TITLE
fix: Improve MinGW ccache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -510,6 +510,13 @@ jobs:
         with:
           name: PrismLauncher-${{ runner.os }}-${{ env.VERSION }}-${{ inputs.build_type }}-x86_64.AppImage
           path: PrismLauncher-${{ runner.os }}-${{ env.VERSION }}-${{ inputs.build_type }}-x86_64.AppImage
+
+      - name: ccache stats (Windows MinGW-w64)
+        if: runner.os == 'Windows' && matrix.msystem != ''
+        shell: msys2 {0}
+        run: |
+          ccache -s
+
   snap:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,9 +154,9 @@ jobs:
         uses: actions/cache@v3.2.4
         with:
           path: '${{ github.workspace }}\.ccache'
-          key: ${{ matrix.os }}-mingw-w64
+          key: ${{ matrix.os }}-mingw-w64-ccache-${{ github.run_id }}
           restore-keys: |
-              ${{ matrix.os }}-mingw-w64
+              ${{ matrix.os }}-mingw-w64-ccache
 
       - name: Setup ccache (Windows MinGW-w64)
         if: runner.os == 'Windows' && matrix.msystem != '' && inputs.build_type == 'Debug'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -149,6 +149,15 @@ jobs:
         with:
           key: ${{ matrix.os }}-qt${{ matrix.qt_ver }}-${{ matrix.architecture }}
 
+      - name: Retrieve ccache cache (Windows MinGW-w64)
+        if: runner.os == 'Windows' && matrix.msystem != '' && inputs.build_type == 'Debug'
+        uses: actions/cache@v3.2.4
+        with:
+          path: '${{ github.workspace }}\.ccache'
+          key: ${{ matrix.os }}-mingw-w64
+          restore-keys: |
+              ${{ matrix.os }}-mingw-w64
+
       - name: Setup ccache (Windows MinGW-w64)
         if: runner.os == 'Windows' && matrix.msystem != '' && inputs.build_type == 'Debug'
         shell: msys2 {0}
@@ -164,15 +173,6 @@ jobs:
         shell: bash
         run: |
           echo "CCACHE_VAR=ccache" >> $GITHUB_ENV
-
-      - name: Retrieve ccache cache (Windows MinGW-w64)
-        if: runner.os == 'Windows' && matrix.msystem != '' && inputs.build_type == 'Debug'
-        uses: actions/cache@v3.2.4
-        with:
-          path: '${{ github.workspace }}\.ccache'
-          key: ${{ matrix.os }}-mingw-w64
-          restore-keys: |
-              ${{ matrix.os }}-mingw-w64
 
       - name: Set short version
         shell: bash


### PR DESCRIPTION
Seeing if I can improve build times by adjusting the MinGW ccache setup

First two commits setup ccache stat logging to match the other CI builds

The last commit gives a unique name to the cache as per the https://github.com/actions/cache/blob/main/tips-and-workarounds.md#update-a-cache

Edit: I could split the ccache stat logging and the cache rename commits into separate PRs if preferred.