### PR TITLE
Use /usr/bin/env bash in launch script

### DIFF
--- a/launcher/Launcher.in
+++ b/launcher/Launcher.in
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Basic start script for running the launcher with the libs packaged with it.
 
 function printerror {


### PR DESCRIPTION
This should make it possible to run these scripts on any system, as /bin/bash is not standard! Notably this fixes the script on NixOS.
