### PR TITLE
Java installations detection fix for Linux

### DIFF
--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -412,8 +412,6 @@ QList<QString> JavaUtils::FindJavaPaths()
 #elif defined(Q_OS_LINUX)
 QList<QString> JavaUtils::FindJavaPaths()
 {
-    qDebug() << "Linux Java detection incomplete - defaulting to \"java\"";
-
     QList<QString> javas;
     javas.append(this->GetDefaultJava()->path);
     auto scanJavaDir = [&](const QString & dirPath)
@@ -421,20 +419,11 @@ QList<QString> JavaUtils::FindJavaPaths()
         QDir dir(dirPath);
         if(!dir.exists())
             return;
-        auto entries = dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot | QDir::NoSymLinks);
+        auto entries = dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
         for(auto & entry: entries)
         {
-
             QString prefix;
-            if(entry.isAbsolute())
-            {
-                prefix = entry.absoluteFilePath();
-            }
-            else
-            {
-                prefix = entry.filePath();
-            }
-
+            prefix = entry.canonicalFilePath();
             javas.append(FS::PathCombine(prefix, "jre/bin/java"));
             javas.append(FS::PathCombine(prefix, "bin/java"));
         }


### PR DESCRIPTION
Fix https://github.com/PrismLauncher/PrismLauncher/issues/790
Now it is able to detect symbolic links and show their real paths. Tested on Gentoo GNU/Linux (my machine, of course)

Signed-off-by: BalkanMadman <zurabid2016@gmail.com>