### PR TITLE
Replace potentially ReDOSable regex

### DIFF
--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -361,7 +361,7 @@ void InstanceImportTask::processModrinth()
     } else {
         QString pack_id;
         if (!m_sourceUrl.isEmpty()) {
-            QRegularExpression regex(R"(data\/(.*)\/versions)");
+            QRegularExpression regex(R"(data\/([^\/]*)\/versions)");
             pack_id = regex.match(m_sourceUrl.toString()).captured(1);
         }
 


### PR DESCRIPTION
Signed-off-by: PandaNinjas <admin@malwarefight.gq>

Original regex takes exponential time, which can be seen with payload `'data/'.repeat(24495) + '\ndata//versions'`
With the new regex, the original payload finishes almost instantly