### PR TITLE
NilLoader mod metadata support 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,6 +448,7 @@ if (NOT ghc_filesystem_FOUND)
 else()
     message(STATUS "Using system ghc_filesystem")
 endif()
+add_subdirectory(libraries/qdcss) # css parser
 
 ############################### Built Artifacts ###############################
 

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -1025,6 +1025,7 @@ target_link_libraries(Launcher_logic
     nbt++
     ${ZLIB_LIBRARIES}
     tomlplusplus::tomlplusplus
+    qdcss
     BuildConfig
     Katabasis
     Qt${QT_VERSION_MAJOR}::Widgets

--- a/launcher/InstancePageProvider.h
+++ b/launcher/InstancePageProvider.h
@@ -39,6 +39,7 @@ public:
         modsPage->setFilter("%1 (*.zip *.jar *.litemod *.nilmod)");
         values.append(modsPage);
         values.append(new CoreModFolderPage(onesix.get(), onesix->coreModList()));
+        values.append(new NilModFolderPage(onesix.get(), onesix->nilModList()));
         values.append(new ResourcePackPage(onesix.get(), onesix->resourcePackList()));
         values.append(new TexturePackPage(onesix.get(), onesix->texturePackList()));
         values.append(new ShaderPackPage(onesix.get(), onesix->shaderPackList()));

--- a/launcher/InstancePageProvider.h
+++ b/launcher/InstancePageProvider.h
@@ -36,7 +36,7 @@ public:
         values.append(new VersionPage(onesix.get()));
         values.append(ManagedPackPage::createPage(onesix.get()));
         auto modsPage = new ModFolderPage(onesix.get(), onesix->loaderModList());
-        modsPage->setFilter("%1 (*.zip *.jar *.litemod)");
+        modsPage->setFilter("%1 (*.zip *.jar *.litemod *.nilmod)");
         values.append(modsPage);
         values.append(new CoreModFolderPage(onesix.get(), onesix->coreModList()));
         values.append(new ResourcePackPage(onesix.get(), onesix->resourcePackList()));

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -290,6 +290,11 @@ QString MinecraftInstance::coreModsDir() const
     return FS::PathCombine(gameRoot(), "coremods");
 }
 
+QString MinecraftInstance::nilModsDir() const
+{
+    return FS::PathCombine(gameRoot(), "nilmods");
+}
+
 QString MinecraftInstance::resourcePacksDir() const
 {
     return FS::PathCombine(gameRoot(), "resourcepacks");
@@ -1123,6 +1128,18 @@ std::shared_ptr<ModFolderModel> MinecraftInstance::coreModList() const
         connect(this, &BaseInstance::runningStatusChanged, m_core_mod_list.get(), &ModFolderModel::disableInteraction);
     }
     return m_core_mod_list;
+}
+
+std::shared_ptr<ModFolderModel> MinecraftInstance::nilModList() const
+{
+    if (!m_nil_mod_list)
+    {
+        bool is_indexed = !APPLICATION->settings()->get("ModMetadataDisabled").toBool();
+        m_nil_mod_list.reset(new ModFolderModel(nilModsDir(), is_indexed));
+        m_nil_mod_list->disableInteraction(isRunning());
+        connect(this, &BaseInstance::runningStatusChanged, m_nil_mod_list.get(), &ModFolderModel::disableInteraction);
+    }
+    return m_nil_mod_list;
 }
 
 std::shared_ptr<ResourcePackFolderModel> MinecraftInstance::resourcePackList() const

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -1135,7 +1135,7 @@ std::shared_ptr<ModFolderModel> MinecraftInstance::nilModList() const
     if (!m_nil_mod_list)
     {
         bool is_indexed = !APPLICATION->settings()->get("ModMetadataDisabled").toBool();
-        m_nil_mod_list.reset(new ModFolderModel(nilModsDir(), is_indexed));
+        m_nil_mod_list.reset(new ModFolderModel(nilModsDir(), is_indexed, false));
         m_nil_mod_list->disableInteraction(isRunning());
         connect(this, &BaseInstance::runningStatusChanged, m_nil_mod_list.get(), &ModFolderModel::disableInteraction);
     }

--- a/launcher/minecraft/MinecraftInstance.h
+++ b/launcher/minecraft/MinecraftInstance.h
@@ -84,6 +84,7 @@ public:
     QString shaderPacksDir() const;
     QString modsRoot() const override;
     QString coreModsDir() const;
+    QString nilModsDir() const;
     QString modsCacheLocation() const;
     QString libDir() const;
     QString worldDir() const;
@@ -116,6 +117,7 @@ public:
     //////  Mod Lists  //////
     std::shared_ptr<ModFolderModel> loaderModList() const;
     std::shared_ptr<ModFolderModel> coreModList() const;
+    std::shared_ptr<ModFolderModel> nilModList() const;
     std::shared_ptr<ResourcePackFolderModel> resourcePackList() const;
     std::shared_ptr<TexturePackFolderModel> texturePackList() const;
     std::shared_ptr<ShaderPackFolderModel> shaderPackList() const;
@@ -170,6 +172,7 @@ protected: // data
     std::shared_ptr<PackProfile> m_components;
     mutable std::shared_ptr<ModFolderModel> m_loader_mod_list;
     mutable std::shared_ptr<ModFolderModel> m_core_mod_list;
+    mutable std::shared_ptr<ModFolderModel> m_nil_mod_list;
     mutable std::shared_ptr<ResourcePackFolderModel> m_resource_pack_list;
     mutable std::shared_ptr<ShaderPackFolderModel> m_shader_pack_list;
     mutable std::shared_ptr<TexturePackFolderModel> m_texture_pack_list;

--- a/launcher/minecraft/launch/ScanModFolders.cpp
+++ b/launcher/minecraft/launch/ScanModFolders.cpp
@@ -55,6 +55,12 @@ void ScanModFolders::executeTask()
     if(!cores->update()) {
         m_coreModsDone = true;
     }
+
+    auto nils = m_inst->nilModList();
+    connect(nils.get(), &ModFolderModel::updateFinished, this, &ScanModFolders::nilModsDone);
+    if(!nils->update()) {
+        m_nilModsDone = true;
+    }
     checkDone();
 }
 
@@ -70,9 +76,15 @@ void ScanModFolders::coreModsDone()
     checkDone();
 }
 
+void ScanModFolders::nilModsDone()
+{
+    m_nilModsDone = true;
+    checkDone();
+}
+
 void ScanModFolders::checkDone()
 {
-    if(m_modsDone && m_coreModsDone) {
+    if(m_modsDone && m_coreModsDone && m_nilModsDone) {
         emitSucceeded();
     }
 }

--- a/launcher/minecraft/launch/ScanModFolders.h
+++ b/launcher/minecraft/launch/ScanModFolders.h
@@ -33,10 +33,12 @@ public:
 private slots:
     void coreModsDone();
     void modsDone();
+    void nilModsDone();
 private:
     void checkDone();
 
 private: // DATA
     bool m_modsDone = false;
+    bool m_nilModsDone = false;
     bool m_coreModsDone = false;
 };

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -50,7 +50,7 @@
 #include "minecraft/mod/tasks/ModFolderLoadTask.h"
 #include "modplatform/ModIndex.h"
 
-ModFolderModel::ModFolderModel(const QString &dir, bool is_indexed, bool create_dir) : ResourceFolderModel(QDir(dir), create_dir), m_is_indexed(is_indexed)
+ModFolderModel::ModFolderModel(const QString &dir, bool is_indexed, bool create_dir) : ResourceFolderModel(QDir(dir), nullptr, create_dir), m_is_indexed(is_indexed)
 {
     m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::VERSION, SortType::DATE, SortType::PROVIDER };
 }

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -50,7 +50,7 @@
 #include "minecraft/mod/tasks/ModFolderLoadTask.h"
 #include "modplatform/ModIndex.h"
 
-ModFolderModel::ModFolderModel(const QString &dir, bool is_indexed) : ResourceFolderModel(QDir(dir)), m_is_indexed(is_indexed)
+ModFolderModel::ModFolderModel(const QString &dir, bool is_indexed, bool create_dir) : ResourceFolderModel(QDir(dir), create_dir), m_is_indexed(is_indexed)
 {
     m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::VERSION, SortType::DATE, SortType::PROVIDER };
 }

--- a/launcher/minecraft/mod/ModFolderModel.h
+++ b/launcher/minecraft/mod/ModFolderModel.h
@@ -75,7 +75,7 @@ public:
         Enable,
         Toggle
     };
-    ModFolderModel(const QString &dir, bool is_indexed = false);
+    ModFolderModel(const QString &dir, bool is_indexed = false, bool create_dir = true);
 
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 

--- a/launcher/minecraft/mod/Resource.cpp
+++ b/launcher/minecraft/mod/Resource.cpp
@@ -37,6 +37,9 @@ void Resource::parseFile()
         if (file_name.endsWith(".zip") || file_name.endsWith(".jar")) {
             m_type = ResourceType::ZIPFILE;
             file_name.chop(4);
+        } else if (file_name.endsWith(".nilmod")) {
+            m_type = ResourceType::ZIPFILE;
+            file_name.chop(7);
         } else if (file_name.endsWith(".litemod")) {
             m_type = ResourceType::LITEMOD;
             file_name.chop(8);

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -12,7 +12,7 @@
 
 #include "tasks/Task.h"
 
-ResourceFolderModel::ResourceFolderModel(QDir dir, bool create_dir, QObject* parent) : QAbstractListModel(parent), m_dir(dir), m_watcher(this)
+ResourceFolderModel::ResourceFolderModel(QDir dir, QObject* parent, bool create_dir) : QAbstractListModel(parent), m_dir(dir), m_watcher(this)
 {
     if (create_dir) {
         FS::ensureFolderPathExists(m_dir.absolutePath());

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -12,9 +12,11 @@
 
 #include "tasks/Task.h"
 
-ResourceFolderModel::ResourceFolderModel(QDir dir, QObject* parent) : QAbstractListModel(parent), m_dir(dir), m_watcher(this)
+ResourceFolderModel::ResourceFolderModel(QDir dir, bool create_dir, QObject* parent) : QAbstractListModel(parent), m_dir(dir), m_watcher(this)
 {
-    FS::ensureFolderPathExists(m_dir.absolutePath());
+    if (create_dir) {
+        FS::ensureFolderPathExists(m_dir.absolutePath());
+    }
 
     m_dir.setFilter(QDir::Readable | QDir::NoDotAndDotDot | QDir::Files | QDir::Dirs);
     m_dir.setSorting(QDir::Name | QDir::IgnoreCase | QDir::LocaleAware);

--- a/launcher/minecraft/mod/ResourceFolderModel.h
+++ b/launcher/minecraft/mod/ResourceFolderModel.h
@@ -24,7 +24,8 @@ class QSortFilterProxyModel;
 class ResourceFolderModel : public QAbstractListModel {
     Q_OBJECT
    public:
-    ResourceFolderModel(QDir, QObject* parent = nullptr);
+    ResourceFolderModel(QDir, bool, QObject* parent = nullptr);
+    ResourceFolderModel(QDir dir, QObject* parent = nullptr) : ResourceFolderModel(dir, true, parent) {};
     ~ResourceFolderModel() override;
 
     /** Starts watching the paths for changes.

--- a/launcher/minecraft/mod/ResourceFolderModel.h
+++ b/launcher/minecraft/mod/ResourceFolderModel.h
@@ -24,8 +24,7 @@ class QSortFilterProxyModel;
 class ResourceFolderModel : public QAbstractListModel {
     Q_OBJECT
    public:
-    ResourceFolderModel(QDir, bool, QObject* parent = nullptr);
-    ResourceFolderModel(QDir dir, QObject* parent = nullptr) : ResourceFolderModel(dir, true, parent) {};
+    ResourceFolderModel(QDir, QObject* parent = nullptr, bool create_dir = true);
     ~ResourceFolderModel() override;
 
     /** Starts watching the paths for changes.

--- a/launcher/minecraft/mod/tasks/LocalModParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalModParseTask.cpp
@@ -434,15 +434,10 @@ bool processZIP(Mod& mod, ProcessingLevel level)
 
         QStringList foundNilMetas;
         for (auto& fname : zip.getFileNameList()) {
-            if (fname.endsWith(".nilmod.css")) {
+            // nilmods can shade nilloader to be able to run as a standalone agent - which includes nilloader's own meta file
+            if (fname.endsWith(".nilmod.css") && fname != "nilloader.nilmod.css") {
                 foundNilMetas.append(fname);
             }
-        }
-
-        if (foundNilMetas.size() > 1 && foundNilMetas.at(0) == "nilloader.nilmod.css") {
-            // nilmods can shade nilloader to be able to run as a standalone agent - which includes nilloader's own meta file
-            // so if there is more than one meta file, ignore nilloader's meta, since it's not the actual mod
-            foundNilMetas.removeFirst();
         }
 
         if (zip.setCurrentFile(foundNilMetas.at(0))) {

--- a/launcher/minecraft/mod/tasks/LocalModParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalModParseTask.cpp
@@ -432,21 +432,22 @@ bool processZIP(Mod& mod, ProcessingLevel level)
         // nilloader uses the filename of the metadata file for the modid, so we can't know the exact filename
         // thankfully, there is a good file to use as a canary so we don't look for nil meta all the time
 
-        QStringList foundNilMetas;
+        QString foundNilMeta;
         for (auto& fname : zip.getFileNameList()) {
             // nilmods can shade nilloader to be able to run as a standalone agent - which includes nilloader's own meta file
             if (fname.endsWith(".nilmod.css") && fname != "nilloader.nilmod.css") {
-                foundNilMetas.append(fname);
+                foundNilMeta = fname;
+                break;
             }
         }
 
-        if (zip.setCurrentFile(foundNilMetas.at(0))) {
+        if (zip.setCurrentFile(foundNilMeta)) {
             if (!file.open(QIODevice::ReadOnly)) {
                 zip.close();
                 return false;
             }
 
-            details = ReadNilModInfo(file.readAll(), foundNilMetas.at(0));
+            details = ReadNilModInfo(file.readAll(), foundNilMeta);
             file.close();
             zip.close();
 

--- a/launcher/ui/pages/instance/ModFolderPage.cpp
+++ b/launcher/ui/pages/instance/ModFolderPage.cpp
@@ -280,5 +280,5 @@ NilModFolderPage::NilModFolderPage(BaseInstance* inst, std::shared_ptr<ModFolder
 
 bool NilModFolderPage::shouldDisplay() const
 {
-    return !m_model->dir().isEmpty();
+    return m_model->dir().exists();
 }

--- a/launcher/ui/pages/instance/ModFolderPage.cpp
+++ b/launcher/ui/pages/instance/ModFolderPage.cpp
@@ -273,3 +273,12 @@ bool CoreModFolderPage::shouldDisplay() const
     }
     return false;
 }
+
+NilModFolderPage::NilModFolderPage(BaseInstance* inst, std::shared_ptr<ModFolderModel> mods, QWidget* parent)
+    : ModFolderPage(inst, mods, parent)
+{}
+
+bool NilModFolderPage::shouldDisplay() const
+{
+    return !m_model->dir().isEmpty();
+}

--- a/launcher/ui/pages/instance/ModFolderPage.h
+++ b/launcher/ui/pages/instance/ModFolderPage.h
@@ -81,3 +81,16 @@ class CoreModFolderPage : public ModFolderPage {
 
     virtual bool shouldDisplay() const override;
 };
+
+class NilModFolderPage : public ModFolderPage {
+   public:
+    explicit NilModFolderPage(BaseInstance* inst, std::shared_ptr<ModFolderModel> mods, QWidget* parent = 0);
+    virtual ~NilModFolderPage() = default;
+
+    virtual QString displayName() const override { return tr("Nilmods"); }
+    virtual QIcon icon() const override { return APPLICATION->getThemedIcon("coremods"); }
+    virtual QString id() const override { return "nilmods"; }
+    virtual QString helpPage() const override { return "Nil-mods"; }
+
+    virtual bool shouldDisplay() const override;
+};

--- a/launcher/ui/pages/instance/ModFolderPage.h
+++ b/launcher/ui/pages/instance/ModFolderPage.h
@@ -90,7 +90,7 @@ class NilModFolderPage : public ModFolderPage {
     virtual QString displayName() const override { return tr("Nilmods"); }
     virtual QIcon icon() const override { return APPLICATION->getThemedIcon("coremods"); }
     virtual QString id() const override { return "nilmods"; }
-    virtual QString helpPage() const override { return "Nil-mods"; }
+    virtual QString helpPage() const override { return "Nilmods"; }
 
     virtual bool shouldDisplay() const override;
 };

--- a/libraries/README.md
+++ b/libraries/README.md
@@ -140,3 +140,11 @@ A TOML language parser. Used by Forge 1.14+ to store mod metadata.
 See [github repo](https://github.com/marzer/tomlplusplus).
 
 Licenced under the MIT licence.
+
+## qdcss
+
+A quick and dirty css parser, used by NilLoader to store mod metadata.
+
+Translated (and heavily trimmed down) from [the original Java code](https://github.com/unascribed/NilLoader/blob/trunk/src/main/java/nilloader/api/lib/qdcss/QDCSS.java) from NilLoader
+
+Licensed under LGPL version 3.

--- a/libraries/qdcss/CMakeLists.txt
+++ b/libraries/qdcss/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.9.4)
+project(qdcss)
+
+if(QT_VERSION_MAJOR EQUAL 5)
+    find_package(Qt5 COMPONENTS Core REQUIRED)
+elseif(Launcher_QT_VERSION_MAJOR EQUAL 6)
+    find_package(Qt6 COMPONENTS Core Core5Compat REQUIRED)
+    list(APPEND qdcss_LIBS Qt${QT_VERSION_MAJOR}::Core5Compat)
+endif()
+
+set(QDCSS_SOURCES
+    include/qdcss.h
+    src/qdcss.cpp
+)
+
+add_library(qdcss STATIC ${QDCSS_SOURCES})
+target_include_directories(qdcss PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_link_libraries(qdcss Qt${QT_VERSION_MAJOR}::Core ${qdcss_LIBS})

--- a/libraries/qdcss/LICENSE
+++ b/libraries/qdcss/LICENSE
@@ -1,0 +1,72 @@
+GNU LESSER GENERAL PUBLIC LICENSE
+Version 3, 29 June 2007
+
+Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+
+Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.
+
+This version of the GNU Lesser General Public License incorporates the terms and conditions of version 3 of the GNU General Public License, supplemented by the additional permissions listed below.
+
+0. Additional Definitions.
+
+As used herein, "this License" refers to version 3 of the GNU Lesser General Public License, and the "GNU GPL" refers to version 3 of the GNU General Public License.
+
+"The Library" refers to a covered work governed by this License, other than an Application or a Combined Work as defined below.
+
+An "Application" is any work that makes use of an interface provided by the Library, but which is not otherwise based on the Library. Defining a subclass of a class defined by the Library is deemed a mode of using an interface provided by the Library.
+
+A "Combined Work" is a work produced by combining or linking an Application with the Library.  The particular version of the Library with which the Combined Work was made is also called the "Linked Version".
+
+The "Minimal Corresponding Source" for a Combined Work means the Corresponding Source for the Combined Work, excluding any source code for portions of the Combined Work that, considered in isolation, are based on the Application, and not on the Linked Version.
+
+The "Corresponding Application Code" for a Combined Work means the object code and/or source code for the Application, including any data and utility programs needed for reproducing the Combined Work from the Application, but excluding the System Libraries of the Combined Work.
+
+1. Exception to Section 3 of the GNU GPL.
+You may convey a covered work under sections 3 and 4 of this License without being bound by section 3 of the GNU GPL.
+
+2. Conveying Modified Versions.
+If you modify a copy of the Library, and, in your modifications, a facility refers to a function or data to be supplied by an Application that uses the facility (other than as an argument passed when the facility is invoked), then you may convey a copy of the modified version:
+
+     a) under this License, provided that you make a good faith effort to ensure that, in the event an Application does not supply the function or data, the facility still operates, and performs whatever part of its purpose remains meaningful, or
+
+     b) under the GNU GPL, with none of the additional permissions of this License applicable to that copy.
+
+3. Object Code Incorporating Material from Library Header Files.
+The object code form of an Application may incorporate material from a header file that is part of the Library.  You may convey such object code under terms of your choice, provided that, if the incorporated material is not limited to numerical parameters, data structure layouts and accessors, or small macros, inline functions and templates (ten or fewer lines in length), you do both of the following:
+
+     a) Give prominent notice with each copy of the object code that the Library is used in it and that the Library and its use are covered by this License.
+
+     b) Accompany the object code with a copy of the GNU GPL and this license document.
+
+4. Combined Works.
+You may convey a Combined Work under terms of your choice that, taken together, effectively do not restrict modification of the portions of the Library contained in the Combined Work and reverse engineering for debugging such modifications, if you also do each of the following:
+
+     a) Give prominent notice with each copy of the Combined Work that the Library is used in it and that the Library and its use are covered by this License.
+
+     b) Accompany the Combined Work with a copy of the GNU GPL and this license document.
+
+     c) For a Combined Work that displays copyright notices during execution, include the copyright notice for the Library among these notices, as well as a reference directing the user to the copies of the GNU GPL and this license document.
+
+     d) Do one of the following:
+
+           0) Convey the Minimal Corresponding Source under the terms of this License, and the Corresponding Application Code in a form suitable for, and under terms that permit, the user to recombine or relink the Application with a modified version of the Linked Version to produce a modified Combined Work, in the manner specified by section 6 of the GNU GPL for conveying Corresponding Source.
+
+          1) Use a suitable shared library mechanism for linking with the Library.  A suitable mechanism is one that (a) uses at run time a copy of the Library already present on the user's computer system, and (b) will operate properly with a modified version of the Library that is interface-compatible with the Linked Version.
+
+     e) Provide Installation Information, but only if you would otherwise be required to provide such information under section 6 of the GNU GPL, and only to the extent that such information is necessary to install and execute a modified version of the Combined Work produced by recombining or relinking the Application with a modified version of the Linked Version. (If you use option 4d0, the Installation Information must accompany the Minimal Corresponding Source and Corresponding Application Code. If you use option 4d1, you must provide the Installation Information in the manner specified by section 6 of the GNU GPL for conveying Corresponding Source.)
+
+5. Combined Libraries.
+You may place library facilities that are a work based on the Library side by side in a single library together with other library facilities that are not Applications and are not covered by this License, and convey such a combined library under terms of your choice, if you do both of the following:
+
+     a) Accompany the combined library with a copy of the same work based on the Library, uncombined with any other library facilities, conveyed under the terms of this License.
+
+     b) Give prominent notice with the combined library that part of it is a work based on the Library, and explaining where to find the accompanying uncombined form of the same work.
+
+6. Revised Versions of the GNU Lesser General Public License.
+The Free Software Foundation may publish revised and/or new versions of the GNU Lesser General Public License from time to time. Such new versions will be similar in spirit to the present version, but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Library as you received it specifies that a certain numbered version of the GNU Lesser General Public License "or any later version" applies to it, you have the option of following the terms and conditions either of that published version or of any later version published by the Free Software Foundation. If the Library as you received it does not specify a version number of the GNU Lesser General Public License, you may choose any version of the GNU Lesser General Public License ever published by the Free Software Foundation.
+
+If the Library as you received it specifies that a proxy can decide whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is permanent authorization for you to choose that version for the Library.
+

--- a/libraries/qdcss/include/qdcss.h
+++ b/libraries/qdcss/include/qdcss.h
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 kumquat-ir 66188216+kumquat-ir@users.noreply.github.com
+//
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #ifndef QDCSS_H
 #define QDCSS_H
 

--- a/libraries/qdcss/include/qdcss.h
+++ b/libraries/qdcss/include/qdcss.h
@@ -1,0 +1,21 @@
+#ifndef QDCSS_H
+#define QDCSS_H
+
+#include <QMap>
+#include <QString>
+#include <QStringList>
+#include <optional>
+
+class QDCSS {
+    // these are all we need to parse a couple string values out of a css string
+    // lots more in the original code, yet to be ported
+    // https://github.com/unascribed/NilLoader/blob/trunk/src/main/java/nilloader/api/lib/qdcss/QDCSS.java
+   public:
+    QDCSS(QString);
+    std::optional<QString>* get(QString);
+
+   private:
+    QMap<QString, QStringList> m_data;
+};
+
+#endif  // QDCSS_H

--- a/libraries/qdcss/src/qdcss.cpp
+++ b/libraries/qdcss/src/qdcss.cpp
@@ -1,0 +1,49 @@
+#include "qdcss.h"
+
+#include <QRegularExpression>
+#include <QRegularExpressionMatch>
+#include <QRegularExpressionMatchIterator>
+
+QRegularExpression ruleset_re = QRegularExpression(R"([#.]?(@?\w+?)\s*\{(.*?)\})", QRegularExpression::DotMatchesEverythingOption);
+QRegularExpression rule_re = QRegularExpression(R"((\S+?)\s*:\s*(?:\"(.*?)(?<!\\)\"|'(.*?)(?<!\\)'|(\S+?))\s*(?:;|$))");
+
+QDCSS::QDCSS(QString s)
+{
+    // not much error handling over here...
+    // the original java code used indeces returned by the matcher for them, but QRE does not expose those
+    QRegularExpressionMatchIterator ruleset_i = ruleset_re.globalMatch(s);
+    while (ruleset_i.hasNext()) {
+        QRegularExpressionMatch ruleset = ruleset_i.next();
+        QString selector = ruleset.captured(1);
+        QString rules = ruleset.captured(2);
+        QRegularExpressionMatchIterator rule_i = rule_re.globalMatch(rules);
+        while (rule_i.hasNext()) {
+            QRegularExpressionMatch rule = rule_i.next();
+            QString property = rule.captured(1);
+            QString value;
+            if (!rule.captured(2).isNull()) {
+                value = rule.captured(2);
+            } else if (!rule.captured(3).isNull()) {
+                value = rule.captured(3);
+            } else {
+                value = rule.captured(4);
+            }
+            QString key = selector + "." + property;
+            if (!m_data.contains(key)) {
+                m_data.insert(key, QStringList());
+            }
+            m_data.find(key)->append(value);
+        }
+    }
+}
+
+std::optional<QString>* QDCSS::get(QString key)
+{
+    auto found = m_data.find(key);
+
+    if (found == m_data.end() || found->empty()) {
+        return new std::optional<QString>;
+    }
+
+    return new std::optional<QString>(found->back());
+}

--- a/libraries/qdcss/src/qdcss.cpp
+++ b/libraries/qdcss/src/qdcss.cpp
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2023 kumquat-ir 66188216+kumquat-ir@users.noreply.github.com
+//
+// SPDX-License-Identifier: LGPL-3.0-only
+
 #include "qdcss.h"
 
 #include <QRegularExpression>


### PR DESCRIPTION
[NilLoader](https://github.com/unascribed/NilLoader) is an auxiliary modloader (like liteloader, i guess) that runs as a java agent (or as a janky coremod for 1.4.7 forge)

It's not very well-known, but there is [a modpack that uses it](https://git.sleeping.town/unascribed/RewindUpsilon) that will be uploaded to modrinth at some point soon(tm), so it would be good to at least be able to parse nil's metadata.

Adds the metadata parser and a seperate page for nilmods, since they can reside either in the main mods folder or in their own, in case a mod loader gets confused if they are in the main folder.

Some notes:
- The page is shown if the folder exists (it is not created automatically), since as an agent, NilLoader can be used with literally any version of minecraft
- Reuses the coremod icon, but given the infrequency that nil will be encountered, that seems fine
- how to do license headers

![image](https://user-images.githubusercontent.com/66188216/218284894-66eea3d4-d44f-403a-aba4-31dad71e0c4d.png)