### PR TITLE
Add missing header to Application.cpp: Fix build failure on KISS Linux

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -79,6 +79,7 @@
 #include <iostream>
 #include <mutex>
 
+#include <QFileOpenEvent>
 #include <QAccessible>
 #include <QCommandLineParser>
 #include <QDir>


### PR DESCRIPTION
Fails to compile on KISS Linux without `QFileOpenEvent`

fixes #858

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
