### PR TITLE
Use makeShared for importing components

### DIFF
--- a/launcher/minecraft/PackProfile.cpp
+++ b/launcher/minecraft/PackProfile.cpp
@@ -763,7 +763,7 @@ bool PackProfile::installComponents(QStringList selectedFiles)
             continue;
         }
 
-        appendComponent(new Component(this, versionFile->uid, versionFile));
+        appendComponent(makeShared<Component>(this, versionFile->uid, versionFile));
     }
 
     scheduleSave();


### PR DESCRIPTION
Merging #735 caused develop to fail, as it still used the implicit constructor for a shared pointer.

To avoid this in the future, I enabled the new merge queue feature of GitHub, which will only merge to develop if the merged commit builds fine.