### PR TITLE
Switch to Qt 6 by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,7 +174,7 @@ set(Launcher_SUBREDDIT_URL "https://www.reddit.com/r/PrismLauncher/" CACHE STRIN
 
 # Builds
 set(Launcher_FORCE_BUNDLED_LIBS OFF CACHE BOOL "Prevent using system libraries, if they are available as submodules")
-set(Launcher_QT_VERSION_MAJOR "5" CACHE STRING "Major Qt version to build against")
+set(Launcher_QT_VERSION_MAJOR "6" CACHE STRING "Major Qt version to build against")
 
 # API Keys
 # NOTE: These API keys are here for convenience. If you rebrand this software or intend to break the terms of service

--- a/flatpak/org.prismlauncher.PrismLauncher.yml
+++ b/flatpak/org.prismlauncher.PrismLauncher.yml
@@ -32,6 +32,7 @@ modules:
     config-opts:
       - -DLauncher_BUILD_PLATFORM=flatpak
       - -DCMAKE_BUILD_TYPE=Debug
+      - -DLauncher_QT_VERSION_MAJOR=5
     build-options:
       env:
         JAVA_HOME: /usr/lib/sdk/openjdk17/jvm/openjdk-17

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -46,7 +46,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optional (lib.versionAtLeast qtbase.version "6") qtwayland;
 
   cmakeFlags = lib.optionals (msaClientID != "") [ "-DLauncher_MSA_CLIENT_ID=${msaClientID}" ]
-    ++ lib.optionals (lib.versionAtLeast qtbase.version "6") [ "-DLauncher_QT_VERSION_MAJOR=6" ];
+    ++ lib.optionals (lib.versionOlder qtbase.version "6") [ "-DLauncher_QT_VERSION_MAJOR=5" ];
   dontWrapQtApps = true;
 
   postUnpack = ''

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -39,6 +39,7 @@ parts:
       - "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
       - "-DENABLE_LTO=ON"
       - "-DLauncher_BUILD_PLATFORM=snap"
+      - "-DLauncher_QT_VERSION_MAJOR=5"
 
 apps:
   prismlauncher:


### PR DESCRIPTION
The world is moving forward. Let's default to Qt 6 when building Prism Launcher.

This will probably break packaging if `Launcher_QT_VERSION_MAJOR` isn't set explicitly.