### PR TITLE
Add setting for downloads directory

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -516,6 +516,7 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
         m_settings->registerSetting("InstanceDir", "instances");
         m_settings->registerSetting({"CentralModsDir", "ModsDir"}, "mods");
         m_settings->registerSetting("IconsDir", "icons");
+        m_settings->registerSetting("DownloadsDir", QStandardPaths::writableLocation(QStandardPaths::DownloadLocation));
 
         // Editors
         m_settings->registerSetting("JsonEditor", QString());

--- a/launcher/ui/dialogs/BlockedModsDialog.cpp
+++ b/launcher/ui/dialogs/BlockedModsDialog.cpp
@@ -184,7 +184,7 @@ void BlockedModsDialog::directoryChanged(QString path)
 /// @brief add the user downloads folder and the global mods folder to the filesystem watcher
 void BlockedModsDialog::setupWatch()
 {
-    const QString downloadsFolder = QStandardPaths::writableLocation(QStandardPaths::DownloadLocation);
+    const QString downloadsFolder = APPLICATION->settings()->get("DownloadsDir").toString();
     const QString modsFolder = APPLICATION->settings()->get("CentralModsDir").toString();
     m_watcher.addPath(downloadsFolder);
     m_watcher.addPath(modsFolder);

--- a/launcher/ui/pages/global/LauncherPage.cpp
+++ b/launcher/ui/pages/global/LauncherPage.cpp
@@ -140,8 +140,8 @@ void LauncherPage::on_instDirBrowseBtn_clicked()
             if (result == QMessageBox::Ok)
             {
                 ui->instDirTextBox->setText(cooked_dir);
-            } 
-        } 
+            }
+        }
         else
         {
             ui->instDirTextBox->setText(cooked_dir);
@@ -160,6 +160,7 @@ void LauncherPage::on_iconsDirBrowseBtn_clicked()
         ui->iconsDirTextBox->setText(cooked_dir);
     }
 }
+
 void LauncherPage::on_modsDirBrowseBtn_clicked()
 {
     QString raw_dir = QFileDialog::getExistingDirectory(this, tr("Mods Folder"), ui->modsDirTextBox->text());
@@ -169,6 +170,17 @@ void LauncherPage::on_modsDirBrowseBtn_clicked()
     {
         QString cooked_dir = FS::NormalizePath(raw_dir);
         ui->modsDirTextBox->setText(cooked_dir);
+    }
+}
+
+void LauncherPage::on_downloadsDirBrowseBtn_clicked()
+{
+    QString raw_dir = QFileDialog::getExistingDirectory(this, tr("Downloads Folder"), ui->downloadsDirTextBox->text());
+
+    if (!raw_dir.isEmpty() && QDir(raw_dir).exists())
+    {
+        QString cooked_dir = FS::NormalizePath(raw_dir);
+        ui->downloadsDirTextBox->setText(cooked_dir);
     }
 }
 
@@ -204,6 +216,7 @@ void LauncherPage::applySettings()
     s->set("InstanceDir", ui->instDirTextBox->text());
     s->set("CentralModsDir", ui->modsDirTextBox->text());
     s->set("IconsDir", ui->iconsDirTextBox->text());
+    s->set("DownloadsDir", ui->downloadsDirTextBox->text());
 
     auto sortMode = (InstSortMode)ui->sortingModeGroup->checkedId();
     switch (sortMode)
@@ -260,6 +273,7 @@ void LauncherPage::loadSettings()
     ui->instDirTextBox->setText(s->get("InstanceDir").toString());
     ui->modsDirTextBox->setText(s->get("CentralModsDir").toString());
     ui->iconsDirTextBox->setText(s->get("IconsDir").toString());
+    ui->downloadsDirTextBox->setText(s->get("DownloadsDir").toString());
 
     QString sortMode = s->get("InstSortMode").toString();
 

--- a/launcher/ui/pages/global/LauncherPage.h
+++ b/launcher/ui/pages/global/LauncherPage.h
@@ -88,6 +88,7 @@ slots:
     void on_instDirBrowseBtn_clicked();
     void on_modsDirBrowseBtn_clicked();
     void on_iconsDirBrowseBtn_clicked();
+    void on_downloadsDirBrowseBtn_clicked();
     void on_metadataDisableBtn_clicked();
 
     /*!

--- a/launcher/ui/pages/global/LauncherPage.ui
+++ b/launcher/ui/pages/global/LauncherPage.ui
@@ -38,7 +38,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="featuresTab">
       <attribute name="title">
@@ -67,13 +67,6 @@
           <string>Folders</string>
          </property>
          <layout class="QGridLayout" name="foldersBoxLayout">
-          <item row="1" column="2">
-           <widget class="QToolButton" name="modsDirBrowseBtn">
-            <property name="text">
-             <string notr="true">...</string>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="2">
            <widget class="QToolButton" name="instDirBrowseBtn">
             <property name="text">
@@ -81,28 +74,11 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="2">
-           <widget class="QToolButton" name="iconsDirBrowseBtn">
-            <property name="text">
-             <string notr="true">...</string>
-            </property>
-           </widget>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="modsDirTextBox"/>
           </item>
           <item row="0" column="1">
            <widget class="QLineEdit" name="instDirTextBox"/>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="labelIconsDir">
-            <property name="text">
-             <string>&amp;Icons:</string>
-            </property>
-            <property name="buddy">
-             <cstring>iconsDirTextBox</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QLineEdit" name="modsDirTextBox"/>
           </item>
           <item row="0" column="0">
            <widget class="QLabel" name="labelInstDir">
@@ -117,6 +93,20 @@
           <item row="2" column="1">
            <widget class="QLineEdit" name="iconsDirTextBox"/>
           </item>
+          <item row="2" column="2">
+           <widget class="QToolButton" name="iconsDirBrowseBtn">
+            <property name="text">
+             <string notr="true">...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QToolButton" name="modsDirBrowseBtn">
+            <property name="text">
+             <string notr="true">...</string>
+            </property>
+           </widget>
+          </item>
           <item row="1" column="0">
            <widget class="QLabel" name="labelModsDir">
             <property name="text">
@@ -124,6 +114,33 @@
             </property>
             <property name="buddy">
              <cstring>modsDirTextBox</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="labelIconsDir">
+            <property name="text">
+             <string>&amp;Icons:</string>
+            </property>
+            <property name="buddy">
+             <cstring>iconsDirTextBox</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="labelDownloadsDir">
+            <property name="text">
+             <string>Downloads:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QLineEdit" name="downloadsDirTextBox"/>
+          </item>
+          <item row="3" column="2">
+           <widget class="QToolButton" name="downloadsDirBrowseBtn">
+            <property name="text">
+             <string>...</string>
             </property>
            </widget>
           </item>

--- a/launcher/ui/pages/global/LauncherPage.ui
+++ b/launcher/ui/pages/global/LauncherPage.ui
@@ -130,7 +130,10 @@
           <item row="3" column="0">
            <widget class="QLabel" name="labelDownloadsDir">
             <property name="text">
-             <string>Downloads:</string>
+             <string>&amp;Downloads:</string>
+            </property>
+            <property name="buddy">
+             <cstring>downloadsDirTextBox</cstring>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
This PR adds a settings button for selecting the `Downloads` directory. Some users change it in their browser, which means that you either always have to manually add your new directory or copy the files. After this PR, you can select your `Downloads` directory in the settings and Prism will default to watching this directory.

![image](https://user-images.githubusercontent.com/25827180/224753380-a457890d-15c1-4418-bdc0-7bad0942b711.png)
