### PR TITLE
Handle partial lines in LoggedProcess

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,10 +24,6 @@ Debug
 build
 /build-*
 
-# direnv / Nix
-.direnv/
-.pre-commit-config.yaml
-
 # Install dirs
 install
 /install-*
@@ -48,7 +44,9 @@ run/
 .cache/
 
 # Nix/NixOS
-result/
+.direnv/
+.pre-commit-config.yaml
+result
 
 # Flatpak
 .flatpak-builder

--- a/launcher/LoggedProcess.cpp
+++ b/launcher/LoggedProcess.cpp
@@ -61,13 +61,10 @@ LoggedProcess::~LoggedProcess()
     }
 }
 
-static QString m_leftover_line;
-
-QStringList reprocess(const QByteArray& data, QTextDecoder& decoder)
+QStringList LoggedProcess::reprocess(const QByteArray& data, QTextDecoder& decoder)
 {
     auto str = decoder.toUnicode(data);
 
-    // FIXME: Flush this out when process exits
     if (!m_leftover_line.isEmpty()) {
         str.prepend(m_leftover_line);
         m_leftover_line = "";

--- a/launcher/LoggedProcess.cpp
+++ b/launcher/LoggedProcess.cpp
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  PolyMC - Minecraft Launcher
- *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2022,2023 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (c) 2023 flowln <flowlnlnln@gmail.com> 
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -60,14 +61,26 @@ LoggedProcess::~LoggedProcess()
     }
 }
 
+static QString m_leftover_line;
+
 QStringList reprocess(const QByteArray& data, QTextDecoder& decoder)
 {
     auto str = decoder.toUnicode(data);
+
+    // FIXME: Flush this out when process exits
+    if (!m_leftover_line.isEmpty()) {
+        str.prepend(m_leftover_line);
+        m_leftover_line = "";
+    }
+
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
     auto lines = str.remove(QChar::CarriageReturn).split(QChar::LineFeed, QString::SkipEmptyParts);
 #else
     auto lines = str.remove(QChar::CarriageReturn).split(QChar::LineFeed, Qt::SkipEmptyParts);
 #endif
+
+    if (!str.endsWith(QChar::LineFeed))
+        m_leftover_line = lines.takeLast();
     return lines;
 }
 

--- a/launcher/LoggedProcess.h
+++ b/launcher/LoggedProcess.h
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
- *  PolyMC - Minecraft Launcher
- *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2022,2023 Sefa Eyeoglu <contact@scrumplex.net>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -88,9 +88,12 @@ private slots:
 private:
     void changeState(LoggedProcess::State state);
 
+    QStringList reprocess(const QByteArray& data, QTextDecoder& decoder);
+
 private:
     QTextDecoder m_err_decoder = QTextDecoder(QTextCodec::codecForLocale());
     QTextDecoder m_out_decoder = QTextDecoder(QTextCodec::codecForLocale());
+    QString m_leftover_line;
     bool m_killed = false;
     State m_state = NotRunning;
     int m_exit_code = 0;


### PR DESCRIPTION
Closes #930

That explains the code about leftover lines we removed before :thinking: 

I am not sure about my FIXME comment here, though. Should we just call reprocess with an empty buffer when the process exits, just to make sure we got all lines?