### PR TITLE
fix: divide minecraftpage into tabs

### DIFF
--- a/launcher/ui/pages/global/MinecraftPage.cpp
+++ b/launcher/ui/pages/global/MinecraftPage.cpp
@@ -46,7 +46,6 @@
 MinecraftPage::MinecraftPage(QWidget *parent) : QWidget(parent), ui(new Ui::MinecraftPage)
 {
     ui->setupUi(this);
-    ui->tabWidget->tabBar()->hide();
     loadSettings();
     updateCheckboxStuff();
 }

--- a/launcher/ui/pages/global/MinecraftPage.ui
+++ b/launcher/ui/pages/global/MinecraftPage.ui
@@ -187,7 +187,7 @@
      </widget>
      <widget class="QWidget" name="tab">
       <attribute name="title">
-       <string>System-related tweaks</string>
+       <string>Tweaks</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_12">
        <item>

--- a/launcher/ui/pages/global/MinecraftPage.ui
+++ b/launcher/ui/pages/global/MinecraftPage.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>936</width>
-    <height>1134</height>
+    <height>541</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -39,7 +39,7 @@
      </property>
      <widget class="QWidget" name="minecraftTab">
       <attribute name="title">
-       <string notr="true">Minecraft</string>
+       <string notr="true">General</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_3">
        <item>
@@ -107,68 +107,6 @@
              </widget>
             </item>
            </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="nativeLibWorkaroundGroupBox">
-         <property name="title">
-          <string>Native library workarounds</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_5">
-          <item>
-           <widget class="QCheckBox" name="useNativeGLFWCheck">
-            <property name="text">
-             <string>Use system installation of &amp;GLFW</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="useNativeOpenALCheck">
-            <property name="text">
-             <string>Use system installation of &amp;OpenAL</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="perfomanceGroupBox">
-         <property name="title">
-          <string>Performance</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_2">
-          <item>
-           <widget class="QCheckBox" name="enableFeralGamemodeCheck">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable Feral Interactive's GameMode, to potentially improve gaming performance.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string>Enable Feral GameMode</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="enableMangoHud">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable MangoHud's advanced performance overlay.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string>Enable MangoHud</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QCheckBox" name="useDiscreteGpuCheck">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use the discrete GPU instead of the primary GPU.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="text">
-             <string>Use discrete GPU</string>
-            </property>
-           </widget>
           </item>
          </layout>
         </widget>
@@ -247,6 +185,88 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="tab">
+      <attribute name="title">
+       <string>System-related tweaks</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_12">
+       <item>
+        <widget class="QGroupBox" name="nativeLibWorkaroundGroupBox">
+         <property name="title">
+          <string>Native library workarounds</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_11">
+          <item>
+           <widget class="QCheckBox" name="useNativeGLFWCheck">
+            <property name="text">
+             <string>Use system installation of &amp;GLFW</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="useNativeOpenALCheck">
+            <property name="text">
+             <string>Use system installation of &amp;OpenAL</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="perfomanceGroupBox">
+         <property name="title">
+          <string>Performance</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <widget class="QCheckBox" name="enableFeralGamemodeCheck">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable Feral Interactive's GameMode, to potentially improve gaming performance.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Enable Feral GameMode</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="enableMangoHud">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable MangoHud's advanced performance overlay.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Enable MangoHud</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="useDiscreteGpuCheck">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use the discrete GPU instead of the primary GPU.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Use discrete GPU</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>
@@ -255,11 +275,6 @@
   <tabstop>maximizedCheckBox</tabstop>
   <tabstop>windowWidthSpinBox</tabstop>
   <tabstop>windowHeightSpinBox</tabstop>
-  <tabstop>useNativeGLFWCheck</tabstop>
-  <tabstop>useNativeOpenALCheck</tabstop>
-  <tabstop>enableFeralGamemodeCheck</tabstop>
-  <tabstop>enableMangoHud</tabstop>
-  <tabstop>useDiscreteGpuCheck</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
this way small screen users can use the launcher setting without having window a bigger than their actual screens
closes partially https://github.com/PrismLauncher/PrismLauncher/issues/220

some screenshots
i tried to resize the new instance dialog but failed at it :/. Not too much of an issue as it's not as bad as what settings was
<img width="1279" alt="general" src="https://user-images.githubusercontent.com/83089242/227716831-4c726c46-e761-40c3-af3c-41356491e8a4.png"> general tab
<img width="1279" alt="System-related tweaks page" src="https://user-images.githubusercontent.com/83089242/227716837-b19da072-746b-469a-afef-b8dc9cf2d514.png"> System-related tweaks tab (here there'd be the perfomance part on linux)

