### PR TITLE
chore: Add development / offline mode compile time flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -193,6 +193,8 @@ set(Launcher_MSA_CLIENT_ID "c36a9fb6-4f2a-41ff-90bd-ae7cc92031eb" CACHE STRING "
 # This key was issued specifically for Prism Launcher
 set(Launcher_CURSEFORGE_API_KEY "$2a$10$wuAJuNZuted3NORVmpgUC.m8sI.pv1tOPKZyBgLFGjxFp/br0lZCC" CACHE STRING "API key for the CurseForge platform")
 
+# Development Mode
+set(Launcher_ALLOW_OFFLINE_MODE OFF CACHE BOOL "Allow testing the Launcher during development without having to log in to a valid account. Disabled by default to prevent piracy.")
 
 #### Check the current Git commit and branch
 include(GetGitRevisionDescription)

--- a/buildconfig/BuildConfig.cpp.in
+++ b/buildconfig/BuildConfig.cpp.in
@@ -106,6 +106,7 @@ Config::Config()
     HELP_URL = "@Launcher_HELP_URL@";
     IMGUR_CLIENT_ID = "@Launcher_IMGUR_CLIENT_ID@";
     MSA_CLIENT_ID = "@Launcher_MSA_CLIENT_ID@";
+    ALLOW_OFFLINE_MODE = "@Launcher_ALLOW_OFFLINE_MODE@";
     FLAME_API_KEY = "@Launcher_CURSEFORGE_API_KEY@";
     META_URL = "@Launcher_META_URL@";
 

--- a/buildconfig/BuildConfig.h
+++ b/buildconfig/BuildConfig.h
@@ -123,6 +123,11 @@ class Config {
     QString MSA_CLIENT_ID;
 
     /**
+     * Whether to allow using the Launcher without logging in to a valid account
+     */
+    bool ALLOW_OFFLINE_MODE;
+
+    /**
      * Client API key for CurseForge
      */
     QString FLAME_API_KEY;

--- a/launcher/ui/pages/global/AccountListPage.cpp
+++ b/launcher/ui/pages/global/AccountListPage.cpp
@@ -188,7 +188,7 @@ void AccountListPage::on_actionAddMicrosoft_triggered()
 
 void AccountListPage::on_actionAddOffline_triggered()
 {
-    if (!m_accounts->anyAccountIsValid()) {
+    if (!BuildConfig.ALLOW_OFFLINE_MODE && !m_accounts->anyAccountIsValid()) {
         QMessageBox::warning(
             this,
             tr("Error"),


### PR DESCRIPTION
This PR adds a compile time flag which allows to disable the (now) mandatory Microsoft login.
It would make developing and testing PrismLauncher much easier.
I personally find it quite a hassle having to log in to my Microsoft account every single time I recompile (and deleting application state in that process to have a clean testing environment).
Commenting out the function just to be quicker at testing stuff seems unnecessarily inconvenient and increases the risk of merge conflicts.
I think issues like this one really are a perfect match for using compile time flags.

I understand that this may be met with some controversy, however I'd like to mention that this does NOT enable piracy per-se.
The flag is disabled by default, so this can only be used if people compile from source.
Users wanting to pirate can do this already by simply removing / commenting out the check and compiling from source.
So from their perspective it doesn't change anything, this change only benefits people who want to use it for legitimate reasons.
