### PR TITLE
Add global .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+# Visual Studio generated .editorconfig file with C++ settings.
+root = true
+
+[*.{c++,cc,cpp,cppm,cxx,h,h++,hh,hpp,hxx,inl,ipp,ixx,tlh,tli}]
+
+# Visual C++ Code Style settings
+
+cpp_generate_documentation_comments = doxygen_triple_slash

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,8 @@
-# Visual Studio generated .editorconfig file with C++ settings.
+# EditorConfig specs and documentation: https://EditorConfig.org
+
+# top-most EditorConfig file
 root = true
 
+# C++ Code Style settings
 [*.{c++,cc,cpp,cppm,cxx,h,h++,hh,hpp,hxx,inl,ipp,ixx,tlh,tli}]
-
-# Visual C++ Code Style settings
-
-cpp_generate_documentation_comments = doxygen_triple_slash
+cpp_generate_documentation_comments = doxygen_slash_star


### PR DESCRIPTION
I asked about if we should include files like this in the repo before on discord and I think ultimately its good to have this, so that devs with any IDE have the correct code style we want in the repo. 
We already have clang-format, which is good and as far as I can tell works with any serious IDE I've encountered. But it doesn't define what doc style to use for documentation comments, e.g.:
```
	/// this is a doxygen documentation comment
	/// \param editor the widget
	/// \param index  
	void myFunc(QWidget* editor, const QModelIndex& index) {

	}
```
vs
```
	/// <summary>
	/// this is a XML documentation comment
	/// </summary>
	/// <param name="editor">the widget</param>
	/// <param name="index "></param>
	/// <returns>some return value</returns>
	QString myFunc(QWidget* editor, const QModelIndex& index) {

	}
```
as the file says it was auto generated by VisualStudio, I can get rid of the excess comments if desired.

I am also not sure any other IDE actually goes for XMLDoc for C/C++ projects. they are more of a .NET thing. But eh, don't think having this hurts anyone.
