### PR TITLE
[Linux] Shorten desktop entry comment field

### DIFF
--- a/program_info/org.prismlauncher.PrismLauncher.desktop.in
+++ b/program_info/org.prismlauncher.PrismLauncher.desktop.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Version=1.0
 Name=Prism Launcher
-Comment=A custom launcher for Minecraft that allows you to easily manage multiple installations of Minecraft at once.
+Comment=Discover, manage, and play Minecraft instances
 Type=Application
 Terminal=false
 Exec=@Launcher_APP_BINARY_NAME@


### PR DESCRIPTION
Shortens the desktop entry comment field which is used to display the description text of a program in application launchers.

There are several other locations where the existing description text exists which may also need updating:

- https://github.com/PrismLauncher/PrismLauncher/blob/8dc3267925537d58a1e9418863b78e4cc55bd1c1/CMakeLists.txt#L307
- https://github.com/PrismLauncher/PrismLauncher/blob/8dc3267925537d58a1e9418863b78e4cc55bd1c1/flake.nix#L2
- https://github.com/PrismLauncher/PrismLauncher/blob/8dc3267925537d58a1e9418863b78e4cc55bd1c1/program_info/org.prismlauncher.PrismLauncher.metainfo.xml.in#L7

I'm unfamiliar with these platforms and files so let me know if you think they should be updated as well.

Closes https://github.com/PrismLauncher/PrismLauncher/issues/1030