### PR TITLE
fix: remove poly from desktop tags

### DIFF
--- a/program_info/org.prismlauncher.PrismLauncher.desktop.in
+++ b/program_info/org.prismlauncher.PrismLauncher.desktop.in
@@ -8,6 +8,6 @@ Exec=@Launcher_APP_BINARY_NAME@
 StartupNotify=true
 Icon=org.prismlauncher.PrismLauncher
 Categories=Game;ActionGame;AdventureGame;Simulation;
-Keywords=game;minecraft;launcher;mc;multimc;polymc;
+Keywords=game;minecraft;mc;
 StartupWMClass=PrismLauncher
 MimeType=application/zip;application/x-modrinth-modpack+zip


### PR DESCRIPTION
this messes with apps that use tag search like rofi, and prism will show up upon searching for poly