### PR TITLE
Add blocked mod `laxCompare` that ignores seperators, whitespace, and case

### DIFF
--- a/launcher/ui/dialogs/BlockedModsDialog.cpp
+++ b/launcher/ui/dialogs/BlockedModsDialog.cpp
@@ -195,7 +195,7 @@ void BlockedModsDialog::watchPath(QString path, bool watch_recursive)
     auto to_watch = QFileInfo(path);
     auto to_watch_path = to_watch.canonicalFilePath();
     if (m_watcher.directories().contains(to_watch_path))
-        return; // don't watch the same path twice (no loops!)
+        return;  // don't watch the same path twice (no loops!)
 
     qDebug() << "[Blocked Mods Dialog] Adding Watch Path:" << path;
     m_watcher.addPath(to_watch_path);
@@ -203,10 +203,9 @@ void BlockedModsDialog::watchPath(QString path, bool watch_recursive)
     if (!to_watch.isDir() || !watch_recursive)
         return;
 
-
     QDirIterator it(to_watch_path, QDir::Filter::Dirs | QDir::Filter::NoDotAndDotDot, QDirIterator::NoIteratorFlags);
     while (it.hasNext()) {
-        QString watch_dir = QDir(it.next()).canonicalPath(); // resolve symlinks and relative paths
+        QString watch_dir = QDir(it.next()).canonicalPath();  // resolve symlinks and relative paths
         watchPath(watch_dir, watch_recursive);
     }
 }
@@ -302,14 +301,35 @@ bool BlockedModsDialog::checkValidPath(QString path)
 {
     const QFileInfo file = QFileInfo(path);
     const QString filename = file.fileName();
-    QString laxFilename(filename);
-    laxFilename.replace('+', ' ');
 
-    QString laxFilename2(filename);
-    laxFilename.replace(' ', '+');
+    auto compare = [](QString fsFilename, QString metadataFilename) {
+        return metadataFilename.compare(fsFilename, Qt::CaseInsensitive) == 0;
+    };
 
-    auto compare = [](QString fsfilename, QString metadataFilename) {
-        return metadataFilename.compare(fsfilename, Qt::CaseInsensitive) == 0;
+    // super lax compare (but not fuzzy)
+    // convert to lowercase
+    // convert all speratores to whitespace
+    // simplify sequence of internal whitespace to a single space
+    // efectivly compare two strings ignoring all separators and case
+    auto laxCompare = [](QString fsfilename, QString metadataFilename) {
+        // allowed character seperators
+        QList<QChar> allowedSeperators = { '-', '+', '.' , '_'};
+
+        // copy in lowercase
+        auto fsName = fsfilename.toLower();
+        auto metaName = metadataFilename.toLower();
+
+        // replace all potential allowed seperatores with whitespace
+        for (auto sep : allowedSeperators) {
+            fsName = fsName.replace(sep, ' ');
+            metaName = metaName.replace(sep, ' ');
+        }
+
+        // remove extraneous whitespace
+        fsName = fsName.simplified();
+        metaName = metaName.simplified();
+
+        return fsName.compare(metaName) == 0;
     };
 
     for (auto& mod : m_mods) {
@@ -317,7 +337,7 @@ bool BlockedModsDialog::checkValidPath(QString path)
             qDebug() << "[Blocked Mods Dialog] Name match found:" << mod.name << "| From path:" << path;
             return true;
         }
-        if (compare(laxFilename, mod.name) || compare(laxFilename2, mod.name)) {
+        if (laxCompare(filename, mod.name)) {
             qDebug() << "[Blocked Mods Dialog] Lax name match found:" << mod.name << "| From path:" << path;
             return true;
         }

--- a/launcher/ui/dialogs/BlockedModsDialog.cpp
+++ b/launcher/ui/dialogs/BlockedModsDialog.cpp
@@ -305,6 +305,9 @@ bool BlockedModsDialog::checkValidPath(QString path)
     QString laxFilename(filename);
     laxFilename.replace('+', ' ');
 
+    QString laxFilename2(filename);
+    laxFilename.replace(' ', '+');
+
     auto compare = [](QString fsfilename, QString metadataFilename) {
         return metadataFilename.compare(fsfilename, Qt::CaseInsensitive) == 0;
     };
@@ -314,7 +317,7 @@ bool BlockedModsDialog::checkValidPath(QString path)
             qDebug() << "[Blocked Mods Dialog] Name match found:" << mod.name << "| From path:" << path;
             return true;
         }
-        if (compare(laxFilename, mod.name)) {
+        if (compare(laxFilename, mod.name) || compare(laxFilename2, mod.name)) {
             qDebug() << "[Blocked Mods Dialog] Lax name match found:" << mod.name << "| From path:" << path;
             return true;
         }


### PR DESCRIPTION
Fix #958
