### PR TITLE
Add image column to resource pages

### DIFF
--- a/launcher/MTPixmapCache.h
+++ b/launcher/MTPixmapCache.h
@@ -95,7 +95,7 @@ class PixmapCache final : public QObject {
     }
 
     /** 
-     *  Mark that a cach miss occured because of a eviciton if too man of these occure to fast the cache size is increased 
+     *  Mark that a cache miss occurred because of a eviction if too many of these occur too fast the cache size is increased 
      * @return if the cache size was increased
      */
     bool _markCacheMissByEviciton()

--- a/launcher/MTPixmapCache.h
+++ b/launcher/MTPixmapCache.h
@@ -3,6 +3,8 @@
 #include <QCoreApplication>
 #include <QPixmapCache>
 #include <QThread>
+#include <QTime>
+#include <QDebug>
 
 #define GET_TYPE()                                                          \
     Qt::ConnectionType type;                                                \
@@ -60,6 +62,8 @@ class PixmapCache final : public QObject {
     DEFINE_FUNC_ONE_PARAM(remove, bool, const QPixmapCache::Key&)
     DEFINE_FUNC_TWO_PARAM(replace, bool, const QPixmapCache::Key&, const QPixmap&)
     DEFINE_FUNC_ONE_PARAM(setCacheLimit, bool, int)
+    DEFINE_FUNC_NO_PARAM(markCacheMissByEviciton, bool)
+    DEFINE_FUNC_ONE_PARAM(setFastEvictionThreshold, bool, int)
 
     // NOTE: Every function returns something non-void to simplify the macros.
    private slots:
@@ -90,6 +94,43 @@ class PixmapCache final : public QObject {
         return true;
     }
 
+    /** 
+     *  Mark that a cach miss occured because of a eviciton if too man of these occure to fast the cache size is increased 
+     * @return if the cache size was increased
+     */
+    bool _markCacheMissByEviciton()
+    {
+        auto now = QTime::currentTime();
+        if (!m_last_cache_miss_by_eviciton.isNull()) {
+            auto diff = m_last_cache_miss_by_eviciton.msecsTo(now);
+            if (diff < 1000) {  // less than a second ago
+                ++m_consecutive_fast_evicitons;
+            } else {
+                m_consecutive_fast_evicitons = 0;
+            }
+        }
+        m_last_cache_miss_by_eviciton = now;
+        if (m_consecutive_fast_evicitons >= m_consecutive_fast_evicitons_threshold) {
+            // double the cache size
+            auto newSize = _cacheLimit() * 2;
+            qDebug() << m_consecutive_fast_evicitons << "pixmap cache misses by eviction happened too fast, doubling cache size to"
+                     << newSize;
+            _setCacheLimit(newSize);
+            m_consecutive_fast_evicitons = 0;
+            return true;
+        }
+        return false;
+    }
+
+    bool _setFastEvictionThreshold(int threshold)
+    {
+        m_consecutive_fast_evicitons_threshold = threshold;
+        return true;
+    }
+
    private:
     static PixmapCache* s_instance;
+    QTime m_last_cache_miss_by_eviciton;
+    int m_consecutive_fast_evicitons = 0;
+    int m_consecutive_fast_evicitons_threshold = 15;
 };

--- a/launcher/minecraft/mod/Mod.cpp
+++ b/launcher/minecraft/mod/Mod.cpp
@@ -206,7 +206,7 @@ void Mod::finishResolvingWithDetails(ModDetails&& details)
     if (!iconPath().isEmpty()) {
         m_pack_image_cache_key.was_read_attempt = false;
     }
-};
+}
 
 auto Mod::provider() const -> std::optional<QString>
 {
@@ -250,7 +250,7 @@ QPixmap Mod::icon(QSize size, Qt::AspectRatioMode mode) const
         qDebug() << "Mod" << name() << "Had it's icon evicted form the cache. reloading...";
         PixmapCache::markCacheMissByEviciton();
     }
-    // Imaged got evicted from the cache or an attmept to load it has not been made. load it and retry.
+    // Image got evicted from the cache or an attempt to load it has not been made. load it and retry.
     m_pack_image_cache_key.was_read_attempt = true;
     ModUtils::loadIconFile(*this);
     return icon(size);

--- a/launcher/minecraft/mod/Mod.cpp
+++ b/launcher/minecraft/mod/Mod.cpp
@@ -41,9 +41,11 @@
 #include <QString>
 #include <QRegularExpression>
 
+#include "MTPixmapCache.h"
 #include "MetadataHandler.h"
 #include "Version.h"
 #include "minecraft/mod/ModDetails.h"
+#include "minecraft/mod/tasks/LocalModParseTask.h"
 
 static ModPlatform::ProviderCapabilities ProviderCaps;
 
@@ -201,6 +203,9 @@ void Mod::finishResolvingWithDetails(ModDetails&& details)
     m_local_details = std::move(details);
     if (metadata)
         setMetadata(std::move(metadata));
+    if (!iconPath().isEmpty()) {
+        m_pack_image_cache_key.was_read_attempt = false;
+    }
 };
 
 auto Mod::provider() const -> std::optional<QString>
@@ -208,6 +213,47 @@ auto Mod::provider() const -> std::optional<QString>
     if (metadata())
         return ProviderCaps.readableName(metadata()->provider);
     return {};
+}
+
+
+void Mod::setIcon(QImage new_image) const
+{
+    QMutexLocker locker(&m_data_lock);
+
+    Q_ASSERT(!new_image.isNull());
+
+    if (m_pack_image_cache_key.key.isValid())
+        PixmapCache::remove(m_pack_image_cache_key.key);
+
+    // scale the image to avoid flooding the pixmapcache
+    auto pixmap = QPixmap::fromImage(new_image.scaled({128, 128}, Qt::AspectRatioMode::KeepAspectRatioByExpanding));
+
+    m_pack_image_cache_key.key = PixmapCache::insert(pixmap);
+    m_pack_image_cache_key.was_ever_used = true;
+    m_pack_image_cache_key.was_read_attempt = true;
+}
+
+QPixmap Mod::icon(QSize size, Qt::AspectRatioMode mode) const
+{
+    QPixmap cached_image;
+    if (PixmapCache::find(m_pack_image_cache_key.key, &cached_image)) {
+        if (size.isNull())
+            return cached_image;
+        return cached_image.scaled(size, mode);
+    }
+
+    // No valid image we can get
+    if ((!m_pack_image_cache_key.was_ever_used && m_pack_image_cache_key.was_read_attempt) || iconPath().isEmpty())
+        return {};
+
+    if (m_pack_image_cache_key.was_ever_used) {
+        qDebug() << "Mod" << name() << "Had it's icon evicted form the cache. reloading...";
+        PixmapCache::markCacheMissByEviciton();
+    }
+    // Imaged got evicted from the cache or an attmept to load it has not been made. load it and retry.
+    m_pack_image_cache_key.was_read_attempt = true;
+    ModUtils::loadIconFile(*this);
+    return icon(size);
 }
 
 bool Mod::valid() const

--- a/launcher/minecraft/mod/Mod.cpp
+++ b/launcher/minecraft/mod/Mod.cpp
@@ -215,6 +215,15 @@ auto Mod::provider() const -> std::optional<QString>
     return {};
 }
 
+auto Mod::licenses() const -> const QList<ModLicense>&
+{
+    return details().licenses;
+}
+
+ auto Mod::issueTracker() const -> QString
+{
+    return details().issue_tracker;
+}
 
 void Mod::setIcon(QImage new_image) const
 {

--- a/launcher/minecraft/mod/Mod.cpp
+++ b/launcher/minecraft/mod/Mod.cpp
@@ -226,7 +226,7 @@ void Mod::setIcon(QImage new_image) const
         PixmapCache::remove(m_pack_image_cache_key.key);
 
     // scale the image to avoid flooding the pixmapcache
-    auto pixmap = QPixmap::fromImage(new_image.scaled({128, 128}, Qt::AspectRatioMode::KeepAspectRatioByExpanding));
+    auto pixmap = QPixmap::fromImage(new_image.scaled({64, 64}, Qt::AspectRatioMode::KeepAspectRatioByExpanding));
 
     m_pack_image_cache_key.key = PixmapCache::insert(pixmap);
     m_pack_image_cache_key.was_ever_used = true;

--- a/launcher/minecraft/mod/Mod.h
+++ b/launcher/minecraft/mod/Mod.h
@@ -38,6 +38,10 @@
 #include <QDateTime>
 #include <QFileInfo>
 #include <QList>
+#include <QImage>
+#include <QMutex>
+#include <QPixmap>
+#include <QPixmapCache>
 
 #include <optional>
 
@@ -65,6 +69,13 @@ public:
     auto status()      const -> ModStatus;
     auto provider()    const -> std::optional<QString>;
 
+    /** Get the intneral path to the mod's icon file*/
+    QString iconPath() const { return m_local_details.icon_file; };
+    /** Gets the icon of the mod, converted to a QPixmap for drawing, and scaled to size. */
+    [[nodiscard]] QPixmap icon(QSize size, Qt::AspectRatioMode mode = Qt::AspectRatioMode::IgnoreAspectRatio) const;
+    /** Thread-safe. */
+    void setIcon(QImage new_image) const;
+
     auto metadata() -> std::shared_ptr<Metadata::ModStruct>;
     auto metadata() const -> const std::shared_ptr<Metadata::ModStruct>;
 
@@ -85,4 +96,13 @@ public:
 
 protected:
     ModDetails m_local_details;
+
+    mutable QMutex m_data_lock;
+
+    struct {
+        QPixmapCache::Key key;
+        bool was_ever_used = false;
+        bool was_read_attempt = false;
+    } mutable m_pack_image_cache_key;
+    
 };

--- a/launcher/minecraft/mod/Mod.h
+++ b/launcher/minecraft/mod/Mod.h
@@ -68,6 +68,8 @@ public:
     auto authors()     const -> QStringList;
     auto status()      const -> ModStatus;
     auto provider()    const -> std::optional<QString>;
+    auto licenses()     const -> const QList<ModLicense>&;
+    auto issueTracker() const -> QString;
 
     /** Get the intneral path to the mod's icon file*/
     QString iconPath() const { return m_local_details.icon_file; };

--- a/launcher/minecraft/mod/ModDetails.h
+++ b/launcher/minecraft/mod/ModDetails.h
@@ -39,6 +39,7 @@
 
 #include <QString>
 #include <QStringList>
+#include <QUrl>
 
 #include "minecraft/mod/MetadataHandler.h"
 
@@ -47,6 +48,77 @@ enum class ModStatus {
     NotInstalled,   // Only the Metadata is present
     NoMetadata,     // Only the JAR is present
     Unknown,        // Default status
+};
+
+struct ModLicense {
+    QString name = {};
+    QString id = {};
+    QString url = {};
+    QString description = {};
+
+    ModLicense() {}
+
+    ModLicense(const QString license) {
+        // FIXME: come up with a better license parseing. 
+        // handle SPDX identifiers? https://spdx.org/licenses/
+        auto parts = license.split(' ');
+        QStringList notNameParts  = {};
+        for (auto part : parts) {
+            auto url = QUrl::fromUserInput(part);
+            if (url.isValid()) {
+                this->url = url.toString();
+                notNameParts.append(part);
+                continue;
+            }
+        }
+
+        for (auto part : notNameParts) {
+            parts.removeOne(part);
+        }
+        
+        auto licensePart = parts.join(' ');
+        this->name = licensePart;
+        this->description = licensePart;
+
+        if (parts.size() == 1) {
+            this->id = parts.first();
+        }
+        
+    }
+
+    ModLicense(const QString name, const QString id, const QString url, const QString description) {
+        this->name = name;
+        this->id = id;
+        this->url = url;
+        this->description = description;
+    }
+
+    ModLicense(const ModLicense& other)
+        : name(other.name)
+        , id(other.id)
+        , url(other.url)
+        , description(other.description)
+    {}
+
+    ModLicense& operator=(const ModLicense& other)
+    {
+        this->name = other.name;
+        this->id = other.id;
+        this->url = other.url;
+        this->description = other.description;
+
+        return *this;
+    }
+
+    ModLicense& operator=(const ModLicense&& other)
+    {
+        this->name = other.name;
+        this->id = other.id;
+        this->url = other.url;
+        this->description = other.description;
+
+        return *this;
+    }
 };
 
 struct ModDetails
@@ -72,6 +144,15 @@ struct ModDetails
     /* List of the author's names */
     QStringList authors = {};
 
+    /* Issue Tracker URL */
+    QString issue_tracker = {};
+
+    /* License */
+    QList<ModLicense> licenses = {};
+
+    /* Path of mod logo */
+    QString icon_file = {};
+
     /* Installation status of the mod */
     ModStatus status = ModStatus::Unknown;
 
@@ -89,6 +170,9 @@ struct ModDetails
         , homeurl(other.homeurl)
         , description(other.description)
         , authors(other.authors)
+        , issue_tracker(other.issue_tracker)
+        , licenses(other.licenses)
+        , icon_file(other.icon_file)
         , status(other.status)
     {}
 
@@ -101,6 +185,9 @@ struct ModDetails
         this->homeurl = other.homeurl;
         this->description = other.description;
         this->authors = other.authors;
+        this->issue_tracker = other.issue_tracker;
+        this->licenses = other.licenses;
+        this->icon_file = other.icon_file;
         this->status = other.status;
 
         return *this;
@@ -115,6 +202,9 @@ struct ModDetails
         this->homeurl = other.homeurl;
         this->description = other.description;
         this->authors = other.authors;
+        this->issue_tracker = other.issue_tracker;
+        this->licenses = other.licenses;
+        this->icon_file = other.icon_file;
         this->status = other.status;
 
         return *this;

--- a/launcher/minecraft/mod/ModDetails.h
+++ b/launcher/minecraft/mod/ModDetails.h
@@ -64,8 +64,11 @@ struct ModLicense {
         auto parts = license.split(' ');
         QStringList notNameParts  = {};
         for (auto part : parts) {
-            auto url = QUrl::fromUserInput(part);
-            if (url.isValid()) {
+            auto url = QUrl(part);
+            if (part.startsWith("(") && part.endsWith(")"))
+                url = QUrl(part.mid(1, part.size() - 2));
+
+            if (url.isValid() && !url.scheme().isEmpty() && !url.host().isEmpty()) {
                 this->url = url.toString();
                 notNameParts.append(part);
                 continue;
@@ -118,6 +121,10 @@ struct ModLicense {
         this->description = other.description;
 
         return *this;
+    }
+
+    bool isEmpty() {
+        return this->name.isEmpty() && this->id.isEmpty() && this->url.isEmpty() && this->description.isEmpty();
     }
 };
 

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -119,7 +119,7 @@ QVariant ModFolderModel::data(const QModelIndex &index, int role) const
         if (column == NAME_COLUMN && (at(row)->isSymLinkUnder(instDirPath()) || at(row)->isMoreThanOneHardLink()))
             return APPLICATION->getThemedIcon("status-yellow");
         if (column == ImageColumn) {
-            return at(row)->icon(QSize(64, 64), Qt::AspectRatioMode::KeepAspectRatioByExpanding);
+            return at(row)->icon({32, 32}, Qt::AspectRatioMode::KeepAspectRatioByExpanding);
         }
         return {};
     }

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -60,7 +60,7 @@ ModFolderModel::ModFolderModel(const QString& dir, BaseInstance* instance, bool 
     m_column_names = QStringList({ "Enable", "Image", "Name", "Version", "Last Modified", "Provider" });
     m_column_names_translated = QStringList({ tr("Enable"), tr("Image"), tr("Name"), tr("Version"), tr("Last Modified"), tr("Provider") });
     m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::NAME , SortType::VERSION, SortType::DATE, SortType::PROVIDER};
-    m_column_resize_modes = { QHeaderView::ResizeToContents, QHeaderView::Interactive, QHeaderView::Stretch, QHeaderView::ResizeToContents, QHeaderView::ResizeToContents};
+    m_column_resize_modes = { QHeaderView::ResizeToContents, QHeaderView::Interactive, QHeaderView::Stretch, QHeaderView::ResizeToContents, QHeaderView::ResizeToContents, QHeaderView::ResizeToContents};
 }
 
 QVariant ModFolderModel::data(const QModelIndex &index, int role) const

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -57,6 +57,8 @@
 ModFolderModel::ModFolderModel(const QString& dir, BaseInstance* instance, bool is_indexed, bool create_dir)
     : ResourceFolderModel(QDir(dir), instance, nullptr, create_dir), m_is_indexed(is_indexed)
 {
+    m_column_names = QStringList({ "Enable", "Image", "Name", "Version", "Last Modified", "Provider" });
+    m_column_names_translated = QStringList({ tr("Enable"), tr("Image"), tr("Name"), tr("Version"), tr("Last Modified"), tr("Provider") });
     m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::NAME , SortType::VERSION, SortType::DATE, SortType::PROVIDER};
     m_column_resize_modes = { QHeaderView::ResizeToContents, QHeaderView::ResizeToContents, QHeaderView::Stretch, QHeaderView::ResizeToContents, QHeaderView::ResizeToContents};
 }
@@ -145,17 +147,12 @@ QVariant ModFolderModel::headerData(int section, Qt::Orientation orientation, in
         switch (section)
         {
         case ActiveColumn:
-            return tr("Enable");
         case NameColumn:
-            return tr("Name");
         case VersionColumn:
-            return tr("Version");
         case DateColumn:
-            return tr("Last changed");
         case ProviderColumn:
-            return tr("Provider");
         case ImageColumn:
-            return tr("Image");
+            return columnNames().at(section);
         default:
             return QVariant();
         }

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -37,6 +37,7 @@
 #include "ModFolderModel.h"
 
 #include <FileSystem.h>
+#include <qheaderview.h>
 #include <QDebug>
 #include <QFileSystemWatcher>
 #include <QIcon>
@@ -56,7 +57,8 @@
 ModFolderModel::ModFolderModel(const QString& dir, std::shared_ptr<const BaseInstance> instance, bool is_indexed, bool create_dir)
     : ResourceFolderModel(QDir(dir), instance, nullptr, create_dir), m_is_indexed(is_indexed)
 {
-    m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::VERSION, SortType::DATE, SortType::PROVIDER, SortType::NAME };
+    m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::NAME , SortType::VERSION, SortType::DATE, SortType::PROVIDER};
+    m_column_resize_modes = { QHeaderView::ResizeToContents, QHeaderView::ResizeToContents, QHeaderView::Stretch, QHeaderView::ResizeToContents, QHeaderView::ResizeToContents};
 }
 
 QVariant ModFolderModel::data(const QModelIndex &index, int role) const
@@ -143,7 +145,7 @@ QVariant ModFolderModel::headerData(int section, Qt::Orientation orientation, in
         switch (section)
         {
         case ActiveColumn:
-            return QString();
+            return tr("Enable");
         case NameColumn:
             return tr("Name");
         case VersionColumn:

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -57,7 +57,7 @@
 ModFolderModel::ModFolderModel(const QString& dir, std::shared_ptr<const BaseInstance> instance, bool is_indexed, bool create_dir)
     : ResourceFolderModel(QDir(dir), instance, nullptr, create_dir), m_is_indexed(is_indexed)
 {
-    m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::VERSION, SortType::DATE, SortType::PROVIDER };
+    m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::VERSION, SortType::DATE, SortType::PROVIDER, SortType::NAME };
 }
 
 QVariant ModFolderModel::data(const QModelIndex &index, int role) const
@@ -118,7 +118,9 @@ QVariant ModFolderModel::data(const QModelIndex &index, int role) const
     case Qt::DecorationRole: {
         if (column == NAME_COLUMN && (at(row)->isSymLinkUnder(instDirPath()) || at(row)->isMoreThanOneHardLink()))
             return APPLICATION->getThemedIcon("status-yellow");
-
+        if (column == ImageColumn) {
+            return at(row)->icon(QSize(64, 64), Qt::AspectRatioMode::KeepAspectRatioByExpanding);
+        }
         return {};
     }
     case Qt::CheckStateRole:
@@ -151,6 +153,8 @@ QVariant ModFolderModel::headerData(int section, Qt::Orientation orientation, in
             return tr("Last changed");
         case ProviderColumn:
             return tr("Provider");
+        case ImageColumn:
+            return tr("Image");
         default:
             return QVariant();
         }

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -60,7 +60,7 @@ ModFolderModel::ModFolderModel(const QString& dir, BaseInstance* instance, bool 
     m_column_names = QStringList({ "Enable", "Image", "Name", "Version", "Last Modified", "Provider" });
     m_column_names_translated = QStringList({ tr("Enable"), tr("Image"), tr("Name"), tr("Version"), tr("Last Modified"), tr("Provider") });
     m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::NAME , SortType::VERSION, SortType::DATE, SortType::PROVIDER};
-    m_column_resize_modes = { QHeaderView::ResizeToContents, QHeaderView::ResizeToContents, QHeaderView::Stretch, QHeaderView::ResizeToContents, QHeaderView::ResizeToContents};
+    m_column_resize_modes = { QHeaderView::ResizeToContents, QHeaderView::Interactive, QHeaderView::Stretch, QHeaderView::ResizeToContents, QHeaderView::ResizeToContents};
 }
 
 QVariant ModFolderModel::data(const QModelIndex &index, int role) const

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -52,7 +52,6 @@
 
 #include "minecraft/mod/tasks/LocalModParseTask.h"
 #include "minecraft/mod/tasks/ModFolderLoadTask.h"
-#include "modplatform/ModIndex.h"
 
 ModFolderModel::ModFolderModel(const QString& dir, std::shared_ptr<const BaseInstance> instance, bool is_indexed, bool create_dir)
     : ResourceFolderModel(QDir(dir), instance, nullptr, create_dir), m_is_indexed(is_indexed)

--- a/launcher/minecraft/mod/ModFolderModel.h
+++ b/launcher/minecraft/mod/ModFolderModel.h
@@ -68,6 +68,7 @@ public:
         VersionColumn,
         DateColumn,
         ProviderColumn,
+        ImageColumn,
         NUM_COLUMNS
     };
     enum ModStatusAction {

--- a/launcher/minecraft/mod/ModFolderModel.h
+++ b/launcher/minecraft/mod/ModFolderModel.h
@@ -64,11 +64,11 @@ public:
     enum Columns
     {
         ActiveColumn = 0,
+        ImageColumn,
         NameColumn,
         VersionColumn,
         DateColumn,
         ProviderColumn,
-        ImageColumn,
         NUM_COLUMNS
     };
     enum ModStatusAction {
@@ -77,6 +77,8 @@ public:
         Toggle
     };
     ModFolderModel(const QString &dir, std::shared_ptr<const BaseInstance> instance, bool is_indexed = false, bool create_dir = true);
+
+    virtual QString id() const override { return "mods"; }
 
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -475,11 +475,9 @@ QVariant ResourceFolderModel::headerData(int section, Qt::Orientation orientatio
         case Qt::DisplayRole:
             switch (section) {
                 case ACTIVE_COLUMN:
-                    return tr("Enable");
                 case NAME_COLUMN:
-                    return tr("Name");
                 case DATE_COLUMN:
-                    return tr("Last modified");
+                    return columnNames().at(section);
                 default:
                     return {};
             }
@@ -509,7 +507,7 @@ void ResourceFolderModel::setupHeaderAction(QAction* act, int column)
 {
     Q_ASSERT(act);
 
-    act->setText(headerData(column, Qt::Orientation::Horizontal).toString());
+    act->setText(columnNames().at(column));
 }
 
 void ResourceFolderModel::saveHiddenColumn(int column, bool hidden)
@@ -518,12 +516,13 @@ void ResourceFolderModel::saveHiddenColumn(int column, bool hidden)
     auto setting = (APPLICATION->settings()->contains(setting_name)) ?
         APPLICATION->settings()->getSetting(setting_name) : APPLICATION->settings()->registerSetting(setting_name);
 
-    auto hiddenColumns = QVariantUtils::toList<int>(setting->get());
-    auto index = hiddenColumns.indexOf(column);
+    auto hiddenColumns = QVariantUtils::toList<QString>(setting->get());
+    auto name = columnNames(false).at(column);
+    auto index = hiddenColumns.indexOf(name);
     if (index >= 0 && !hidden) {
         hiddenColumns.removeAt(index);
     } else if ( index < 0 && hidden) {
-        hiddenColumns.append(column);
+        hiddenColumns.append(name);
     }
     setting->set(QVariantUtils::fromList(hiddenColumns));
 }

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -513,10 +513,10 @@ void ResourceFolderModel::setupHeaderAction(QAction* act, int column)
 void ResourceFolderModel::saveHiddenColumn(int column, bool hidden)
 {
     auto const setting_name = QString("UI/%1_Page/HiddenColumns").arg(id());
-    auto setting = (APPLICATION->settings()->contains(setting_name)) ?
-        APPLICATION->settings()->getSetting(setting_name) : APPLICATION->settings()->registerSetting(setting_name);
+    auto setting = (m_instance->settings()->contains(setting_name)) ?
+        m_instance->settings()->getSetting(setting_name) : m_instance->settings()->registerSetting(setting_name);
 
-    auto hiddenColumns = QVariantUtils::toList<QString>(setting->get());
+    auto hiddenColumns = setting->get().toStringList();
     auto name = columnNames(false).at(column);
     auto index = hiddenColumns.indexOf(name);
     if (index >= 0 && !hidden) {
@@ -524,30 +524,33 @@ void ResourceFolderModel::saveHiddenColumn(int column, bool hidden)
     } else if ( index < 0 && hidden) {
         hiddenColumns.append(name);
     }
-    setting->set(QVariantUtils::fromList(hiddenColumns));
+    setting->set(hiddenColumns);
 }
 
 void ResourceFolderModel::loadHiddenColumns(QTreeView *tree)
 {
     auto const setting_name = QString("UI/%1_Page/HiddenColumns").arg(id());
-    auto setting = (APPLICATION->settings()->contains(setting_name)) ?
-        APPLICATION->settings()->getSetting(setting_name) : APPLICATION->settings()->registerSetting(setting_name);
+    auto setting = (m_instance->settings()->contains(setting_name)) ?
+        m_instance->settings()->getSetting(setting_name) : m_instance->settings()->registerSetting(setting_name);
 
-    auto hiddenColumns = QVariantUtils::toList<int>(setting->get().toList());
-    for (auto col : hiddenColumns) {
-        tree->setColumnHidden(col, true);
+    auto hiddenColumns = setting->get().toStringList();
+    auto col_names = columnNames(false);
+    for (auto col_name : hiddenColumns) {
+        auto index = col_names.indexOf(col_name);
+        if (index >= 0)
+            tree->setColumnHidden(index, true);
     }
 
 }
 
-std::unique_ptr<QMenu> ResourceFolderModel::createHeaderContextMenu(QWidget* parent, QTreeView* tree)
+QMenu* ResourceFolderModel::createHeaderContextMenu(QTreeView* tree)
 {
-    auto menu = std::make_unique<QMenu>(parent);
+    auto menu = new QMenu(tree);
 
     menu->addSeparator()->setText(tr("Show / Hide Columns"));
 
     for (int col = 0; col < columnCount(); ++col) {
-        auto act = new QAction();
+        auto act = new QAction(menu);
         setupHeaderAction(act, col);
 
         act->setCheckable(true);

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -558,6 +558,10 @@ QMenu* ResourceFolderModel::createHeaderContextMenu(QTreeView* tree)
 
         connect(act, &QAction::toggled, tree, [this, col, tree](bool toggled){
             tree->setColumnHidden(col, !toggled);
+            for(int c = 0; c < columnCount(); ++c) {
+                if (m_column_resize_modes.at(c) == QHeaderView::ResizeToContents)
+                    tree->resizeColumnToContents(c);
+            }
             saveHiddenColumn(col, !toggled);
         });
 

--- a/launcher/minecraft/mod/ResourceFolderModel.h
+++ b/launcher/minecraft/mod/ResourceFolderModel.h
@@ -201,7 +201,7 @@ class ResourceFolderModel : public QAbstractListModel {
     QList<SortType> m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::DATE };
     QStringList m_column_names = {"Enable", "Name", "Last Modified"};
     QStringList m_column_names_translated = {tr("Enable"), tr("Name"), tr("Last Modified")};
-    QList<QHeaderView::ResizeMode> m_column_resize_modes = { QHeaderView::Stretch, QHeaderView::ResizeToContents, QHeaderView::ResizeToContents };
+    QList<QHeaderView::ResizeMode> m_column_resize_modes = {  QHeaderView::ResizeToContents, QHeaderView::Stretch, QHeaderView::ResizeToContents };
 
     bool m_can_interact = true;
 

--- a/launcher/minecraft/mod/ResourceFolderModel.h
+++ b/launcher/minecraft/mod/ResourceFolderModel.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <QHeaderView>
+#include <QAction>
+#include <QTreeView>
 #include <QAbstractListModel>
 #include <QDir>
 #include <QFileSystemWatcher>
@@ -28,6 +31,8 @@ class ResourceFolderModel : public QAbstractListModel {
    public:
     ResourceFolderModel(QDir, std::shared_ptr<const BaseInstance>, QObject* parent = nullptr, bool create_dir = true);
     ~ResourceFolderModel() override;
+
+    virtual QString id() const { return "resource"; }
 
     /** Starts watching the paths for changes.
      *
@@ -110,6 +115,11 @@ class ResourceFolderModel : public QAbstractListModel {
 
     [[nodiscard]] QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
 
+    void setupHeaderAction(QAction* act, int column);
+    void saveHiddenColumn(int column, bool hidden);
+    void loadHiddenColumns(QTreeView* tree);
+    std::unique_ptr<QMenu> createHeaderContextMenu(QWidget* parent, QTreeView* tree);
+    
     /** This creates a proxy model to filter / sort the model for a UI.
      *
      *  The actual comparisons and filtering are done directly by the Resource, so to modify behavior go there instead!
@@ -117,6 +127,7 @@ class ResourceFolderModel : public QAbstractListModel {
     QSortFilterProxyModel* createFilterProxyModel(QObject* parent = nullptr);
 
     [[nodiscard]] SortType columnToSortKey(size_t column) const;
+    [[nodiscard]] QList<QHeaderView::ResizeMode> columnResizeModes() const { return m_column_resize_modes; }
 
     class ProxyModel : public QSortFilterProxyModel {
        public:
@@ -187,6 +198,7 @@ class ResourceFolderModel : public QAbstractListModel {
     // Represents the relationship between a column's index (represented by the list index), and it's sorting key.
     // As such, the order in with they appear is very important!
     QList<SortType> m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::DATE };
+    QList<QHeaderView::ResizeMode> m_column_resize_modes = { QHeaderView::Stretch, QHeaderView::ResizeToContents, QHeaderView::ResizeToContents };
 
     bool m_can_interact = true;
 

--- a/launcher/minecraft/mod/ResourceFolderModel.h
+++ b/launcher/minecraft/mod/ResourceFolderModel.h
@@ -97,6 +97,7 @@ class ResourceFolderModel : public QAbstractListModel {
 
     /* Basic columns */
     enum Columns { ACTIVE_COLUMN = 0, NAME_COLUMN, DATE_COLUMN, NUM_COLUMNS };
+    QStringList columnNames(bool translated = true) const { return translated ? m_column_names_translated : m_column_names; };
 
     [[nodiscard]] int rowCount(const QModelIndex& parent = {}) const override { return parent.isValid() ? 0 : static_cast<int>(size()); }
     [[nodiscard]] int columnCount(const QModelIndex& parent = {}) const override { return parent.isValid() ? 0 : NUM_COLUMNS; };
@@ -198,6 +199,8 @@ class ResourceFolderModel : public QAbstractListModel {
     // Represents the relationship between a column's index (represented by the list index), and it's sorting key.
     // As such, the order in with they appear is very important!
     QList<SortType> m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::DATE };
+    QStringList m_column_names = {"Enable", "Name", "Last Modified"};
+    QStringList m_column_names_translated = {tr("Enable"), tr("Name"), tr("Last Modified")};
     QList<QHeaderView::ResizeMode> m_column_resize_modes = { QHeaderView::Stretch, QHeaderView::ResizeToContents, QHeaderView::ResizeToContents };
 
     bool m_can_interact = true;

--- a/launcher/minecraft/mod/ResourceFolderModel.h
+++ b/launcher/minecraft/mod/ResourceFolderModel.h
@@ -119,7 +119,7 @@ class ResourceFolderModel : public QAbstractListModel {
     void setupHeaderAction(QAction* act, int column);
     void saveHiddenColumn(int column, bool hidden);
     void loadHiddenColumns(QTreeView* tree);
-    std::unique_ptr<QMenu> createHeaderContextMenu(QWidget* parent, QTreeView* tree);
+    QMenu* createHeaderContextMenu(QTreeView* tree);
     
     /** This creates a proxy model to filter / sort the model for a UI.
      *

--- a/launcher/minecraft/mod/ResourcePack.cpp
+++ b/launcher/minecraft/mod/ResourcePack.cpp
@@ -49,7 +49,7 @@ void ResourcePack::setImage(QImage new_image) const
         PixmapCache::instance().remove(m_pack_image_cache_key.key);
 
     // scale the image to avoid flooding the pixmapcache
-    auto pixmap = QPixmap::fromImage(new_image.scaled(QSize(128, 128), Qt::AspectRatioMode::KeepAspectRatioByExpanding));
+    auto pixmap = QPixmap::fromImage(new_image.scaled({64, 64}, Qt::AspectRatioMode::KeepAspectRatioByExpanding));
 
     m_pack_image_cache_key.key = PixmapCache::instance().insert(pixmap);
     m_pack_image_cache_key.was_ever_used = true;

--- a/launcher/minecraft/mod/ResourcePack.cpp
+++ b/launcher/minecraft/mod/ResourcePack.cpp
@@ -39,7 +39,7 @@ void ResourcePack::setDescription(QString new_description)
     m_description = new_description;
 }
 
-void ResourcePack::setImage(QImage new_image)
+void ResourcePack::setImage(QImage new_image) const
 {
     QMutexLocker locker(&m_data_lock);
 
@@ -48,7 +48,10 @@ void ResourcePack::setImage(QImage new_image)
     if (m_pack_image_cache_key.key.isValid())
         PixmapCache::instance().remove(m_pack_image_cache_key.key);
 
-    m_pack_image_cache_key.key = PixmapCache::instance().insert(QPixmap::fromImage(new_image));
+    // scale the image to avoid flooding the pixmapcache
+    auto pixmap = QPixmap::fromImage(new_image.scaled(QSize(128, 128), Qt::AspectRatioMode::KeepAspectRatioByExpanding));
+
+    m_pack_image_cache_key.key = PixmapCache::instance().insert(pixmap);
     m_pack_image_cache_key.was_ever_used = true;
 
     // This can happen if the pixmap is too big to fit in the cache :c
@@ -58,21 +61,25 @@ void ResourcePack::setImage(QImage new_image)
     }
 }
 
-QPixmap ResourcePack::image(QSize size)
+QPixmap ResourcePack::image(QSize size, Qt::AspectRatioMode mode) const
 {
     QPixmap cached_image;
     if (PixmapCache::instance().find(m_pack_image_cache_key.key, &cached_image)) {
         if (size.isNull())
             return cached_image;
-        return cached_image.scaled(size);
+        return cached_image.scaled(size, mode);
     }
 
     // No valid image we can get
-    if (!m_pack_image_cache_key.was_ever_used)
+    if (!m_pack_image_cache_key.was_ever_used) {
         return {};
+    } else {
+        qDebug() << "Resource Pack" << name() << "Had it's image evicted from the cache. reloading...";
+        PixmapCache::markCacheMissByEviciton();
+    }
 
     // Imaged got evicted from the cache. Re-process it and retry.
-    ResourcePackUtils::process(*this);
+    ResourcePackUtils::processPackPNG(*this);
     return image(size);
 }
 

--- a/launcher/minecraft/mod/ResourcePack.h
+++ b/launcher/minecraft/mod/ResourcePack.h
@@ -31,7 +31,7 @@ class ResourcePack : public Resource {
     [[nodiscard]] QString description() const { return m_description; }
 
     /** Gets the image of the resource pack, converted to a QPixmap for drawing, and scaled to size. */
-    [[nodiscard]] QPixmap image(QSize size);
+    [[nodiscard]] QPixmap image(QSize size, Qt::AspectRatioMode mode = Qt::AspectRatioMode::IgnoreAspectRatio) const;
 
     /** Thread-safe. */
     void setPackFormat(int new_format_id);
@@ -40,7 +40,7 @@ class ResourcePack : public Resource {
     void setDescription(QString new_description);
 
     /** Thread-safe. */
-    void setImage(QImage new_image);
+    void setImage(QImage new_image) const;
 
     bool valid() const override;
 
@@ -67,5 +67,5 @@ class ResourcePack : public Resource {
     struct {
         QPixmapCache::Key key;
         bool was_ever_used = false;
-    } m_pack_image_cache_key;
+    } mutable m_pack_image_cache_key;
 };

--- a/launcher/minecraft/mod/ResourcePackFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourcePackFolderModel.cpp
@@ -158,12 +158,10 @@ QVariant ResourcePackFolderModel::headerData(int section, Qt::Orientation orient
                     return {};
             }
         case Qt::SizeHintRole:
-            switch (section) {
-                case ImageColumn:
-                    return QSize(64,0);
-                default:
-                    return {};
+            if (section == ImageColumn) {
+                return QSize(64,0);
             }
+            return {};
         default:
             return {};
     }

--- a/launcher/minecraft/mod/ResourcePackFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourcePackFolderModel.cpp
@@ -53,7 +53,7 @@ ResourcePackFolderModel::ResourcePackFolderModel(const QString& dir, BaseInstanc
     m_column_names = QStringList({ "Enable", "Image", "Name", "Pack Format", "Last Modified" });
     m_column_names_translated = QStringList({ tr("Enable"), tr("Image"), tr("Name"), tr("Pack Format"), tr("Last Modified") });
     m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::NAME, SortType::PACK_FORMAT, SortType::DATE};
-    m_column_resize_modes = { QHeaderView::ResizeToContents, QHeaderView::ResizeToContents, QHeaderView::Stretch, QHeaderView::ResizeToContents};
+    m_column_resize_modes = { QHeaderView::ResizeToContents, QHeaderView::Interactive, QHeaderView::Stretch, QHeaderView::ResizeToContents};
 
 }
 

--- a/launcher/minecraft/mod/ResourcePackFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourcePackFolderModel.cpp
@@ -35,6 +35,8 @@
  */
 
 #include "ResourcePackFolderModel.h"
+#include <qnamespace.h>
+#include <qsize.h>
 
 #include <QIcon>
 #include <QStyle>
@@ -48,7 +50,7 @@
 ResourcePackFolderModel::ResourcePackFolderModel(const QString& dir, std::shared_ptr<const BaseInstance> instance)
     : ResourceFolderModel(QDir(dir), instance)
 {
-    m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::PACK_FORMAT, SortType::DATE };
+    m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::PACK_FORMAT, SortType::DATE, SortType::NAME };
 }
 
 QVariant ResourcePackFolderModel::data(const QModelIndex& index, int role) const
@@ -84,9 +86,11 @@ QVariant ResourcePackFolderModel::data(const QModelIndex& index, int role) const
                     return {};
             }
         case Qt::DecorationRole: {
-            if (column == NAME_COLUMN && (at(row)->isSymLinkUnder(instDirPath()) || at(row)->isMoreThanOneHardLink()))
+            if (column == NameColumn && (at(row)->isSymLinkUnder(instDirPath()) || at(row)->isMoreThanOneHardLink()))
                 return APPLICATION->getThemedIcon("status-yellow");
-
+            if (column == ImageColumn) {
+                return at(row)->image(QSize(64, 64), Qt::AspectRatioMode::KeepAspectRatioByExpanding);
+            }
             return {};
         }
         case Qt::ToolTipRole: {
@@ -94,7 +98,7 @@ QVariant ResourcePackFolderModel::data(const QModelIndex& index, int role) const
                 //: The string being explained by this is in the format: ID (Lower version - Upper version)
                 return tr("The resource pack format ID, as well as the Minecraft versions it was designed for.");
             }
-            if (column == NAME_COLUMN) {
+            if (column == NameColumn) {
                 if (at(row)->isSymLinkUnder(instDirPath())) {
                     return m_resources[row]->internal_id() +
                         tr("\nWarning: This resource is symbolically linked from elsewhere. Editing it will also change the original."
@@ -133,6 +137,8 @@ QVariant ResourcePackFolderModel::headerData(int section, Qt::Orientation orient
                     return tr("Pack Format");
                 case DateColumn:
                     return tr("Last changed");
+                case ImageColumn:
+                    return tr("Image");
                 default:
                     return {};
             }
@@ -148,6 +154,13 @@ QVariant ResourcePackFolderModel::headerData(int section, Qt::Orientation orient
                     return tr("The resource pack format ID, as well as the Minecraft versions it was designed for.");
                 case DateColumn:
                     return tr("The date and time this resource pack was last changed (or added).");
+                default:
+                    return {};
+            }
+        case Qt::SizeHintRole:
+            switch (section) {
+                case ImageColumn:
+                    return QSize(64,0);
                 default:
                     return {};
             }

--- a/launcher/minecraft/mod/ResourcePackFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourcePackFolderModel.cpp
@@ -50,7 +50,9 @@
 ResourcePackFolderModel::ResourcePackFolderModel(const QString& dir, std::shared_ptr<const BaseInstance> instance)
     : ResourceFolderModel(QDir(dir), instance)
 {
-    m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::PACK_FORMAT, SortType::DATE, SortType::NAME };
+    m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::NAME, SortType::PACK_FORMAT, SortType::DATE};
+    m_column_resize_modes = { QHeaderView::ResizeToContents, QHeaderView::ResizeToContents, QHeaderView::Stretch, QHeaderView::ResizeToContents};
+
 }
 
 QVariant ResourcePackFolderModel::data(const QModelIndex& index, int role) const
@@ -130,7 +132,7 @@ QVariant ResourcePackFolderModel::headerData(int section, Qt::Orientation orient
         case Qt::DisplayRole:
             switch (section) {
                 case ActiveColumn:
-                    return QString();
+                    return tr("Enable");
                 case NameColumn:
                     return tr("Name");
                 case PackFormatColumn:

--- a/launcher/minecraft/mod/ResourcePackFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourcePackFolderModel.cpp
@@ -50,6 +50,8 @@
 ResourcePackFolderModel::ResourcePackFolderModel(const QString& dir, BaseInstance* instance)
     : ResourceFolderModel(QDir(dir), instance)
 {
+    m_column_names = QStringList({ "Enable", "Image", "Name", "Pack Format", "Last Modified" });
+    m_column_names_translated = QStringList({ tr("Enable"), tr("Image"), tr("Name"), tr("Pack Format"), tr("Last Modified") });
     m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::NAME, SortType::PACK_FORMAT, SortType::DATE};
     m_column_resize_modes = { QHeaderView::ResizeToContents, QHeaderView::ResizeToContents, QHeaderView::Stretch, QHeaderView::ResizeToContents};
 
@@ -132,15 +134,11 @@ QVariant ResourcePackFolderModel::headerData(int section, Qt::Orientation orient
         case Qt::DisplayRole:
             switch (section) {
                 case ActiveColumn:
-                    return tr("Enable");
                 case NameColumn:
-                    return tr("Name");
                 case PackFormatColumn:
-                    return tr("Pack Format");
                 case DateColumn:
-                    return tr("Last changed");
                 case ImageColumn:
-                    return tr("Image");
+                    return columnNames().at(section);
                 default:
                     return {};
             }

--- a/launcher/minecraft/mod/ResourcePackFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourcePackFolderModel.cpp
@@ -89,7 +89,7 @@ QVariant ResourcePackFolderModel::data(const QModelIndex& index, int role) const
             if (column == NameColumn && (at(row)->isSymLinkUnder(instDirPath()) || at(row)->isMoreThanOneHardLink()))
                 return APPLICATION->getThemedIcon("status-yellow");
             if (column == ImageColumn) {
-                return at(row)->image(QSize(64, 64), Qt::AspectRatioMode::KeepAspectRatioByExpanding);
+                return at(row)->image({32, 32}, Qt::AspectRatioMode::KeepAspectRatioByExpanding);
             }
             return {};
         }

--- a/launcher/minecraft/mod/ResourcePackFolderModel.h
+++ b/launcher/minecraft/mod/ResourcePackFolderModel.h
@@ -14,6 +14,7 @@ public:
         NameColumn,
         PackFormatColumn,
         DateColumn,
+        ImageColumn,
         NUM_COLUMNS
     };
 

--- a/launcher/minecraft/mod/ResourcePackFolderModel.h
+++ b/launcher/minecraft/mod/ResourcePackFolderModel.h
@@ -11,14 +11,16 @@ public:
     enum Columns
     {
         ActiveColumn = 0,
+        ImageColumn,
         NameColumn,
         PackFormatColumn,
         DateColumn,
-        ImageColumn,
         NUM_COLUMNS
     };
 
     explicit ResourcePackFolderModel(const QString &dir, std::shared_ptr<const BaseInstance> instance);
+
+    virtual QString id() const override { return "resourcepacks"; }
 
     [[nodiscard]] QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 

--- a/launcher/minecraft/mod/ShaderPackFolderModel.h
+++ b/launcher/minecraft/mod/ShaderPackFolderModel.h
@@ -9,4 +9,6 @@ class ShaderPackFolderModel : public ResourceFolderModel {
     explicit ShaderPackFolderModel(const QString& dir, std::shared_ptr<const BaseInstance> instance)
         : ResourceFolderModel(QDir(dir), instance)
     {}
+    
+    virtual QString id() const override { return "shaderpacks"; }
 };

--- a/launcher/minecraft/mod/TexturePack.cpp
+++ b/launcher/minecraft/mod/TexturePack.cpp
@@ -23,6 +23,8 @@
 #include <QMap>
 #include <QRegularExpression>
 
+#include "MTPixmapCache.h"
+
 #include "minecraft/mod/tasks/LocalTexturePackParseTask.h"
 
 void TexturePack::setDescription(QString new_description)
@@ -32,34 +34,41 @@ void TexturePack::setDescription(QString new_description)
     m_description = new_description;
 }
 
-void TexturePack::setImage(QImage new_image)
+void TexturePack::setImage(QImage new_image) const
 {
     QMutexLocker locker(&m_data_lock);
 
     Q_ASSERT(!new_image.isNull());
 
     if (m_pack_image_cache_key.key.isValid())
-        QPixmapCache::remove(m_pack_image_cache_key.key);
+        PixmapCache::remove(m_pack_image_cache_key.key);
 
-    m_pack_image_cache_key.key = QPixmapCache::insert(QPixmap::fromImage(new_image));
+    // scale the image to avoid flooding the pixmapcache
+    auto pixmap = QPixmap::fromImage(new_image.scaled(QSize(128, 128), Qt::AspectRatioMode::KeepAspectRatioByExpanding));
+
+    m_pack_image_cache_key.key = PixmapCache::insert(pixmap);
     m_pack_image_cache_key.was_ever_used = true;
 }
 
-QPixmap TexturePack::image(QSize size)
+QPixmap TexturePack::image(QSize size, Qt::AspectRatioMode mode) const
 {
     QPixmap cached_image;
-    if (QPixmapCache::find(m_pack_image_cache_key.key, &cached_image)) {
+    if (PixmapCache::find(m_pack_image_cache_key.key, &cached_image)) {
         if (size.isNull())
             return cached_image;
-        return cached_image.scaled(size);
+        return cached_image.scaled(size, mode);
     }
 
     // No valid image we can get
-    if (!m_pack_image_cache_key.was_ever_used)
+    if (!m_pack_image_cache_key.was_ever_used) {
         return {};
+    } else {
+        qDebug() << "Texture Pack" << name() << "Had it's image evicted from the cache. reloading...";
+        PixmapCache::markCacheMissByEviciton();
+    }
 
     // Imaged got evicted from the cache. Re-process it and retry.
-    TexturePackUtils::process(*this);
+    TexturePackUtils::processPackPNG(*this);
     return image(size);
 }
 

--- a/launcher/minecraft/mod/TexturePack.cpp
+++ b/launcher/minecraft/mod/TexturePack.cpp
@@ -44,7 +44,7 @@ void TexturePack::setImage(QImage new_image) const
         PixmapCache::remove(m_pack_image_cache_key.key);
 
     // scale the image to avoid flooding the pixmapcache
-    auto pixmap = QPixmap::fromImage(new_image.scaled(QSize(128, 128), Qt::AspectRatioMode::KeepAspectRatioByExpanding));
+    auto pixmap = QPixmap::fromImage(new_image.scaled({64, 64}, Qt::AspectRatioMode::KeepAspectRatioByExpanding));
 
     m_pack_image_cache_key.key = PixmapCache::insert(pixmap);
     m_pack_image_cache_key.was_ever_used = true;

--- a/launcher/minecraft/mod/TexturePack.h
+++ b/launcher/minecraft/mod/TexturePack.h
@@ -40,13 +40,13 @@ class TexturePack : public Resource {
     [[nodiscard]] QString description() const { return m_description; }
 
     /** Gets the image of the texture pack, converted to a QPixmap for drawing, and scaled to size. */
-    [[nodiscard]] QPixmap image(QSize size);
+    [[nodiscard]] QPixmap image(QSize size, Qt::AspectRatioMode mode = Qt::AspectRatioMode::IgnoreAspectRatio) const;
 
     /** Thread-safe. */
     void setDescription(QString new_description);
 
     /** Thread-safe. */
-    void setImage(QImage new_image);
+    void setImage(QImage new_image) const;
 
     bool valid() const override;
 
@@ -65,5 +65,5 @@ class TexturePack : public Resource {
     struct {
         QPixmapCache::Key key;
         bool was_ever_used = false;
-    } m_pack_image_cache_key;
+    } mutable m_pack_image_cache_key;
 };

--- a/launcher/minecraft/mod/TexturePackFolderModel.cpp
+++ b/launcher/minecraft/mod/TexturePackFolderModel.cpp
@@ -96,7 +96,7 @@ QVariant TexturePackFolderModel::data(const QModelIndex& index, int role) const
             if (column == NameColumn && (at(row)->isSymLinkUnder(instDirPath()) || at(row)->isMoreThanOneHardLink()))
                 return APPLICATION->getThemedIcon("status-yellow");
             if (column == ImageColumn) {
-                return at(row)->image(QSize(64, 64), Qt::AspectRatioMode::KeepAspectRatioByExpanding);
+                return at(row)->image({32, 32}, Qt::AspectRatioMode::KeepAspectRatioByExpanding);
             }
             return {};
         }

--- a/launcher/minecraft/mod/TexturePackFolderModel.cpp
+++ b/launcher/minecraft/mod/TexturePackFolderModel.cpp
@@ -101,12 +101,10 @@ QVariant TexturePackFolderModel::data(const QModelIndex& index, int role) const
             return {};
         }
         case Qt::CheckStateRole:
-            switch (column) {
-                case ActiveColumn:
-                    return m_resources[row]->enabled() ? Qt::Checked : Qt::Unchecked;
-                default:
-                    return {};
+            if (column == ActiveColumn) {
+                    return m_resources[row]->enabled() ? Qt::Checked : Qt::Unchecked;   
             }
+            return {};
         default:
             return {};
     }

--- a/launcher/minecraft/mod/TexturePackFolderModel.cpp
+++ b/launcher/minecraft/mod/TexturePackFolderModel.cpp
@@ -48,7 +48,7 @@ TexturePackFolderModel::TexturePackFolderModel(const QString& dir, BaseInstance*
     m_column_names = QStringList({ "Enable", "Image", "Name", "Last Modified" });
     m_column_names_translated = QStringList({ tr("Enable"), tr("Image"), tr("Name"), tr("Last Modified") });
     m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::NAME, SortType::DATE };
-    m_column_resize_modes = { QHeaderView::ResizeToContents, QHeaderView::ResizeToContents, QHeaderView::Stretch, QHeaderView::ResizeToContents};
+    m_column_resize_modes = { QHeaderView::ResizeToContents, QHeaderView::Interactive, QHeaderView::Stretch, QHeaderView::ResizeToContents};
 
 }
 

--- a/launcher/minecraft/mod/TexturePackFolderModel.cpp
+++ b/launcher/minecraft/mod/TexturePackFolderModel.cpp
@@ -45,7 +45,9 @@
 TexturePackFolderModel::TexturePackFolderModel(const QString& dir, std::shared_ptr<const BaseInstance> instance)
     : ResourceFolderModel(QDir(dir), instance)
 {
-    m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::DATE, SortType::NAME };
+    m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::NAME, SortType::DATE };
+    m_column_resize_modes = { QHeaderView::ResizeToContents, QHeaderView::ResizeToContents, QHeaderView::Stretch, QHeaderView::ResizeToContents};
+
 }
 
 Task* TexturePackFolderModel::createUpdateTask()
@@ -115,6 +117,8 @@ QVariant TexturePackFolderModel::headerData(int section, Qt::Orientation orienta
     switch (role) {
         case Qt::DisplayRole:
             switch (section) {
+                case ActiveColumn:
+                    return tr("Enable");
                 case NameColumn:
                     return tr("Name");
                 case DateColumn:
@@ -150,3 +154,4 @@ int TexturePackFolderModel::columnCount(const QModelIndex& parent) const
 {
     return parent.isValid() ? 0 : NUM_COLUMNS;
 }
+

--- a/launcher/minecraft/mod/TexturePackFolderModel.cpp
+++ b/launcher/minecraft/mod/TexturePackFolderModel.cpp
@@ -45,6 +45,8 @@
 TexturePackFolderModel::TexturePackFolderModel(const QString& dir, BaseInstance* instance)
     : ResourceFolderModel(QDir(dir), instance)
 {
+    m_column_names = QStringList({ "Enable", "Image", "Name", "Last Modified" });
+    m_column_names_translated = QStringList({ tr("Enable"), tr("Image"), tr("Name"), tr("Last Modified") });
     m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::NAME, SortType::DATE };
     m_column_resize_modes = { QHeaderView::ResizeToContents, QHeaderView::ResizeToContents, QHeaderView::Stretch, QHeaderView::ResizeToContents};
 
@@ -118,13 +120,10 @@ QVariant TexturePackFolderModel::headerData(int section, Qt::Orientation orienta
         case Qt::DisplayRole:
             switch (section) {
                 case ActiveColumn:
-                    return tr("Enable");
                 case NameColumn:
-                    return tr("Name");
                 case DateColumn:
-                    return tr("Last modified");
                 case ImageColumn:
-                    return tr("Image");
+                    return columnNames().at(section);
                 default:
                     return {};
             }

--- a/launcher/minecraft/mod/TexturePackFolderModel.h
+++ b/launcher/minecraft/mod/TexturePackFolderModel.h
@@ -38,12 +38,32 @@
 
 #include "ResourceFolderModel.h"
 
+#include "TexturePack.h"
+
 class TexturePackFolderModel : public ResourceFolderModel
 {
     Q_OBJECT
 
 public:
+
+    enum Columns
+    {
+        ActiveColumn = 0,
+        NameColumn,
+        DateColumn,
+        ImageColumn,
+        NUM_COLUMNS
+    };
+
     explicit TexturePackFolderModel(const QString &dir, std::shared_ptr<const BaseInstance> instance);
+
+    [[nodiscard]] QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+
+    [[nodiscard]] QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+    [[nodiscard]] int columnCount(const QModelIndex &parent) const override;
+
     [[nodiscard]] Task* createUpdateTask() override;
     [[nodiscard]] Task* createParseTask(Resource&) override;
+
+    RESOURCE_HELPERS(TexturePack)
 };

--- a/launcher/minecraft/mod/TexturePackFolderModel.h
+++ b/launcher/minecraft/mod/TexturePackFolderModel.h
@@ -49,13 +49,15 @@ public:
     enum Columns
     {
         ActiveColumn = 0,
+        ImageColumn,
         NameColumn,
         DateColumn,
-        ImageColumn,
         NUM_COLUMNS
     };
 
     explicit TexturePackFolderModel(const QString &dir, std::shared_ptr<const BaseInstance> instance);
+
+    virtual QString id() const override { return "texturepacks"; }
 
     [[nodiscard]] QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 

--- a/launcher/minecraft/mod/tasks/LocalModParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalModParseTask.cpp
@@ -184,7 +184,8 @@ ModDetails ReadMCModTOML(QByteArray contents)
     } else if (auto licenseDatum =(*modsTable)["license"].as_string()) {
         license = QString::fromStdString(licenseDatum->get());
     }
-    details.licenses.push_back(ModLicense(license));
+    if (!license.isEmpty())
+        details.licenses.append(ModLicense(license));
 
     QString logoFile = "";
     if (auto logoFileDatum = tomlData["logoFile"].as_string()) {

--- a/launcher/minecraft/mod/tasks/LocalModParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalModParseTask.cpp
@@ -268,12 +268,12 @@ ModDetails ReadFabricModInfo(QByteArray contents)
                     }
                 }
                 if (largest > 0) {
-                    auto key = QString::number(largest) + "x" + largest;
+                    auto key = QString::number(largest) + "x" + QString::number(largest);
                     details.icon_file = obj.value(key).toString();
                 } else { // parsing the sizes failed
                     // take the first
-                    for (auto icon : obj) {
-                        details.icon_file = icon.toString();
+                    for (auto i : obj) {
+                        details.icon_file = i.toString();
                         break;
                     }
                 }
@@ -355,12 +355,12 @@ ModDetails ReadQuiltModInfo(QByteArray contents)
                     }
                 }
                 if (largest > 0) {
-                    auto key = QString::number(largest) + "x" + largest;
+                    auto key = QString::number(largest) + "x" + QString::number(largest);
                     details.icon_file = obj.value(key).toString();
                 } else { // parsing the sizes failed
                     // take the first
-                    for (auto icon : obj) {
-                        details.icon_file = icon.toString();
+                    for (auto i : obj) {
+                        details.icon_file = i.toString();
                         break;
                     }
                 }

--- a/launcher/minecraft/mod/tasks/LocalModParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalModParseTask.cpp
@@ -52,6 +52,10 @@ ModDetails ReadMCModInfo(QByteArray contents)
             authors = firstObj.value("authors").toArray();
         }
 
+        if (firstObj.contains("logoFile")) {
+            details.icon_file = firstObj.value("logoFile").toString();
+        }
+
         for (auto author : authors) {
             details.authors.append(author.toString());
         }
@@ -166,6 +170,30 @@ ModDetails ReadMCModTOML(QByteArray contents)
     }
     details.homeurl = homeurl;
 
+    QString issueTrackerURL = "";
+    if (auto issueTrackerURLDatum = tomlData["issueTrackerURL"].as_string()) {
+        issueTrackerURL = QString::fromStdString(issueTrackerURLDatum->get());
+    } else if (auto issueTrackerURLDatum = (*modsTable)["issueTrackerURL"].as_string()) {
+        issueTrackerURL = QString::fromStdString(issueTrackerURLDatum->get());
+    }
+    details.issue_tracker = issueTrackerURL;
+
+    QString license = "";
+    if (auto licenseDatum = tomlData["license"].as_string()) {
+        license = QString::fromStdString(licenseDatum->get());
+    } else if (auto licenseDatum =(*modsTable)["license"].as_string()) {
+        license = QString::fromStdString(licenseDatum->get());
+    }
+    details.licenses.push_back(ModLicense(license));
+
+    QString logoFile = "";
+    if (auto logoFileDatum = tomlData["logoFile"].as_string()) {
+        logoFile = QString::fromStdString(logoFileDatum->get());
+    } else if (auto logoFileDatum =(*modsTable)["logoFile"].as_string()) {
+        logoFile = QString::fromStdString(logoFileDatum->get());
+    }
+    details.icon_file = logoFile;
+
     return details;
 }
 
@@ -200,6 +228,57 @@ ModDetails ReadFabricModInfo(QByteArray contents)
 
             if (contact.contains("homepage")) {
                 details.homeurl = contact.value("homepage").toString();
+            }
+            if (contact.contains("issues")) {
+                details.issue_tracker = contact.value("issues").toString();
+            }
+        }
+
+        if (object.contains("license")) {
+            auto license = object.value("license");
+            if (license.isArray()) {
+                for (auto l : license.toArray()) {
+                    if (l.isString()) {
+                        details.licenses.append(ModLicense(l.toString()));
+                    } else if (l.isObject()) {
+                        auto obj = l.toObject();
+                        details.licenses.append(ModLicense(obj.value("name").toString(), obj.value("id").toString(),
+                                                           obj.value("url").toString(), obj.value("description").toString()));
+                    }
+                }
+            } else if (license.isString()) {
+                details.licenses.append(ModLicense(license.toString()));
+            } else if (license.isObject()) {
+                auto obj = license.toObject();
+                details.licenses.append(ModLicense(obj.value("name").toString(), obj.value("id").toString(), obj.value("url").toString(),
+                                                   obj.value("description").toString()));
+            }
+        }
+
+        if (object.contains("icon")) {
+            auto icon = object.value("icon");
+            if (icon.isObject()) {
+                auto obj = icon.toObject();
+                // take the largest icon
+                int largest = 0;
+                for (auto key : obj.keys()) {
+                    auto size = key.split('x').first().toInt();
+                    if (size > largest) {
+                        largest = size;
+                    }
+                }
+                if (largest > 0) {
+                    auto key = QString::number(largest) + "x" + largest;
+                    details.icon_file = obj.value(key).toString();
+                } else { // parsing the sizes failed
+                    // take the first
+                    for (auto icon : obj) {
+                        details.icon_file = icon.toString();
+                        break;
+                    }
+                }
+            } else if (icon.isString()) {
+                details.icon_file = icon.toString();
             }
         }
     }
@@ -238,6 +317,58 @@ ModDetails ReadQuiltModInfo(QByteArray contents)
         if (modContact.contains("homepage")) {
             details.homeurl = Json::requireString(modContact.value("homepage"));
         }
+        if (modContact.contains("issues")) {
+            details.issue_tracker = Json::requireString(modContact.value("issues"));
+        }
+
+        if (modMetadata.contains("license")) {
+            auto license = modMetadata.value("license");
+            if (license.isArray()) {
+                for (auto l : license.toArray()) {
+                    if (l.isString()) {
+                        details.licenses.append(ModLicense(l.toString()));
+                    } else if (l.isObject()) {
+                        auto obj = l.toObject();
+                        details.licenses.append(ModLicense(obj.value("name").toString(), obj.value("id").toString(),
+                                                           obj.value("url").toString(), obj.value("description").toString()));
+                    }
+                }
+            } else if (license.isString()) {
+                details.licenses.append(ModLicense(license.toString()));
+            } else if (license.isObject()) {
+                auto obj = license.toObject();
+                details.licenses.append(ModLicense(obj.value("name").toString(), obj.value("id").toString(), obj.value("url").toString(),
+                                                   obj.value("description").toString()));
+            }
+        }
+
+        if (modMetadata.contains("icon")) {
+            auto icon = modMetadata.value("icon");
+            if (icon.isObject()) {
+                auto obj = icon.toObject();
+                // take the largest icon
+                int largest = 0;
+                for (auto key : obj.keys()) {
+                    auto size = key.split('x').first().toInt();
+                    if (size > largest) {
+                        largest = size;
+                    }
+                }
+                if (largest > 0) {
+                    auto key = QString::number(largest) + "x" + largest;
+                    details.icon_file = obj.value(key).toString();
+                } else { // parsing the sizes failed
+                    // take the first
+                    for (auto icon : obj) {
+                        details.icon_file = icon.toString();
+                        break;
+                    }
+                }
+            } else if (icon.isString()) {
+                details.icon_file = icon.toString();
+            }
+        }
+
     }
     return details;
 }
@@ -513,6 +644,85 @@ bool validate(QFileInfo file)
 {
     Mod mod{ file };
     return ModUtils::process(mod, ProcessingLevel::BasicInfoOnly) && mod.valid();
+}
+
+bool processIconPNG(const Mod& mod, QByteArray&& raw_data)
+{
+    auto img = QImage::fromData(raw_data);
+    if (!img.isNull()) {
+        mod.setIcon(img);
+    } else {
+        qWarning() << "Failed to parse mod logo:" << mod.iconPath() << "from" << mod.name();
+        return false;
+    }
+    return true;
+}
+
+bool loadIconFile(const Mod& mod) {
+    if (mod.iconPath().isEmpty()) {
+        qWarning() << "No Iconfile set, be sure to parse the mod first";
+        return false;
+    }
+
+    auto png_invalid = [&mod]() {
+        qWarning() << "Mod at" << mod.fileinfo().filePath() << "does not have a valid icon";
+        return false;
+    };
+
+    switch (mod.type()) {
+        case ResourceType::FOLDER:
+        {
+            QFileInfo icon_info(FS::PathCombine(mod.fileinfo().filePath(), mod.iconPath()));
+            if (icon_info.exists() && icon_info.isFile()) {
+                QFile icon(icon_info.filePath());
+                if (!icon.open(QIODevice::ReadOnly))
+                    return false;
+                auto data = icon.readAll();
+                
+                bool icon_result = ModUtils::processIconPNG(mod, std::move(data));
+
+                icon.close();
+
+                if (!icon_result) {
+                    return png_invalid();  // icon invalid
+                }
+            }
+        }
+        case ResourceType::ZIPFILE:
+        {
+            QuaZip zip(mod.fileinfo().filePath());
+            if (!zip.open(QuaZip::mdUnzip))
+                return false;
+
+            QuaZipFile file(&zip);
+
+            if (zip.setCurrentFile(mod.iconPath())) {
+                if (!file.open(QIODevice::ReadOnly)) {
+                    qCritical() << "Failed to open file in zip.";
+                    zip.close();
+                    return png_invalid();
+                }
+
+                auto data = file.readAll();
+
+                bool icon_result = ModUtils::processIconPNG(mod, std::move(data));
+
+                file.close();
+                if (!icon_result) {
+                    return png_invalid();  // icon png invalid
+                }
+            } else {
+                return png_invalid();  // could not set icon as current file.
+            }
+        }
+        case ResourceType::LITEMOD:
+        {
+            return false; // can lightmods even have icons?
+        }
+        default:
+            qWarning() << "Invalid type for mod, can not load icon.";
+            return false;
+    }
 }
 
 }  // namespace ModUtils

--- a/launcher/minecraft/mod/tasks/LocalModParseTask.h
+++ b/launcher/minecraft/mod/tasks/LocalModParseTask.h
@@ -25,6 +25,9 @@ bool processLitemod(Mod& mod, ProcessingLevel level = ProcessingLevel::Full);
 
 /** Checks whether a file is valid as a mod or not. */
 bool validate(QFileInfo file);
+
+bool processIconPNG(const Mod& mod, QByteArray&& raw_data);
+bool loadIconFile(const Mod& mod);
 }  // namespace ModUtils
 
 class LocalModParseTask : public Task {

--- a/launcher/minecraft/mod/tasks/LocalResourcePackParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalResourcePackParseTask.cpp
@@ -165,15 +165,16 @@ bool processZIP(ResourcePack& pack, ProcessingLevel level)
         bool pack_png_result = ResourcePackUtils::processPackPNG(pack, std::move(data));
 
         file.close();
+        zip.close();
         if (!pack_png_result) {
             return png_invalid();  // pack.png invalid
         }
     } else {
+        zip.close();
         return png_invalid();  // could not set pack.mcmeta as current file.
     }
 
     zip.close();
-
     return true;
 }
 
@@ -193,7 +194,7 @@ bool processMCMeta(ResourcePack& pack, QByteArray&& raw_data)
     return true;
 }
 
-bool processPackPNG(ResourcePack& pack, QByteArray&& raw_data)
+bool processPackPNG(const ResourcePack& pack, QByteArray&& raw_data)
 {
     auto img = QImage::fromData(raw_data);
     if (!img.isNull()) {
@@ -203,6 +204,68 @@ bool processPackPNG(ResourcePack& pack, QByteArray&& raw_data)
         return false;
     }
     return true;
+}
+
+bool processPackPNG(const ResourcePack& pack)
+{   
+    auto png_invalid = [&pack]() {
+        qWarning() << "Resource pack at" << pack.fileinfo().filePath() << "does not have a valid pack.png";
+        return false;
+    };
+
+    switch (pack.type()) {
+        case ResourceType::FOLDER: 
+        {
+            QFileInfo image_file_info(FS::PathCombine(pack.fileinfo().filePath(), "pack.png"));
+            if (image_file_info.exists() && image_file_info.isFile()) {
+                QFile pack_png_file(image_file_info.filePath());
+                if (!pack_png_file.open(QIODevice::ReadOnly))
+                    return png_invalid();  // can't open pack.png file
+
+                auto data = pack_png_file.readAll();
+
+                bool pack_png_result = ResourcePackUtils::processPackPNG(pack, std::move(data));
+
+                pack_png_file.close();
+                if (!pack_png_result) {
+                    return png_invalid();  // pack.png invalid
+                }
+            } else {
+                return png_invalid();  // pack.png does not exists or is not a valid file.
+            }
+        }
+        case ResourceType::ZIPFILE:
+        {
+            Q_ASSERT(pack.type() == ResourceType::ZIPFILE);
+
+            QuaZip zip(pack.fileinfo().filePath());
+            if (!zip.open(QuaZip::mdUnzip))
+                return false;  // can't open zip file
+
+            QuaZipFile file(&zip);
+            if (zip.setCurrentFile("pack.png")) {
+                if (!file.open(QIODevice::ReadOnly)) {
+                    qCritical() << "Failed to open file in zip.";
+                    zip.close();
+                    return png_invalid();
+                }
+
+                auto data = file.readAll();
+
+                bool pack_png_result = ResourcePackUtils::processPackPNG(pack, std::move(data));
+
+                file.close();
+                if (!pack_png_result) {
+                    return png_invalid();  // pack.png invalid
+                }
+            } else {
+                return png_invalid();  // could not set pack.mcmeta as current file.
+            }
+        }
+        default:
+            qWarning() << "Invalid type for resource pack parse task!";
+            return false;
+    }
 }
 
 bool validate(QFileInfo file)

--- a/launcher/minecraft/mod/tasks/LocalResourcePackParseTask.h
+++ b/launcher/minecraft/mod/tasks/LocalResourcePackParseTask.h
@@ -35,7 +35,10 @@ bool processZIP(ResourcePack& pack, ProcessingLevel level = ProcessingLevel::Ful
 bool processFolder(ResourcePack& pack, ProcessingLevel level = ProcessingLevel::Full);
 
 bool processMCMeta(ResourcePack& pack, QByteArray&& raw_data);
-bool processPackPNG(ResourcePack& pack, QByteArray&& raw_data);
+bool processPackPNG(const ResourcePack& pack, QByteArray&& raw_data);
+
+/// processes ONLY the pack.png (rest of the pack may be invalid)
+bool processPackPNG(const ResourcePack& pack);
 
 /** Checks whether a file is valid as a resource pack or not. */
 bool validate(QFileInfo file);

--- a/launcher/minecraft/mod/tasks/LocalTexturePackParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalTexturePackParseTask.cpp
@@ -131,6 +131,7 @@ bool processZIP(TexturePack& pack, ProcessingLevel level)
         bool packPNG_result = TexturePackUtils::processPackPNG(pack, std::move(data));
 
         file.close();
+        zip.close();
         if (!packPNG_result) {
             return false;
         }
@@ -147,7 +148,7 @@ bool processPackTXT(TexturePack& pack, QByteArray&& raw_data)
     return true;
 }
 
-bool processPackPNG(TexturePack& pack, QByteArray&& raw_data)
+bool processPackPNG(const TexturePack& pack, QByteArray&& raw_data)
 {
     auto img = QImage::fromData(raw_data);
     if (!img.isNull()) {
@@ -157,6 +158,70 @@ bool processPackPNG(TexturePack& pack, QByteArray&& raw_data)
         return false;
     }
     return true;
+}
+
+bool processPackPNG(const TexturePack& pack)
+{   
+    auto png_invalid = [&pack]() {
+        qWarning() << "Texture pack at" << pack.fileinfo().filePath() << "does not have a valid pack.png";
+        return false;
+    };
+
+    switch (pack.type()) {
+        case ResourceType::FOLDER: 
+        {
+            QFileInfo image_file_info(FS::PathCombine(pack.fileinfo().filePath(), "pack.png"));
+            if (image_file_info.exists() && image_file_info.isFile()) {
+                QFile pack_png_file(image_file_info.filePath());
+                if (!pack_png_file.open(QIODevice::ReadOnly))
+                    return png_invalid();  // can't open pack.png file
+
+                auto data = pack_png_file.readAll();
+
+                bool pack_png_result = TexturePackUtils::processPackPNG(pack, std::move(data));
+
+                pack_png_file.close();
+                if (!pack_png_result) {
+                    return png_invalid();  // pack.png invalid
+                }
+            } else {
+                return png_invalid();  // pack.png does not exists or is not a valid file.
+            }
+        }
+        case ResourceType::ZIPFILE:
+        {
+            Q_ASSERT(pack.type() == ResourceType::ZIPFILE);
+
+            QuaZip zip(pack.fileinfo().filePath());
+            if (!zip.open(QuaZip::mdUnzip))
+                return false;  // can't open zip file
+
+            QuaZipFile file(&zip);
+            if (zip.setCurrentFile("pack.png")) {
+                if (!file.open(QIODevice::ReadOnly)) {
+                    qCritical() << "Failed to open file in zip.";
+                    zip.close();
+                    return png_invalid();
+                }
+
+                auto data = file.readAll();
+
+                bool pack_png_result = TexturePackUtils::processPackPNG(pack, std::move(data));
+
+                file.close();
+                if (!pack_png_result) {
+                    zip.close();
+                    return png_invalid();  // pack.png invalid
+                }
+            } else {
+                zip.close();
+                return png_invalid();  // could not set pack.mcmeta as current file.
+            }
+        }
+        default:
+            qWarning() << "Invalid type for resource pack parse task!";
+            return false;
+    }
 }
 
 bool validate(QFileInfo file)

--- a/launcher/minecraft/mod/tasks/LocalTexturePackParseTask.h
+++ b/launcher/minecraft/mod/tasks/LocalTexturePackParseTask.h
@@ -36,7 +36,10 @@ bool processZIP(TexturePack& pack, ProcessingLevel level = ProcessingLevel::Full
 bool processFolder(TexturePack& pack, ProcessingLevel level = ProcessingLevel::Full);
 
 bool processPackTXT(TexturePack& pack, QByteArray&& raw_data);
-bool processPackPNG(TexturePack& pack, QByteArray&& raw_data);
+bool processPackPNG(const TexturePack& pack, QByteArray&& raw_data);
+
+/// processes ONLY the pack.png (rest of the pack may be invalid)
+bool processPackPNG(const TexturePack& pack);
 
 /** Checks whether a file is valid as a texture pack or not. */
 bool validate(QFileInfo file);

--- a/launcher/ui/pages/instance/ExternalResourcesPage.cpp
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.cpp
@@ -76,8 +76,9 @@ void ExternalResourcesPage::ShowContextMenu(const QPoint& pos)
 
 void ExternalResourcesPage::ShowHeaderContextMenu(const QPoint& pos)
 {
-    auto menu = m_model->createHeaderContextMenu(this, ui->treeView);
+    auto menu = m_model->createHeaderContextMenu(ui->treeView);
     menu->exec(ui->treeView->mapToGlobal(pos));
+    menu->deleteLater();
 }
 
 void ExternalResourcesPage::openedImpl()

--- a/launcher/ui/pages/instance/ExternalResourcesPage.cpp
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.cpp
@@ -24,6 +24,8 @@ ExternalResourcesPage::ExternalResourcesPage(BaseInstance* instance, std::shared
     m_filterModel->setSourceModel(m_model.get());
     m_filterModel->setFilterKeyColumn(-1);
     ui->treeView->setModel(m_filterModel);
+    // must come after setModel
+    ui->treeView->setResizeModes(m_model->columnResizeModes());
 
     ui->treeView->installEventFilter(this);
     ui->treeView->sortByColumn(1, Qt::AscendingOrder);
@@ -44,6 +46,13 @@ ExternalResourcesPage::ExternalResourcesPage(BaseInstance* instance, std::shared
     auto selection_model = ui->treeView->selectionModel();
     connect(selection_model, &QItemSelectionModel::currentChanged, this, &ExternalResourcesPage::current);
     connect(ui->filterEdit, &QLineEdit::textChanged, this, &ExternalResourcesPage::filterTextChanged);
+
+    auto viewHeader = ui->treeView->header();
+    viewHeader->setContextMenuPolicy(Qt::CustomContextMenu);
+
+    connect(viewHeader, &QHeaderView::customContextMenuRequested, this, &ExternalResourcesPage::ShowHeaderContextMenu);
+
+    m_model->loadHiddenColumns(ui->treeView);
 }
 
 ExternalResourcesPage::~ExternalResourcesPage()
@@ -63,6 +72,12 @@ void ExternalResourcesPage::ShowContextMenu(const QPoint& pos)
     auto menu = ui->actionsToolbar->createContextMenu(this, tr("Context menu"));
     menu->exec(ui->treeView->mapToGlobal(pos));
     delete menu;
+}
+
+void ExternalResourcesPage::ShowHeaderContextMenu(const QPoint& pos)
+{
+    auto menu = m_model->createHeaderContextMenu(this, ui->treeView);
+    menu->exec(ui->treeView->mapToGlobal(pos));
 }
 
 void ExternalResourcesPage::openedImpl()

--- a/launcher/ui/pages/instance/ExternalResourcesPage.cpp
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.cpp
@@ -96,7 +96,6 @@ void ExternalResourcesPage::itemActivated(const QModelIndex&)
         return;
 
     auto selection = m_filterModel->mapSelectionToSource(ui->treeView->selectionModel()->selection());
-    m_model->setResourceEnabled(selection.indexes(), EnableAction::TOGGLE);
 }
 
 void ExternalResourcesPage::filterTextChanged(const QString& newContents)

--- a/launcher/ui/pages/instance/ExternalResourcesPage.h
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.h
@@ -60,6 +60,7 @@ class ExternalResourcesPage : public QMainWindow, public BasePage {
     virtual void viewConfigs();
 
     void ShowContextMenu(const QPoint& pos);
+    void ShowHeaderContextMenu(const QPoint& pos);
 
    protected:
     BaseInstance* m_instance = nullptr;

--- a/launcher/ui/pages/instance/ExternalResourcesPage.ui
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.ui
@@ -62,6 +62,9 @@
       <property name="dragDropMode">
        <enum>QAbstractItemView::DropOnly</enum>
       </property>
+      <property name="uniformRowHeights">
+       <bool>true</bool>
+      </property>
      </widget>
     </item>
    </layout>

--- a/launcher/ui/widgets/InfoFrame.cpp
+++ b/launcher/ui/widgets/InfoFrame.cpp
@@ -88,7 +88,7 @@ void InfoFrame::updateWithMod(Mod const& m)
         setDescription(m.description());
     }
 
-    setImage();
+    setImage(m.icon({64,64}));
 }
 
 void InfoFrame::updateWithResource(const Resource& resource)

--- a/launcher/ui/widgets/InfoFrame.cpp
+++ b/launcher/ui/widgets/InfoFrame.cpp
@@ -47,6 +47,8 @@ InfoFrame::InfoFrame(QWidget *parent) :
     ui->setupUi(this);
     ui->descriptionLabel->setHidden(true);
     ui->nameLabel->setHidden(true);
+    ui->licenseLabel->setHidden(true);
+    ui->issueTrackerLabel->setHidden(true);
     updateHiddenState();
 }
 
@@ -89,6 +91,40 @@ void InfoFrame::updateWithMod(Mod const& m)
     }
 
     setImage(m.icon({64,64}));
+
+    auto licenses = m.licenses();
+    QString licenseText = "";
+    if (!licenses.empty()) {
+        for (auto l : licenses) {
+            if (!licenseText.isEmpty()) {
+                licenseText += "\n"; // add newline between licenses
+            }
+            if (!l.name.isEmpty()) {
+                if (l.url.isEmpty()) {
+                    licenseText += l.name;
+                } else {
+                    licenseText += "<a href=\"" + l.url + "\">" + l.name + "</a>";
+                }
+            } else if (!l.url.isEmpty()) {
+                licenseText += "<a href=\"" + l.url + "\">" + l.url + "</a>";
+            }
+            if (!l.description.isEmpty() && l.description != l.name) {
+               licenseText += " " + l.description;
+            }
+        } 
+    }
+    if (!licenseText.isEmpty()) {
+        setLicense(tr("License: %1").arg(licenseText));
+    } else {
+        setLicense();
+    }
+
+    QString issueTracker = "";
+    if (!m.issueTracker().isEmpty()) {
+        issueTracker += tr("Report issues to: ");
+        issueTracker += "<a href=\"" + m.issueTracker() + "\">" + m.issueTracker() + "</a>";
+    } 
+    setIssueTracker(issueTracker);
 }
 
 void InfoFrame::updateWithResource(const Resource& resource)
@@ -177,16 +213,16 @@ void InfoFrame::clear()
     setName();
     setDescription();
     setImage();
+    setLicense();
+    setIssueTracker();
 }
 
 void InfoFrame::updateHiddenState()
 {
-    if(ui->descriptionLabel->isHidden() && ui->nameLabel->isHidden())
-    {
+    if (ui->descriptionLabel->isHidden() && ui->nameLabel->isHidden() && ui->licenseLabel->isHidden() &&
+        ui->issueTrackerLabel->isHidden()) {
         setHidden(true);
-    }
-    else
-    {
+    } else {
         setHidden(false);
     }
 }
@@ -251,6 +287,66 @@ void InfoFrame::setDescription(QString text)
     ui->descriptionLabel->setText(labeltext);
 }
 
+void InfoFrame::setLicense(QString text)
+{
+    if(text.isEmpty())
+    {
+        ui->licenseLabel->setHidden(true);
+        updateHiddenState();
+        return;
+    }
+    else
+    {
+        ui->licenseLabel->setHidden(false);
+        updateHiddenState();
+    }
+    ui->licenseLabel->setToolTip("");
+    QString intermediatetext = text.trimmed();
+    bool prev(false);
+    QChar rem('\n');
+    QString finaltext;
+    finaltext.reserve(intermediatetext.size());
+    foreach(const QChar& c, intermediatetext)
+    {
+        if(c == rem && prev){
+            continue;
+        }
+        prev = c == rem;
+        finaltext += c;
+    }
+    QString labeltext;
+    labeltext.reserve(300);
+    if(finaltext.length() > 290)
+    {
+        ui->licenseLabel->setOpenExternalLinks(false);
+        ui->licenseLabel->setTextFormat(Qt::TextFormat::RichText);
+        m_description = text;
+        // This allows injecting HTML here.
+        labeltext.append("<html><body>" + finaltext.left(287) + "<a href=\"#mod_desc\">...</a></body></html>");
+        QObject::connect(ui->licenseLabel, &QLabel::linkActivated, this, &InfoFrame::licenseEllipsisHandler);
+    }
+    else
+    {
+        ui->licenseLabel->setTextFormat(Qt::TextFormat::AutoText);
+        labeltext.append(finaltext);
+    }
+    ui->licenseLabel->setText(labeltext);
+}
+
+void InfoFrame::setIssueTracker(QString text)
+{
+    if(text.isEmpty())
+    {
+        ui->issueTrackerLabel->setHidden(true);
+    }
+    else
+    {
+        ui->issueTrackerLabel->setText(text);
+        ui->issueTrackerLabel->setHidden(false);
+    }
+    updateHiddenState();
+}
+
 void InfoFrame::setImage(QPixmap img)
 {
     if (img.isNull()) {
@@ -272,6 +368,20 @@ void InfoFrame::descriptionEllipsisHandler(QString link)
     else
     {
         m_current_box->setText(m_description);
+    }
+}
+
+void InfoFrame::licenseEllipsisHandler(QString link)
+{
+    if(!m_current_box)
+    {
+        m_current_box = CustomMessageBox::selectable(this, "", m_license);
+        connect(m_current_box, &QMessageBox::finished, this, &InfoFrame::boxClosed);
+        m_current_box->show();
+    }
+    else
+    {
+        m_current_box->setText(m_license);
     }
 }
 

--- a/launcher/ui/widgets/InfoFrame.h
+++ b/launcher/ui/widgets/InfoFrame.h
@@ -36,6 +36,8 @@ class InfoFrame : public QFrame {
     void setName(QString text = {});
     void setDescription(QString text = {});
     void setImage(QPixmap img = {});
+    void setLicense(QString text = {});
+    void setIssueTracker(QString text = {});
 
     void clear();
 
@@ -48,6 +50,7 @@ class InfoFrame : public QFrame {
 
    public slots:
     void descriptionEllipsisHandler(QString link);
+    void licenseEllipsisHandler(QString link);
     void boxClosed(int result);
 
    private:
@@ -56,5 +59,6 @@ class InfoFrame : public QFrame {
    private:
     Ui::InfoFrame* ui;
     QString m_description;
+    QString m_license;
     class QMessageBox* m_current_box = nullptr;
 };

--- a/launcher/ui/widgets/InfoFrame.ui
+++ b/launcher/ui/widgets/InfoFrame.ui
@@ -35,25 +35,28 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="0" column="1">
-    <widget class="QLabel" name="nameLabel">
+   <item row="0" column="0" rowspan="2">
+    <widget class="QLabel" name="iconLabel">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>64</width>
+       <height>64</height>
+      </size>
+     </property>
      <property name="text">
       <string notr="true"/>
      </property>
-     <property name="textFormat">
-      <enum>Qt::RichText</enum>
+     <property name="scaledContents">
+      <bool>false</bool>
      </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-     <property name="openExternalLinks">
-      <bool>true</bool>
-     </property>
-     <property name="textInteractionFlags">
-      <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+     <property name="margin">
+      <number>0</number>
      </property>
     </widget>
    </item>
@@ -82,28 +85,69 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0" rowspan="2">
-    <widget class="QLabel" name="iconLabel">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>64</width>
-       <height>64</height>
-      </size>
-     </property>
+   <item row="0" column="1">
+    <widget class="QLabel" name="nameLabel">
      <property name="text">
       <string notr="true"/>
      </property>
-     <property name="scaledContents">
-      <bool>false</bool>
+     <property name="textFormat">
+      <enum>Qt::RichText</enum>
      </property>
-     <property name="margin">
-      <number>0</number>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="openExternalLinks">
+      <bool>true</bool>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLabel" name="licenseLabel">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::RichText</enum>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="openExternalLinks">
+      <bool>true</bool>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QLabel" name="issueTrackerLabel">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="textFormat">
+      <enum>Qt::RichText</enum>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+     <property name="openExternalLinks">
+      <bool>true</bool>
+     </property>
+     <property name="textInteractionFlags">
+      <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
      </property>
     </widget>
    </item>

--- a/launcher/ui/widgets/ModListView.cpp
+++ b/launcher/ui/widgets/ModListView.cpp
@@ -79,3 +79,12 @@ void ModListView::setModel ( QAbstractItemModel* model )
         });
     }
 }
+
+void ModListView::setResizeModes(const QList<QHeaderView::ResizeMode> &modes)
+{
+    auto head = header();
+    for(int i = 0; i < modes.count(); i++) {
+        head->setSectionResizeMode(i, modes[i]);
+    }
+}
+

--- a/launcher/ui/widgets/ModListView.h
+++ b/launcher/ui/widgets/ModListView.h
@@ -14,6 +14,7 @@
  */
 
 #pragma once
+#include <QHeaderView>
 #include <QTreeView>
 
 class ModListView: public QTreeView
@@ -22,4 +23,5 @@ class ModListView: public QTreeView
 public:
     explicit ModListView ( QWidget* parent = 0 );
     virtual void setModel ( QAbstractItemModel* model );
+    virtual void setResizeModes (const QList<QHeaderView::ResizeMode>& modes);
 };


### PR DESCRIPTION
- Fixes exiting bug where simple selecting a resource would toggle it's enabled checkbox
- Load extra mod info from disk (image/icon/logo path, license, issueTracker) into `ModDetails`
- Add image column to resource pages for Mods, Resource Packs and Texture Packs
- Add rightclick menu to hide columns -> state saved to settings per page type
- Fix `PixmapCache` so that it can track cache misses from evictions (marked externally) and autogrow if they happen too fast.
- data providers can now set column resize modes

Fixes #1197
Fixes #356