### PR TITLE
feat: launcher logs now go into the `logs/` directory

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -373,7 +373,9 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
 
     // init the logger
     {
-        static const QString logBase = BuildConfig.LAUNCHER_NAME + "-%0.log";
+        static const QString logBase = FS::PathCombine("logs", BuildConfig.LAUNCHER_NAME + "-%0.log");
+        FS::ensureFolderPathExists("logs"); // this can fail, but there is no need to throw an error *yet*, since it also triggers the error message below!
+
         auto moveFile = [](const QString &oldName, const QString &newName)
         {
             QFile::remove(newName);
@@ -398,7 +400,7 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
                     "(%1)\n"
                     "\n"
                     "The launcher cannot continue until you fix this problem."
-                ).arg(dataPath)
+                ).arg(dataPath+"/logs")
             );
             return;
         }
@@ -1655,6 +1657,7 @@ bool Application::handleDataMigration(const QString& currentData,
         matcher->add(std::make_shared<SimplePrefixMatcher>(configFile));
         matcher->add(std::make_shared<SimplePrefixMatcher>(
             BuildConfig.LAUNCHER_CONFIGFILE));  // it's possible that we already used that directory before
+        matcher->add(std::make_shared<SimplePrefixMatcher>("logs/"));
         matcher->add(std::make_shared<SimplePrefixMatcher>("accounts.json"));
         matcher->add(std::make_shared<SimplePrefixMatcher>("accounts/"));
         matcher->add(std::make_shared<SimplePrefixMatcher>("assets/"));

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -400,7 +400,7 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
                     "(%1)\n"
                     "\n"
                     "The launcher cannot continue until you fix this problem."
-                ).arg(dataPath+"/logs")
+                ).arg(dataPath)
             );
             return;
         }


### PR DESCRIPTION
Before this PR, we had this kind of file in the launcher's data root:
![image](https://github.com/PrismLauncher/PrismLauncher/assets/61910521/b2b3119b-4a2e-48fa-bbe7-111a58629c36)
Now, these files go into the `logs/` directory:
![image](https://github.com/PrismLauncher/PrismLauncher/assets/61910521/c9fbfbf1-129b-4f9c-9a9c-263f15a2e52c)

Also, closes #136.