### PR TITLE
feat: Don't hide the settings tab when an instance is running

### DIFF
--- a/launcher/ui/pages/instance/InstanceSettingsPage.cpp
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.cpp
@@ -60,11 +60,15 @@ InstanceSettingsPage::InstanceSettingsPage(BaseInstance *inst, QWidget *parent)
     m_settings = inst->settings();
     ui->setupUi(this);
 
+    // As the signal will (probably) not be triggered once we click edit, let's update it manually instead.
+    updateRunningStatus(m_instance->isRunning());
+
     accountMenu = new QMenu(this);
     // Use undocumented property... https://stackoverflow.com/questions/7121718/create-a-scrollbar-in-a-submenu-qt
     accountMenu->setStyleSheet("QMenu { menu-scrollable: 1; }");
     ui->instanceAccountSelector->setMenu(accountMenu);
 
+    connect(m_instance, &BaseInstance::runningStatusChanged, this, &InstanceSettingsPage::updateRunningStatus);
     connect(ui->openGlobalJavaSettingsButton, &QCommandLinkButton::clicked, this, &InstanceSettingsPage::globalSettingsButtonClicked);
     connect(APPLICATION, &Application::globalSettingsAboutToOpen, this, &InstanceSettingsPage::applySettings);
     connect(APPLICATION, &Application::globalSettingsClosed, this, &InstanceSettingsPage::loadSettings);
@@ -74,7 +78,7 @@ InstanceSettingsPage::InstanceSettingsPage(BaseInstance *inst, QWidget *parent)
 
 bool InstanceSettingsPage::shouldDisplay() const
 {
-    return !m_instance->isRunning();
+    return true;
 }
 
 InstanceSettingsPage::~InstanceSettingsPage()
@@ -551,4 +555,9 @@ void InstanceSettingsPage::updateThresholds()
         QPixmap pix = icon.pixmap(height, height);
         ui->labelMaxMemIcon->setPixmap(pix);
     }
+}
+
+void InstanceSettingsPage::updateRunningStatus(bool running)
+{
+    setEnabled(!running);
 }

--- a/launcher/ui/pages/instance/InstanceSettingsPage.cpp
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.cpp
@@ -76,11 +76,6 @@ InstanceSettingsPage::InstanceSettingsPage(BaseInstance *inst, QWidget *parent)
     updateThresholds();
 }
 
-bool InstanceSettingsPage::shouldDisplay() const
-{
-    return true;
-}
-
 InstanceSettingsPage::~InstanceSettingsPage()
 {
     delete ui;

--- a/launcher/ui/pages/instance/InstanceSettingsPage.h
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.h
@@ -75,7 +75,6 @@ public:
     {
         return "Instance-settings";
     }
-    virtual bool shouldDisplay() const override;
     void retranslate() override;
 
     void updateThresholds();

--- a/launcher/ui/pages/instance/InstanceSettingsPage.h
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.h
@@ -81,6 +81,7 @@ public:
     void updateThresholds();
 
 private slots:
+    void updateRunningStatus(bool running);
     void on_javaDetectBtn_clicked();
     void on_javaTestBtn_clicked();
     void on_javaBrowseBtn_clicked();


### PR DESCRIPTION
Before, when an instance was launched, the "Settings" tab in the edit menu would just disappear. Now everything in this tab just gets greyed out.

https://github.com/PrismLauncher/PrismLauncher/assets/61910521/e9dbb4f7-6ad8-433b-8650-584da4dd7dfc

closes #854 