### PR TITLE
fix accounts menus

### DIFF
--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -199,7 +199,6 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui::MainWi
         helpMenuButton->setPopupMode(QToolButton::InstantPopup);
 
         auto accountMenuButton = dynamic_cast<QToolButton*>(ui->mainToolBar->widgetForAction(ui->actionAccountsButton));
-        ui->actionAccountsButton->setMenu(ui->accountsMenu);
         accountMenuButton->setPopupMode(QToolButton::InstantPopup);
     }
 
@@ -414,15 +413,6 @@ void MainWindow::keyReleaseEvent(QKeyEvent *event)
 
 void MainWindow::retranslateUi()
 {
-    auto accounts = APPLICATION->accounts();
-    MinecraftAccountPtr defaultAccount = accounts->defaultAccount();
-    if(defaultAccount) {
-        auto profileLabel = profileInUseFilter(defaultAccount->profileName(), defaultAccount->isInUse());
-        ui->actionAccountsButton->setText(profileLabel);
-    }
-    else {
-        ui->actionAccountsButton->setText(tr("Accounts"));
-    }
 
     if (m_selectedInstance) {
         m_statusLeft->setText(m_selectedInstance->getStatusbarDescription());
@@ -431,6 +421,12 @@ void MainWindow::retranslateUi()
     }
 
     ui->retranslateUi(this);
+
+    MinecraftAccountPtr defaultAccount = APPLICATION->accounts()->defaultAccount();
+    if(defaultAccount) {
+        auto profileLabel = profileInUseFilter(defaultAccount->profileName(), defaultAccount->isInUse());
+        ui->actionAccountsButton->setText(profileLabel);
+    }
 
     changeIconButton->setToolTip(ui->actionChangeInstIcon->toolTip());
     renameButton->setToolTip(ui->actionRenameInstance->toolTip());
@@ -673,6 +669,15 @@ void MainWindow::repopulateAccountsMenu()
 {
     ui->accountsMenu->clear();
 
+    // NOTE: this is done so the accounts button text is not set to the accounts menu title
+    QMenu *accountsButtonMenu = ui->actionAccountsButton->menu();
+    if (accountsButtonMenu) {
+        accountsButtonMenu->clear();
+    } else {
+        accountsButtonMenu = new QMenu(this);
+        ui->actionAccountsButton->setMenu(accountsButtonMenu);
+    }
+
     auto accounts = APPLICATION->accounts();
     MinecraftAccountPtr defaultAccount = accounts->defaultAccount();
 
@@ -686,6 +691,8 @@ void MainWindow::repopulateAccountsMenu()
             ui->actionAccountsButton->setText(profileLabel);
         }
     }
+
+    QActionGroup* accountsGroup = new QActionGroup(this);
 
     if (accounts->count() <= 0)
     {
@@ -702,6 +709,7 @@ void MainWindow::repopulateAccountsMenu()
             QAction *action = new QAction(profileLabel, this);
             action->setData(i);
             action->setCheckable(true);
+            action->setActionGroup(accountsGroup);
             if (defaultAccount == account)
             {
                 action->setChecked(true);
@@ -730,6 +738,7 @@ void MainWindow::repopulateAccountsMenu()
 
     ui->actionNoDefaultAccount->setData(-1);
     ui->actionNoDefaultAccount->setChecked(!defaultAccount);
+    ui->actionNoDefaultAccount->setActionGroup(accountsGroup);
 
     ui->accountsMenu->addAction(ui->actionNoDefaultAccount);
 
@@ -737,6 +746,8 @@ void MainWindow::repopulateAccountsMenu()
 
     ui->accountsMenu->addSeparator();
     ui->accountsMenu->addAction(ui->actionManageAccounts);
+
+    accountsButtonMenu->addActions(ui->accountsMenu->actions());
 }
 
 void MainWindow::updatesAllowedChanged(bool allowed)

--- a/launcher/ui/pages/instance/InstanceSettingsPage.h
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.h
@@ -95,12 +95,11 @@ private slots:
 
     void updateAccountsMenu();
     QIcon getFaceForAccount(MinecraftAccountPtr account);
-    void changeInstanceAccount();
+    void changeInstanceAccount(int index);
 
 private:
     Ui::InstanceSettingsPage *ui;
     BaseInstance *m_instance;
     SettingsObjectPtr m_settings;
     unique_qobject_ptr<JavaCommon::TestCheck> checker;
-    QMenu *accountMenu = nullptr;
 };

--- a/launcher/ui/pages/instance/InstanceSettingsPage.ui
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.ui
@@ -636,14 +636,7 @@
              </widget>
             </item>
             <item row="0" column="1">
-             <widget class="QToolButton" name="instanceAccountSelector">
-              <property name="popupMode">
-               <enum>QToolButton::InstantPopup</enum>
-              </property>
-              <property name="toolButtonStyle">
-               <enum>Qt::ToolButtonTextBesideIcon</enum>
-              </property>
-             </widget>
+             <widget class="QComboBox" name="instanceAccountSelector"/>
             </item>
            </layout>
           </item>


### PR DESCRIPTION
this makes the instance settings account selector a QComboBox instead of a QToolButton to fix some bugs and clean up the code
and fixes the main toolbar account selector name not being set to the selected account when starting the launcher