### PR TITLE
WIP: Add update blacklist

### DIFF
--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -66,7 +66,7 @@ BaseInstance::BaseInstance(SettingsObjectPtr globalSettings, SettingsObjectPtr s
     m_settings->registerSetting("totalTimePlayed", 0);
     m_settings->registerSetting("lastTimePlayed", 0);
 
-    m_settings->registerSetting("linkedInstances", "[]");
+    m_settings->registerSetting("linkedInstances", QVariantList({}));
 
     // Game time override
     auto gameTimeOverride = m_settings->registerSetting("OverrideGameTime", false);

--- a/launcher/BaseInstance.h
+++ b/launcher/BaseInstance.h
@@ -181,6 +181,16 @@ public:
     virtual SettingsObjectPtr settings();
 
     /*!
+     * \brief Get this instance's settings object.
+     * This settings object *may* store instance-specific settings.
+     *
+     * Note that this method *is* const and *will not* call loadSpecificSettings()
+     *
+     * \return A pointer to this instance's settings object.
+     */
+    virtual SettingsObjectPtr getSettingsConst() const { return m_settings; }
+
+    /*!
      * \brief Loads settings specific to an instance type if they're not already loaded.
      */
     virtual void loadSpecificSettings() = 0;

--- a/launcher/QVariantUtils.h
+++ b/launcher/QVariantUtils.h
@@ -37,18 +37,20 @@
 #pragma once
 
 
+#include <qhash.h>
 #include <QVariant>
 #include <QList>
+#include <QMap>
 
 namespace QVariantUtils {
 
 template <typename T> 
 inline QList<T> toList(QVariant src) {
-    QVariantList variantList = src.toList();
+    QVariantList variant_l = src.toList();
 
     QList<T> list_t;
-    list_t.reserve(variantList.size());
-    for (const QVariant& v : variantList)
+    list_t.reserve(variant_l.size());
+    for (const QVariant& v : variant_l)
     {
         list_t.append(v.value<T>());
     }
@@ -57,14 +59,15 @@ inline QList<T> toList(QVariant src) {
 
 template <typename T> 
 inline QVariant fromList(QList<T> val) {
-    QVariantList variantList;
-    variantList.reserve(val.size());
+    QVariantList variant_l;
+    variant_l.reserve(val.size());
     for (const T& v : val)
     {
-        variantList.append(v);
+        variant_l.append(v);
     }
 
-    return variantList;
+    return variant_l;
 }
 
 }
+

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -195,11 +195,14 @@ void MinecraftInstance::loadSpecificSettings()
     // Use account for instance, this does not have a global override
     m_settings->registerSetting("UseAccountForInstance", false);
     m_settings->registerSetting("InstanceAccountId", "");
+    
+    // Mod group settings
+    m_settings->registerSetting("Mods/UpdateIgnoreList", QVariantList({}));
 
     qDebug() << "Instance-type specific settings were loaded!";
 
     setSpecificSettingsLoaded(true);
-
+    
     updateRuntimeContext();
 }
 
@@ -1109,7 +1112,7 @@ JavaVersion MinecraftInstance::getJavaVersion()
     return JavaVersion(settings()->get("JavaVersion").toString());
 }
 
-std::shared_ptr<ModFolderModel> MinecraftInstance::loaderModList() const
+std::shared_ptr<ModFolderModel> MinecraftInstance::loaderModList()
 {
     if (!m_loader_mod_list)
     {
@@ -1121,7 +1124,7 @@ std::shared_ptr<ModFolderModel> MinecraftInstance::loaderModList() const
     return m_loader_mod_list;
 }
 
-std::shared_ptr<ModFolderModel> MinecraftInstance::coreModList() const
+std::shared_ptr<ModFolderModel> MinecraftInstance::coreModList()
 {
     if (!m_core_mod_list)
     {
@@ -1133,7 +1136,7 @@ std::shared_ptr<ModFolderModel> MinecraftInstance::coreModList() const
     return m_core_mod_list;
 }
 
-std::shared_ptr<ModFolderModel> MinecraftInstance::nilModList() const
+std::shared_ptr<ModFolderModel> MinecraftInstance::nilModList()
 {
     if (!m_nil_mod_list)
     {
@@ -1145,7 +1148,7 @@ std::shared_ptr<ModFolderModel> MinecraftInstance::nilModList() const
     return m_nil_mod_list;
 }
 
-std::shared_ptr<ResourcePackFolderModel> MinecraftInstance::resourcePackList() const
+std::shared_ptr<ResourcePackFolderModel> MinecraftInstance::resourcePackList()
 {
     if (!m_resource_pack_list)
     {
@@ -1154,7 +1157,7 @@ std::shared_ptr<ResourcePackFolderModel> MinecraftInstance::resourcePackList() c
     return m_resource_pack_list;
 }
 
-std::shared_ptr<TexturePackFolderModel> MinecraftInstance::texturePackList() const
+std::shared_ptr<TexturePackFolderModel> MinecraftInstance::texturePackList()
 {
     if (!m_texture_pack_list)
     {
@@ -1163,7 +1166,7 @@ std::shared_ptr<TexturePackFolderModel> MinecraftInstance::texturePackList() con
     return m_texture_pack_list;
 }
 
-std::shared_ptr<ShaderPackFolderModel> MinecraftInstance::shaderPackList() const
+std::shared_ptr<ShaderPackFolderModel> MinecraftInstance::shaderPackList()
 {
     if (!m_shader_pack_list)
     {
@@ -1172,7 +1175,7 @@ std::shared_ptr<ShaderPackFolderModel> MinecraftInstance::shaderPackList() const
     return m_shader_pack_list;
 }
 
-std::shared_ptr<WorldList> MinecraftInstance::worldList() const
+std::shared_ptr<WorldList> MinecraftInstance::worldList()
 {
     if (!m_world_list)
     {

--- a/launcher/minecraft/MinecraftInstance.h
+++ b/launcher/minecraft/MinecraftInstance.h
@@ -115,13 +115,13 @@ public:
     std::shared_ptr<PackProfile> getPackProfile() const;
 
     //////  Mod Lists  //////
-    std::shared_ptr<ModFolderModel> loaderModList() const;
-    std::shared_ptr<ModFolderModel> coreModList() const;
-    std::shared_ptr<ModFolderModel> nilModList() const;
-    std::shared_ptr<ResourcePackFolderModel> resourcePackList() const;
-    std::shared_ptr<TexturePackFolderModel> texturePackList() const;
-    std::shared_ptr<ShaderPackFolderModel> shaderPackList() const;
-    std::shared_ptr<WorldList> worldList() const;
+    std::shared_ptr<ModFolderModel> loaderModList();
+    std::shared_ptr<ModFolderModel> coreModList();
+    std::shared_ptr<ModFolderModel> nilModList();
+    std::shared_ptr<ResourcePackFolderModel> resourcePackList();
+    std::shared_ptr<TexturePackFolderModel> texturePackList();
+    std::shared_ptr<ShaderPackFolderModel> shaderPackList();
+    std::shared_ptr<WorldList> worldList();
     std::shared_ptr<GameOptions> gameOptionsModel() const;
 
     //////  Launch stuff //////

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -216,11 +216,10 @@ bool ModFolderModel::setModUpdate(const QModelIndexList& indexes, EnableAction a
 
         int row = idx.row();
         auto& resource = m_resources[row];
-        auto fileName = resource->fileinfo().fileName();
 
         auto update_ignore_list = QVariantUtils::toList<QString>(m_instance->getSettingsConst()->get(QStringList({"Mods", "UpdateIgnoreList"}).join('/')));
 
-        bool in_ignore_list = update_ignore_list.contains(fileName);
+        bool in_ignore_list = update_ignore_list.contains(resource->name());
         
         bool update = true;
         switch (action) {
@@ -242,9 +241,9 @@ bool ModFolderModel::setModUpdate(const QModelIndexList& indexes, EnableAction a
         }
             
         if (in_ignore_list && update) {
-            update_ignore_list.removeOne(fileName);
+            update_ignore_list.removeOne(resource->name());
         } else if (!in_ignore_list && !update) {
-            update_ignore_list.append(fileName);
+            update_ignore_list.append(resource->name());
         }
 
         m_instance->settings()->set(QStringList({"Mods", "UpdateIgnoreList"}).join('/'), QVariantUtils::fromList(update_ignore_list));

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -130,7 +130,7 @@ QVariant ModFolderModel::data(const QModelIndex &index, int role) const
             return at(row)->enabled() ? Qt::Checked : Qt::Unchecked;
         case UpdateColumn: {
             auto update_ignore_list = QVariantUtils::toList<QString>(m_instance->getSettingsConst()->get(QStringList({"Mods", "UpdateIgnoreList"}).join('/')));
-            return update_ignore_list.contains(at(row)->fileinfo().fileName()) ? Qt::Checked : Qt::Unchecked;
+            return !update_ignore_list.contains(at(row)->name()) ? Qt::Checked : Qt::Unchecked;
         }
         default:
             return QVariant();

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -194,7 +194,10 @@ bool ModFolderModel::setData(const QModelIndex& index, const QVariant& value, in
         return false;
 
     if (role == Qt::CheckStateRole) {
-
+        if (index.column() == UpdateColumn) {
+            return setModUpdate({ index }, EnableAction::TOGGLE);
+        }
+        return setResourceEnabled({ index }, EnableAction::TOGGLE); 
     }
 
     return false;

--- a/launcher/minecraft/mod/ModFolderModel.h
+++ b/launcher/minecraft/mod/ModFolderModel.h
@@ -68,6 +68,7 @@ public:
         VersionColumn,
         DateColumn,
         ProviderColumn,
+        UpdateColumn,
         NUM_COLUMNS
     };
     enum ModStatusAction {
@@ -75,11 +76,16 @@ public:
         Enable,
         Toggle
     };
-    ModFolderModel(const QString &dir, std::shared_ptr<const BaseInstance> instance, bool is_indexed = false, bool create_dir = true);
+    ModFolderModel(const QString &dir, std::shared_ptr<BaseInstance> instance, bool is_indexed = false, bool create_dir = true);
 
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+
+    bool setData(const QModelIndex& index, const QVariant& value, int role) override;
+
+    bool setModUpdate(const QModelIndexList& indexes, EnableAction action);
+
     int columnCount(const QModelIndex &parent) const override;
 
     [[nodiscard]] Task* createUpdateTask() override;

--- a/launcher/minecraft/mod/Resource.h
+++ b/launcher/minecraft/mod/Resource.h
@@ -21,7 +21,8 @@ enum class SortType {
     VERSION,
     ENABLED,
     PACK_FORMAT,
-    PROVIDER
+    PROVIDER,
+    UPDATE
 };
 
 enum class EnableAction {

--- a/launcher/minecraft/mod/ResourceFolderModel.h
+++ b/launcher/minecraft/mod/ResourceFolderModel.h
@@ -1,11 +1,14 @@
 #pragma once
 
+#include <QTreeView>
+#include <QWidget>
 #include <QAbstractListModel>
 #include <QDir>
 #include <QFileSystemWatcher>
 #include <QMutex>
 #include <QSet>
 #include <QSortFilterProxyModel>
+#include <memory>
 
 #include "Resource.h"
 
@@ -26,7 +29,7 @@ class QSortFilterProxyModel;
 class ResourceFolderModel : public QAbstractListModel {
     Q_OBJECT
    public:
-    ResourceFolderModel(QDir, std::shared_ptr<const BaseInstance>, QObject* parent = nullptr, bool create_dir = true);
+    ResourceFolderModel(QDir, std::shared_ptr<BaseInstance>, QObject* parent = nullptr, bool create_dir = true);
     ~ResourceFolderModel() override;
 
     /** Starts watching the paths for changes.
@@ -109,6 +112,10 @@ class ResourceFolderModel : public QAbstractListModel {
     bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole) override;
 
     [[nodiscard]] QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+  
+    void setupHeaderAction(QAction* act, int column);
+    std::unique_ptr<QMenu> createHeaderContextMenu(QWidget* parent, QTreeView* tree); 
+
 
     /** This creates a proxy model to filter / sort the model for a UI.
      *
@@ -191,7 +198,7 @@ class ResourceFolderModel : public QAbstractListModel {
     bool m_can_interact = true;
 
     QDir m_dir;
-    std::shared_ptr<const BaseInstance> m_instance;
+    std::shared_ptr<BaseInstance> m_instance;
     QFileSystemWatcher m_watcher;
     bool m_is_watching = false;
 

--- a/launcher/minecraft/mod/ResourcePackFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourcePackFolderModel.cpp
@@ -45,7 +45,7 @@
 #include "minecraft/mod/tasks/BasicFolderLoadTask.h"
 #include "minecraft/mod/tasks/LocalResourcePackParseTask.h"
 
-ResourcePackFolderModel::ResourcePackFolderModel(const QString& dir, std::shared_ptr<const BaseInstance> instance)
+ResourcePackFolderModel::ResourcePackFolderModel(const QString& dir, std::shared_ptr<BaseInstance> instance)
     : ResourceFolderModel(QDir(dir), instance)
 {
     m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::PACK_FORMAT, SortType::DATE };

--- a/launcher/minecraft/mod/ResourcePackFolderModel.h
+++ b/launcher/minecraft/mod/ResourcePackFolderModel.h
@@ -17,7 +17,7 @@ public:
         NUM_COLUMNS
     };
 
-    explicit ResourcePackFolderModel(const QString &dir, std::shared_ptr<const BaseInstance> instance);
+    explicit ResourcePackFolderModel(const QString &dir, std::shared_ptr<BaseInstance> instance);
 
     [[nodiscard]] QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 

--- a/launcher/minecraft/mod/ShaderPackFolderModel.h
+++ b/launcher/minecraft/mod/ShaderPackFolderModel.h
@@ -6,7 +6,7 @@ class ShaderPackFolderModel : public ResourceFolderModel {
     Q_OBJECT
 
    public:
-    explicit ShaderPackFolderModel(const QString& dir, std::shared_ptr<const BaseInstance> instance)
+    explicit ShaderPackFolderModel(const QString& dir, std::shared_ptr<BaseInstance> instance)
         : ResourceFolderModel(QDir(dir), instance)
     {}
 };

--- a/launcher/minecraft/mod/TexturePackFolderModel.cpp
+++ b/launcher/minecraft/mod/TexturePackFolderModel.cpp
@@ -39,7 +39,7 @@
 #include "minecraft/mod/tasks/BasicFolderLoadTask.h"
 #include "minecraft/mod/tasks/LocalTexturePackParseTask.h"
 
-TexturePackFolderModel::TexturePackFolderModel(const QString& dir, std::shared_ptr<const BaseInstance> instance)
+TexturePackFolderModel::TexturePackFolderModel(const QString& dir, std::shared_ptr<BaseInstance> instance)
     : ResourceFolderModel(QDir(dir), instance)
 {}
 

--- a/launcher/minecraft/mod/TexturePackFolderModel.h
+++ b/launcher/minecraft/mod/TexturePackFolderModel.h
@@ -43,7 +43,7 @@ class TexturePackFolderModel : public ResourceFolderModel
     Q_OBJECT
 
 public:
-    explicit TexturePackFolderModel(const QString &dir, std::shared_ptr<const BaseInstance> instance);
+    explicit TexturePackFolderModel(const QString &dir, std::shared_ptr<BaseInstance> instance);
     [[nodiscard]] Task* createUpdateTask() override;
     [[nodiscard]] Task* createParseTask(Resource&) override;
 };

--- a/launcher/modplatform/flame/FlameCheckUpdate.cpp
+++ b/launcher/modplatform/flame/FlameCheckUpdate.cpp
@@ -125,6 +125,11 @@ void FlameCheckUpdate::executeTask()
             emit checkFailed(mod, tr("Disabled mods won't be updated, to prevent mod duplication issues!"));
             continue;
         }
+        
+        if (m_blacklist.contains(mod->fileinfo().fileName())) {
+            qDebug() << "Ignoring" << mod->fileinfo().fileName() << "Because it is in blacklist";
+            continue;
+        }
 
         setStatus(tr("Getting API response from CurseForge for '%1'...").arg(mod->name()));
         setProgress(i++, m_mods.size());

--- a/launcher/modplatform/flame/FlameCheckUpdate.cpp
+++ b/launcher/modplatform/flame/FlameCheckUpdate.cpp
@@ -126,7 +126,7 @@ void FlameCheckUpdate::executeTask()
             continue;
         }
         
-        if (m_blacklist.contains(mod->fileinfo().fileName())) {
+        if (m_blacklist.contains(mod->name())) {
             qDebug() << "Ignoring" << mod->fileinfo().fileName() << "Because it is in blacklist";
             continue;
         }

--- a/launcher/modplatform/flame/FlameCheckUpdate.h
+++ b/launcher/modplatform/flame/FlameCheckUpdate.h
@@ -8,8 +8,12 @@ class FlameCheckUpdate : public CheckUpdateTask {
     Q_OBJECT
 
    public:
-    FlameCheckUpdate(QList<Mod*>& mods, std::list<Version>& mcVersions, std::optional<ResourceAPI::ModLoaderTypes> loaders, std::shared_ptr<ModFolderModel> mods_folder)
-        : CheckUpdateTask(mods, mcVersions, loaders, mods_folder)
+    FlameCheckUpdate(QList<Mod*>& mods,
+                     std::list<Version>& mcVersions,
+                     std::optional<ResourceAPI::ModLoaderTypes> loaders,
+                     std::shared_ptr<ModFolderModel> mods_folder,
+                     QStringList blacklist = {})
+        : CheckUpdateTask(mods, mcVersions, loaders, mods_folder), m_blacklist(blacklist)
     {}
 
    public slots:
@@ -20,6 +24,7 @@ class FlameCheckUpdate : public CheckUpdateTask {
 
    private:
     NetJob* m_net_job = nullptr;
+    QStringList m_blacklist = {};
 
     bool m_was_aborted = false;
 };

--- a/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
+++ b/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
@@ -46,7 +46,7 @@ void ModrinthCheckUpdate::executeTask()
             continue;
         }
 
-        if (m_blacklist.contains(mod->fileinfo().fileName())) {
+        if (m_blacklist.contains(mod->name())) {
             qDebug() << "Ignoring" << mod->fileinfo().fileName() << "Because it is in blacklist";
             continue;
         }

--- a/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
+++ b/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
@@ -46,6 +46,11 @@ void ModrinthCheckUpdate::executeTask()
             continue;
         }
 
+        if (m_blacklist.contains(mod->fileinfo().fileName())) {
+            qDebug() << "Ignoring" << mod->fileinfo().fileName() << "Because it is in blacklist";
+            continue;
+        }
+
         auto hash = mod->metadata()->hash;
 
         // Sadly the API can only handle one hash type per call, se we

--- a/launcher/modplatform/modrinth/ModrinthCheckUpdate.h
+++ b/launcher/modplatform/modrinth/ModrinthCheckUpdate.h
@@ -8,8 +8,12 @@ class ModrinthCheckUpdate : public CheckUpdateTask {
     Q_OBJECT
 
    public:
-    ModrinthCheckUpdate(QList<Mod*>& mods, std::list<Version>& mcVersions, std::optional<ResourceAPI::ModLoaderTypes> loaders, std::shared_ptr<ModFolderModel> mods_folder)
-        : CheckUpdateTask(mods, mcVersions, loaders, mods_folder)
+    ModrinthCheckUpdate(QList<Mod*>& mods,
+                        std::list<Version>& mcVersions,
+                        std::optional<ResourceAPI::ModLoaderTypes> loaders,
+                        std::shared_ptr<ModFolderModel> mods_folder,
+                        QStringList blacklist = {})
+        : CheckUpdateTask(mods, mcVersions, loaders, mods_folder), m_blacklist(blacklist)
     {}
 
    public slots:
@@ -20,4 +24,5 @@ class ModrinthCheckUpdate : public CheckUpdateTask {
 
    private:
     NetJob::Ptr m_net_job = nullptr;
+    QStringList m_blacklist = {};
 };

--- a/launcher/settings/INIFile.cpp
+++ b/launcher/settings/INIFile.cpp
@@ -99,8 +99,17 @@ QVariant INIFile::get(QString key, QVariant def) const
         return this->operator[](key);
 }
 
+QVariant INIFile::get(QStringList key, QVariant def) const
+{
+    return this->get(key.join('/'), def);
+}
+
 void INIFile::set(QString key, QVariant val)
 {
     this->operator[](key) = val;
 }
 
+void INIFile::set(QStringList key, QVariant val)
+{
+    this->set(key.join('/'), val);
+}

--- a/launcher/settings/INIFile.h
+++ b/launcher/settings/INIFile.h
@@ -53,5 +53,7 @@ public:
     bool saveFile(QString fileName);
 
     QVariant get(QString key, QVariant def) const;
+    QVariant get(QStringList key, QVariant def) const;
     void set(QString key, QVariant val);
+    void set(QStringList key, QVariant val);
 };

--- a/launcher/ui/dialogs/ModUpdateDialog.cpp
+++ b/launcher/ui/dialogs/ModUpdateDialog.cpp
@@ -18,7 +18,10 @@
 #include "modplatform/flame/FlameCheckUpdate.h"
 #include "modplatform/modrinth/ModrinthCheckUpdate.h"
 
+#include "QVariantUtils.h"
+
 #include <QTextBrowser>
+#include <QString>
 #include <QTreeWidgetItem>
 
 #include <optional>
@@ -85,17 +88,19 @@ void ModUpdateDialog::checkCandidates()
     auto versions = mcVersions(m_instance);
     auto loaders = mcLoaders(m_instance);
 
+    auto update_ignore_list = QVariantUtils::toList<QString>(m_instance->getSettingsConst()->get(QStringList({"Mods", "UpdateIgnoreList"}).join('/')));
+
     SequentialTask check_task(m_parent, tr("Checking for updates"));
 
     if (!m_modrinth_to_update.empty()) {
-        m_modrinth_check_task.reset(new ModrinthCheckUpdate(m_modrinth_to_update, versions, loaders, m_mod_model));
+        m_modrinth_check_task.reset(new ModrinthCheckUpdate(m_modrinth_to_update, versions, loaders, m_mod_model, update_ignore_list));
         connect(m_modrinth_check_task.get(), &CheckUpdateTask::checkFailed, this,
                 [this](Mod* mod, QString reason, QUrl recover_url) { m_failed_check_update.append({mod, reason, recover_url}); });
         check_task.addTask(m_modrinth_check_task);
     }
 
     if (!m_flame_to_update.empty()) {
-        m_flame_check_task.reset(new FlameCheckUpdate(m_flame_to_update, versions, loaders, m_mod_model));
+        m_flame_check_task.reset(new FlameCheckUpdate(m_flame_to_update, versions, loaders, m_mod_model, update_ignore_list));
         connect(m_flame_check_task.get(), &CheckUpdateTask::checkFailed, this,
                 [this](Mod* mod, QString reason, QUrl recover_url) { m_failed_check_update.append({mod, reason, recover_url}); });
         check_task.addTask(m_flame_check_task);

--- a/launcher/ui/dialogs/ModUpdateDialog.cpp
+++ b/launcher/ui/dialogs/ModUpdateDialog.cpp
@@ -41,13 +41,15 @@ static std::optional<ResourceAPI::ModLoaderTypes> mcLoaders(BaseInstance* inst)
 ModUpdateDialog::ModUpdateDialog(QWidget* parent,
                                  BaseInstance* instance,
                                  const std::shared_ptr<ModFolderModel> mods,
-                                 QList<Mod*>& search_for)
+                                 QList<Mod*>& search_for,
+                                 bool use_blacklist)
     : ReviewMessageBox(parent, tr("Confirm mods to update"), "")
     , m_parent(parent)
     , m_mod_model(mods)
     , m_candidates(search_for)
     , m_second_try_metadata(new ConcurrentTask())
     , m_instance(instance)
+    , m_use_blacklist(use_blacklist)
 {
     ReviewMessageBox::setGeometry(0, 0, 800, 600);
 
@@ -89,6 +91,8 @@ void ModUpdateDialog::checkCandidates()
     auto loaders = mcLoaders(m_instance);
 
     auto update_ignore_list = QVariantUtils::toList<QString>(m_instance->getSettingsConst()->get(QStringList({"Mods", "UpdateIgnoreList"}).join('/')));
+    if (!m_use_blacklist)
+        update_ignore_list.clear(); // clear the list
 
     SequentialTask check_task(m_parent, tr("Checking for updates"));
 

--- a/launcher/ui/dialogs/ModUpdateDialog.h
+++ b/launcher/ui/dialogs/ModUpdateDialog.h
@@ -19,7 +19,8 @@ class ModUpdateDialog final : public ReviewMessageBox {
     explicit ModUpdateDialog(QWidget* parent,
                              BaseInstance* instance,
                              const std::shared_ptr<ModFolderModel> mod_model,
-                             QList<Mod*>& search_for);
+                             QList<Mod*>& search_for,
+                             bool use_blacklist = true);
 
     void checkCandidates();
 
@@ -59,4 +60,5 @@ class ModUpdateDialog final : public ReviewMessageBox {
 
     bool m_no_updates = false;
     bool m_aborted = false;
+    bool m_use_blacklist;
 };

--- a/launcher/ui/pages/instance/ExternalResourcesPage.cpp
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.cpp
@@ -1,4 +1,7 @@
 #include "ExternalResourcesPage.h"
+
+#include <QHeaderView>
+
 #include "ui/dialogs/CustomMessageBox.h"
 #include "ui_ExternalResourcesPage.h"
 
@@ -28,7 +31,7 @@ ExternalResourcesPage::ExternalResourcesPage(BaseInstance* instance, std::shared
     ui->treeView->installEventFilter(this);
     ui->treeView->sortByColumn(1, Qt::AscendingOrder);
     ui->treeView->setContextMenuPolicy(Qt::CustomContextMenu);
-
+    
     // The default function names by Qt are pretty ugly, so let's just connect the actions manually,
     // to make it easier to read :)
     connect(ui->actionAddItem, &QAction::triggered, this, &ExternalResourcesPage::addItem);
@@ -44,6 +47,12 @@ ExternalResourcesPage::ExternalResourcesPage(BaseInstance* instance, std::shared
     auto selection_model = ui->treeView->selectionModel();
     connect(selection_model, &QItemSelectionModel::currentChanged, this, &ExternalResourcesPage::current);
     connect(ui->filterEdit, &QLineEdit::textChanged, this, &ExternalResourcesPage::filterTextChanged);
+
+    auto viewHeader = ui->treeView->header();
+    viewHeader->setContextMenuPolicy(Qt::CustomContextMenu);
+
+    connect(viewHeader, &QHeaderView::customContextMenuRequested, this, &ExternalResourcesPage::ShowHeaderContextMenu);
+
 }
 
 ExternalResourcesPage::~ExternalResourcesPage()
@@ -63,6 +72,12 @@ void ExternalResourcesPage::ShowContextMenu(const QPoint& pos)
     auto menu = ui->actionsToolbar->createContextMenu(this, tr("Context menu"));
     menu->exec(ui->treeView->mapToGlobal(pos));
     delete menu;
+}
+
+void ExternalResourcesPage::ShowHeaderContextMenu(const QPoint& pos)
+{
+    auto menu = m_model->createHeaderContextMenu(this, ui->treeView);
+    menu->exec(ui->treeView->mapToGlobal(pos));
 }
 
 void ExternalResourcesPage::openedImpl()

--- a/launcher/ui/pages/instance/ExternalResourcesPage.h
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.h
@@ -60,6 +60,7 @@ class ExternalResourcesPage : public QMainWindow, public BasePage {
     virtual void viewConfigs();
 
     void ShowContextMenu(const QPoint& pos);
+    void ShowHeaderContextMenu(const QPoint& pos);
 
    protected:
     BaseInstance* m_instance = nullptr;

--- a/launcher/ui/pages/instance/ExternalResourcesPage.ui
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1042</width>
+    <width>620</width>
     <height>501</height>
    </rect>
   </property>
@@ -152,6 +152,22 @@
    </property>
    <property name="toolTip">
     <string>Try to check or update all selected resources (all resources if none are selected)</string>
+   </property>
+  </action>
+  <action name="actionEnableUpdates">
+   <property name="text">
+    <string>Ena&amp;ble Updates</string>
+   </property>
+   <property name="toolTip">
+    <string>Mark resource to be updated</string>
+   </property>
+  </action>
+  <action name="actionDisableUpdates">
+   <property name="text">
+    <string>Disable U&amp;pdates</string>
+   </property>
+   <property name="toolTip">
+    <string>Mark resource to prevent it from being updated</string>
    </property>
   </action>
  </widget>

--- a/launcher/ui/pages/instance/ModFolderPage.h
+++ b/launcher/ui/pages/instance/ModFolderPage.h
@@ -65,6 +65,9 @@ class ModFolderPage : public ExternalResourcesPage {
     void installMods();
     void updateMods();
 
+    void enableUpdates();
+    void disableUpdates();
+
    protected:
     std::shared_ptr<ModFolderModel> m_model;
 };

--- a/tests/INIFile_test.cpp
+++ b/tests/INIFile_test.cpp
@@ -2,6 +2,9 @@
 
 #include <QList>
 #include <QVariant>
+#include <QMap>
+#include <QHash>
+#include <qtestcase.h>
 #include <settings/INIFile.h>
 
 #include <QVariantUtils.h>
@@ -53,10 +56,8 @@ slots:
 
     void test_SaveLoadLists()
     {
-        QString slist_strings = "(\"a\",\"b\",\"c\")";
-        QStringList list_strings = {"a", "b", "c"};
+        QStringList list_strings = {"a", "b", "c", "a,b", "c,d,e", "f\",", "\"g", "h"};
 
-        QString slist_numbers = "(1,2,3,10)";
         QList<int> list_numbers = {1, 2, 3, 10};
 
         QString filename = "test_SaveLoadLists.ini";
@@ -78,6 +79,48 @@ slots:
 
         QCOMPARE(out_list_strings, list_strings);
         QCOMPARE(out_list_numbers, list_numbers);
+    }
+
+    void test_SaveLoadMapHash()
+    {
+        QMap<QString, QVariant> map;
+        map.insert("key_int", 10);
+        map.insert("key_str", "This is a String");
+        map.insert("key_int_list", QVariantList({1, 2, 3}));
+        map.insert("key_string_list", QVariantList({"a", "b", "c"}));
+
+        QHash<QString, QVariant> hash;
+        hash.insert("key_int", 20);
+        hash.insert("key_str", "This is also String");
+        hash.insert("key_int_list", QVariantList({4, 5, 6}));
+        hash.insert("key_string_list", QVariantList({"e", "f", "g"}));
+        
+        QString filename = "test_SaveLoadMapOrHash.ini";
+        INIFile f;
+        f.set("key_map", map);
+        f.set("key_hash", hash);
+        f.set("group1/key1", 1);
+        f.set("group1/key2", "a");
+        f.set("group2/sub1/key1", 2);
+        f.set("group2/sub2/key1", "b");
+        f.set({"group3", "key1"}, QVariantList({"This is a string", 1000, false}));
+        f.saveFile(filename);
+        
+        // load
+        INIFile f2;
+        f2.loadFile(filename);
+
+        auto out_map = f2.get("key_map", {}).toMap();
+        auto out_hash = f2.get("key_hash", {}).toHash();
+
+        QCOMPARE(out_map, map);
+        QCOMPARE(out_hash, hash);
+        QCOMPARE(f2.get("group1/key1", 1).toInt(), 1);
+        QCOMPARE(f2.get("group1/key2", "a").toString(), "a");
+        QCOMPARE(f2.get("group2/sub1/key1", 2).toInt(), 2);
+        QCOMPARE(f2.get("group2/sub2/key1", "b").toString(), "b");
+        QCOMPARE(f2.get({"group3", "key1"}, QVariantList({})).toList(), QVariantList({"This is a string", 1000, false}));
+
     }
 };
 


### PR DESCRIPTION
Adds an "update" colume to the mods page with checkboxs for if the mod should be updated by the "check updates" button.

unticking the checkbox adds the mod's name to a settings array of "UpdateIgnoreList" under a "Mods" section.
this list is passed as a black list to the update tasks.

- sidebar & context menu action are added to disable/enable mod updates for selected groups
- blacklist is ignored for explicit selection when clicking "check for updates"

this PR also adds a context menu to the tree view header to hide and unhide columns in "External Resource" pages.

This PR *also* fixes a bug where selecting a mod in the list would also toggle it's "enabled" checkbox.

Note that the verison and timestamp colums are hidden in the below screenshot
![2023-05-16_19-08](https://github.com/PrismLauncher/PrismLauncher/assets/508861/74bb7ef2-fcee-472c-9de1-b294afc3bfe5)


