### PR TITLE
fix: System theme colors on windows

### DIFF
--- a/launcher/ui/themes/SystemTheme.cpp
+++ b/launcher/ui/themes/SystemTheme.cpp
@@ -43,7 +43,7 @@ SystemTheme::SystemTheme()
 {
     themeDebugLog() << "Determining System Theme...";
     const auto& style = QApplication::style();
-    systemPalette = style->standardPalette();
+    systemPalette = QApplication::palette();
     QString lowerThemeName = style->objectName();
     themeDebugLog() << "System theme seems to be:" << lowerThemeName;
     QStringList styles = QStyleFactory::keys();


### PR DESCRIPTION
apparently changing this one line fixes the colors on windows, needs testing to see if it breaks anything on other platforms and if it actually works universally

fixes #1085 
bug introduced with Qt 6.5.0 in #983
possibly related Qt bug report: https://bugreports.qt.io/browse/QTBUG-58268