### PR TITLE
Refactor Nix Flake

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,1 +1,14 @@
-(import nix/flake-compat.nix).defaultNix
+(
+  import
+  (
+    let
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in
+      fetchTarball {
+        url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+        sha256 = lock.nodes.flake-compat.locked.narHash;
+      }
+  )
+  {src = ./.;}
+)
+.defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -16,29 +16,34 @@
         "type": "github"
       }
     },
-    "flake-compat_2": {
-      "flake": false,
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
       "locked": {
-        "lastModified": 1673956053,
-        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "lastModified": 1683560683,
+        "narHash": "sha256-XAygPMN5Xnk/W2c1aW0jyEa6lfMDZWlQgiNtmHXytPc=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "006c75898cf814ef9497252b022e91c946ba8e17",
         "type": "github"
       },
       "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
         "type": "github"
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1676283394,
-        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
         "type": "github"
       },
       "original": {
@@ -100,33 +105,37 @@
         "type": "github"
       }
     },
-    "nixpkgs-stable": {
+    "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1673800717,
-        "narHash": "sha256-SFHraUqLSu5cC6IxTprex/nTsI81ZQAtDvlBvGDWfnA=",
+        "dir": "lib",
+        "lastModified": 1682879489,
+        "narHash": "sha256-sASwo8gBt7JDnOOstnps90K1wxmVfyhsTPPNTGBPjjg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2f9fd351ec37f5d479556cd48be4ca340da59b8f",
+        "rev": "da45bf6ec7bbcc5d1e14d3795c025199f28e0de0",
         "type": "github"
       },
       "original": {
+        "dir": "lib",
         "owner": "NixOS",
-        "ref": "nixos-22.11",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "pre-commit-hooks": {
       "inputs": {
-        "flake-compat": "flake-compat_2",
-        "flake-utils": [
-          "flake-utils"
+        "flake-compat": [
+          "flake-compat"
         ],
+        "flake-utils": "flake-utils",
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixpkgs"
         ],
-        "nixpkgs-stable": "nixpkgs-stable"
+        "nixpkgs-stable": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1678376203,
@@ -145,10 +154,25 @@
     "root": {
       "inputs": {
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
+        "flake-parts": "flake-parts",
         "libnbtplusplus": "libnbtplusplus",
         "nixpkgs": "nixpkgs",
         "pre-commit-hooks": "pre-commit-hooks"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -35,15 +35,12 @@
       }
     },
     "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
         "type": "github"
       },
       "original": {
@@ -91,11 +88,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1678693419,
-        "narHash": "sha256-bbSv5yqZAW6dz+3f3f3pOUZbxpPN+3OgCljgn7P+nnQ=",
+        "lastModified": 1685012353,
+        "narHash": "sha256-U3oOge4cHnav8OLGdRVhL45xoRj4Ppd+It6nPC9nNIU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8e3fad82be64c06fbfb9fd43993aec9ef4623936",
+        "rev": "aeb75dba965e790de427b73315d5addf91a54955",
         "type": "github"
       },
       "original": {
@@ -138,11 +135,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1678376203,
-        "narHash": "sha256-3tyYGyC8h7fBwncLZy5nCUjTJPrHbmNwp47LlNLOHSM=",
+        "lastModified": 1684842236,
+        "narHash": "sha256-rYWsIXHvNhVQ15RQlBUv67W3YnM+Pd+DuXGMvCBq2IE=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "1a20b9708962096ec2481eeb2ddca29ed747770a",
+        "rev": "61e567d6497bc9556f391faebe5e410e6623217f",
         "type": "github"
       },
       "original": {
@@ -158,21 +155,6 @@
         "libnbtplusplus": "libnbtplusplus",
         "nixpkgs": "nixpkgs",
         "pre-commit-hooks": "pre-commit-hooks"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -3,11 +3,12 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
+    flake-parts.url = "github:hercules-ci/flake-parts";
     pre-commit-hooks = {
       url = "github:cachix/pre-commit-hooks.nix";
       inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-utils.follows = "flake-utils";
+      inputs.nixpkgs-stable.follows = "nixpkgs";
+      inputs.flake-compat.follows = "flake-compat";
     };
     flake-compat = {
       url = "github:edolstra/flake-compat";
@@ -19,73 +20,8 @@
     };
   };
 
-  outputs = {
-    self,
-    nixpkgs,
-    flake-utils,
-    pre-commit-hooks,
-    libnbtplusplus,
-    ...
-  }: let
-    # User-friendly version number.
-    version = builtins.substring 0 8 self.lastModifiedDate;
-
-    # Supported systems (qtbase is currently broken for "aarch64-darwin")
-    supportedSystems = with flake-utils.lib.system; [
-      x86_64-linux
-      x86_64-darwin
-      aarch64-linux
-    ];
-
-    packagesFn = pkgs: {
-      prismlauncher-qt5 = pkgs.libsForQt5.callPackage ./nix {
-        inherit version self libnbtplusplus;
-      };
-      prismlauncher = pkgs.qt6Packages.callPackage ./nix {
-        inherit version self libnbtplusplus;
-      };
-    };
-  in
-    flake-utils.lib.eachSystem supportedSystems (system: let
-      pkgs = nixpkgs.legacyPackages.${system};
-    in {
-      checks = {
-        pre-commit-check = pre-commit-hooks.lib.${system}.run {
-          src = ./.;
-          hooks = {
-            markdownlint.enable = true;
-
-            alejandra.enable = true;
-            deadnix.enable = true;
-
-            clang-format = {
-              enable =
-                false; # As most of the codebase is **not** formatted, we don't want clang-format yet
-              types_or = ["c" "c++"];
-            };
-          };
-        };
-      };
-
-      packages = let
-        packages = packagesFn pkgs;
-      in
-        packages // {default = packages.prismlauncher;};
-
-      devShells.default = pkgs.mkShell {
-        inherit (self.checks.${system}.pre-commit-check) shellHook;
-        packages = with pkgs; [
-          nodePackages.markdownlint-cli
-          alejandra
-          deadnix
-          clang-tools
-        ];
-
-        inputsFrom = [self.packages.${system}.default];
-        buildInputs = with pkgs; [ccache ninja];
-      };
-    })
-    // {
-      overlays.default = final: _: (packagesFn final);
-    };
+  outputs = inputs:
+    inputs.flake-parts.lib.mkFlake
+    {inherit inputs;}
+    {imports = [./nix];};
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,100 +1,32 @@
 {
-  lib,
-  stdenv,
-  cmake,
-  ninja,
-  jdk8,
-  jdk17,
-  zlib,
-  file,
-  wrapQtAppsHook,
-  xorg,
-  libpulseaudio,
-  qtbase,
-  qtsvg,
-  qtwayland,
-  libGL,
-  quazip,
-  glfw,
-  openal,
-  extra-cmake-modules,
-  tomlplusplus,
-  ghc_filesystem,
-  cmark,
-  msaClientID ? "",
-  jdks ? [jdk17 jdk8],
-  gamemodeSupport ? true,
-  gamemode,
-  # flake
+  inputs,
   self,
-  version,
-  libnbtplusplus,
-}:
-stdenv.mkDerivation rec {
-  pname = "prismlauncher";
-  inherit version;
-
-  src = lib.cleanSource self;
-
-  nativeBuildInputs = [extra-cmake-modules cmake file jdk17 ninja wrapQtAppsHook];
-  buildInputs =
-    [
-      qtbase
-      qtsvg
-      zlib
-      quazip
-      ghc_filesystem
-      tomlplusplus
-      cmark
-    ]
-    ++ lib.optional (lib.versionAtLeast qtbase.version "6") qtwayland
-    ++ lib.optional gamemodeSupport gamemode.dev;
-
-  cmakeFlags =
-    lib.optionals (msaClientID != "") ["-DLauncher_MSA_CLIENT_ID=${msaClientID}"]
-    ++ lib.optionals (lib.versionOlder qtbase.version "6") ["-DLauncher_QT_VERSION_MAJOR=5"];
-
-  postUnpack = ''
-    rm -rf source/libraries/libnbtplusplus
-    mkdir source/libraries/libnbtplusplus
-    ln -s ${libnbtplusplus}/* source/libraries/libnbtplusplus
-    chmod -R +r+w source/libraries/libnbtplusplus
-    chown -R $USER: source/libraries/libnbtplusplus
-  '';
-
-  qtWrapperArgs = let
-    libpath = with xorg;
-      lib.makeLibraryPath ([
-          libX11
-          libXext
-          libXcursor
-          libXrandr
-          libXxf86vm
-          libpulseaudio
-          libGL
-          glfw
-          openal
-          stdenv.cc.cc.lib
-        ]
-        ++ lib.optional gamemodeSupport gamemode.lib);
-  in [
-    "--set LD_LIBRARY_PATH /run/opengl-driver/lib:${libpath}"
-    "--prefix PRISMLAUNCHER_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks}"
-    # xorg.xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
-    "--prefix PATH : ${lib.makeBinPath [xorg.xrandr]}"
+  ...
+}: {
+  imports = [
+    ./dev.nix
+    ./distribution.nix
   ];
 
-  meta = with lib; {
-    homepage = "https://prismlauncher.org/";
-    description = "A free, open source launcher for Minecraft";
-    longDescription = ''
-      Allows you to have multiple, separate instances of Minecraft (each with
-      their own mods, texture packs, saves, etc) and helps you manage them and
-      their associated options with a simple interface.
-    '';
-    platforms = platforms.linux;
-    changelog = "https://github.com/PrismLauncher/PrismLauncher/releases/tag/${version}";
-    license = licenses.gpl3Only;
-    maintainers = with maintainers; [minion3665 Scrumplex];
+  _module.args = {
+    # User-friendly version number.
+    version = builtins.substring 0 8 self.lastModifiedDate;
   };
+
+  perSystem = {system, ...}: {
+    # Nixpkgs instantiated for supported systems with our overlay.
+    _module.args.pkgs = import inputs.nixpkgs {
+      inherit system;
+      overlays = [self.overlays.default];
+    };
+  };
+
+  # Supported systems.
+  systems = [
+    "x86_64-linux"
+    "x86_64-darwin"
+    "aarch64-linux"
+    # Disabled due to qtbase being currently broken for "aarch64-darwin."
+    # "aarch64-darwin"
+  ];
 }

--- a/nix/dev.nix
+++ b/nix/dev.nix
@@ -16,6 +16,7 @@
 
           alejandra.enable = true;
           deadnix.enable = true;
+          nil.enable = true;
 
           clang-format = {
             enable =
@@ -33,6 +34,7 @@
         alejandra
         deadnix
         clang-tools
+        nil
       ];
 
       inputsFrom = [self.packages.${system}.default];

--- a/nix/dev.nix
+++ b/nix/dev.nix
@@ -1,0 +1,44 @@
+{
+  inputs,
+  self,
+  ...
+}: {
+  perSystem = {
+    system,
+    pkgs,
+    ...
+  }: {
+    checks = {
+      pre-commit-check = inputs.pre-commit-hooks.lib.${system}.run {
+        src = self;
+        hooks = {
+          markdownlint.enable = true;
+
+          alejandra.enable = true;
+          deadnix.enable = true;
+
+          clang-format = {
+            enable =
+              false; # As most of the codebase is **not** formatted, we don't want clang-format yet
+            types_or = ["c" "c++"];
+          };
+        };
+      };
+    };
+
+    devShells.default = pkgs.mkShell {
+      inherit (self.checks.${system}.pre-commit-check) shellHook;
+      packages = with pkgs; [
+        nodePackages.markdownlint-cli
+        alejandra
+        deadnix
+        clang-tools
+      ];
+
+      inputsFrom = [self.packages.${system}.default];
+      buildInputs = with pkgs; [ccache ninja];
+    };
+
+    formatter = pkgs.alejandra;
+  };
+}

--- a/nix/distribution.nix
+++ b/nix/distribution.nix
@@ -6,13 +6,13 @@
 }: {
   perSystem = {pkgs, ...}: {
     packages = {
-      inherit (pkgs) prismlauncher prismlauncher-qt5;
+      inherit (pkgs) prismlauncher-qt5-unwrapped prismlauncher-qt5 prismlauncher-unwrapped prismlauncher;
       default = pkgs.prismlauncher;
     };
   };
 
   flake = {
-    overlays.default = _: prev: let
+    overlays.default = final: prev: let
       # Helper function to build prism against different versions of Qt.
       mkPrism = qt:
         qt.callPackage ./package.nix {
@@ -20,8 +20,10 @@
           inherit self version;
         };
     in {
-      prismlauncher = mkPrism prev.qt6Packages;
-      prismlauncher-qt5 = mkPrism prev.libsForQt5;
+      prismlauncher-qt5-unwrapped = mkPrism final.libsForQt5;
+      prismlauncher-qt5 = prev.prismlauncher-qt5.override {inherit (final) prismlauncher-unwrapped;};
+      prismlauncher-unwrapped = mkPrism final.qt6Packages;
+      prismlauncher = prev.prismlauncher.override {inherit (final) prismlauncher-unwrapped;};
     };
   };
 }

--- a/nix/distribution.nix
+++ b/nix/distribution.nix
@@ -21,7 +21,7 @@
         };
     in {
       prismlauncher-qt5-unwrapped = mkPrism final.libsForQt5;
-      prismlauncher-qt5 = prev.prismlauncher-qt5.override {inherit (final) prismlauncher-unwrapped;};
+      prismlauncher-qt5 = prev.prismlauncher-qt5.override {prismlauncher-unwrapped = final.prismlauncher-qt5-unwrapped;};
       prismlauncher-unwrapped = mkPrism final.qt6Packages;
       prismlauncher = prev.prismlauncher.override {inherit (final) prismlauncher-unwrapped;};
     };

--- a/nix/distribution.nix
+++ b/nix/distribution.nix
@@ -1,0 +1,27 @@
+{
+  inputs,
+  self,
+  version,
+  ...
+}: {
+  perSystem = {pkgs, ...}: {
+    packages = {
+      inherit (pkgs) prismlauncher prismlauncher-qt5;
+      default = pkgs.prismlauncher;
+    };
+  };
+
+  flake = {
+    overlays.default = _: prev: let
+      # Helper function to build prism against different versions of Qt.
+      mkPrism = qt:
+        qt.callPackage ./package.nix {
+          inherit (inputs) libnbtplusplus;
+          inherit self version;
+        };
+    in {
+      prismlauncher = mkPrism prev.qt6Packages;
+      prismlauncher-qt5 = mkPrism prev.libsForQt5;
+    };
+  };
+}

--- a/nix/flake-compat.nix
+++ b/nix/flake-compat.nix
@@ -1,9 +1,0 @@
-let
-  lock = builtins.fromJSON (builtins.readFile ../flake.lock);
-  inherit (lock.nodes.flake-compat.locked) rev narHash;
-  flake-compat = fetchTarball {
-    url = "https://github.com/edolstra/flake-compat/archive/${rev}.tar.gz";
-    sha256 = narHash;
-  };
-in
-  import flake-compat {src = ../.;}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,100 @@
+{
+  lib,
+  stdenv,
+  cmake,
+  ninja,
+  jdk8,
+  jdk17,
+  zlib,
+  file,
+  wrapQtAppsHook,
+  xorg,
+  libpulseaudio,
+  qtbase,
+  qtsvg,
+  qtwayland,
+  libGL,
+  quazip,
+  glfw,
+  openal,
+  extra-cmake-modules,
+  tomlplusplus,
+  ghc_filesystem,
+  cmark,
+  msaClientID ? "",
+  jdks ? [jdk17 jdk8],
+  gamemodeSupport ? true,
+  gamemode,
+  # flake
+  self,
+  version,
+  libnbtplusplus,
+}:
+stdenv.mkDerivation rec {
+  pname = "prismlauncher";
+  inherit version;
+
+  src = lib.cleanSource self;
+
+  nativeBuildInputs = [extra-cmake-modules cmake file jdk17 ninja wrapQtAppsHook];
+  buildInputs =
+    [
+      qtbase
+      qtsvg
+      zlib
+      quazip
+      ghc_filesystem
+      tomlplusplus
+      cmark
+    ]
+    ++ lib.optional (lib.versionAtLeast qtbase.version "6") qtwayland
+    ++ lib.optional gamemodeSupport gamemode.dev;
+
+  cmakeFlags =
+    lib.optionals (msaClientID != "") ["-DLauncher_MSA_CLIENT_ID=${msaClientID}"]
+    ++ lib.optionals (lib.versionOlder qtbase.version "6") ["-DLauncher_QT_VERSION_MAJOR=5"];
+
+  postUnpack = ''
+    rm -rf source/libraries/libnbtplusplus
+    mkdir source/libraries/libnbtplusplus
+    ln -s ${libnbtplusplus}/* source/libraries/libnbtplusplus
+    chmod -R +r+w source/libraries/libnbtplusplus
+    chown -R $USER: source/libraries/libnbtplusplus
+  '';
+
+  qtWrapperArgs = let
+    libpath = with xorg;
+      lib.makeLibraryPath ([
+          libX11
+          libXext
+          libXcursor
+          libXrandr
+          libXxf86vm
+          libpulseaudio
+          libGL
+          glfw
+          openal
+          stdenv.cc.cc.lib
+        ]
+        ++ lib.optional gamemodeSupport gamemode.lib);
+  in [
+    "--set LD_LIBRARY_PATH /run/opengl-driver/lib:${libpath}"
+    "--prefix PRISMLAUNCHER_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks}"
+    # xorg.xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
+    "--prefix PATH : ${lib.makeBinPath [xorg.xrandr]}"
+  ];
+
+  meta = with lib; {
+    homepage = "https://prismlauncher.org/";
+    description = "A free, open source launcher for Minecraft";
+    longDescription = ''
+      Allows you to have multiple, separate instances of Minecraft (each with
+      their own mods, texture packs, saves, etc) and helps you manage them and
+      their associated options with a simple interface.
+    '';
+    platforms = platforms.linux;
+    changelog = "https://github.com/PrismLauncher/PrismLauncher/releases/tag/${version}";
+    license = licenses.gpl3Only;
+    maintainers = with maintainers; [minion3665 Scrumplex];
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -3,86 +3,51 @@
   stdenv,
   cmake,
   ninja,
-  jdk8,
   jdk17,
   zlib,
-  file,
-  wrapQtAppsHook,
-  xorg,
-  libpulseaudio,
   qtbase,
-  qtsvg,
-  qtwayland,
-  libGL,
   quazip,
-  glfw,
-  openal,
   extra-cmake-modules,
   tomlplusplus,
-  ghc_filesystem,
   cmark,
-  msaClientID ? "",
-  jdks ? [jdk17 jdk8],
-  gamemodeSupport ? true,
+  ghc_filesystem,
   gamemode,
-  # flake
+  msaClientID ? null,
+  gamemodeSupport ? true,
   self,
   version,
   libnbtplusplus,
 }:
 stdenv.mkDerivation rec {
-  pname = "prismlauncher";
+  pname = "prismlauncher-unwrapped";
   inherit version;
 
   src = lib.cleanSource self;
 
-  nativeBuildInputs = [extra-cmake-modules cmake file jdk17 ninja wrapQtAppsHook];
+  nativeBuildInputs = [extra-cmake-modules cmake jdk17 ninja];
   buildInputs =
     [
       qtbase
-      qtsvg
       zlib
       quazip
       ghc_filesystem
       tomlplusplus
       cmark
     ]
-    ++ lib.optional (lib.versionAtLeast qtbase.version "6") qtwayland
-    ++ lib.optional gamemodeSupport gamemode.dev;
+    ++ lib.optional gamemodeSupport gamemode;
+
+  hardeningEnable = ["pie"];
 
   cmakeFlags =
-    lib.optionals (msaClientID != "") ["-DLauncher_MSA_CLIENT_ID=${msaClientID}"]
+    lib.optionals (msaClientID != null) ["-DLauncher_MSA_CLIENT_ID=${msaClientID}"]
     ++ lib.optionals (lib.versionOlder qtbase.version "6") ["-DLauncher_QT_VERSION_MAJOR=5"];
 
   postUnpack = ''
     rm -rf source/libraries/libnbtplusplus
-    mkdir source/libraries/libnbtplusplus
-    ln -s ${libnbtplusplus}/* source/libraries/libnbtplusplus
-    chmod -R +r+w source/libraries/libnbtplusplus
-    chown -R $USER: source/libraries/libnbtplusplus
+    ln -s ${libnbtplusplus} source/libraries/libnbtplusplus
   '';
 
-  qtWrapperArgs = let
-    libpath = with xorg;
-      lib.makeLibraryPath ([
-          libX11
-          libXext
-          libXcursor
-          libXrandr
-          libXxf86vm
-          libpulseaudio
-          libGL
-          glfw
-          openal
-          stdenv.cc.cc.lib
-        ]
-        ++ lib.optional gamemodeSupport gamemode.lib);
-  in [
-    "--set LD_LIBRARY_PATH /run/opengl-driver/lib:${libpath}"
-    "--prefix PRISMLAUNCHER_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks}"
-    # xorg.xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
-    "--prefix PATH : ${lib.makeBinPath [xorg.xrandr]}"
-  ];
+  dontWrapQtApps = true;
 
   meta = with lib; {
     homepage = "https://prismlauncher.org/";

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,11 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
-  ]
+  ],
+  "nix": {
+    "enabled": true
+  },
+  "lockFileMaintenance": {
+    "enabled": true
+  }
 }


### PR DESCRIPTION
this makes a few opinionated changes to the flake, mainly moving from flake-utils to [flake-parts](https://flake.parts/). i think this is a good fit for the project as we already had other functions separated into the `nix/` folder, and flake-parts allows us to do this in a much more efficient way. 

other notable changes include using the overlay from `self` to create the `packages` attrset (since there's not much point in fully evaluating a package function twice), adding [nil](https://github.com/oxalica/nil) as a pre-commit hook, and officially setting the formatter to alejandra after https://github.com/PrismLauncher/PrismLauncher/commit/9dff1bac838b5a827b1e323bdc983b0f7d1e61bd

i have also enabled nix lockfile maintenance for renovate, which should help us make sure we're able to consistently build against latest unstable :)