### PR TITLE
Validate input lengths on mrpack export

### DIFF
--- a/launcher/ui/dialogs/ExportMrPackDialog.cpp
+++ b/launcher/ui/dialogs/ExportMrPackDialog.cpp
@@ -26,6 +26,7 @@
 #include <QFileSystemModel>
 #include <QJsonDocument>
 #include <QMessageBox>
+#include <QPushButton>
 #include "FastFileIconProvider.h"
 #include "FileSystem.h"
 #include "MMCZip.h"
@@ -37,6 +38,13 @@ ExportMrPackDialog::ExportMrPackDialog(InstancePtr instance, QWidget* parent)
     ui->setupUi(this);
     ui->name->setText(instance->name());
     ui->summary->setText(instance->notes().split(QRegularExpression("\\r?\\n"))[0]);
+
+    // ensure a valid pack is generated
+    // the name and version fields mustn't be empty
+    connect(ui->name, &QLineEdit::textEdited, this, &ExportMrPackDialog::validate);
+    connect(ui->version, &QLineEdit::textEdited, this, &ExportMrPackDialog::validate);
+    // the instance name can technically be empty
+    validate();
 
     QFileSystemModel* model = new QFileSystemModel(this);
     model->setIconProvider(&icons);
@@ -106,4 +114,10 @@ void ExportMrPackDialog::done(int result)
     }
 
     QDialog::done(result);
+}
+
+void ExportMrPackDialog::validate()
+{
+    const bool invalid = ui->name->text().isEmpty() || ui->version->text().isEmpty();
+    ui->buttonBox->button(QDialogButtonBox::Ok)->setDisabled(invalid);
 }

--- a/launcher/ui/dialogs/ExportMrPackDialog.h
+++ b/launcher/ui/dialogs/ExportMrPackDialog.h
@@ -35,6 +35,7 @@ class ExportMrPackDialog : public QDialog {
     ~ExportMrPackDialog();
 
     void done(int result) override;
+    void validate();
 
    private:
     const InstancePtr instance;

--- a/launcher/ui/dialogs/ExportMrPackDialog.ui
+++ b/launcher/ui/dialogs/ExportMrPackDialog.ui
@@ -51,7 +51,11 @@
        <widget class="QLineEdit" name="name"/>
       </item>
       <item row="1" column="1">
-       <widget class="QLineEdit" name="version"/>
+       <widget class="QLineEdit" name="version">
+        <property name="text">
+         <string>1.0.0</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
Previously I thought Modrinth's website allowed you to alter to name after uploading the file, but it seems the version title and name in the json is distinct (same with version number).