### PR TITLE
Renamed requires

### DIFF
--- a/launcher/meta/JsonFormat.cpp
+++ b/launcher/meta/JsonFormat.cpp
@@ -56,10 +56,10 @@ static Version::Ptr parseCommonVersion(const QString &uid, const QJsonObject &ob
     version->setType(ensureString(obj, "type", QString()));
     version->setRecommended(ensureBoolean(obj, QString("recommended"), false));
     version->setVolatile(ensureBoolean(obj, QString("volatile"), false));
-    RequireSet requires, conflicts;
-    parseRequires(obj, &requires, "requires");
+    RequireSet reqs, conflicts;
+    parseRequires(obj, &reqs, "requires");
     parseRequires(obj, &conflicts, "conflicts");
-    version->setRequires(requires, conflicts);
+    version->setRequires(reqs, conflicts);
     return version;
 }
 
@@ -176,7 +176,6 @@ void parseRequires(const QJsonObject& obj, RequireSet* ptr, const char * keyName
 {
     if(obj.contains(keyName))
     {
-        QSet<QString> requires;
         auto reqArray = requireArray(obj, keyName);
         auto iter = reqArray.begin();
         while(iter != reqArray.end())

--- a/launcher/meta/Version.cpp
+++ b/launcher/meta/Version.cpp
@@ -116,9 +116,9 @@ void Meta::Version::setTime(const qint64 time)
     emit timeChanged();
 }
 
-void Meta::Version::setRequires(const Meta::RequireSet &requires, const Meta::RequireSet &conflicts)
+void Meta::Version::setRequires(const Meta::RequireSet &reqs, const Meta::RequireSet &conflicts)
 {
-    m_requires = requires;
+    m_requires = reqs;
     m_conflicts = conflicts;
     emit requiresChanged();
 }

--- a/launcher/meta/Version.h
+++ b/launcher/meta/Version.h
@@ -63,7 +63,7 @@ public:
     {
         return m_time;
     }
-    const Meta::RequireSet &requires() const
+    const Meta::RequireSet &requiredSet() const
     {
         return m_requires;
     }
@@ -91,7 +91,7 @@ public:
 public: // for usage by format parsers only
     void setType(const QString &type);
     void setTime(const qint64 time);
-    void setRequires(const Meta::RequireSet &requires, const Meta::RequireSet &conflicts);
+    void setRequires(const Meta::RequireSet &reqs, const Meta::RequireSet &conflicts);
     void setVolatile(bool volatile_);
     void setRecommended(bool recommended);
     void setProvidesRecommendations();

--- a/launcher/meta/VersionList.cpp
+++ b/launcher/meta/VersionList.cpp
@@ -77,7 +77,7 @@ QVariant VersionList::data(const QModelIndex &index, int role) const
     case ParentVersionRole:
     {
         // FIXME: HACK: this should be generic and be replaced by something else. Anything that is a hard 'equals' dep is a 'parent uid'.
-        auto & reqs = version->requires();
+        auto & reqs = version->requiredSet();
         auto iter = std::find_if(reqs.begin(), reqs.end(), [](const Require & req)
         {
             return req.uid == "net.minecraft";
@@ -92,7 +92,7 @@ QVariant VersionList::data(const QModelIndex &index, int role) const
 
     case UidRole: return version->uid();
     case TimeRole: return version->time();
-    case RequiresRole: return QVariant::fromValue(version->requires());
+    case RequiresRole: return QVariant::fromValue(version->requiredSet());
     case SortRole: return version->rawTime();
     case VersionPtrRole: return QVariant::fromValue(version);
     case RecommendedRole: return version->isRecommended();

--- a/launcher/minecraft/Component.cpp
+++ b/launcher/minecraft/Component.cpp
@@ -451,9 +451,9 @@ void Component::updateCachedData()
             m_cachedVolatile = file->m_volatile;
             changed = true;
         }
-        if(!deepCompare(m_cachedRequires, file->requires))
+        if(!deepCompare(m_cachedRequires, file->m_requires))
         {
-            m_cachedRequires = file->requires;
+            m_cachedRequires = file->m_requires;
             changed = true;
         }
         if(!deepCompare(m_cachedConflicts, file->conflicts))

--- a/launcher/minecraft/OneSixVersionFormat.cpp
+++ b/launcher/minecraft/OneSixVersionFormat.cpp
@@ -276,7 +276,7 @@ VersionFilePtr OneSixVersionFormat::versionFileFromJson(const QJsonDocument &doc
 
     if (root.contains("requires"))
     {
-        Meta::parseRequires(root, &out->requires);
+        Meta::parseRequires(root, &out->m_requires);
     }
     QString dependsOnMinecraftVersion = root.value("mcVersion").toString();
     if(!dependsOnMinecraftVersion.isEmpty())
@@ -284,9 +284,9 @@ VersionFilePtr OneSixVersionFormat::versionFileFromJson(const QJsonDocument &doc
         Meta::Require mcReq;
         mcReq.uid = "net.minecraft";
         mcReq.equalsVersion = dependsOnMinecraftVersion;
-        if (out->requires.count(mcReq) == 0)
+        if (out->m_requires.count(mcReq) == 0)
         {
-            out->requires.insert(mcReq);
+            out->m_requires.insert(mcReq);
         }
     }
     if (root.contains("conflicts"))
@@ -392,9 +392,9 @@ QJsonDocument OneSixVersionFormat::versionFileToJson(const VersionFilePtr &patch
         }
         root.insert("mods", array);
     }
-    if(!patch->requires.empty())
+    if(!patch->m_requires.empty())
     {
-        Meta::serializeRequires(root, &patch->requires, "requires");
+        Meta::serializeRequires(root, &patch->m_requires, "requires");
     }
     if(!patch->conflicts.empty())
     {

--- a/launcher/minecraft/VersionFile.h
+++ b/launcher/minecraft/VersionFile.h
@@ -138,7 +138,7 @@ public: /* data */
      * Prism Launcher: set of packages this depends on
      * NOTE: this is shared with the meta format!!!
      */
-    Meta::RequireSet requires;
+    Meta::RequireSet m_requires;
 
     /**
      * Prism Launcher: set of packages this conflicts with

--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
@@ -352,7 +352,7 @@ QString PackInstallTask::getVersionForLoader(QString uid)
         if(m_version.loader.recommended || m_version.loader.latest) {
             for (int i = 0; i < vlist->versions().size(); i++) {
                 auto version = vlist->versions().at(i);
-                auto reqs = version->requires();
+                auto reqs = version->requiredSet();
 
                 // filter by minecraft version, if the loader depends on a certain version.
                 // not all mod loaders depend on a given Minecraft version, so we won't do this

--- a/launcher/ui/pages/modplatform/atlauncher/AtlUserInteractionSupportImpl.cpp
+++ b/launcher/ui/pages/modplatform/atlauncher/AtlUserInteractionSupportImpl.cpp
@@ -68,7 +68,7 @@ QString AtlUserInteractionSupportImpl::chooseVersion(Meta::VersionList::Ptr vlis
     // select recommended build
     for (int i = 0; i < vlist->versions().size(); i++) {
         auto version = vlist->versions().at(i);
-        auto reqs = version->requires();
+        auto reqs = version->requiredSet();
 
         // filter by minecraft version, if the loader depends on a certain version.
         if (minecraftVersion != nullptr) {


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
Now that the [requires](https://en.cppreference.com/w/cpp/keyword/requires) is a keyword in C++20 I get a warning regarding that:
```
In file included from ~/.cache/paru/clone/prismlauncher-git/src/PrismLauncher/launcher/meta/Version.h:26,
                 from ~/.cache/paru/clone/prismlauncher-git/src/PrismLauncher/launcher/meta/VersionList.h:23,
                 from ~/.cache/paru/clone/prismlauncher-git/src/PrismLauncher/launcher/meta/Index.h:22,
                 from ~/.cache/paru/clone/prismlauncher-git/src/PrismLauncher/tests/Index_test.cpp:3:
~/.cache/paru/clone/prismlauncher-git/src/PrismLauncher/launcher/minecraft/VersionFile.h:141:22: warning: identifier ‘requires’ is a keyword in C++20 [-Wc++20-compat]
  141 |     Meta::RequireSet requires;
      |                      ^~~~~~~~
```
This PR resolves the mentioned warnings
