### PR TITLE
fix: save meta custom url as string, not QUrl

### DIFF
--- a/launcher/ui/pages/global/APIPage.cpp
+++ b/launcher/ui/pages/global/APIPage.cpp
@@ -177,7 +177,7 @@ void APIPage::applySettings()
         metaURL.setScheme("https");
     }
 
-    s->set("MetaURLOverride", metaURL);
+    s->set("MetaURLOverride", metaURL.toString());
     QString flameKey = ui->flameKey->text();
     s->set("FlameKeyOverride", flameKey);
     QString modrinthToken = ui->modrinthToken->text();


### PR DESCRIPTION
(hopefully) fixes #1113 

config file with current develop when inputting a working url: 
![image](https://github.com/PrismLauncher/PrismLauncher/assets/31988415/88b352b8-8364-44e0-9d45-60277e24bf7f)

config file with this PR with same working url:
![image](https://github.com/PrismLauncher/PrismLauncher/assets/31988415/4b5c844e-f7e9-42e4-b14f-1c97d41c3795)

