### PR TITLE
fix: fix crash when selecting resource/texture/shader packs

### DIFF
--- a/launcher/ui/dialogs/ResourceDownloadDialog.cpp
+++ b/launcher/ui/dialogs/ResourceDownloadDialog.cpp
@@ -253,6 +253,8 @@ QList<BasePage*> ResourcePackDownloadDialog::getPages()
     if (APPLICATION->capabilities() & Application::SupportsFlame)
         pages.append(FlameResourcePackPage::create(this, *m_instance));
 
+    m_selectedPage = dynamic_cast<ResourcePackResourcePage*>(pages[0]);
+
     return pages;
 }
 
@@ -278,6 +280,8 @@ QList<BasePage*> TexturePackDownloadDialog::getPages()
     if (APPLICATION->capabilities() & Application::SupportsFlame)
         pages.append(FlameTexturePackPage::create(this, *m_instance));
 
+    m_selectedPage = dynamic_cast<TexturePackResourcePage*>(pages[0]);
+
     return pages;
 }
 
@@ -300,6 +304,8 @@ QList<BasePage*> ShaderPackDownloadDialog::getPages()
     QList<BasePage*> pages;
 
     pages.append(ModrinthShaderPackPage::create(this, *m_instance));
+
+    m_selectedPage = dynamic_cast<ShaderPackResourcePage*>(pages[0]);
 
     return pages;
 }


### PR DESCRIPTION
`m_selectedPage` was a nullptr on the resource, texture and shader packs download pages until another page was selected