### PR TITLE
Resolve fallthrough issues around codebase

### DIFF
--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -187,8 +187,8 @@ void LaunchController::login() {
         switch(m_accountToUse->accountState()) {
             case AccountState::Offline: {
                 m_session->wants_online = false;
-                // NOTE: fallthrough is intentional
             }
+            /* fallthrough */
             case AccountState::Online: {
                 if(!m_session->wants_online) {
                     // we ask the user for a player name
@@ -267,8 +267,8 @@ void LaunchController::login() {
                 // This means some sort of soft error that we can fix with a refresh ... so let's refresh.
             case AccountState::Unchecked: {
                 m_accountToUse->refresh();
-                // NOTE: fallthrough intentional
             }
+            /* fallthrough */
             case AccountState::Working: {
                 // refresh is in progress, we need to wait for it to finish to proceed.
                 ProgressDialog progDialog(m_parentWidget);

--- a/launcher/VersionProxyModel.cpp
+++ b/launcher/VersionProxyModel.cpp
@@ -185,80 +185,50 @@ QVariant VersionProxyModel::data(const QModelIndex &index, int role) const
                     return QVariant();
             }
         }
-        case Qt::ToolTipRole:
-        {
-            switch(column)
-            {
-                case Name:
-                {
-                    if(hasRecommended)
+        case Qt::ToolTipRole: {
+            if (column == Name && hasRecommended) {
+                auto value = sourceModel()->data(parentIndex, BaseVersionList::RecommendedRole);
+                if(value.toBool()) {
+                    return tr("Recommended");
+                }
+                else if(hasLatest) {
+                    auto value = sourceModel()->data(parentIndex, BaseVersionList::LatestRole);
+                    if(value.toBool())
                     {
-                        auto value = sourceModel()->data(parentIndex, BaseVersionList::RecommendedRole);
-                        if(value.toBool())
-                        {
-                            return tr("Recommended");
-                        }
-                        else if(hasLatest)
-                        {
-                            auto value = sourceModel()->data(parentIndex, BaseVersionList::LatestRole);
-                            if(value.toBool())
-                            {
-                                return tr("Latest");
-                            }
-                        }
-                        else if(index.row() == 0)
-                        {
-                            return tr("Latest");
-                        }
+                        return tr("Latest");
                     }
                 }
-                default:
-                {
-                    return sourceModel()->data(parentIndex, BaseVersionList::VersionIdRole);
+                else if(index.row() == 0) {
+                    return tr("Latest");
                 }
             }
+            return sourceModel()->data(parentIndex, BaseVersionList::VersionIdRole);
         }
-        case Qt::DecorationRole:
-        {
-            switch(column)
-            {
-                case Name:
-                {
-                    if(hasRecommended)
-                    {
-                        auto value = sourceModel()->data(parentIndex, BaseVersionList::RecommendedRole);
-                        if(value.toBool())
-                        {
-                            return APPLICATION->getThemedIcon("star");
-                        }
-                        else if(hasLatest)
-                        {
-                            auto value = sourceModel()->data(parentIndex, BaseVersionList::LatestRole);
-                            if(value.toBool())
-                            {
-                                return APPLICATION->getThemedIcon("bug");
-                            }
-                        }
-                        else if(index.row() == 0)
-                        {
-                            return APPLICATION->getThemedIcon("bug");
-                        }
-                        QPixmap pixmap;
-                        QPixmapCache::find("placeholder", &pixmap);
-                        if(!pixmap)
-                        {
-                            QPixmap px(16,16);
-                            px.fill(Qt::transparent);
-                            QPixmapCache::insert("placeholder", px);
-                            return px;
-                        }
-                        return pixmap;
+        case Qt::DecorationRole: {
+            if (column == Name && hasRecommended) {
+                auto value = sourceModel()->data(parentIndex, BaseVersionList::RecommendedRole);
+                if(value.toBool()) {
+                    return APPLICATION->getThemedIcon("star");
+                } else if(hasLatest) {
+                    auto value = sourceModel()->data(parentIndex, BaseVersionList::LatestRole);
+                    if(value.toBool()) {
+                        return APPLICATION->getThemedIcon("bug");
                     }
                 }
-                default:
-                {
-                    return QVariant();
+                else if(index.row() == 0) {
+                    return APPLICATION->getThemedIcon("bug");
                 }
+                QPixmap pixmap;
+                QPixmapCache::find("placeholder", &pixmap);
+                if(!pixmap) {
+                    QPixmap px(16,16);
+                    px.fill(Qt::transparent);
+                    QPixmapCache::insert("placeholder", px);
+                    return px;
+                }
+                return pixmap;
+            } else {
+                return QVariant();
             }
         }
         default:

--- a/launcher/meta/Index.cpp
+++ b/launcher/meta/Index.cpp
@@ -48,8 +48,8 @@ QVariant Index::data(const QModelIndex &index, int role) const
         switch (index.column())
         {
         case 0: return list->humanReadable();
-        default: break;
         }
+        break;
     case UidRole: return list->uid();
     case NameRole: return list->name();
     case ListPtrRole: return QVariant::fromValue(list);

--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -328,6 +328,9 @@ QVariant AccountList::data(const QModelIndex &index, int role) const
                     case AccountState::Gone: {
                         return tr("Gone", "Account status");
                     }
+                    case default: {
+                        return tr("Unknown", "Account status");
+                    }
                 }
             }
 

--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -328,7 +328,7 @@ QVariant AccountList::data(const QModelIndex &index, int role) const
                     case AccountState::Gone: {
                         return tr("Gone", "Account status");
                     }
-                    case default: {
+                    default: {
                         return tr("Unknown", "Account status");
                     }
                 }

--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -357,11 +357,12 @@ QVariant AccountList::data(const QModelIndex &index, int role) const
             return QVariant::fromValue(account);
 
         case Qt::CheckStateRole:
-            switch (index.column())
-            {
-                case ProfileNameColumn:
-                    return account == m_defaultAccount ? Qt::Checked : Qt::Unchecked;
+            if (index.column() == ProfileNameColumn) {
+                return account == m_defaultAccount ? Qt::Checked : Qt::Unchecked;
+            } else {
+                return QVariant();
             }
+            
 
         default:
             return QVariant();

--- a/launcher/minecraft/auth/Yggdrasil.cpp
+++ b/launcher/minecraft/auth/Yggdrasil.cpp
@@ -273,6 +273,7 @@ void Yggdrasil::processReply() {
             AccountTaskState::STATE_FAILED_GONE,
             tr("The Mojang account no longer exists. It may have been migrated to a Microsoft account.")
         );
+        return;
     }
     default:
         changeState(

--- a/launcher/minecraft/mod/DataPack.cpp
+++ b/launcher/minecraft/mod/DataPack.cpp
@@ -74,6 +74,7 @@ std::pair<int, bool> DataPack::compare(const Resource& other, SortType type) con
             auto res = Resource::compare(other, type);
             if (res.first != 0)
                 return res;
+            break;
         }
         case SortType::PACK_FORMAT: {
             auto this_ver = packFormat();
@@ -83,6 +84,7 @@ std::pair<int, bool> DataPack::compare(const Resource& other, SortType type) con
                 return { 1, type == SortType::PACK_FORMAT };
             if (this_ver < other_ver)
                 return { -1, type == SortType::PACK_FORMAT };
+            break;
         }
     }
     return { 0, false };

--- a/launcher/minecraft/mod/Mod.cpp
+++ b/launcher/minecraft/mod/Mod.cpp
@@ -89,6 +89,7 @@ std::pair<int, bool> Mod::compare(const Resource& other, SortType type) const
             auto res = Resource::compare(other, type);
             if (res.first != 0)
                 return res;
+            break;
         }
         case SortType::VERSION: {
             auto this_ver = Version(version());
@@ -97,11 +98,13 @@ std::pair<int, bool> Mod::compare(const Resource& other, SortType type) const
                 return { 1, type == SortType::VERSION };
             if (this_ver < other_ver)
                 return { -1, type == SortType::VERSION };
+            break;
         }
         case SortType::PROVIDER: {
             auto compare_result = QString::compare(provider().value_or("Unknown"), cast_other->provider().value_or("Unknown"), Qt::CaseInsensitive);
             if (compare_result != 0)
                 return { compare_result, type == SortType::PROVIDER };
+            break;
         }
     }
     return { 0, false };

--- a/launcher/minecraft/mod/Resource.cpp
+++ b/launcher/minecraft/mod/Resource.cpp
@@ -71,6 +71,7 @@ std::pair<int, bool> Resource::compare(const Resource& other, SortType type) con
                 return { 1, type == SortType::ENABLED };
             if (!enabled() && other.enabled())
                 return { -1, type == SortType::ENABLED };
+            break;
         case SortType::NAME: {
             QString this_name{ name() };
             QString other_name{ other.name() };
@@ -81,12 +82,14 @@ std::pair<int, bool> Resource::compare(const Resource& other, SortType type) con
             auto compare_result = QString::compare(this_name, other_name, Qt::CaseInsensitive);
             if (compare_result != 0)
                 return { compare_result, type == SortType::NAME };
+            break;
         }
         case SortType::DATE:
             if (dateTimeChanged() > other.dateTimeChanged())
                 return { 1, type == SortType::DATE };
             if (dateTimeChanged() < other.dateTimeChanged())
                 return { -1, type == SortType::DATE };
+            break;
     }
 
     return { 0, false };

--- a/launcher/minecraft/mod/ResourcePack.cpp
+++ b/launcher/minecraft/mod/ResourcePack.cpp
@@ -95,6 +95,7 @@ std::pair<int, bool> ResourcePack::compare(const Resource& other, SortType type)
             auto res = Resource::compare(other, type);
             if (res.first != 0)
                 return res;
+            break;
         }
         case SortType::PACK_FORMAT: {
             auto this_ver = packFormat();
@@ -104,6 +105,7 @@ std::pair<int, bool> ResourcePack::compare(const Resource& other, SortType type)
                 return { 1, type == SortType::PACK_FORMAT };
             if (this_ver < other_ver)
                 return { -1, type == SortType::PACK_FORMAT };
+            break;
         }
     }
     return { 0, false };

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -467,8 +467,9 @@ void FlameCreationTask::setupDownloadJob(QEventLoop& loop)
         switch (result.type) {
             case Flame::File::Type::Folder: {
                 logWarning(tr("This 'Folder' may need extracting: %1").arg(relpath));
-                // fall-through intentional, we treat these as plain old mods and dump them wherever.
+                // fallthrough intentional, we treat these as plain old mods and dump them wherever.
             }
+            /* fallthrough */
             case Flame::File::Type::SingleFile:
             case Flame::File::Type::Mod: {
                 if (!result.url.isEmpty()) {

--- a/launcher/translations/TranslationsModel.cpp
+++ b/launcher/translations/TranslationsModel.cpp
@@ -454,6 +454,7 @@ QVariant TranslationsModel::data(const QModelIndex& index, int role) const
                 return QString("%1%").arg(lang.percentTranslated(), 3, 'f', 1);
             }
         }
+        qWarning("TranslationModel::data not implemented when role is DisplayRole");
     }
     case Qt::ToolTipRole:
     {

--- a/launcher/ui/instanceview/AccessibleInstanceView.cpp
+++ b/launcher/ui/instanceview/AccessibleInstanceView.cpp
@@ -248,8 +248,8 @@ bool AccessibleInstanceView::selectColumn(int column)
             if (view()->selectionBehavior() != QAbstractItemView::SelectColumns && rowCount() > 1) {
                 return false;
             }
-            // fallthrough intentional
         }
+        /* fallthrough */
         case QAbstractItemView::ContiguousSelection: {
             if ((!column || !view()->selectionModel()->isColumnSelected(column - 1, view()->rootIndex())) && !view()->selectionModel()->isColumnSelected(column + 1, view()->rootIndex())) {
                 view()->clearSelection();

--- a/launcher/ui/pages/instance/WorldListPage.cpp
+++ b/launcher/ui/pages/instance/WorldListPage.cpp
@@ -338,6 +338,7 @@ void WorldListPage::mceditState(LoggedProcess::State state)
         case LoggedProcess::Aborted:
         {
             failed = true;
+            break;
         }
         case LoggedProcess::Running:
         case LoggedProcess::Finished:

--- a/launcher/ui/setupwizard/JavaWizardPage.cpp
+++ b/launcher/ui/setupwizard/JavaWizardPage.cpp
@@ -69,6 +69,7 @@ bool JavaWizardPage::validatePage()
         case JavaSettingsWidget::ValidationStatus::AllOK:
         {
             settings->set("JavaPath", m_java_widget->javaPath());
+            break;
         }
         case JavaSettingsWidget::ValidationStatus::JavaBad:
         {

--- a/libraries/murmur2/src/MurmurHash2.cpp
+++ b/libraries/murmur2/src/MurmurHash2.cpp
@@ -89,8 +89,10 @@ void FourBytes_MurmurHash2(const unsigned char* data, IncrementalHashInfo& prev)
         switch (prev.len) {
             case 3:
                 prev.h ^= data[2] << 16;
+                /* fall through */
             case 2:
                 prev.h ^= data[1] << 8;
+                /* fall through */
             case 1:
                 prev.h ^= data[0];
                 prev.h *= m;


### PR DESCRIPTION
Benefit: Resolves the warning/error from -Wimplicit-fallthrough
Things done:
- makes it clear that the fallthrough in Murmur2 is not a bug. 
- Add defaults to AccountList.cpp
Unresolved issues:
```
/home/pandaninjas/PrismLauncher/launcher/translations/TranslationsModel.cpp:446:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
/home/pandaninjas/PrismLauncher/launcher/meta/Index.cpp:48:9: warning: this statement may fall through [-Wimplicit-fallthrough=]
/home/pandaninjas/PrismLauncher/launcher/modplatform/flame/FlameInstanceCreationTask.cpp:469:30: warning: this statement may fall through [-Wimplicit-fallthrough=]
/home/pandaninjas/PrismLauncher/launcher/VersionProxyModel.cpp:214:17: warning: this statement may fall through [-Wimplicit-fallthrough=]
/home/pandaninjas/PrismLauncher/launcher/VersionProxyModel.cpp:257:17: warning: this statement may fall through [-Wimplicit-fallthrough=]
/home/pandaninjas/PrismLauncher/launcher/ui/setupwizard/JavaWizardPage.cpp:71:62: warning: this statement may fall through [-Wimplicit-fallthrough=]
/home/pandaninjas/PrismLauncher/launcher/LaunchController.cpp:189:41: warning: this statement may fall through [-Wimplicit-fallthrough=]
/home/pandaninjas/PrismLauncher/launcher/LaunchController.cpp:269:40: warning: this statement may fall through [-Wimplicit-fallthrough=]
/home/pandaninjas/PrismLauncher/launcher/ui/pages/instance/WorldListPage.cpp:340:20: warning: this statement may fall through [-Wimplicit-fallthrough=]
/home/pandaninjas/PrismLauncher/launcher/ui/instanceview/AccessibleInstanceView.cpp:248:13: warning: this statement may fall through [-Wimplicit-fallthrough=]
```