### PR TITLE
chore: bump macOS requirement to 11.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
 
           - os: macos-12
             name: macOS
-            macosx_deployment_target: 10.15
+            macosx_deployment_target: 11.0
             qt_ver: 6
             qt_host: mac
             qt_arch: ''


### PR DESCRIPTION
Noticed only now that Qt 6.5 bumps the macOS requirement to macOS 11. This was basically already effective in prism since with the Qt 6.5 bump pr macOS 10.15 user's wouldn't be able to run this, but updating the requirement here makes it more clear for the end user trying to run prism on macOS 10.15
