### PR TITLE
fix(nix): use prismlauncher-unwrapped in devShell

### DIFF
--- a/nix/dev.nix
+++ b/nix/dev.nix
@@ -37,7 +37,7 @@
         nil
       ];
 
-      inputsFrom = [self.packages.${system}.default];
+      inputsFrom = [self.packages.${system}.prismlauncher-unwrapped];
       buildInputs = with pkgs; [ccache ninja];
     };
 


### PR DESCRIPTION
fixes a regression from https://github.com/PrismLauncher/PrismLauncher/pull/1093 where the devShell didn't have the proper buildInputs due to the wrapped version of prism being used. oopsie!

Signed-off-by: seth <getchoo@tuta.io>
