### PR TITLE
Fix bugs when updating curseforge modpacks

### DIFF
--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -153,6 +153,9 @@ bool FlameCreationTask::updateInstance()
 
                     old_files.remove(file.key());
                     files_iterator = files.erase(files_iterator);
+
+                    if (files_iterator != files.begin())
+                        files_iterator--;
                 }
             }
 


### PR DESCRIPTION
Tiny change to correct some faulty loop behavior. Fixes a segfault I've run into under Qt5. More generally, it should also fix files getting re-downloaded unnecessarily.