### PR TITLE
Add JavaVendor as an instance override

### DIFF
--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -149,9 +149,10 @@ void MinecraftInstance::loadSpecificSettings()
 
         // special!
         m_settings->registerPassthrough(global_settings->getSetting("JavaTimestamp"), javaOrLocation);
-        m_settings->registerPassthrough(global_settings->getSetting("JavaVersion"), javaOrLocation);
         m_settings->registerPassthrough(global_settings->getSetting("JavaArchitecture"), javaOrLocation);
         m_settings->registerPassthrough(global_settings->getSetting("JavaRealArchitecture"), javaOrLocation);
+        m_settings->registerPassthrough(global_settings->getSetting("JavaVersion"), javaOrLocation);
+        m_settings->registerPassthrough(global_settings->getSetting("JavaVendor"), javaOrLocation);
 
         // Window Size
         auto windowSetting = m_settings->registerSetting("OverrideWindow", false);


### PR DESCRIPTION
This should suppress a critical error that gets printed every time an instance gets launched, as JavaCheck wants to store the vendor in the instance settings.

This was probably introduced with the Multi-Arch support I wrote a year ago.