### PR TITLE
Hide the Git commit entry on the About dialog when the build doesn't have git stuff support

### DIFF
--- a/buildconfig/BuildConfig.cpp.in
+++ b/buildconfig/BuildConfig.cpp.in
@@ -82,6 +82,7 @@ Config::Config()
     {
         GIT_REFSPEC = "refs/heads/stable";
         GIT_TAG = versionString();
+        GIT_COMMIT = "";
     }
 
     if (GIT_REFSPEC.startsWith("refs/heads/"))


### PR DESCRIPTION
This hides the Git commit string `GITDIR-NOTFOUND` on the About page when building a package from the bundled source archive. This was introduced by #1140 for packages that use the bundled tar.gz source file :slightly_smiling_face: 
