### PR TITLE
Modrinth: use default icon for non-managed packs

### DIFF
--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
@@ -214,7 +214,7 @@ bool ModrinthCreationTask::createInstance()
 
     if (m_instIcon != "default") {
         instance.setIconKey(m_instIcon);
-    } else {
+    } else if (!m_managed_id.isEmpty()) {
         instance.setIconKey("modrinth");
     }
 


### PR DESCRIPTION
If the modrinth pack isn't managed, the default icon will be used.

Fixes: #317


