### PR TITLE
ScreenshotsPage fixes

### DIFF
--- a/launcher/ui/pages/instance/ScreenshotsPage.cpp
+++ b/launcher/ui/pages/instance/ScreenshotsPage.cpp
@@ -146,7 +146,11 @@ public:
         m_thumbnailCache->add("placeholder", APPLICATION->getThemedIcon("screenshot-placeholder"));
         connect(&watcher, SIGNAL(fileChanged(QString)), SLOT(fileChanged(QString)));
     }
-    virtual ~FilterModel() { m_thumbnailingPool.waitForDone(500); }
+    virtual ~FilterModel() {
+        m_thumbnailingPool.clear();
+        if (!m_thumbnailingPool.waitForDone(500))
+            qDebug() << "Thumbnail pool took longer than 500ms to finish";
+    }
     virtual QVariant data(const QModelIndex &proxyIndex, int role = Qt::DisplayRole) const
     {
         auto model = sourceModel();

--- a/launcher/ui/pages/instance/ScreenshotsPage.cpp
+++ b/launcher/ui/pages/instance/ScreenshotsPage.cpp
@@ -145,7 +145,6 @@ public:
         m_thumbnailCache = std::make_shared<SharedIconCache>();
         m_thumbnailCache->add("placeholder", APPLICATION->getThemedIcon("screenshot-placeholder"));
         connect(&watcher, SIGNAL(fileChanged(QString)), SLOT(fileChanged(QString)));
-        // FIXME: the watched file set is not updated when files are removed
     }
     virtual ~FilterModel() { m_thumbnailingPool.waitForDone(500); }
     virtual QVariant data(const QModelIndex &proxyIndex, int role = Qt::DisplayRole) const
@@ -214,10 +213,12 @@ private slots:
     void fileChanged(QString filepath)
     {
         m_thumbnailCache->setStale(filepath);
-        thumbnailImage(filepath);
         // reinsert the path...
         watcher.removePath(filepath);
-        watcher.addPath(filepath);
+        if (QFile::exists(filepath)) {
+            watcher.addPath(filepath);
+            thumbnailImage(filepath);
+        }
     }
 
 private:

--- a/launcher/ui/pages/instance/ScreenshotsPage.cpp
+++ b/launcher/ui/pages/instance/ScreenshotsPage.cpp
@@ -96,37 +96,30 @@ public:
             return;
         if ((info.suffix().compare("png", Qt::CaseInsensitive) != 0))
             return;
-        int tries = 5;
-        while (tries)
-        {
-            if (!m_cache->stale(m_path))
-                return;
-            QImage image(m_path);
-            if (image.isNull())
-            {
-                QThread::msleep(500);
-                tries--;
-                continue;
-            }
-            QImage small;
-            if (image.width() > image.height())
-                small = image.scaledToWidth(512).scaledToWidth(256, Qt::SmoothTransformation);
-            else
-                small = image.scaledToHeight(512).scaledToHeight(256, Qt::SmoothTransformation);
-            QPoint offset((256 - small.width()) / 2, (256 - small.height()) / 2);
-            QImage square(QSize(256, 256), QImage::Format_ARGB32);
-            square.fill(Qt::transparent);
-
-            QPainter painter(&square);
-            painter.drawImage(offset, small);
-            painter.end();
-
-            QIcon icon(QPixmap::fromImage(square));
-            m_cache->add(m_path, icon);
-            m_resultEmitter.emitResultsReady(m_path);
+        if (!m_cache->stale(m_path))
+            return;
+        QImage image(m_path);
+        if (image.isNull()) {
+            m_resultEmitter.emitResultsFailed(m_path);
+            qDebug() << "Error loading screenshot: " + m_path + ". Perhaps too large?";
             return;
         }
-        m_resultEmitter.emitResultsFailed(m_path);
+        QImage small;
+        if (image.width() > image.height())
+            small = image.scaledToWidth(512).scaledToWidth(256, Qt::SmoothTransformation);
+        else
+            small = image.scaledToHeight(512).scaledToHeight(256, Qt::SmoothTransformation);
+        QPoint offset((256 - small.width()) / 2, (256 - small.height()) / 2);
+        QImage square(QSize(256, 256), QImage::Format_ARGB32);
+        square.fill(Qt::transparent);
+
+        QPainter painter(&square);
+        painter.drawImage(offset, small);
+        painter.end();
+
+        QIcon icon(QPixmap::fromImage(square));
+        m_cache->add(m_path, icon);
+        m_resultEmitter.emitResultsReady(m_path);
     }
     QString m_path;
     SharedIconCachePtr m_cache;


### PR DESCRIPTION
Changes:
- Remove screenshot path from watcher if the file no longer exists.
- Clear the thumbnailing pool on page delete. 
- Do not retry multiple times to thumbnail a null image.

The commit logs have more detail.

Fixes: #1201 

---

This won't fix missing thumbnails for large images that require more memory than the default QImage allocation threshold (>128MiB). Increasing it does not seem worthwhile to me.

I'm only just getting acquainted  with the code base so please point out any pitfalls or issues in what I've done.
FWIW, the changes work for me.