### PR TITLE
Add missing space in java checker debug message

### DIFF
--- a/launcher/java/JavaChecker.cpp
+++ b/launcher/java/JavaChecker.cpp
@@ -128,7 +128,7 @@ void JavaChecker::finished(int exitcode, QProcess::ExitStatus status)
     result.outLog = m_stdout;
     qDebug() << "STDOUT" << m_stdout;
     qWarning() << "STDERR" << m_stderr;
-    qDebug() << "Java checker finished with status " << status << " exit code " << exitcode;
+    qDebug() << "Java checker finished with status" << status << "exit code" << exitcode;
 
     if (status == QProcess::CrashExit || exitcode == 1)
     {

--- a/launcher/java/JavaChecker.cpp
+++ b/launcher/java/JavaChecker.cpp
@@ -85,7 +85,7 @@ void JavaChecker::performCheck()
     process->setProgram(m_path);
     process->setProcessChannelMode(QProcess::SeparateChannels);
     process->setProcessEnvironment(CleanEnviroment());
-    qDebug() << "Running java checker: " + m_path + " " + args.join(" ");;
+    qDebug() << "Running java checker:" << m_path << args.join(" ");
 
     connect(process.get(), QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this, &JavaChecker::finished);
     connect(process.get(), &QProcess::errorOccurred, this, &JavaChecker::error);

--- a/launcher/java/JavaChecker.cpp
+++ b/launcher/java/JavaChecker.cpp
@@ -85,7 +85,7 @@ void JavaChecker::performCheck()
     process->setProgram(m_path);
     process->setProcessChannelMode(QProcess::SeparateChannels);
     process->setProcessEnvironment(CleanEnviroment());
-    qDebug() << "Running java checker: " + m_path + args.join(" ");;
+    qDebug() << "Running java checker: " + m_path + " " + args.join(" ");;
 
     connect(process.get(), QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this, &JavaChecker::finished);
     connect(process.get(), &QProcess::errorOccurred, this, &JavaChecker::error);


### PR DESCRIPTION
Currently the Java checker debug output looks like this:
```
"Running java checker: java-jar /usr/share/prismlauncher/JavaCheck.jar"
"Running java checker: /usr/lib/jvm/java-17-temurin/jre/bin/java-jar /usr/share/prismlauncher/JavaCheck.jar"
"Running java checker: /usr/lib/jvm/java-17-temurin/bin/java-jar /usr/share/prismlauncher/JavaCheck.jar"
"Running java checker: /usr/lib/jvm/java-11-temurin/jre/bin/java-jar /usr/share/prismlauncher/JavaCheck.jar"
"Running java checker: /usr/lib/jvm/java-11-temurin/bin/java-jar /usr/share/prismlauncher/JavaCheck.jar"
"Running java checker: /usr/lib/jvm/java-20-temurin/jre/bin/java-jar /usr/share/prismlauncher/JavaCheck.jar"
"Running java checker: /usr/lib/jvm/java-20-temurin/bin/java-jar /usr/share/prismlauncher/JavaCheck.jar"
"Running java checker: /usr/lib/jvm/java-8-temurin/jre/bin/java-jar /usr/share/prismlauncher/JavaCheck.jar"
"Running java checker: /usr/lib/jvm/java-8-temurin/bin/java-jar /usr/share/prismlauncher/JavaCheck.jar
```

This PR adds the missing space between the java path and the `-jar` argument.