### PR TITLE
modrinth: use encoded url when exporting pack

### DIFF
--- a/launcher/modplatform/modrinth/ModrinthPackExportTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackExportTask.cpp
@@ -134,8 +134,8 @@ void ModrinthPackExportTask::collectHashes()
                     QCryptographicHash sha1(QCryptographicHash::Algorithm::Sha1);
                     sha1.addData(data);
 
-                    ResolvedFile file{ sha1.result().toHex(), sha512.result().toHex(), url.toString(), openFile.size() };
-                    resolvedFiles[relative] = file;
+                    ResolvedFile resolvedFile{ sha1.result().toHex(), sha512.result().toHex(), url.toEncoded(), openFile.size() };
+                    resolvedFiles[relative] = resolvedFile;
 
                     // nice! we've managed to resolve based on local metadata!
                     // no need to enqueue it


### PR DESCRIPTION
Ensures that necessary url components such as spaces are encoded.
Prevents an error when submitting the resulting file to modrinth.

For example,

The `QUrl::toString()` representation of
```
https://cdn.modrinth.com/data/QdG47OkI/versions/7ainrOrH/modelfix-1.8-fabric%20%281%29.jar
```
Encodes the url to:
```
https://cdn.modrinth.com/data/QdG47OkI/versions/7ainrOrH/modelfix-1.8-fabric %281%29.jar
```

This is fine when printing to the console, but we should be exporting the encoded url with `QUrl::toEncoded()` if we expect it to be processed as a url.

The result is
```
https://cdn.modrinth.com/data/QdG47OkI/versions/7ainrOrH/modelfix-1.8-fabric%20%281%29.jar
```

This hasn't broken importing the resulting `.mrpack` file in PrismLauncher, but it does break importing the file on Modrinth.

See https://discord.com/channels/734077874708938864/1120070731242410024

Fixes: #1226