### PR TITLE
Fix for JavaVersion & friends not updating

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -594,7 +594,7 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
 
         // Java Settings
         m_settings->registerSetting("JavaPath", "");
-        m_settings->registerSetting("JavaTimestamp", 0);
+        m_settings->registerSetting("JavaSignature", "");
         m_settings->registerSetting("JavaArchitecture", "");
         m_settings->registerSetting("JavaRealArchitecture", "");
         m_settings->registerSetting("JavaVersion", "");

--- a/launcher/launch/steps/CheckJava.cpp
+++ b/launcher/launch/steps/CheckJava.cpp
@@ -81,15 +81,20 @@ void CheckJava::executeTask()
     }
 
     QFileInfo javaInfo(realJavaPath);
-    qlonglong javaUnixTime = javaInfo.lastModified().toMSecsSinceEpoch();
-    auto storedUnixTime = settings->get("JavaTimestamp").toLongLong();
+    qint64 javaUnixTime = javaInfo.lastModified().toMSecsSinceEpoch();
+    auto storedSignature = settings->get("JavaSignature").toString();
     auto storedArchitecture = settings->get("JavaArchitecture").toString();
     auto storedRealArchitecture = settings->get("JavaRealArchitecture").toString();
     auto storedVersion = settings->get("JavaVersion").toString();
     auto storedVendor = settings->get("JavaVendor").toString();
-    m_javaUnixTime = javaUnixTime;
+
+    QCryptographicHash hash(QCryptographicHash::Sha1);
+    hash.addData(QByteArray::number(javaUnixTime));
+    hash.addData(m_javaPath.toUtf8());
+    m_javaSignature = hash.result().toHex();
+
     // if timestamps are not the same, or something is missing, check!
-    if (javaUnixTime != storedUnixTime || storedVersion.size() == 0
+    if (m_javaSignature != storedSignature || storedVersion.size() == 0
         || storedArchitecture.size() == 0 || storedRealArchitecture.size() == 0
         || storedVendor.size() == 0)
     {
@@ -140,7 +145,7 @@ void CheckJava::checkJavaFinished(JavaCheckResult result)
             instance->settings()->set("JavaArchitecture", result.mojangPlatform);
             instance->settings()->set("JavaRealArchitecture", result.realPlatform);
             instance->settings()->set("JavaVendor", result.javaVendor);
-            instance->settings()->set("JavaTimestamp", m_javaUnixTime);
+            instance->settings()->set("JavaSignature", m_javaSignature);
             emitSucceeded();
             return;
         }

--- a/launcher/launch/steps/CheckJava.h
+++ b/launcher/launch/steps/CheckJava.h
@@ -40,6 +40,6 @@ private:
 
 private:
     QString m_javaPath;
-    qlonglong m_javaUnixTime;
+    QString m_javaSignature;
     JavaCheckerPtr m_JavaChecker;
 };

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -148,7 +148,7 @@ void MinecraftInstance::loadSpecificSettings()
         m_settings->registerOverride(global_settings->getSetting("IgnoreJavaCompatibility"), javaOrLocation);
 
         // special!
-        m_settings->registerPassthrough(global_settings->getSetting("JavaTimestamp"), javaOrLocation);
+        m_settings->registerPassthrough(global_settings->getSetting("JavaSignature"), javaOrLocation);
         m_settings->registerPassthrough(global_settings->getSetting("JavaArchitecture"), javaOrLocation);
         m_settings->registerPassthrough(global_settings->getSetting("JavaRealArchitecture"), javaOrLocation);
         m_settings->registerPassthrough(global_settings->getSetting("JavaVersion"), javaOrLocation);


### PR DESCRIPTION
I'm tired, forgive me if none of this makes sense

For a while, there was a bug which caused JavaVersion to be updated every time. This was fixed in #1195. However, by fixing this it caused another issue to resurface...

this uses a hopefully more robust sha1 hash of: {the modification date, the path}.

fixes #1250 (if it works as intended)