### PR TITLE
Add Git Blame ignore file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# .git-blame-ignore-revs
+
+# tabs -> spaces
+bbb3b3e6f6e3c0f95873f22e6d0a4aaf350f49d9


### PR DESCRIPTION
This should make Git Blames easier as we won't see the tabs -> spaces commit anymore.

GitHub uses this file automatically: https://docs.github.com/en/repositories/working-with-files/using-files/viewing-a-file#ignore-commits-in-the-blame-view