### PR TITLE
fix(filesystem): track failed copies and clones

### DIFF
--- a/launcher/FileSystem.cpp
+++ b/launcher/FileSystem.cpp
@@ -36,7 +36,7 @@
  */
 
 #include "FileSystem.h"
-#include <qpair.h>
+#include <QPair>
 
 #include "BuildConfig.h"
 

--- a/launcher/FileSystem.cpp
+++ b/launcher/FileSystem.cpp
@@ -36,6 +36,7 @@
  */
 
 #include "FileSystem.h"
+#include <qpair.h>
 
 #include "BuildConfig.h"
 
@@ -246,6 +247,7 @@ bool copy::operator()(const QString& offset, bool dryRun)
 {
     using copy_opts = fs::copy_options;
     m_copied = 0;  // reset counter
+    m_failedPaths.clear();
 
 // NOTE always deep copy on windows. the alternatives are too messy.
 #if defined Q_OS_WIN32
@@ -277,6 +279,9 @@ bool copy::operator()(const QString& offset, bool dryRun)
             qWarning() << "Failed to copy files:" << QString::fromStdString(err.message());
             qDebug() << "Source file:" << src_path;
             qDebug() << "Destination file:" << dst_path;
+            m_failedPaths.append(dst_path);
+            emit copyFailed(relative_dst_path);
+            return;
         }
         m_copied++;
         emit fileCopied(relative_dst_path);
@@ -1072,6 +1077,7 @@ bool clone::operator()(const QString& offset, bool dryRun)
     }
 
     m_cloned = 0;  // reset counter
+    m_failedClones.clear();
 
     auto src = PathCombine(m_src.absolutePath(), offset);
     auto dst = PathCombine(m_dst.absolutePath(), offset);
@@ -1092,6 +1098,9 @@ bool clone::operator()(const QString& offset, bool dryRun)
             qDebug() << "Failed to clone files: error" << err.value() << "message" << QString::fromStdString(err.message());
             qDebug() << "Source file:" << src_path;
             qDebug() << "Destination file:" << dst_path;
+            m_failedClones.append(qMakePair(src_path, dst_path));
+            emit cloneFailed(src_path, dst_path);
+            return;
         }
         m_cloned++;
         emit fileCloned(src_path, dst_path);

--- a/launcher/FileSystem.h
+++ b/launcher/FileSystem.h
@@ -43,6 +43,7 @@
 #include <system_error>
 
 #include <QDir>
+#include <QPair>
 #include <QFlags>
 #include <QLocalServer>
 #include <QObject>
@@ -112,9 +113,12 @@ class copy : public QObject {
     bool operator()(bool dryRun = false) { return operator()(QString(), dryRun); }
 
     int totalCopied() { return m_copied; }
+    int totalFailed() { return m_failedPaths.length(); }
+    QStringList failed() { return m_failedPaths; }
 
    signals:
     void fileCopied(const QString& relativeName);
+    void copyFailed(const QString& relativeName);
     // TODO: maybe add a "shouldCopy" signal in the future?
 
    private:
@@ -127,6 +131,7 @@ class copy : public QObject {
     QDir m_src;
     QDir m_dst;
     int m_copied;
+    QStringList m_failedPaths;
 };
 
 struct LinkPair {
@@ -471,6 +476,9 @@ class clone : public QObject {
     bool operator()(bool dryRun = false) { return operator()(QString(), dryRun); }
 
     int totalCloned() { return m_cloned; }
+    int totalFailed() { return m_failedClones.length(); }
+
+    QList<QPair<QString, QString>> failed() { return m_failedClones; }
 
    signals:
     void fileCloned(const QString& src, const QString& dst);
@@ -485,6 +493,7 @@ class clone : public QObject {
     QDir m_src;
     QDir m_dst;
     int m_cloned;
+    QList<QPair<QString, QString>> m_failedClones;
 };
 
 /**


### PR DESCRIPTION
Notice during a review of Trials work on shortcuts.
copies and clones that failed are still added to the total succeeded copies and clones.
in fact there is no way to track *what* failed. This fixes that. both with a signal and with a fetch-able list.
