### PR TITLE
Add BMCLAPI as an alternative download source

### DIFF
--- a/buildconfig/BuildConfig.h
+++ b/buildconfig/BuildConfig.h
@@ -169,8 +169,11 @@ class Config {
     /**
      * BMCLAPI (Minecraft assets and libraries mirror) URLs
      */
+    QString BMCLAPI_BASE = "https://bmclapi2.bangbang93.com/";
     QString BMCLAPI_RESOURCE_BASE = "https://bmclapi2.bangbang93.com/assets/";
     QString BMCLAPI_LIBRARY_BASE = "https://bmclapi2.bangbang93.com/maven/";
+    QString BMCLAPI_FORGE_BASE = BMCLAPI_LIBRARY_BASE;
+    QString BMCLAPI_FABRIC_BASE = BMCLAPI_LIBRARY_BASE;
 
     QString versionString() const;
     /**

--- a/buildconfig/BuildConfig.h
+++ b/buildconfig/BuildConfig.h
@@ -166,6 +166,12 @@ class Config {
 
     QString FLAME_BASE_URL = "https://api.curseforge.com/v1";
 
+    /**
+     * BMCLAPI (Minecraft assets and libraries mirror) URLs
+     */
+    QString BMCLAPI_RESOURCE_BASE = "https://bmclapi2.bangbang93.com/assets/";
+    QString BMCLAPI_LIBRARY_BASE = "https://bmclapi2.bangbang93.com/maven/";
+
     QString versionString() const;
     /**
      * \brief Converts the Version to a string.

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -618,6 +618,9 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
         m_settings->registerSetting("ShowGlobalGameTime", true);
         m_settings->registerSetting("RecordGameTime", true);
 
+        // Minecraft assets and libraries download mirror
+        m_settings->registerSetting("UseBMCLAPI", false);
+
         // Minecraft launch method
         m_settings->registerSetting("MCLaunchMethod", "LauncherPart");
 

--- a/launcher/minecraft/AssetsUtils.cpp
+++ b/launcher/minecraft/AssetsUtils.cpp
@@ -330,6 +330,8 @@ QString AssetObject::getLocalPath()
 
 QUrl AssetObject::getUrl()
 {
+    if (APPLICATION->settings()->get("UseBMCLAPI").toBool())
+        return BuildConfig.BMCLAPI_RESOURCE_BASE + getRelPath();
     return BuildConfig.RESOURCE_BASE + getRelPath();
 }
 

--- a/launcher/minecraft/Library.cpp
+++ b/launcher/minecraft/Library.cpp
@@ -129,6 +129,10 @@ QList<NetAction::Ptr> Library::getDownloads(
 
         if (useBMCLAPI) {
             url.replace(BuildConfig.LIBRARY_BASE, BuildConfig.BMCLAPI_LIBRARY_BASE);
+            url.replace("https://launcher.mojang.com/", BuildConfig.BMCLAPI_BASE);
+            url.replace("https://piston-data.mojang.com/", BuildConfig.BMCLAPI_BASE);
+            url.replace("https://maven.minecraftforge.net/", BuildConfig.BMCLAPI_BASE);
+            url.replace("https://maven.fabricmc.net/", BuildConfig.BMCLAPI_FABRIC_BASE);
         }
 
         if(sha1.size())

--- a/launcher/minecraft/Library.cpp
+++ b/launcher/minecraft/Library.cpp
@@ -83,7 +83,8 @@ QList<NetAction::Ptr> Library::getDownloads(
     const RuntimeContext & runtimeContext,
     class HttpMetaCache* cache,
     QStringList& failedLocalFiles,
-    const QString & overridePath
+    const QString & overridePath,
+    bool useBMCLAPI
 ) const
 {
     QList<NetAction::Ptr> out;
@@ -125,6 +126,10 @@ QList<NetAction::Ptr> Library::getDownloads(
 
         // Don't add a time limit for the libraries cache entry validity
         options |= Net::Download::Option::MakeEternal;
+
+        if (useBMCLAPI) {
+            url.replace(BuildConfig.LIBRARY_BASE, BuildConfig.BMCLAPI_LIBRARY_BASE);
+        }
 
         if(sha1.size())
         {

--- a/launcher/minecraft/Library.h
+++ b/launcher/minecraft/Library.h
@@ -189,7 +189,7 @@ public: /* methods */
 
     // Get a list of downloads for this library
     QList<NetAction::Ptr> getDownloads(const RuntimeContext & runtimeContext, class HttpMetaCache * cache,
-                                     QStringList & failedLocalFiles, const QString & overridePath) const;
+                                     QStringList & failedLocalFiles, const QString & overridePath, bool useBMCLAPI) const;
 
     QString getCompatibleNative(const RuntimeContext & runtimeContext) const;
 

--- a/launcher/minecraft/update/AssetUpdateTask.cpp
+++ b/launcher/minecraft/update/AssetUpdateTask.cpp
@@ -78,7 +78,10 @@ void AssetUpdateTask::assetIndexFinished()
     auto job = index.getDownloadJob();
     if(job)
     {
-        setStatus(tr("Getting the assets files from Mojang..."));
+        if (APPLICATION->settings()->get("UseBMCLAPI").toBool())
+            setStatus(tr("Getting the assets files from BMCLAPI..."));
+        else
+            setStatus(tr("Getting the assets files from Mojang..."));
         downloadJob = job;
         connect(downloadJob.get(), &NetJob::succeeded, this, &AssetUpdateTask::emitSucceeded);
         connect(downloadJob.get(), &NetJob::failed, this, &AssetUpdateTask::assetsFailed);

--- a/launcher/minecraft/update/LibrariesTask.cpp
+++ b/launcher/minecraft/update/LibrariesTask.cpp
@@ -24,6 +24,7 @@ void LibrariesTask::executeTask()
     downloadJob.reset(job);
 
     auto metacache = APPLICATION->metacache();
+    auto useBMCLAPI = APPLICATION->settings()->get("UseBMCLAPI").toBool();
 
     auto processArtifactPool = [&](const QList<LibraryPtr> & pool, QStringList & errors, const QString & localPath)
     {
@@ -34,7 +35,7 @@ void LibrariesTask::executeTask()
                 emitFailed(tr("Null jar is specified in the metadata, aborting."));
                 return false;
             }
-            auto dls = lib->getDownloads(inst->runtimeContext(), metacache.get(), errors, localPath);
+            auto dls = lib->getDownloads(inst->runtimeContext(), metacache.get(), errors, localPath, useBMCLAPI);
             for(auto dl : dls)
             {
                 downloadJob->addNetAction(dl);

--- a/launcher/ui/pages/global/MinecraftPage.cpp
+++ b/launcher/ui/pages/global/MinecraftPage.cpp
@@ -86,6 +86,9 @@ void MinecraftPage::applySettings()
     s->set("UseNativeOpenAL", ui->useNativeOpenALCheck->isChecked());
     s->set("UseNativeGLFW", ui->useNativeGLFWCheck->isChecked());
 
+    // Minecraft assets and libraries download mirror
+    s->set("UseBMCLAPI", ui->useBMCLAPI->isChecked());
+
     // Peformance related options
     s->set("EnableFeralGamemode", ui->enableFeralGamemodeCheck->isChecked());
     s->set("EnableMangoHud", ui->enableMangoHud->isChecked());
@@ -116,6 +119,8 @@ void MinecraftPage::loadSettings()
     ui->enableFeralGamemodeCheck->setChecked(s->get("EnableFeralGamemode").toBool());
     ui->enableMangoHud->setChecked(s->get("EnableMangoHud").toBool());
     ui->useDiscreteGpuCheck->setChecked(s->get("UseDiscreteGpu").toBool());
+
+    ui->useBMCLAPI->setChecked(s->get("UseBMCLAPI").toBool());
 
 #if !defined(Q_OS_LINUX)
     ui->perfomanceGroupBox->setVisible(false);

--- a/launcher/ui/pages/global/MinecraftPage.ui
+++ b/launcher/ui/pages/global/MinecraftPage.ui
@@ -253,6 +253,22 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="downloadMirrorGroupBox">
+         <property name="title">
+          <string>Download mirror</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_5">
+          <item>
+           <widget class="QCheckBox" name="useBMCLAPI">
+            <property name="text">
+             <string>Use &amp;BMCLAPI as aseets and libraries download source</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/tests/Library_test.cpp
+++ b/tests/Library_test.cpp
@@ -96,7 +96,7 @@ slots:
         QStringList failedFiles;
         Library test("test.package:testname:testversion");
         test.setRepositoryURL("file://foo/bar");
-        auto downloads = test.getDownloads(r, cache.get(), failedFiles, QString());
+        auto downloads = test.getDownloads(r, cache.get(), failedFiles, QString(), false);
         QCOMPARE(downloads.size(), 1);
         QCOMPARE(failedFiles, {});
         NetAction::Ptr dl = downloads[0];
@@ -109,7 +109,7 @@ slots:
         QCOMPARE(test.isNative(), false);
         QStringList failedFiles;
         test.setHint("local");
-        auto downloads = test.getDownloads(r, cache.get(), failedFiles, QString());
+        auto downloads = test.getDownloads(r, cache.get(), failedFiles, QString(), false);
         QCOMPARE(downloads.size(), 0);
         QCOMPARE(failedFiles, {"testname-testversion.jar"});
     }
@@ -120,7 +120,7 @@ slots:
         QCOMPARE(test.isNative(), false);
         QStringList failedFiles;
         test.setHint("local");
-        auto downloads = test.getDownloads(r, cache.get(), failedFiles, QFINDTESTDATA("testdata/Library"));
+        auto downloads = test.getDownloads(r, cache.get(), failedFiles, QFINDTESTDATA("testdata/Library"), false);
         QCOMPARE(downloads.size(), 0);
         qDebug() << failedFiles;
         QCOMPARE(failedFiles.size(), 0);
@@ -147,7 +147,7 @@ slots:
             QCOMPARE(native32, {});
             QCOMPARE(native64, {});
             QStringList failedFiles;
-            auto dls = test.getDownloads(r, cache.get(), failedFiles, QString());
+            auto dls = test.getDownloads(r, cache.get(), failedFiles, QString(), false);
             QCOMPARE(dls.size(), 1);
             QCOMPARE(failedFiles, {});
             auto dl = dls[0];
@@ -171,7 +171,7 @@ slots:
             QCOMPARE(native32, getStorage("test/package/testname/testversion/testname-testversion-linux-32.jar"));
             QCOMPARE(native64, getStorage("test/package/testname/testversion/testname-testversion-linux-64.jar"));
             QStringList failedFiles;
-            auto dls = test.getDownloads(r, cache.get(), failedFiles, QString());
+            auto dls = test.getDownloads(r, cache.get(), failedFiles, QString(), false);
             QCOMPARE(dls.size(), 2);
             QCOMPARE(failedFiles, {});
             QCOMPARE(dls[0]->m_url, QUrl("file://foo/bar/test/package/testname/testversion/testname-testversion-linux-32.jar"));
@@ -186,7 +186,7 @@ slots:
             QCOMPARE(native32, getStorage("test/package/testname/testversion/testname-testversion-windows-32.jar"));
             QCOMPARE(native64, getStorage("test/package/testname/testversion/testname-testversion-windows-64.jar"));
             QStringList failedFiles;
-            auto dls = test.getDownloads(r, cache.get(), failedFiles, QString());
+            auto dls = test.getDownloads(r, cache.get(), failedFiles, QString(), false);
             QCOMPARE(dls.size(), 2);
             QCOMPARE(failedFiles, {});
             QCOMPARE(dls[0]->m_url, QUrl("file://foo/bar/test/package/testname/testversion/testname-testversion-windows-32.jar"));
@@ -201,7 +201,7 @@ slots:
             QCOMPARE(native32, getStorage("test/package/testname/testversion/testname-testversion-osx-32.jar"));
             QCOMPARE(native64, getStorage("test/package/testname/testversion/testname-testversion-osx-64.jar"));
             QStringList failedFiles;
-            auto dls = test.getDownloads(r, cache.get(), failedFiles, QString());
+            auto dls = test.getDownloads(r, cache.get(), failedFiles, QString(), false);
             QCOMPARE(dls.size(), 2);
             QCOMPARE(failedFiles, {});
             QCOMPARE(dls[0]->m_url, QUrl("file://foo/bar/test/package/testname/testversion/testname-testversion-osx-32.jar"));
@@ -224,7 +224,7 @@ slots:
             QCOMPARE(native32, {QFileInfo(QFINDTESTDATA("testdata/Library/testname-testversion-linux-32.jar")).absoluteFilePath()});
             QCOMPARE(native64, {QFileInfo(QFINDTESTDATA("testdata/Library") + "/testname-testversion-linux-64.jar").absoluteFilePath()});
             QStringList failedFiles;
-            auto dls = test.getDownloads(r, cache.get(), failedFiles, QFINDTESTDATA("testdata/Library"));
+            auto dls = test.getDownloads(r, cache.get(), failedFiles, QFINDTESTDATA("testdata/Library"), false);
             QCOMPARE(dls.size(), 0);
             QCOMPARE(failedFiles, {QFileInfo(QFINDTESTDATA("testdata/Library") + "/testname-testversion-linux-64.jar").absoluteFilePath()});
         }
@@ -244,7 +244,7 @@ slots:
         r.system = "linux";
         {
             QStringList failedFiles;
-            auto dls = test->getDownloads(r, cache.get(), failedFiles, QString());
+            auto dls = test->getDownloads(r, cache.get(), failedFiles, QString(), false);
             QCOMPARE(dls.size(), 1);
             QCOMPARE(failedFiles, {});
             QCOMPARE(dls[0]->m_url, QUrl("https://libraries.minecraft.net/com/paulscode/codecwav/20101023/codecwav-20101023.jar"));
@@ -262,7 +262,7 @@ slots:
         r.system = "linux";
         {
             QStringList failedFiles;
-            auto dls = test->getDownloads(r, cache.get(), failedFiles, QFINDTESTDATA("testdata/Library"));
+            auto dls = test->getDownloads(r, cache.get(), failedFiles, QFINDTESTDATA("testdata/Library"), false);
             QCOMPARE(dls.size(), 0);
             QCOMPARE(failedFiles, {});
         }
@@ -283,7 +283,7 @@ slots:
         r.system = "linux";
         {
             QStringList failedFiles;
-            auto dls = test->getDownloads(r, cache.get(), failedFiles, QFINDTESTDATA("testdata/Library"));
+            auto dls = test->getDownloads(r, cache.get(), failedFiles, QFINDTESTDATA("testdata/Library"), false);
             QCOMPARE(dls.size(), 0);
             QCOMPARE(failedFiles, {});
         }
@@ -299,7 +299,7 @@ slots:
         QCOMPARE(native32, {});
         QCOMPARE(native64, {});
         QStringList failedFiles;
-        auto dls = test->getDownloads(r, cache.get(), failedFiles, QString());
+        auto dls = test->getDownloads(r, cache.get(), failedFiles, QString(), false);
         QCOMPARE(dls.size(), 1);
         QCOMPARE(failedFiles, {});
         QCOMPARE(dls[0]->m_url, QUrl("https://libraries.minecraft.net/org/lwjgl/lwjgl/lwjgl-platform/2.9.4-nightly-20150209/lwjgl-platform-2.9.4-nightly-20150209-natives-osx.jar"));
@@ -315,7 +315,7 @@ slots:
         QCOMPARE(native32, getStorage("tv/twitch/twitch-platform/5.16/twitch-platform-5.16-natives-windows-32.jar"));
         QCOMPARE(native64, getStorage("tv/twitch/twitch-platform/5.16/twitch-platform-5.16-natives-windows-64.jar"));
         QStringList failedFiles;
-        auto dls = test->getDownloads(r, cache.get(), failedFiles, QString());
+        auto dls = test->getDownloads(r, cache.get(), failedFiles, QString(), false);
         QCOMPARE(dls.size(), 2);
         QCOMPARE(failedFiles, {});
         QCOMPARE(dls[0]->m_url, QUrl("https://libraries.minecraft.net/tv/twitch/twitch-platform/5.16/twitch-platform-5.16-natives-windows-32.jar"));


### PR DESCRIPTION
## Motivation

The official Minecraft assets server is hosted with Amazon S3, and Chinese users cannot access the server with a decent download speed. The [BMCLAPI project](https://bmclapidoc.bangbang93.com/) (You may use a translator) is set up to solve that problem by mirroring the Minecraft resources. As is documented in the website, the project provides free access for all Minecraft launchers that requires downloading Minecraft resources, and this pull request is to integrate that into the Prism Launcher.

## Changes

- Added an option in the `Settings->Minecraft->Tweaks` page, allowing user to use the BMCLAPI server.
- Of course, when the option is selected, we will use a different url for downloading assets and libraries.
- When using the server, the text which was `Getting the assets files from Mojang...` will be `Getting the assets files from BMCLAPI...`.
- Because the Application instance doesn't exist when running tests, I changed the signature of the `Library::getDownloads` so that it doesn't need to access the settings when running tests. Also changed the tests.

Closes #837