### PR TITLE
fix: segfault in progress dialog

### DIFF
--- a/launcher/ui/dialogs/ProgressDialog.cpp
+++ b/launcher/ui/dialogs/ProgressDialog.cpp
@@ -113,7 +113,7 @@ void ProgressDialog::updateSize()
 
     QSize newSize = this->size();
     // if the current window is too small
-    if ((lastSize != minSize) && (lastSize.height() < newSize.height()))
+    if ((lastSize != newSize) && (lastSize.height() < newSize.height()))
     {
         QSize sizeDiff = lastSize - newSize; // last size was smaller, the results should be negative
         // center on old position after resize

--- a/launcher/ui/dialogs/ProgressDialog.cpp
+++ b/launcher/ui/dialogs/ProgressDialog.cpp
@@ -34,7 +34,7 @@
  */
 
 #include "ProgressDialog.h"
-#include <qpoint.h>
+#include <QPoint>
 #include "ui_ProgressDialog.h"
 
 #include <limits>

--- a/launcher/ui/dialogs/ProgressDialog.cpp
+++ b/launcher/ui/dialogs/ProgressDialog.cpp
@@ -113,7 +113,7 @@ void ProgressDialog::updateSize()
 
     QSize newSize = this->size();
     // if the current window is too small
-    if ((lastSize != minSize) && (lastSize.height() < minSize.height()))
+    if ((lastSize != minSize) && (lastSize.height() < newSize.height()))
     {
         QSize sizeDiff = lastSize - newSize; // last size was smaller, the results should be negative
         // center on old position after resize

--- a/launcher/ui/dialogs/ProgressDialog.cpp
+++ b/launcher/ui/dialogs/ProgressDialog.cpp
@@ -69,6 +69,7 @@ ProgressDialog::ProgressDialog(QWidget* parent) : QDialog(parent), ui(new Ui::Pr
     setAttribute(Qt::WidgetAttribute::WA_QuitOnClose, true);
     setSkipButton(false);
     changeProgress(0, 100);
+    updateSize();
 }
 
 void ProgressDialog::setSkipButton(bool present, QString label)
@@ -98,29 +99,27 @@ void ProgressDialog::updateSize()
 {   
     QSize lastSize = this->size();
     QPoint lastPos = this->pos();
-    int minHeight = minimumSizeHint().height();
-    if (ui->taskProgressScrollArea->isHidden())
-        minHeight -= ui->taskProgressScrollArea->minimumSizeHint().height();
-    QSize labelMinSize = ui->globalStatusLabel->minimumSize();
-    int labelHeight = ui->globalStatusLabel->height();
-    if (labelHeight > labelMinSize.height())
-        minHeight += labelHeight - labelMinSize.height(); // account for multiline label
-    minHeight = std::max(minHeight, 0);
+    int minHeight = ui->globalStatusDetailsLabel->minimumSize().height() + (ui->verticalLayout->spacing() * 2);
+    minHeight += ui->globalProgressBar->minimumSize().height() + ui->verticalLayout->spacing();
+    if (!ui->taskProgressScrollArea->isHidden())
+        minHeight += ui->taskProgressScrollArea->minimumSizeHint().height() + ui->verticalLayout->spacing();
+    if (ui->skipButton->isVisible())
+        minHeight += ui->skipButton->height() + ui->verticalLayout->spacing();
+    minHeight = std::max(minHeight, 60);
     QSize minSize = QSize(480, minHeight);
 
+    setMinimumSize(minSize);
+    adjustSize();
+
+    QSize newSize = this->size();
     // if the current window is too small
     if ((lastSize != minSize) && (lastSize.height() < minSize.height()))
     {
-        resize(minSize);
-
-        QSize newSize = this->size();
         QSize sizeDiff = lastSize - newSize; // last size was smaller, the results should be negative
         // center on old position after resize
         QPoint newPos(lastPos.x() + (sizeDiff.width() / 2), lastPos.y() + (sizeDiff.height() / 2));
         this->move(newPos);
     }
-
-    setMinimumSize(minSize);
 
 }
 
@@ -211,7 +210,9 @@ void ProgressDialog::onTaskSucceeded()
 void ProgressDialog::changeStatus(const QString& status)
 {
     ui->globalStatusLabel->setText(task->getStatus());
+    ui->globalStatusLabel->adjustSize();
     ui->globalStatusDetailsLabel->setText(task->getDetails());
+    ui->globalStatusDetailsLabel->adjustSize();
 
     updateSize();
 }


### PR DESCRIPTION
### Breakdown
- dialog tries to resize after unhiding the sub-task scroll area
- after resize attempts to recenter on parent
  - calls `parentWidget()->{x|y}()`
  - what if there is no parent? `nullptr->()` = segfault
### Fix
- recenter on last pos, don't access parent

~~potentially~~ fixes: #1229
