### PR TITLE
Various UI tweaks

### DIFF
--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -61,6 +61,7 @@ ModFolderModel::ModFolderModel(const QString& dir, BaseInstance* instance, bool 
     m_column_names_translated = QStringList({ tr("Enable"), tr("Image"), tr("Name"), tr("Version"), tr("Last Modified"), tr("Provider") });
     m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::NAME , SortType::VERSION, SortType::DATE, SortType::PROVIDER};
     m_column_resize_modes = { QHeaderView::ResizeToContents, QHeaderView::Interactive, QHeaderView::Stretch, QHeaderView::ResizeToContents, QHeaderView::ResizeToContents, QHeaderView::ResizeToContents};
+    m_columnsHideable =  { false, true, false, true, true, true };
 }
 
 QVariant ModFolderModel::data(const QModelIndex &index, int role) const

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -550,6 +550,8 @@ QMenu* ResourceFolderModel::createHeaderContextMenu(QTreeView* tree)
     menu->addSeparator()->setText(tr("Show / Hide Columns"));
 
     for (int col = 0; col < columnCount(); ++col) {
+        // Skip creating actions for columns that should not be hidden
+        if (!m_columnsHideable.at(col)) continue;
         auto act = new QAction(menu);
         setupHeaderAction(act, col);
 

--- a/launcher/minecraft/mod/ResourceFolderModel.h
+++ b/launcher/minecraft/mod/ResourceFolderModel.h
@@ -202,6 +202,7 @@ class ResourceFolderModel : public QAbstractListModel {
     QStringList m_column_names = {"Enable", "Name", "Last Modified"};
     QStringList m_column_names_translated = {tr("Enable"), tr("Name"), tr("Last Modified")};
     QList<QHeaderView::ResizeMode> m_column_resize_modes = {  QHeaderView::ResizeToContents, QHeaderView::Stretch, QHeaderView::ResizeToContents };
+    QList<bool> m_columnsHideable = { false, false, true };
 
     bool m_can_interact = true;
 

--- a/launcher/minecraft/mod/ResourcePackFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourcePackFolderModel.cpp
@@ -54,7 +54,7 @@ ResourcePackFolderModel::ResourcePackFolderModel(const QString& dir, BaseInstanc
     m_column_names_translated = QStringList({ tr("Enable"), tr("Image"), tr("Name"), tr("Pack Format"), tr("Last Modified") });
     m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::NAME, SortType::PACK_FORMAT, SortType::DATE};
     m_column_resize_modes = { QHeaderView::ResizeToContents, QHeaderView::Interactive, QHeaderView::Stretch, QHeaderView::ResizeToContents, QHeaderView::ResizeToContents };
-
+    m_columnsHideable =  { false, true, false, true, true };
 }
 
 QVariant ResourcePackFolderModel::data(const QModelIndex& index, int role) const

--- a/launcher/minecraft/mod/TexturePackFolderModel.cpp
+++ b/launcher/minecraft/mod/TexturePackFolderModel.cpp
@@ -49,6 +49,7 @@ TexturePackFolderModel::TexturePackFolderModel(const QString& dir, BaseInstance*
     m_column_names_translated = QStringList({ tr("Enable"), tr("Image"), tr("Name"), tr("Last Modified") });
     m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::NAME, SortType::DATE };
     m_column_resize_modes = { QHeaderView::ResizeToContents, QHeaderView::Interactive, QHeaderView::Stretch, QHeaderView::ResizeToContents};
+    m_columnsHideable =  { false, true, false, true };
 
 }
 

--- a/launcher/ui/dialogs/SkinUploadDialog.ui
+++ b/launcher/ui/dialogs/SkinUploadDialog.ui
@@ -42,7 +42,7 @@
          </size>
         </property>
         <property name="text">
-         <string notr="true">...</string>
+         <string>Browse</string>
         </property>
        </widget>
       </item>

--- a/launcher/ui/pages/global/ExternalToolsPage.ui
+++ b/launcher/ui/pages/global/ExternalToolsPage.ui
@@ -47,7 +47,7 @@
             <item>
              <widget class="QPushButton" name="jprofilerPathBtn">
               <property name="text">
-               <string notr="true">...</string>
+               <string>Browse</string>
               </property>
              </widget>
             </item>
@@ -84,7 +84,7 @@
             <item>
              <widget class="QPushButton" name="jvisualvmPathBtn">
               <property name="text">
-               <string notr="true">...</string>
+               <string>Browse</string>
               </property>
              </widget>
             </item>
@@ -121,7 +121,7 @@
             <item>
              <widget class="QPushButton" name="mceditPathBtn">
               <property name="text">
-               <string notr="true">...</string>
+               <string>Browse</string>
               </property>
              </widget>
             </item>
@@ -166,7 +166,7 @@
           <item row="0" column="2">
            <widget class="QToolButton" name="jsonEditorBrowseBtn">
             <property name="text">
-             <string notr="true">...</string>
+             <string>Browse</string>
             </property>
            </widget>
           </item>

--- a/launcher/ui/pages/global/JavaPage.ui
+++ b/launcher/ui/pages/global/JavaPage.ui
@@ -160,117 +160,7 @@
           <string>Java Runtime</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_3">
-          <item row="3" column="1">
-           <widget class="QPushButton" name="javaDetectBtn">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>&amp;Auto-detect...</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="labelJVMArgs">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>JVM arguments:</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="labelJavaPath">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>&amp;Java path:</string>
-            </property>
-            <property name="buddy">
-             <cstring>javaPathTextBox</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="2">
-           <widget class="QPushButton" name="javaTestBtn">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>&amp;Test</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1" colspan="2">
-           <layout class="QHBoxLayout" name="horizontalLayout">
-            <item>
-             <widget class="QLineEdit" name="javaPathTextBox"/>
-            </item>
-            <item>
-             <widget class="QPushButton" name="javaBrowseBtn">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>28</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="text">
-               <string notr="true">...</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item row="4" column="1">
-           <widget class="QCheckBox" name="skipCompatibilityCheckbox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="toolTip">
-             <string>If enabled, the launcher will not check if an instance is compatible with the selected Java version.</string>
-            </property>
-            <property name="text">
-             <string>&amp;Skip Java compatibility checks</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="1">
-           <widget class="QCheckBox" name="skipJavaWizardCheckbox">
-            <property name="toolTip">
-             <string>If enabled, the launcher will not prompt you to choose a Java version if one isn't found.</string>
-            </property>
-            <property name="text">
-             <string>Skip Java &amp;Wizard</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1" colspan="2">
+          <item row="7" column="0" colspan="3">
            <widget class="QPlainTextEdit" name="jvmArgsTextBox">
             <property name="enabled">
              <bool>true</bool>
@@ -286,6 +176,114 @@
               <width>16777215</width>
               <height>100</height>
              </size>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QCheckBox" name="skipCompatibilityCheckbox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>If enabled, the launcher will not check if an instance is compatible with the selected Java version.</string>
+            </property>
+            <property name="text">
+             <string>&amp;Skip Java compatibility checks</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0" colspan="3">
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <item>
+             <widget class="QPushButton" name="javaDetectBtn">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>&amp;Auto-detect...</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="javaTestBtn">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>&amp;Test</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="labelJVMArgs">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>JVM arguments:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0" colspan="3">
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+             <widget class="QLabel" name="labelJavaPath">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>&amp;Java path:</string>
+              </property>
+              <property name="buddy">
+               <cstring>javaPathTextBox</cstring>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLineEdit" name="javaPathTextBox"/>
+            </item>
+            <item>
+             <widget class="QPushButton" name="javaBrowseBtn">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="text">
+               <string>Browse</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="5" column="0">
+           <widget class="QCheckBox" name="skipJavaWizardCheckbox">
+            <property name="toolTip">
+             <string>If enabled, the launcher will not prompt you to choose a Java version if one isn't found.</string>
+            </property>
+            <property name="text">
+             <string>Skip Java &amp;Wizard</string>
             </property>
            </widget>
           </item>
@@ -317,8 +315,6 @@
   <tabstop>permGenSpinBox</tabstop>
   <tabstop>javaBrowseBtn</tabstop>
   <tabstop>javaPathTextBox</tabstop>
-  <tabstop>javaDetectBtn</tabstop>
-  <tabstop>javaTestBtn</tabstop>
   <tabstop>tabWidget</tabstop>
  </tabstops>
  <resources/>

--- a/launcher/ui/pages/global/LauncherPage.ui
+++ b/launcher/ui/pages/global/LauncherPage.ui
@@ -99,7 +99,7 @@
           <item row="3" column="2">
            <widget class="QToolButton" name="downloadsDirBrowseBtn">
             <property name="text">
-             <string notr="true">...</string>
+             <string>Browse</string>
             </property>
            </widget>
           </item>
@@ -109,7 +109,7 @@
           <item row="1" column="2">
            <widget class="QToolButton" name="modsDirBrowseBtn">
             <property name="text">
-             <string notr="true">...</string>
+             <string>Browse</string>
             </property>
            </widget>
           </item>
@@ -126,14 +126,14 @@
           <item row="0" column="2">
            <widget class="QToolButton" name="instDirBrowseBtn">
             <property name="text">
-             <string notr="true">...</string>
+             <string>Browse</string>
             </property>
            </widget>
           </item>
           <item row="2" column="2">
            <widget class="QToolButton" name="iconsDirBrowseBtn">
             <property name="text">
-             <string notr="true">...</string>
+             <string>Browse</string>
             </property>
            </widget>
           </item>

--- a/launcher/ui/pages/instance/InstanceSettingsPage.ui
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.ui
@@ -61,31 +61,7 @@
           <bool>false</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout">
-          <item row="0" column="0" colspan="3">
-           <widget class="QLineEdit" name="javaPathTextBox"/>
-          </item>
-          <item row="1" column="0">
-           <widget class="QPushButton" name="javaDetectBtn">
-            <property name="text">
-             <string>Auto-detect...</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QPushButton" name="javaBrowseBtn">
-            <property name="text">
-             <string>Browse...</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="2">
-           <widget class="QPushButton" name="javaTestBtn">
-            <property name="text">
-             <string>Test</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0">
+          <item row="4" column="0">
            <widget class="QCheckBox" name="skipCompatibilityCheckbox">
             <property name="toolTip">
              <string>If enabled, the launcher will not check if an instance is compatible with the selected Java version.</string>
@@ -94,6 +70,38 @@
              <string>Skip Java compatibility checks</string>
             </property>
            </widget>
+          </item>
+          <item row="1" column="0">
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <item>
+             <widget class="QLineEdit" name="javaPathTextBox"/>
+            </item>
+            <item>
+             <widget class="QPushButton" name="javaBrowseBtn">
+              <property name="text">
+               <string>Browse</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="2" column="0">
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <item>
+             <widget class="QPushButton" name="javaDetectBtn">
+              <property name="text">
+               <string>Auto-detect...</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="javaTestBtn">
+              <property name="text">
+               <string>Test</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </widget>
@@ -674,10 +682,6 @@
   <tabstop>openGlobalJavaSettingsButton</tabstop>
   <tabstop>settingsTabs</tabstop>
   <tabstop>javaSettingsGroupBox</tabstop>
-  <tabstop>javaPathTextBox</tabstop>
-  <tabstop>javaDetectBtn</tabstop>
-  <tabstop>javaBrowseBtn</tabstop>
-  <tabstop>javaTestBtn</tabstop>
   <tabstop>memoryGroupBox</tabstop>
   <tabstop>minMemSpinBox</tabstop>
   <tabstop>maxMemSpinBox</tabstop>

--- a/launcher/ui/widgets/PageContainer_p.h
+++ b/launcher/ui/widgets/PageContainer_p.h
@@ -103,6 +103,7 @@ public:
         setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Expanding);
         setItemDelegate(new PageViewDelegate(this));
         setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+        // Adjust margins when using Breeze theme
         setProperty("_kde_side_panel_view", true);
     }
 

--- a/launcher/ui/widgets/PageContainer_p.h
+++ b/launcher/ui/widgets/PageContainer_p.h
@@ -103,6 +103,7 @@ public:
         setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Expanding);
         setItemDelegate(new PageViewDelegate(this));
         setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+        setProperty("_kde_side_panel_view", true);
     }
 
     virtual QSize sizeHint() const

--- a/launcher/ui/widgets/WideBar.cpp
+++ b/launcher/ui/widgets/WideBar.cpp
@@ -195,8 +195,10 @@ static void copyAction(QAction* from, QAction* to)
 
 void WideBar::showVisibilityMenu(QPoint const& position)
 {
-    if (!m_bar_menu)
+    if (!m_bar_menu) {
         m_bar_menu = std::make_unique<QMenu>(this);
+        m_bar_menu->setTearOffEnabled(true);
+    }
 
     if (m_menu_state == MenuState::Dirty) {
         for (auto* old_action : m_bar_menu->actions())


### PR DESCRIPTION
I wanted to do more stuff but got lazy lol
Anyway, heres what i did:
All the browse files button text is now "Browse" instead of some being "Browse...", "Browse" or just "..."
The instance and global java settings UI are more consistent and have a better layout
Global java page:
Before: 
![image](https://github.com/PrismLauncher/PrismLauncher/assets/69596237/f199ed66-7041-4f45-8101-72d32747b2e2)
After:
![image](https://github.com/PrismLauncher/PrismLauncher/assets/69596237/41e23702-905a-456c-8c19-7a0e01116d4e)
Instance java page:
Before: 
![image](https://github.com/PrismLauncher/PrismLauncher/assets/69596237/56d267bc-693c-49f0-916a-d20db8549665)
After:
![image](https://github.com/PrismLauncher/PrismLauncher/assets/69596237/67fe6584-92a6-4486-8eaa-50bb2d163d6b)

The page container list view has a property that makes Breeze and other qstyles aware that its a sidebar so they hide the ugly outline
Before/After:
![image](https://github.com/PrismLauncher/PrismLauncher/assets/69596237/9f506b08-5865-46b4-b466-d1ac1e874d55)

And i also enabled tearing off the widebar context menu so you can pop it off on a window to easily toggle the checkboxes without reopening the menu each time