### PR TITLE
Don't allow edit of NullInstances

### DIFF
--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -1287,7 +1287,7 @@ void MainWindow::on_actionEditInstance_triggered()
         APPLICATION->showInstanceWindow(m_selectedInstance);
     } else  {
         CustomMessageBox::selectable(this, tr("Instance not editable"), 
-                                     tr("This instance is not editable. it may be broken, invalid, or too old. Check logs for details,"),
+                                     tr("This instance is not editable. It may be broken, invalid, or too old. Check logs for details."),
                                      QMessageBox::Critical)->show();
     }
 }

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -1279,7 +1279,17 @@ void MainWindow::globalSettingsClosed()
 
 void MainWindow::on_actionEditInstance_triggered()
 {
-    APPLICATION->showInstanceWindow(m_selectedInstance);
+
+    if (!m_selectedInstance)
+        return;
+
+    if (m_selectedInstance->canEdit()) {
+        APPLICATION->showInstanceWindow(m_selectedInstance);
+    } else  {
+        CustomMessageBox::selectable(this, tr("Instance not editable"), 
+                                     tr("This instance is not editable. it may be broken, invalid, or too old. Check logs for details,"),
+                                     QMessageBox::Critical)->show();
+    }
 }
 
 void MainWindow::on_actionManageAccounts_triggered()


### PR DESCRIPTION
They probably need to be de-crufted but this should prevent any future crashes from similar shenanigans.