### PR TITLE
Do not reset shared pointer if it's already empty

### DIFF
--- a/launcher/modplatform/EnsureMetadataTask.cpp
+++ b/launcher/modplatform/EnsureMetadataTask.cpp
@@ -145,7 +145,8 @@ void EnsureMetadataTask::executeTask()
         connect(project_task.get(), &Task::finished, this, [=] {
             invalidade_leftover();
             project_task->deleteLater();
-            m_current_task = nullptr;
+            if (m_current_task)
+                m_current_task.reset();
         });
 
         m_current_task = project_task;

--- a/launcher/modplatform/EnsureMetadataTask.cpp
+++ b/launcher/modplatform/EnsureMetadataTask.cpp
@@ -154,7 +154,8 @@ void EnsureMetadataTask::executeTask()
 
     connect(version_task.get(), &Task::finished, [=] {
         version_task->deleteLater();
-        m_current_task = nullptr;
+        if (m_current_task)
+            m_current_task.reset();
     });
 
     if (m_mods.size() > 1)


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
maybe it fixes issue #1340.
This is the only crash I was able to reproduce by trying the described steps(also it was random and not at window closing but at abort action).
