### PR TITLE
feat: add toggle for quilt beacon

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -9,6 +9,7 @@
  *  Copyright (C) 2022 Tayou <tayou@gmx.net>
  *  Copyright (C) 2023 TheKodeToad <TheKodeToad@proton.me>
  *  Copyright (C) 2023 Rachel Powers <508861+Ryex@users.noreply.github.com>
+ *  Copyright (C) 2023 seth <getchoo at tuta dot io>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -604,6 +605,9 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
         m_settings->registerSetting("JvmArgs", "");
         m_settings->registerSetting("IgnoreJavaCompatibility", false);
         m_settings->registerSetting("IgnoreJavaWizard", false);
+
+        // Mod loader settings
+        m_settings->registerSetting("DisableQuiltBeacon", false);
 
         // Native library workarounds
         m_settings->registerSetting("UseNativeOpenAL", false);

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -3,7 +3,8 @@
  *  Prism Launcher - Minecraft Launcher
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
  *  Copyright (C) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
- *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
+ *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>\
+ *  Copyright (c) 2023 seth <getchoo at tuta dot io>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -185,6 +186,10 @@ void MinecraftInstance::loadSpecificSettings()
         auto miscellaneousOverride = m_settings->registerSetting("OverrideMiscellaneous", false);
         m_settings->registerOverride(global_settings->getSetting("CloseAfterLaunch"), miscellaneousOverride);
         m_settings->registerOverride(global_settings->getSetting("QuitAfterGameStop"), miscellaneousOverride);
+
+        // Mod loader specific options
+        auto modLoaderSettings = m_settings->registerSetting("OverrideModLoaderSettings", false);
+        m_settings->registerOverride(global_settings->getSetting("DisableQuiltBeacon"), modLoaderSettings);
 
         m_settings->set("InstanceType", "OneSix");
     }
@@ -390,6 +395,9 @@ QStringList MinecraftInstance::extraArguments()
         QStringList jar, temp1, temp2, temp3;
         agent->library()->getApplicableFiles(runtimeContext(), jar, temp1, temp2, temp3, getLocalLibraryPath());
         list.append("-javaagent:"+jar[0]+(agent->argument().isEmpty() ? "" : "="+agent->argument()));
+    }
+    if (version->getModLoaders().value() & ResourceAPI::Quilt && settings()->get("DisableQuiltBeacon").toBool()) {
+        list.append("-Dloader.disable_beacon=true");
     }
     return list;
 }

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -3,7 +3,7 @@
  *  Prism Launcher - Minecraft Launcher
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
  *  Copyright (C) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
- *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>\
+ *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *  Copyright (c) 2023 seth <getchoo at tuta dot io>
  *
  *  This program is free software: you can redistribute it and/or modify

--- a/launcher/ui/pages/global/MinecraftPage.cpp
+++ b/launcher/ui/pages/global/MinecraftPage.cpp
@@ -2,6 +2,7 @@
 /*
  *  PolyMC - Minecraft Launcher
  *  Copyright (c) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
+ *  Copyright (C) 2023 seth <getchoo at tuta dot io>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -99,6 +100,9 @@ void MinecraftPage::applySettings()
     // Miscellaneous
     s->set("CloseAfterLaunch", ui->closeAfterLaunchCheck->isChecked());
     s->set("QuitAfterGameStop", ui->quitAfterGameStopCheck->isChecked());
+
+    // Mod loader settings
+    s->set("DisableQuiltBeacon", ui->disableQuiltBeaconCheckBox->isChecked());
 }
 
 void MinecraftPage::loadSettings()
@@ -137,6 +141,8 @@ void MinecraftPage::loadSettings()
 
     ui->closeAfterLaunchCheck->setChecked(s->get("CloseAfterLaunch").toBool());
     ui->quitAfterGameStopCheck->setChecked(s->get("QuitAfterGameStop").toBool());
+
+    ui->disableQuiltBeaconCheckBox->setChecked(s->get("DisableQuiltBeacon").toBool());
 }
 
 void MinecraftPage::retranslate()

--- a/launcher/ui/pages/global/MinecraftPage.ui
+++ b/launcher/ui/pages/global/MinecraftPage.ui
@@ -191,6 +191,22 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_12">
        <item>
+        <widget class="QGroupBox" name="modLoaderSettingsGroupBox">
+         <property name="title">
+          <string>Mod loader settings</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_13">
+          <item>
+           <widget class="QCheckBox" name="disableQuiltBeaconCheckBox">
+            <property name="text">
+             <string>Disable Quilt's Beacon</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QGroupBox" name="nativeLibWorkaroundGroupBox">
          <property name="title">
           <string>Native library workarounds</string>

--- a/launcher/ui/pages/global/MinecraftPage.ui
+++ b/launcher/ui/pages/global/MinecraftPage.ui
@@ -199,7 +199,10 @@
           <item>
            <widget class="QCheckBox" name="disableQuiltBeaconCheckBox">
             <property name="text">
-             <string>Disable Quilt's Beacon</string>
+             <string>Disable Quilt Loader Beacon</string>
+            </property>
+            <property name="toolTip">
+             <string>Disable Quilt loader's beacon for counting monthly active users</string>
             </property>
            </widget>
           </item>

--- a/launcher/ui/pages/instance/InstanceSettingsPage.cpp
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.cpp
@@ -3,6 +3,7 @@
  *  PolyMC - Minecraft Launcher
  *  Copyright (c) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2023 seth <getchoo at tuta dot io>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -50,9 +51,9 @@
 #include "Application.h"
 #include "minecraft/auth/AccountList.h"
 
+#include "FileSystem.h"
 #include "java/JavaInstallList.h"
 #include "java/JavaUtils.h"
-#include "FileSystem.h"
 
 InstanceSettingsPage::InstanceSettingsPage(BaseInstance *inst, QWidget *parent)
     : QWidget(parent), ui(new Ui::InstanceSettingsPage), m_instance(inst)
@@ -280,6 +281,14 @@ void InstanceSettingsPage::applySettings()
         m_settings->reset("InstanceAccountId");
     }
 
+    bool overrideModLoaderSettings = ui->modLoaderSettingsGroupBox->isChecked();
+    m_settings->set("OverrideModLoaderSettings", overrideModLoaderSettings);
+    if (overrideModLoaderSettings) {
+        m_settings->set("DisableQuiltBeacon", ui->disableQuiltBeaconCheckBox->isChecked());
+    } else {
+        m_settings->reset("DisableQuiltBeacon");
+    }
+
     // FIXME: This should probably be called by a signal instead
     m_instance->updateRuntimeContext();
 }
@@ -380,6 +389,10 @@ void InstanceSettingsPage::loadSettings()
 
     ui->instanceAccountGroupBox->setChecked(m_settings->get("UseAccountForInstance").toBool());
     updateAccountsMenu();
+
+    // Mod loader specific settings
+    ui->modLoaderSettingsGroupBox->setChecked(m_settings->get("OverrideModLoaderSettings").toBool());
+    ui->disableQuiltBeaconCheckBox->setChecked(m_settings->get("DisableQuiltBeacon").toBool());
 }
 
 void InstanceSettingsPage::on_javaDetectBtn_clicked()

--- a/launcher/ui/pages/instance/InstanceSettingsPage.ui
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.ui
@@ -542,6 +542,28 @@
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout_9">
        <item>
+        <widget class="QGroupBox" name="modLoaderSettingsGroupBox">
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+         <property name="title">
+          <string>Mod loader settings</string>
+         </property>
+         <layout class="QVBoxLayout" name="VerticalLayout_16">
+          <item>
+           <widget class="QCheckBox" name="disableQuiltBeaconCheckBox">
+            <property name="text">
+             <string>Disable Quilt's Beacon</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QGroupBox" name="gameTimeGroupBox">
          <property name="enabled">
           <bool>true</bool>

--- a/launcher/ui/pages/instance/InstanceSettingsPage.ui
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.ui
@@ -556,7 +556,10 @@
           <item>
            <widget class="QCheckBox" name="disableQuiltBeaconCheckBox">
             <property name="text">
-             <string>Disable Quilt's Beacon</string>
+             <string>Disable Quilt Loader Beacon</string>
+            </property>
+            <property name="toolTip">
+             <string>Disable Quilt loader's beacon for counting monthly active users</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
following the announcement of (extremely basic) [telemetry](https://quiltmc.org/en/blog/2023-06-26-mau-beacon) being added to quilt, and their team recommending toggles being added to launchers - similar to their [installer](https://github.com/QuiltMC/quilt-installer/pull/39) - this adds the toggle to prism!

i also created a new mod loader settings section, in case we have ever want to add other loader specific settings in the future. i am considering hiding this for now in non quilt instance settings pages, but since the jvm argument isn't applied anyways, i think it's probably fine /shrug