### PR TITLE
Fix warning

### DIFF
--- a/launcher/BaseVersion.h
+++ b/launcher/BaseVersion.h
@@ -15,16 +15,15 @@
 
 #pragma once
 
-#include <memory>
-#include <QString>
 #include <QMetaType>
+#include <QString>
+#include <memory>
 
 /*!
  * An abstract base class for versions.
  */
-class BaseVersion
-{
-public:
+class BaseVersion {
+   public:
     using Ptr = std::shared_ptr<BaseVersion>;
     virtual ~BaseVersion() {}
     /*!
@@ -45,14 +44,8 @@ public:
      */
     virtual QString typeString() const = 0;
 
-    virtual bool operator<(BaseVersion &a)
-    {
-        return name() < a.name();
-    };
-    virtual bool operator>(BaseVersion &a)
-    {
-        return name() > a.name();
-    };
+    virtual bool operator<(BaseVersion& a) { return name() < a.name(); };
+    virtual bool operator>(BaseVersion& a) { return name() > a.name(); };
 };
 
 Q_DECLARE_METATYPE(BaseVersion::Ptr)

--- a/launcher/java/JavaInstall.cpp
+++ b/launcher/java/JavaInstall.cpp
@@ -18,6 +18,7 @@
 
 #include "JavaInstall.h"
 
+#include "BaseVersion.h"
 #include "StringUtils.h"
 
 bool JavaInstall::operator<(const JavaInstall& rhs)
@@ -42,4 +43,22 @@ bool JavaInstall::operator==(const JavaInstall& rhs)
 bool JavaInstall::operator>(const JavaInstall& rhs)
 {
     return (!operator<(rhs)) && (!operator==(rhs));
+}
+
+bool JavaInstall::operator<(BaseVersion& a)
+{
+    try {
+        return operator<(dynamic_cast<JavaInstall&>(a));
+    } catch (const std::bad_cast& e) {
+        return BaseVersion::operator<(a);
+    }
+}
+
+bool JavaInstall::operator>(BaseVersion& a)
+{
+    try {
+        return operator>(dynamic_cast<JavaInstall&>(a));
+    } catch (const std::bad_cast& e) {
+        return BaseVersion::operator>(a);
+    }
 }

--- a/launcher/java/JavaInstall.cpp
+++ b/launcher/java/JavaInstall.cpp
@@ -1,3 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (c) 2023 Trial97 <alexandru.tripon97@gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include "JavaInstall.h"
 
 #include "StringUtils.h"

--- a/launcher/java/JavaInstall.cpp
+++ b/launcher/java/JavaInstall.cpp
@@ -2,28 +2,26 @@
 
 #include "StringUtils.h"
 
-bool JavaInstall::operator<(const JavaInstall &rhs)
+bool JavaInstall::operator<(const JavaInstall& rhs)
 {
     auto archCompare = StringUtils::naturalCompare(arch, rhs.arch, Qt::CaseInsensitive);
-    if(archCompare != 0)
+    if (archCompare != 0)
         return archCompare < 0;
-    if(id < rhs.id)
-    {
+    if (id < rhs.id) {
         return true;
     }
-    if(id > rhs.id)
-    {
+    if (id > rhs.id) {
         return false;
     }
     return StringUtils::naturalCompare(path, rhs.path, Qt::CaseInsensitive) < 0;
 }
 
-bool JavaInstall::operator==(const JavaInstall &rhs)
+bool JavaInstall::operator==(const JavaInstall& rhs)
 {
     return arch == rhs.arch && id == rhs.id && path == rhs.path;
 }
 
-bool JavaInstall::operator>(const JavaInstall &rhs)
+bool JavaInstall::operator>(const JavaInstall& rhs)
 {
     return (!operator<(rhs)) && (!operator==(rhs));
 }

--- a/launcher/java/JavaInstall.h
+++ b/launcher/java/JavaInstall.h
@@ -3,31 +3,18 @@
 #include "BaseVersion.h"
 #include "JavaVersion.h"
 
-struct JavaInstall : public BaseVersion
-{
-    JavaInstall(){}
-    JavaInstall(QString id, QString arch, QString path)
-    : id(id), arch(arch), path(path)
-    {
-    }
-    virtual QString descriptor()
-    {
-        return id.toString();
-    }
+struct JavaInstall : public BaseVersion {
+    JavaInstall() {}
+    JavaInstall(QString id, QString arch, QString path) : id(id), arch(arch), path(path) {}
+    virtual QString descriptor() { return id.toString(); }
 
-    virtual QString name()
-    {
-        return id.toString();
-    }
+    virtual QString name() { return id.toString(); }
 
-    virtual QString typeString() const
-    {
-        return arch;
-    }
+    virtual QString typeString() const { return arch; }
 
-    bool operator<(const JavaInstall & rhs);
-    bool operator==(const JavaInstall & rhs);
-    bool operator>(const JavaInstall & rhs);
+    bool operator<(const JavaInstall& rhs);
+    bool operator==(const JavaInstall& rhs);
+    bool operator>(const JavaInstall& rhs);
 
     JavaVersion id;
     QString arch;

--- a/launcher/java/JavaInstall.h
+++ b/launcher/java/JavaInstall.h
@@ -1,3 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (c) 2023 Trial97 <alexandru.tripon97@gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #pragma once
 
 #include "BaseVersion.h"

--- a/launcher/java/JavaInstall.h
+++ b/launcher/java/JavaInstall.h
@@ -30,6 +30,8 @@ struct JavaInstall : public BaseVersion {
 
     virtual QString typeString() const { return arch; }
 
+    virtual bool operator<(BaseVersion& a) override;
+    virtual bool operator>(BaseVersion& a) override;
     bool operator<(const JavaInstall& rhs);
     bool operator==(const JavaInstall& rhs);
     bool operator>(const JavaInstall& rhs);


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
this should fix this annoying warning:
```
In file included from PrismLauncher/launcher/BaseVersionList.h:22,
                 from PrismLauncher/launcher/java/JavaInstallList.h:21,
                 from PrismLauncher/launcher/java/JavaUtils.h:21,
                 from PrismLauncher/launcher/launch/steps/CheckJava.cpp:37:
PrismLauncher/launcher/BaseVersion.h:48:18: warning: ‘virtual bool BaseVersion::operator<(BaseVersion&)’ was hidden [-Woverloaded-virtual=]
   48 |     virtual bool operator<(BaseVersion &a)
      |                  ^~~~~~~~
In file included from PrismLauncher/launcher/java/JavaInstallList.h:25:
PrismLauncher/launcher/java/JavaInstall.h:15:10: note:   by ‘bool JavaInstall::operator<(const JavaInstall&)’
   15 |     bool operator<(const JavaInstall& rhs);
      |          ^~~~~~~~
PrismLauncher/launcher/BaseVersion.h:52:18: warning: ‘virtual bool BaseVersion::operator>(BaseVersion&)’ was hidden [-Woverloaded-virtual=]
   52 |     virtual bool operator>(BaseVersion &a)
      |                  ^~~~~~~~
PrismLauncher/launcher/java/JavaInstall.h:17:10: note:   by ‘bool JavaInstall::operator>(const JavaInstall&)’
   17 |     bool operator>(const JavaInstall& rhs);
```