### PR TITLE
Add Backport action

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,32 @@
+name: Backport
+on:
+  pull_request_target:
+    types: [closed, labeled]
+
+# WARNING:
+# When extending this action, be aware that $GITHUB_TOKEN allows write access to
+# the GitHub repository. This means that it should not evaluate user input in a
+# way that allows code injection.
+
+permissions:
+  contents: read
+
+jobs:
+  backport:
+    permissions:
+      contents: write # for korthout/backport-action to create branch
+      pull-requests: write # for korthout/backport-action to create PR to backport
+    name: Backport Pull Request
+    if: github.repository_owner == 'PrismLauncher' && github.event.pull_request.merged == true && (github.event_name != 'labeled' || startsWith('backport', github.event.label.name))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Create backport PRs
+        uses: korthout/backport-action@v1.3.1
+        with:
+          # Config README: https://github.com/korthout/backport-action#backport-action
+          pull_description: |-
+            Bot-based backport to `${target_branch}`, triggered by a label in #${pull_number}.
+


### PR DESCRIPTION
This is the same backport workflow used by NixOS/nixpkgs. Works as expected in my own testing.

To backport a PR, just add a `backport <branchname>` label to PRs. This can also be done after the PR in question was merged already.
