### PR TITLE
Make Launch Offline not launch online in 1.6+

### DIFF
--- a/launcher/minecraft/auth/AuthSession.cpp
+++ b/launcher/minecraft/auth/AuthSession.cpp
@@ -26,6 +26,7 @@ bool AuthSession::MakeOffline(QString offline_playername)
         return false;
     }
     session = "-";
+    access_token = "0";
     player_name = offline_playername;
     status = PlayableOffline;
     return true;


### PR DESCRIPTION
Before, only `session` was assigned, which is only used for pre-1.6 versions. However, modern versions use `access_token`, and also check for `"0"` instead of `"-"`.