### PR TITLE
[Linux] Switch to garnix for Nix builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -586,33 +586,3 @@ jobs:
         with:
           bundle: "Prism Launcher.flatpak"
           manifest-path: flatpak/org.prismlauncher.PrismLauncher.yml 
-
-  nix:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        package:
-          - prismlauncher
-          - prismlauncher-qt5
-    steps:
-      - name: Clone repository
-        if: inputs.build_type == 'Debug'
-        uses: actions/checkout@v3
-        with:
-          submodules: 'true'
-      - name: Install nix
-        if: inputs.build_type == 'Debug'
-        uses: cachix/install-nix-action@v22
-        with:
-          install_url: https://nixos.org/nix/install
-          extra_nix_config: |
-            auto-optimise-store = true
-            experimental-features = nix-command flakes
-      - uses: cachix/cachix-action@v12
-        if: inputs.build_type == 'Debug'
-        with:
-          name: prismlauncher
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - name: Build
-        if: inputs.build_type == 'Debug'
-        run: nix build .#${{ matrix.package }} --print-build-logs

--- a/garnix.yaml
+++ b/garnix.yaml
@@ -1,0 +1,5 @@
+builds:
+  exclude: []
+  include:
+    - "devShells.*-linux.*"
+    - "packages.*-linux.*"


### PR DESCRIPTION
this adds a garnix.yaml to cache our dev shells and packages for nix. the only setup required for admins is installing the github app - instructions for which can be found [here](https://garnix.io/hello-garnix)

this currently only builds for linux, but in the future it will allow us to build for aarch64-darwin. it also enables caching for pull requests, unlike our current solution with gha and cachix

Signed-off-by: seth <getchoo@tuta.io>
