### PR TITLE
disable darwin in flake + cleanup garnix.yaml + fix markdownlint warnings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ In an effort to ensure that the code you contribute is actually compatible with 
 
 This can be done by appending `-s` to your `git commit` call, or by manually appending the following text to your commit message:
 
-```
+```text
 <commit message>
 
 Signed-off-by: Author name <Author email>
@@ -27,7 +27,7 @@ Signed-off-by: Author name <Author email>
 
 By signing off your work, you agree to the terms below:
 
-```
+```text
 Developer's Certificate of Origin 1.1
 
 By making a contribution to this project, I certify that:
@@ -61,7 +61,6 @@ As a bonus, you can also [cryptographically sign your commits][gh-signing-commit
 
 [gh-signing-commits]: https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
 [gh-vigilant-mode]: https://docs.github.com/en/authentication/managing-commit-signature-verification/displaying-verification-statuses-for-all-of-your-commits
-
 
 ## Backporting to Release Branches
 

--- a/garnix.yaml
+++ b/garnix.yaml
@@ -1,5 +1,6 @@
 builds:
   exclude: []
   include:
-    - "devShells.*-linux.*"
-    - "packages.*-linux.*"
+    - "checks.x86_64-linux.*"
+    - "devShells.*.*"
+    - "packages.*.*"

--- a/libraries/README.md
+++ b/libraries/README.md
@@ -61,7 +61,7 @@ The `standard` and `legacy` launchers are available.
 
 Example (some parts have been censored):
 
-```
+```text
 mod legacyjavafixer-1.0
 mainClass net.minecraft.launchwrapper.Launch
 param --username

--- a/nix/NIX.md
+++ b/nix/NIX.md
@@ -53,7 +53,8 @@ home.packages = [ pkgs.prismlauncher ];
 
 ### Without flakes-enabled nix
 
-#### Using channels
+<details>
+<summary>Using channels</summary>
 
 ```sh
 nix-channel --add https://github.com/PrismLauncher/PrismLauncher/archive/master.tar.gz prismlauncher
@@ -61,7 +62,10 @@ nix-channel --update prismlauncher
 nix-env -iA prismlauncher
 ```
 
-#### Using the overlay
+</details>
+
+<details>
+<summary>Using the overlay</summary>
 
 ```nix
 # In your configuration.nix:
@@ -73,6 +77,8 @@ nix-env -iA prismlauncher
   environment.systemPackages = with pkgs; [ prismlauncher ];
 }
 ```
+
+</details>
 
 ## Running ad-hoc
 

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -24,9 +24,9 @@
   # Supported systems.
   systems = [
     "x86_64-linux"
-    "x86_64-darwin"
     "aarch64-linux"
-    # Disabled due to qtbase being currently broken for "aarch64-darwin."
+    # Disabled due to our packages not supporting darwin yet.
+    # "x86_64-darwin"
     # "aarch64-darwin"
   ];
 }


### PR DESCRIPTION
Parent PR: #1434 
this fixes some of the glob expressions in the garnix config (apparently it doesn't support `*-linux`, who knew right?), disables all outputs for darwin as neither the packages or dev shell work, and cleans up the markdownlint warnings from the pre-commit check
