### PR TITLE
[Windows] Fix attaching logs to console

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -135,13 +135,16 @@
 #include "updater/MacSparkleUpdater.h"
 #endif
 
-
 #if defined Q_OS_WIN32
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
-#include <windows.h>
+#include <fcntl.h>
+#include <io.h>
 #include <stdio.h>
+#include <windows.h>
+#include <iostream>
+
 #endif
 
 #define STRINGIFY(x) #x
@@ -168,32 +171,115 @@ void appDebugOutput(QtMsgType type, const QMessageLogContext &context, const QSt
     fflush(stderr);
 }
 
-}
+}  // namespace
 
-Application::Application(int &argc, char **argv) : QApplication(argc, argv)
+
+#if defined Q_OS_WIN32
+
+// taken from https://stackoverflow.com/a/25927081
+// getting a proper output to console with redirection support on windows is apearently hell
+void BindCrtHandlesToStdHandles(bool bindStdIn, bool bindStdOut, bool bindStdErr)
+{
+    // Re-initialize the C runtime "FILE" handles with clean handles bound to "nul". We do this because it has been
+    // observed that the file number of our standard handle file objects can be assigned internally to a value of -2
+    // when not bound to a valid target, which represents some kind of unknown internal invalid state. In this state our
+    // call to "_dup2" fails, as it specifically tests to ensure that the target file number isn't equal to this value
+    // before allowing the operation to continue. We can resolve this issue by first "re-opening" the target files to
+    // use the "nul" device, which will place them into a valid state, after which we can redirect them to our target
+    // using the "_dup2" function.
+    if (bindStdIn) {
+        FILE* dummyFile;
+        freopen_s(&dummyFile, "nul", "r", stdin);
+    }
+    if (bindStdOut) {
+        FILE* dummyFile;
+        freopen_s(&dummyFile, "nul", "w", stdout);
+    }
+    if (bindStdErr) {
+        FILE* dummyFile;
+        freopen_s(&dummyFile, "nul", "w", stderr);
+    }
+
+    // Redirect unbuffered stdin from the current standard input handle
+    if (bindStdIn) {
+        HANDLE stdHandle = GetStdHandle(STD_INPUT_HANDLE);
+        if (stdHandle != INVALID_HANDLE_VALUE) {
+            int fileDescriptor = _open_osfhandle((intptr_t)stdHandle, _O_TEXT);
+            if (fileDescriptor != -1) {
+                FILE* file = _fdopen(fileDescriptor, "r");
+                if (file != NULL) {
+                    int dup2Result = _dup2(_fileno(file), _fileno(stdin));
+                    if (dup2Result == 0) {
+                        setvbuf(stdin, NULL, _IONBF, 0);
+                    }
+                }
+            }
+        }
+    }
+
+    // Redirect unbuffered stdout to the current standard output handle
+    if (bindStdOut) {
+        HANDLE stdHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+        if (stdHandle != INVALID_HANDLE_VALUE) {
+            int fileDescriptor = _open_osfhandle((intptr_t)stdHandle, _O_TEXT);
+            if (fileDescriptor != -1) {
+                FILE* file = _fdopen(fileDescriptor, "w");
+                if (file != NULL) {
+                    int dup2Result = _dup2(_fileno(file), _fileno(stdout));
+                    if (dup2Result == 0) {
+                        setvbuf(stdout, NULL, _IONBF, 0);
+                    }
+                }
+            }
+        }
+    }
+
+    // Redirect unbuffered stderr to the current standard error handle
+    if (bindStdErr) {
+        HANDLE stdHandle = GetStdHandle(STD_ERROR_HANDLE);
+        if (stdHandle != INVALID_HANDLE_VALUE) {
+            int fileDescriptor = _open_osfhandle((intptr_t)stdHandle, _O_TEXT);
+            if (fileDescriptor != -1) {
+                FILE* file = _fdopen(fileDescriptor, "w");
+                if (file != NULL) {
+                    int dup2Result = _dup2(_fileno(file), _fileno(stderr));
+                    if (dup2Result == 0) {
+                        setvbuf(stderr, NULL, _IONBF, 0);
+                    }
+                }
+            }
+        }
+    }
+
+    // Clear the error state for each of the C++ standard stream objects. We need to do this, as attempts to access the
+    // standard streams before they refer to a valid target will cause the iostream objects to enter an error state. In
+    // versions of Visual Studio after 2005, this seems to always occur during startup regardless of whether anything
+    // has been read from or written to the targets or not.
+    if (bindStdIn) {
+        std::wcin.clear();
+        std::cin.clear();
+    }
+    if (bindStdOut) {
+        std::wcout.clear();
+        std::cout.clear();
+    }
+    if (bindStdErr) {
+        std::wcerr.clear();
+        std::cerr.clear();
+    }
+}
+#endif
+
+Application::Application(int& argc, char** argv) : QApplication(argc, argv)
 {
 #if defined Q_OS_WIN32
-    // attach the parent console
-    if(AttachConsole(ATTACH_PARENT_PROCESS))
-    {
-        // if attach succeeds, reopen and sync all the i/o
-        if(freopen("CON", "w", stdout))
-        {
-            std::cout.sync_with_stdio();
+    // attach the parent console if stdout not already captured
+    auto stdout_type = GetFileType(GetStdHandle(STD_OUTPUT_HANDLE));
+    if (stdout_type == FILE_TYPE_CHAR || stdout_type == FILE_TYPE_UNKNOWN) {
+        if (AttachConsole(ATTACH_PARENT_PROCESS)) {
+            BindCrtHandlesToStdHandles(true, true, true);
+            consoleAttached = true;
         }
-        if(freopen("CON", "w", stderr))
-        {
-            std::cerr.sync_with_stdio();
-        }
-        if(freopen("CON", "r", stdin))
-        {
-            std::cin.sync_with_stdio();
-        }
-        auto out = GetStdHandle (STD_OUTPUT_HANDLE);
-        DWORD written;
-        const char * endline = "\n";
-        WriteConsole(out, endline, strlen(endline), &written, NULL);
-        consoleAttached = true;
     }
 #endif
     setOrganizationName(BuildConfig.LAUNCHER_NAME);

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -136,15 +136,7 @@
 #endif
 
 #if defined Q_OS_WIN32
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#include <fcntl.h>
-#include <io.h>
-#include <stdio.h>
-#include <windows.h>
-#include <iostream>
-
+#include "WindowsConsole.h"
 #endif
 
 #define STRINGIFY(x) #x
@@ -174,112 +166,13 @@ void appDebugOutput(QtMsgType type, const QMessageLogContext &context, const QSt
 }  // namespace
 
 
-#if defined Q_OS_WIN32
-
-// taken from https://stackoverflow.com/a/25927081
-// getting a proper output to console with redirection support on windows is apearently hell
-void BindCrtHandlesToStdHandles(bool bindStdIn, bool bindStdOut, bool bindStdErr)
-{
-    // Re-initialize the C runtime "FILE" handles with clean handles bound to "nul". We do this because it has been
-    // observed that the file number of our standard handle file objects can be assigned internally to a value of -2
-    // when not bound to a valid target, which represents some kind of unknown internal invalid state. In this state our
-    // call to "_dup2" fails, as it specifically tests to ensure that the target file number isn't equal to this value
-    // before allowing the operation to continue. We can resolve this issue by first "re-opening" the target files to
-    // use the "nul" device, which will place them into a valid state, after which we can redirect them to our target
-    // using the "_dup2" function.
-    if (bindStdIn) {
-        FILE* dummyFile;
-        freopen_s(&dummyFile, "nul", "r", stdin);
-    }
-    if (bindStdOut) {
-        FILE* dummyFile;
-        freopen_s(&dummyFile, "nul", "w", stdout);
-    }
-    if (bindStdErr) {
-        FILE* dummyFile;
-        freopen_s(&dummyFile, "nul", "w", stderr);
-    }
-
-    // Redirect unbuffered stdin from the current standard input handle
-    if (bindStdIn) {
-        HANDLE stdHandle = GetStdHandle(STD_INPUT_HANDLE);
-        if (stdHandle != INVALID_HANDLE_VALUE) {
-            int fileDescriptor = _open_osfhandle((intptr_t)stdHandle, _O_TEXT);
-            if (fileDescriptor != -1) {
-                FILE* file = _fdopen(fileDescriptor, "r");
-                if (file != NULL) {
-                    int dup2Result = _dup2(_fileno(file), _fileno(stdin));
-                    if (dup2Result == 0) {
-                        setvbuf(stdin, NULL, _IONBF, 0);
-                    }
-                }
-            }
-        }
-    }
-
-    // Redirect unbuffered stdout to the current standard output handle
-    if (bindStdOut) {
-        HANDLE stdHandle = GetStdHandle(STD_OUTPUT_HANDLE);
-        if (stdHandle != INVALID_HANDLE_VALUE) {
-            int fileDescriptor = _open_osfhandle((intptr_t)stdHandle, _O_TEXT);
-            if (fileDescriptor != -1) {
-                FILE* file = _fdopen(fileDescriptor, "w");
-                if (file != NULL) {
-                    int dup2Result = _dup2(_fileno(file), _fileno(stdout));
-                    if (dup2Result == 0) {
-                        setvbuf(stdout, NULL, _IONBF, 0);
-                    }
-                }
-            }
-        }
-    }
-
-    // Redirect unbuffered stderr to the current standard error handle
-    if (bindStdErr) {
-        HANDLE stdHandle = GetStdHandle(STD_ERROR_HANDLE);
-        if (stdHandle != INVALID_HANDLE_VALUE) {
-            int fileDescriptor = _open_osfhandle((intptr_t)stdHandle, _O_TEXT);
-            if (fileDescriptor != -1) {
-                FILE* file = _fdopen(fileDescriptor, "w");
-                if (file != NULL) {
-                    int dup2Result = _dup2(_fileno(file), _fileno(stderr));
-                    if (dup2Result == 0) {
-                        setvbuf(stderr, NULL, _IONBF, 0);
-                    }
-                }
-            }
-        }
-    }
-
-    // Clear the error state for each of the C++ standard stream objects. We need to do this, as attempts to access the
-    // standard streams before they refer to a valid target will cause the iostream objects to enter an error state. In
-    // versions of Visual Studio after 2005, this seems to always occur during startup regardless of whether anything
-    // has been read from or written to the targets or not.
-    if (bindStdIn) {
-        std::wcin.clear();
-        std::cin.clear();
-    }
-    if (bindStdOut) {
-        std::wcout.clear();
-        std::cout.clear();
-    }
-    if (bindStdErr) {
-        std::wcerr.clear();
-        std::cerr.clear();
-    }
-}
-#endif
 
 Application::Application(int& argc, char** argv) : QApplication(argc, argv)
 {
 #if defined Q_OS_WIN32
     // attach the parent console if stdout not already captured
-    auto stdout_type = GetFileType(GetStdHandle(STD_OUTPUT_HANDLE));
-    if (stdout_type == FILE_TYPE_CHAR || stdout_type == FILE_TYPE_UNKNOWN) {
-        if (AttachConsole(ATTACH_PARENT_PROCESS)) {
-            BindCrtHandlesToStdHandles(true, true, true);
-            consoleAttached = true;
-        }
+    if (AttachWindowsConsole()) {
+        consoleAttached = true;
     }
 #endif
     setOrganizationName(BuildConfig.LAUNCHER_NAME);

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -1018,6 +1018,14 @@ SET(LAUNCHER_SOURCES
     ui/instanceview/VisualGroup.h
 )
 
+if(WIN32)
+    set(LAUNCHER_SOURCES
+        WindowsConsole.cpp
+        WindowsConsole.h
+        ${LAUNCHER_SOURCES}
+    )
+endif()
+
 qt_wrap_ui(LAUNCHER_UI
     ui/MainWindow.ui
     ui/setupwizard/PasteWizardPage.ui

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -563,6 +563,9 @@ set(ATLAUNCHER_SOURCES
 )
 
 set(LINKEXE_SOURCES
+    WindowsConsole.cpp
+    WindowsConsole.h
+
     filelink/FileLink.h
     filelink/FileLink.cpp
     FileSystem.h

--- a/launcher/WindowsConsole.cpp
+++ b/launcher/WindowsConsole.cpp
@@ -1,0 +1,134 @@
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2022 Rachel Powers <508861+Ryex@users.noreply.github.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <fcntl.h>
+#include <io.h>
+#include <stdio.h>
+#include <windows.h>
+#include <iostream>
+
+// taken from https://stackoverflow.com/a/25927081
+// getting a proper output to console with redirection support on windows is apparently hell
+void BindCrtHandlesToStdHandles(bool bindStdIn, bool bindStdOut, bool bindStdErr)
+{
+    // Re-initialize the C runtime "FILE" handles with clean handles bound to "nul". We do this because it has been
+    // observed that the file number of our standard handle file objects can be assigned internally to a value of -2
+    // when not bound to a valid target, which represents some kind of unknown internal invalid state. In this state our
+    // call to "_dup2" fails, as it specifically tests to ensure that the target file number isn't equal to this value
+    // before allowing the operation to continue. We can resolve this issue by first "re-opening" the target files to
+    // use the "nul" device, which will place them into a valid state, after which we can redirect them to our target
+    // using the "_dup2" function.
+    if (bindStdIn) {
+        FILE* dummyFile;
+        freopen_s(&dummyFile, "nul", "r", stdin);
+    }
+    if (bindStdOut) {
+        FILE* dummyFile;
+        freopen_s(&dummyFile, "nul", "w", stdout);
+    }
+    if (bindStdErr) {
+        FILE* dummyFile;
+        freopen_s(&dummyFile, "nul", "w", stderr);
+    }
+
+    // Redirect unbuffered stdin from the current standard input handle
+    if (bindStdIn) {
+        HANDLE stdHandle = GetStdHandle(STD_INPUT_HANDLE);
+        if (stdHandle != INVALID_HANDLE_VALUE) {
+            int fileDescriptor = _open_osfhandle((intptr_t)stdHandle, _O_TEXT);
+            if (fileDescriptor != -1) {
+                FILE* file = _fdopen(fileDescriptor, "r");
+                if (file != NULL) {
+                    int dup2Result = _dup2(_fileno(file), _fileno(stdin));
+                    if (dup2Result == 0) {
+                        setvbuf(stdin, NULL, _IONBF, 0);
+                    }
+                }
+            }
+        }
+    }
+
+    // Redirect unbuffered stdout to the current standard output handle
+    if (bindStdOut) {
+        HANDLE stdHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+        if (stdHandle != INVALID_HANDLE_VALUE) {
+            int fileDescriptor = _open_osfhandle((intptr_t)stdHandle, _O_TEXT);
+            if (fileDescriptor != -1) {
+                FILE* file = _fdopen(fileDescriptor, "w");
+                if (file != NULL) {
+                    int dup2Result = _dup2(_fileno(file), _fileno(stdout));
+                    if (dup2Result == 0) {
+                        setvbuf(stdout, NULL, _IONBF, 0);
+                    }
+                }
+            }
+        }
+    }
+
+    // Redirect unbuffered stderr to the current standard error handle
+    if (bindStdErr) {
+        HANDLE stdHandle = GetStdHandle(STD_ERROR_HANDLE);
+        if (stdHandle != INVALID_HANDLE_VALUE) {
+            int fileDescriptor = _open_osfhandle((intptr_t)stdHandle, _O_TEXT);
+            if (fileDescriptor != -1) {
+                FILE* file = _fdopen(fileDescriptor, "w");
+                if (file != NULL) {
+                    int dup2Result = _dup2(_fileno(file), _fileno(stderr));
+                    if (dup2Result == 0) {
+                        setvbuf(stderr, NULL, _IONBF, 0);
+                    }
+                }
+            }
+        }
+    }
+
+    // Clear the error state for each of the C++ standard stream objects. We need to do this, as attempts to access the
+    // standard streams before they refer to a valid target will cause the iostream objects to enter an error state. In
+    // versions of Visual Studio after 2005, this seems to always occur during startup regardless of whether anything
+    // has been read from or written to the targets or not.
+    if (bindStdIn) {
+        std::wcin.clear();
+        std::cin.clear();
+    }
+    if (bindStdOut) {
+        std::wcout.clear();
+        std::cout.clear();
+    }
+    if (bindStdErr) {
+        std::wcerr.clear();
+        std::cerr.clear();
+    }
+}
+
+
+bool AttachWindowsConsole() {
+    auto stdout_type = GetFileType(GetStdHandle(STD_OUTPUT_HANDLE));
+    if (stdout_type == FILE_TYPE_CHAR || stdout_type == FILE_TYPE_UNKNOWN) {
+        if (AttachConsole(ATTACH_PARENT_PROCESS)) {
+            BindCrtHandlesToStdHandles(true, true, true);
+            return true;
+        }
+    }
+    return false;
+}
+
+

--- a/launcher/WindowsConsole.h
+++ b/launcher/WindowsConsole.h
@@ -1,0 +1,25 @@
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2022 Rachel Powers <508861+Ryex@users.noreply.github.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma once
+
+void BindCrtHandlesToStdHandles(bool bindStdIn, bool bindStdOut, bool bindStdErr);
+bool AttachWindowsConsole();

--- a/launcher/filelink/FileLink.cpp
+++ b/launcher/filelink/FileLink.cpp
@@ -170,7 +170,7 @@ void FileLinkApp::runLink()
             FS::LinkResult result = { src_path, dst_path, QString::fromStdString(os_err.message()), os_err.value() };
             m_path_results.append(result);
         } else {
-            FS::LinkResult result = { src_path, dst_path };
+            FS::LinkResult result = { src_path, dst_path, "", 0};
             m_path_results.append(result);
         }
     }
@@ -230,7 +230,7 @@ void FileLinkApp::readPathPairs()
     in >> numLinks;
     qDebug() << "numLinks" << numLinks;
 
-    for (int i = 0; i < numLinks; i++) {
+    for (unsigned int i = 0; i < numLinks; i++) {
         FS::LinkPair pair;
         in >> pair.src;
         in >> pair.dst;
@@ -253,7 +253,6 @@ FileLinkApp::~FileLinkApp()
         fclose(stdout);
         fclose(stdin);
         fclose(stderr);
-        FreeConsole();
     }
 #endif
 }

--- a/launcher/filelink/FileLink.cpp
+++ b/launcher/filelink/FileLink.cpp
@@ -37,11 +37,7 @@
 #include <sys.h>
 
 #if defined Q_OS_WIN32
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#include <stdio.h>
-#include <windows.h>
+#include "WindowsConsole.h"
 #endif
 
 // Snippet from https://github.com/gulrak/filesystem#using-it-as-single-file-header
@@ -67,21 +63,7 @@ FileLinkApp::FileLinkApp(int& argc, char** argv) : QCoreApplication(argc, argv),
 {
 #if defined Q_OS_WIN32
     // attach the parent console
-    if (AttachConsole(ATTACH_PARENT_PROCESS)) {
-        // if attach succeeds, reopen and sync all the i/o
-        if (freopen("CON", "w", stdout)) {
-            std::cout.sync_with_stdio();
-        }
-        if (freopen("CON", "w", stderr)) {
-            std::cerr.sync_with_stdio();
-        }
-        if (freopen("CON", "r", stdin)) {
-            std::cin.sync_with_stdio();
-        }
-        auto out = GetStdHandle(STD_OUTPUT_HANDLE);
-        DWORD written;
-        const char* endline = "\n";
-        WriteConsole(out, endline, strlen(endline), &written, NULL);
+    if (AttachWindowsConsole()) {
         consoleAttached = true;
     }
 #endif


### PR DESCRIPTION
This changes how the windows console is attached so that io redirection works properly. Before this changes redirection was completely broken in windows. This is a step towards better cli.
this also drops the usage of insecure `freopen` and clears that warning.
