### PR TITLE
Don't reset meta URL on launch

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -713,7 +713,7 @@ Application::Application(int &argc, char **argv) : QApplication(argc, argv)
             QUrl metaUrl(m_settings->get("MetaURLOverride").toString());
 
             // get rid of invalid meta urls
-            if (!metaUrl.isValid() || metaUrl.scheme() != "http" || metaUrl.scheme() != "https")
+            if (!metaUrl.isValid() || (metaUrl.scheme() != "http" && metaUrl.scheme() != "https"))
                 m_settings->reset("MetaURLOverride");
         }
 


### PR DESCRIPTION
Looks like I introduced a logic error in PrismLauncher/PrismLauncher#1325
