### PR TITLE
Don't omit empty lines in log output

### DIFF
--- a/launcher/LoggedProcess.cpp
+++ b/launcher/LoggedProcess.cpp
@@ -65,11 +65,7 @@ QStringList LoggedProcess::reprocess(const QByteArray& data, QTextDecoder& decod
         m_leftover_line = "";
     }
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
     auto lines = str.remove(QChar::CarriageReturn).split(QChar::LineFeed);
-#else
-    auto lines = str.remove(QChar::CarriageReturn).split(QChar::LineFeed);
-#endif
 
     m_leftover_line = lines.takeLast();
     return lines;

--- a/launcher/LoggedProcess.cpp
+++ b/launcher/LoggedProcess.cpp
@@ -66,13 +66,12 @@ QStringList LoggedProcess::reprocess(const QByteArray& data, QTextDecoder& decod
     }
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-    auto lines = str.remove(QChar::CarriageReturn).split(QChar::LineFeed, QString::SkipEmptyParts);
+    auto lines = str.remove(QChar::CarriageReturn).split(QChar::LineFeed);
 #else
-    auto lines = str.remove(QChar::CarriageReturn).split(QChar::LineFeed, Qt::SkipEmptyParts);
+    auto lines = str.remove(QChar::CarriageReturn).split(QChar::LineFeed);
 #endif
 
-    if (!str.endsWith(QChar::LineFeed))
-        m_leftover_line = lines.takeLast();
+    m_leftover_line = lines.takeLast();
     return lines;
 }
 


### PR DESCRIPTION
Preserving empty lines in the game log ensures that crash reports and debugging information has necessary whitespace - the previous behaviour made crash reports hard to read.

The commit that introduced this behaviour is https://github.com/PrismLauncher/PrismLauncher/commit/a14476c5fbd87f2a765b3f8807950bd728f282b2 - seems to be an unrelated fix, so I don't think there is anything that relies on empty lines being removed.
