### PR TITLE
Fix transparency in skin icon

### DIFF
--- a/launcher/SkinUtils.cpp
+++ b/launcher/SkinUtils.cpp
@@ -35,6 +35,7 @@ QPixmap getFaceFromCache(QString username, int height, int width)
         QPixmap skinTexture(fskin.fileName());
         if (!skinTexture.isNull()) {
             QPixmap skin = QPixmap(8, 8);
+            skin.fill(QColorConstants::Transparent);
             QPainter painter(&skin);
             painter.drawPixmap(0, 0, skinTexture.copy(8, 8, 8, 8));
             painter.drawPixmap(0, 0, skinTexture.copy(40, 8, 8, 8));

--- a/launcher/SkinUtils.cpp
+++ b/launcher/SkinUtils.cpp
@@ -35,7 +35,11 @@ QPixmap getFaceFromCache(QString username, int height, int width)
         QPixmap skinTexture(fskin.fileName());
         if (!skinTexture.isNull()) {
             QPixmap skin = QPixmap(8, 8);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
             skin.fill(QColorConstants::Transparent);
+#else
+            skin.fill(QColor(0, 0, 0, 0));
+#endif
             QPainter painter(&skin);
             painter.drawPixmap(0, 0, skinTexture.copy(8, 8, 8, 8));
             painter.drawPixmap(0, 0, skinTexture.copy(40, 8, 8, 8));

--- a/launcher/minecraft/auth/MinecraftAccount.cpp
+++ b/launcher/minecraft/auth/MinecraftAccount.cpp
@@ -126,6 +126,7 @@ QPixmap MinecraftAccount::getFace() const
         return QPixmap();
     }
     QPixmap skin = QPixmap(8, 8);
+    skin.fill(QColorConstants::Transparent);
     QPainter painter(&skin);
     painter.drawPixmap(0, 0, skinTexture.copy(8, 8, 8, 8));
     painter.drawPixmap(0, 0, skinTexture.copy(40, 8, 8, 8));

--- a/launcher/minecraft/auth/MinecraftAccount.cpp
+++ b/launcher/minecraft/auth/MinecraftAccount.cpp
@@ -37,6 +37,7 @@
 
 #include "MinecraftAccount.h"
 
+#include <QColor>
 #include <QCryptographicHash>
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -126,7 +127,11 @@ QPixmap MinecraftAccount::getFace() const
         return QPixmap();
     }
     QPixmap skin = QPixmap(8, 8);
+#if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     skin.fill(QColorConstants::Transparent);
+#else
+    skin.fill(QColor(0, 0, 0, 0));
+#endif
     QPainter painter(&skin);
     painter.drawPixmap(0, 0, skinTexture.copy(8, 8, 8, 8));
     painter.drawPixmap(0, 0, skinTexture.copy(40, 8, 8, 8));


### PR DESCRIPTION
QPainter has a bug where drawing transparency to a freshly initialized, empty QPixmap causes garbage data to be drawn. This broke the rendering of the skin icon. The fix is simply to fill the QPixmap with empty transparent pixels beforehand.

Signed-off-by: lumiscosity <averyrudelphe@gmail.com>
