### PR TITLE
Fix task progress being stuck if a task is aborted

### DIFF
--- a/launcher/tasks/ConcurrentTask.cpp
+++ b/launcher/tasks/ConcurrentTask.cpp
@@ -88,6 +88,7 @@ bool ConcurrentTask::abort()
     QMutableHashIterator<Task*, Task::Ptr> doing_iter(m_doing);
     while (doing_iter.hasNext()) {
         auto task = doing_iter.next();
+        disconnect(task->get(), &Task::aborted, this, 0);
         suceedeed &= (task.value())->abort();
     }
 
@@ -130,6 +131,7 @@ void ConcurrentTask::startNext()
 
     connect(next.get(), &Task::succeeded, this, [this, next]() { subTaskSucceeded(next); });
     connect(next.get(), &Task::failed, this, [this, next](QString msg) { subTaskFailed(next, msg); });
+    connect(next.get(), &Task::aborted, this, [this, next] { subTaskFailed(next, "Aborted"); });
 
     connect(next.get(), &Task::status, this, [this, next](QString msg) { subTaskStatus(next, msg); });
     connect(next.get(), &Task::details, this, [this, next](QString msg) { subTaskDetails(next, msg); });


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
In case a subtask decides to abort the concurrent task hangs until it's manually aborted by the user.
There are not many places where this happens but just to be sure that all exit cases for a subtask are handled.
There are some issues open that complains about the fact that a certain task hangs(https://github.com/PrismLauncher/PrismLauncher/issues/1199 ,https://github.com/PrismLauncher/PrismLauncher/issues/1484).

* Yeah the net API overhaul should solve the issues regarding downloading stuff, this is for other tasks.
* When this happens no message is displayed to the user as the concurrent task will always be successful, see:   https://github.com/PrismLauncher/PrismLauncher/pull/1364