### PR TITLE
Fix browse button size in Skin Upload dialog

### DIFF
--- a/launcher/ui/dialogs/SkinUploadDialog.ui
+++ b/launcher/ui/dialogs/SkinUploadDialog.ui
@@ -35,12 +35,6 @@
           <verstretch>0</verstretch>
          </sizepolicy>
         </property>
-        <property name="maximumSize">
-         <size>
-          <width>28</width>
-          <height>16777215</height>
-         </size>
-        </property>
         <property name="text">
          <string>Browse</string>
         </property>


### PR DESCRIPTION
Parent PR: #1324

This is what it looked like before:
![Upload Skin menu in Prism Launcher](https://scrumplex.rocks/img/1692341483_ip2eiW.png)