### PR TITLE
Improvements to modpack UX

### DIFF
--- a/launcher/modplatform/ResourceAPI.h
+++ b/launcher/modplatform/ResourceAPI.h
@@ -109,6 +109,8 @@ class ResourceAPI {
     };
     struct ProjectInfoCallbacks {
         std::function<void(QJsonDocument&, ModPlatform::IndexedPack)> on_succeed;
+        std::function<void(QString const& reason)> on_fail;
+        std::function<void()> on_abort;
     };
 
     struct DependencySearchArgs {

--- a/launcher/modplatform/ResourceAPI.h
+++ b/launcher/modplatform/ResourceAPI.h
@@ -108,7 +108,7 @@ class ResourceAPI {
         void operator=(ProjectInfoArgs other) { pack = other.pack; }
     };
     struct ProjectInfoCallbacks {
-        std::function<void(QJsonDocument&, ModPlatform::IndexedPack)> on_succeed;
+        std::function<void(QJsonDocument&, const ModPlatform::IndexedPack&)> on_succeed;
         std::function<void(QString const& reason)> on_fail;
         std::function<void()> on_abort;
     };

--- a/launcher/modplatform/helpers/NetworkResourceAPI.cpp
+++ b/launcher/modplatform/helpers/NetworkResourceAPI.cpp
@@ -72,7 +72,8 @@ Task::Ptr NetworkResourceAPI::getProjectInfo(ProjectInfoArgs&& args, ProjectInfo
 
         callbacks.on_succeed(doc, args.pack);
     });
-
+    QObject::connect(job.get(), &NetJob::failed, [callbacks](QString reason) { callbacks.on_fail(reason); });
+    QObject::connect(job.get(), &NetJob::aborted, [callbacks] { callbacks.on_abort(); });
     return job;
 }
 

--- a/launcher/ui/pages/modplatform/ResourceModel.cpp
+++ b/launcher/ui/pages/modplatform/ResourceModel.cpp
@@ -133,7 +133,7 @@ void ResourceModel::search()
         return;
 
     if (m_search_term.startsWith("#")) {
-        auto projectId = m_search_term.removeFirst();
+        auto projectId = m_search_term.mid(1);
         if (!projectId.isEmpty()) {
             ResourceAPI::ProjectInfoCallbacks callbacks;
 

--- a/launcher/ui/pages/modplatform/ResourceModel.cpp
+++ b/launcher/ui/pages/modplatform/ResourceModel.cpp
@@ -132,6 +132,36 @@ void ResourceModel::search()
     if (hasActiveSearchJob())
         return;
 
+    if (m_search_term.startsWith("#")) {
+        auto projectId = m_search_term.removeFirst();
+        if (!projectId.isEmpty()) {
+            ResourceAPI::ProjectInfoCallbacks callbacks;
+
+            // Use defaults if no callbacks are set
+            if (!callbacks.on_fail)
+                callbacks.on_fail = [this](QString reason) {
+                    if (!s_running_models.constFind(this).value())
+                        return;
+                    searchRequestFailed(reason, -1);
+                };
+            if (!callbacks.on_abort)
+                callbacks.on_abort = [this] {
+                    if (!s_running_models.constFind(this).value())
+                        return;
+                    searchRequestAborted();
+                };
+
+            if (!callbacks.on_succeed)
+                callbacks.on_succeed = [this](auto& doc, auto pack) {
+                    if (!s_running_models.constFind(this).value())
+                        return;
+                    searchRequestForOneSucceeded(doc);
+                };
+            if (auto job = m_api->getProjectInfo({ projectId }, std::move(callbacks)); job)
+                runSearchJob(job);
+            return;
+        }
+    }
     auto args{ createSearchArguments() };
 
     auto callbacks{ createSearchCallbacks() };
@@ -193,6 +223,12 @@ void ResourceModel::loadEntry(QModelIndex& entry)
                 if (!s_running_models.constFind(this).value())
                     return;
                 infoRequestSucceeded(doc, pack, entry);
+            };
+        if (!callbacks.on_fail)
+            callbacks.on_fail = [this](QString reason) {
+                if (!s_running_models.constFind(this).value())
+                    return;
+                QMessageBox::critical(nullptr, tr("Error"), tr("A network error occurred. Could not load project info:%1").arg(reason));
             };
 
         if (auto job = m_api->getProjectInfo(std::move(args), std::move(callbacks)); job)
@@ -369,6 +405,27 @@ void ResourceModel::searchRequestSucceeded(QJsonDocument& doc)
 
     beginInsertRows(QModelIndex(), m_packs.size(), m_packs.size() + newList.size() - 1);
     m_packs.append(newList);
+    endInsertRows();
+}
+
+void ResourceModel::searchRequestForOneSucceeded(QJsonDocument& doc)
+{
+    ModPlatform::IndexedPack::Ptr pack = std::make_shared<ModPlatform::IndexedPack>();
+
+    try {
+        auto obj = Json::requireObject(doc);
+        if (obj.contains("data"))
+            obj = Json::requireObject(obj, "data");
+        loadIndexedPack(*pack, obj);
+    } catch (const JSONValidationError& e) {
+        qDebug() << doc;
+        qWarning() << "Error while reading " << debugName() << " resource info: " << e.cause();
+    }
+
+    m_search_state = SearchState::Finished;
+
+    beginInsertRows(QModelIndex(), m_packs.size(), m_packs.size() + 1);
+    m_packs.append(pack);
     endInsertRows();
 }
 

--- a/launcher/ui/pages/modplatform/ResourceModel.cpp
+++ b/launcher/ui/pages/modplatform/ResourceModel.cpp
@@ -137,26 +137,22 @@ void ResourceModel::search()
         if (!projectId.isEmpty()) {
             ResourceAPI::ProjectInfoCallbacks callbacks;
 
-            // Use defaults if no callbacks are set
-            if (!callbacks.on_fail)
-                callbacks.on_fail = [this](QString reason) {
-                    if (!s_running_models.constFind(this).value())
-                        return;
-                    searchRequestFailed(reason, -1);
-                };
-            if (!callbacks.on_abort)
-                callbacks.on_abort = [this] {
-                    if (!s_running_models.constFind(this).value())
-                        return;
-                    searchRequestAborted();
-                };
+            callbacks.on_fail = [this](QString reason) {
+                if (!s_running_models.constFind(this).value())
+                    return;
+                searchRequestFailed(reason, -1);
+            };
+            callbacks.on_abort = [this] {
+                if (!s_running_models.constFind(this).value())
+                    return;
+                searchRequestAborted();
+            };
 
-            if (!callbacks.on_succeed)
-                callbacks.on_succeed = [this](auto& doc, auto& pack) {
-                    if (!s_running_models.constFind(this).value())
-                        return;
-                    searchRequestForOneSucceeded(doc);
-                };
+            callbacks.on_succeed = [this](auto& doc, auto& pack) {
+                if (!s_running_models.constFind(this).value())
+                    return;
+                searchRequestForOneSucceeded(doc);
+            };
             if (auto job = m_api->getProjectInfo({ projectId }, std::move(callbacks)); job)
                 runSearchJob(job);
             return;

--- a/launcher/ui/pages/modplatform/ResourceModel.cpp
+++ b/launcher/ui/pages/modplatform/ResourceModel.cpp
@@ -152,7 +152,7 @@ void ResourceModel::search()
                 };
 
             if (!callbacks.on_succeed)
-                callbacks.on_succeed = [this](auto& doc, auto pack) {
+                callbacks.on_succeed = [this](auto& doc, auto& pack) {
                     if (!s_running_models.constFind(this).value())
                         return;
                     searchRequestForOneSucceeded(doc);
@@ -219,9 +219,10 @@ void ResourceModel::loadEntry(QModelIndex& entry)
 
         // Use default if no callbacks are set
         if (!callbacks.on_succeed)
-            callbacks.on_succeed = [this, entry](auto& doc, auto pack) {
+            callbacks.on_succeed = [this, entry](auto& doc, auto& newpack) {
                 if (!s_running_models.constFind(this).value())
                     return;
+                auto pack = newpack;
                 infoRequestSucceeded(doc, pack, entry);
             };
         if (!callbacks.on_fail)

--- a/launcher/ui/pages/modplatform/ResourceModel.h
+++ b/launcher/ui/pages/modplatform/ResourceModel.h
@@ -149,6 +149,7 @@ class ResourceModel : public QAbstractListModel {
    private:
     /* Default search request callbacks */
     void searchRequestSucceeded(QJsonDocument&);
+    void searchRequestForOneSucceeded(QJsonDocument&);
     void searchRequestFailed(QString reason, int network_error_code);
     void searchRequestAborted();
 

--- a/launcher/ui/pages/modplatform/ResourcePage.cpp
+++ b/launcher/ui/pages/modplatform/ResourcePage.cpp
@@ -44,9 +44,6 @@
 #include <QKeyEvent>
 
 #include "Markdown.h"
-#include "ResourceDownloadTask.h"
-
-#include "minecraft/MinecraftInstance.h"
 
 #include "ui/dialogs/ResourceDownloadDialog.h"
 #include "ui/pages/modplatform/ResourceModel.h"

--- a/launcher/ui/pages/modplatform/atlauncher/AtlFilterModel.cpp
+++ b/launcher/ui/pages/modplatform/atlauncher/AtlFilterModel.cpp
@@ -67,9 +67,10 @@ bool FilterModel::filterAcceptsRow(int sourceRow, const QModelIndex& sourceParen
     if (searchTerm.isEmpty()) {
         return true;
     }
-
     QModelIndex index = sourceModel()->index(sourceRow, 0, sourceParent);
     ATLauncher::IndexedPack pack = sourceModel()->data(index, Qt::UserRole).value<ATLauncher::IndexedPack>();
+    if (searchTerm.startsWith("#"))
+        return QString::number(pack.id) == searchTerm.mid(1);
     return pack.name.contains(searchTerm, Qt::CaseInsensitive);
 }
 

--- a/launcher/ui/pages/modplatform/atlauncher/AtlListModel.cpp
+++ b/launcher/ui/pages/modplatform/atlauncher/AtlListModel.cpp
@@ -21,6 +21,7 @@
 #include <Json.h>
 
 #include "net/ApiDownload.h"
+#include "ui/widgets/ProjectItem.h"
 
 namespace Atl {
 
@@ -46,27 +47,50 @@ QVariant ListModel::data(const QModelIndex& index, int role) const
     }
 
     ATLauncher::IndexedPack pack = modpacks.at(pos);
-    if (role == Qt::DisplayRole) {
-        return pack.name;
-    } else if (role == Qt::ToolTipRole) {
-        return pack.name;
-    } else if (role == Qt::DecorationRole) {
-        if (m_logoMap.contains(pack.safeName)) {
-            return (m_logoMap.value(pack.safeName));
+    switch (role) {
+        case Qt::ToolTipRole: {
+            if (pack.description.length() > 100) {
+                // some magic to prevent to long tooltips and replace html linebreaks
+                QString edit = pack.description.left(97);
+                edit = edit.left(edit.lastIndexOf("<br>")).left(edit.lastIndexOf(" ")).append("...");
+                return edit;
+            }
+            return pack.description;
         }
-        auto icon = APPLICATION->getThemedIcon("atlauncher-placeholder");
+        case Qt::DecorationRole: {
+            if (m_logoMap.contains(pack.safeName)) {
+                return (m_logoMap.value(pack.safeName));
+            }
+            auto icon = APPLICATION->getThemedIcon("atlauncher-placeholder");
 
-        auto url = QString(BuildConfig.ATL_DOWNLOAD_SERVER_URL + "launcher/images/%1.png").arg(pack.safeName.toLower());
-        ((ListModel*)this)->requestLogo(pack.safeName, url);
+            auto url = QString(BuildConfig.ATL_DOWNLOAD_SERVER_URL + "launcher/images/%1.png").arg(pack.safeName.toLower());
+            ((ListModel*)this)->requestLogo(pack.safeName, url);
 
-        return icon;
-    } else if (role == Qt::UserRole) {
-        QVariant v;
-        v.setValue(pack);
-        return v;
+            return icon;
+        }
+        case Qt::UserRole: {
+            QVariant v;
+            v.setValue(pack);
+            return v;
+        }
+        case Qt::DisplayRole:
+            return pack.name;
+        case Qt::SizeHintRole:
+            return QSize(0, 58);
+        // Custom data
+        case UserDataTypes::TITLE:
+            return pack.name;
+        case UserDataTypes::DESCRIPTION:
+            return pack.description;
+        case UserDataTypes::SELECTED:
+            return false;
+        case UserDataTypes::INSTALLED:
+            return false;
+        default:
+            break;
     }
 
-    return QVariant();
+    return {};
 }
 
 void ListModel::request()

--- a/launcher/ui/pages/modplatform/atlauncher/AtlPage.cpp
+++ b/launcher/ui/pages/modplatform/atlauncher/AtlPage.cpp
@@ -35,11 +35,11 @@
  */
 
 #include "AtlPage.h"
+#include "ui/widgets/ProjectItem.h"
 #include "ui_AtlPage.h"
 
 #include "BuildConfig.h"
 
-#include "AtlOptionalModDialog.h"
 #include "AtlUserInteractionSupportImpl.h"
 #include "modplatform/atlauncher/ATLPackInstallTask.h"
 #include "ui/dialogs/NewInstanceDialog.h"
@@ -71,6 +71,8 @@ AtlPage::AtlPage(NewInstanceDialog* dialog, QWidget* parent) : QWidget(parent), 
     connect(ui->sortByBox, &QComboBox::currentTextChanged, this, &AtlPage::onSortingSelectionChanged);
     connect(ui->packView->selectionModel(), &QItemSelectionModel::currentChanged, this, &AtlPage::onSelectionChanged);
     connect(ui->versionSelectionBox, &QComboBox::currentTextChanged, this, &AtlPage::onVersionSelectionChanged);
+
+    ui->packView->setItemDelegate(new ProjectItemDelegate(this));
 }
 
 AtlPage::~AtlPage()

--- a/launcher/ui/pages/modplatform/atlauncher/AtlPage.ui
+++ b/launcher/ui/pages/modplatform/atlauncher/AtlPage.ui
@@ -11,44 +11,7 @@
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="0" colspan="2">
-    <layout class="QGridLayout" name="gridLayout_3">
-     <item row="1" column="0">
-      <widget class="QTreeView" name="packView">
-       <property name="alternatingRowColors">
-        <bool>true</bool>
-       </property>
-       <property name="iconSize">
-        <size>
-         <width>96</width>
-         <height>48</height>
-        </size>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QTextBrowser" name="packDescription">
-       <property name="openExternalLinks">
-        <bool>true</bool>
-       </property>
-       <property name="openLinks">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0" colspan="2">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Warning: This is still a work in progress. If you run into issues with the imported modpack, it may be a bug.</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="2" column="0" colspan="2">
+   <item row="3" column="0" colspan="2">
     <layout class="QGridLayout" name="gridLayout_4" columnstretch="0,0,0" rowminimumheight="0" columnminimumwidth="0,0,0">
      <item row="0" column="2">
       <widget class="QComboBox" name="versionSelectionBox"/>
@@ -68,12 +31,64 @@
      </item>
     </layout>
    </item>
-   <item row="0" column="0">
+   <item row="2" column="0" colspan="2">
+    <layout class="QGridLayout" name="gridLayout_3">
+     <item row="1" column="1">
+      <widget class="QTextBrowser" name="packDescription">
+       <property name="openExternalLinks">
+        <bool>true</bool>
+       </property>
+       <property name="openLinks">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QTreeView" name="packView">
+       <property name="alternatingRowColors">
+        <bool>true</bool>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>96</width>
+         <height>48</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0">
     <widget class="QLineEdit" name="searchEdit">
      <property name="placeholderText">
       <string>Search and filter...</string>
      </property>
      <property name="clearButtonEnabled">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QPushButton" name="pushButton">
+     <property name="text">
+      <string>Search</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QLabel" name="label_2">
+     <property name="font">
+      <font>
+       <italic>true</italic>
+      </font>
+     </property>
+     <property name="text">
+      <string>Warning: This is still a work in progress. If you run into issues with the imported modpack, it may be a bug.</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="wordWrap">
       <bool>true</bool>
      </property>
     </widget>

--- a/launcher/ui/pages/modplatform/flame/FlameModel.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameModel.cpp
@@ -173,7 +173,7 @@ void ListModel::performPaginatedSearch()
                 callbacks.on_fail = [this](QString reason) { searchRequestFailed(reason); };
 
             if (!callbacks.on_succeed)
-                callbacks.on_succeed = [this](auto& doc, auto pack) { searchRequestForOneSucceeded(doc); };
+                callbacks.on_succeed = [this](auto& doc, auto& pack) { searchRequestForOneSucceeded(doc); };
             static const FlameAPI api;
             if (auto job = api.getProjectInfo({ projectId }, std::move(callbacks)); job) {
                 jobPtr = job;

--- a/launcher/ui/pages/modplatform/flame/FlameModel.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameModel.cpp
@@ -168,12 +168,8 @@ void ListModel::performPaginatedSearch()
         if (!projectId.isEmpty()) {
             ResourceAPI::ProjectInfoCallbacks callbacks;
 
-            // Use defaults if no callbacks are set
-            if (!callbacks.on_fail)
-                callbacks.on_fail = [this](QString reason) { searchRequestFailed(reason); };
-
-            if (!callbacks.on_succeed)
-                callbacks.on_succeed = [this](auto& doc, auto& pack) { searchRequestForOneSucceeded(doc); };
+            callbacks.on_fail = [this](QString reason) { searchRequestFailed(reason); };
+            callbacks.on_succeed = [this](auto& doc, auto& pack) { searchRequestForOneSucceeded(doc); };
             static const FlameAPI api;
             if (auto job = api.getProjectInfo({ projectId }, std::move(callbacks)); job) {
                 jobPtr = job;

--- a/launcher/ui/pages/modplatform/flame/FlameModel.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameModel.cpp
@@ -164,7 +164,7 @@ void ListModel::fetchMore(const QModelIndex& parent)
 void ListModel::performPaginatedSearch()
 {
     if (currentSearchTerm.startsWith("#")) {
-        auto projectId = currentSearchTerm.removeFirst();
+        auto projectId = currentSearchTerm.mid(1);
         if (!projectId.isEmpty()) {
             ResourceAPI::ProjectInfoCallbacks callbacks;
 

--- a/launcher/ui/pages/modplatform/flame/FlameModel.h
+++ b/launcher/ui/pages/modplatform/flame/FlameModel.h
@@ -40,6 +40,8 @@ class ListModel : public QAbstractListModel {
     void getLogo(const QString& logo, const QString& logoUrl, LogoCallback callback);
     void searchWithTerm(const QString& term, const int sort);
 
+    [[nodiscard]] bool hasActiveSearchJob() const { return jobPtr && jobPtr->isRunning(); }
+
    private slots:
     void performPaginatedSearch();
 
@@ -48,6 +50,7 @@ class ListModel : public QAbstractListModel {
 
     void searchRequestFinished();
     void searchRequestFailed(QString reason);
+    void searchRequestForOneSucceeded(QJsonDocument&);
 
    private:
     void requestLogo(QString file, QString url);
@@ -63,7 +66,7 @@ class ListModel : public QAbstractListModel {
     int currentSort = 0;
     int nextSearchOffset = 0;
     enum SearchState { None, CanPossiblyFetchMore, ResetRequested, Finished } searchState = None;
-    NetJob::Ptr jobPtr;
+    Task::Ptr jobPtr;
     std::shared_ptr<QByteArray> response = std::make_shared<QByteArray>();
 };
 

--- a/launcher/ui/pages/modplatform/flame/FlameModel.h
+++ b/launcher/ui/pages/modplatform/flame/FlameModel.h
@@ -41,6 +41,7 @@ class ListModel : public QAbstractListModel {
     void searchWithTerm(const QString& term, const int sort);
 
     [[nodiscard]] bool hasActiveSearchJob() const { return jobPtr && jobPtr->isRunning(); }
+    [[nodiscard]] Task::Ptr activeSearchJob() { return hasActiveSearchJob() ? jobPtr : nullptr; }
 
    private slots:
     void performPaginatedSearch();

--- a/launcher/ui/pages/modplatform/flame/FlamePage.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.cpp
@@ -50,7 +50,8 @@
 
 static FlameAPI api;
 
-FlamePage::FlamePage(NewInstanceDialog* dialog, QWidget* parent) : QWidget(parent), ui(new Ui::FlamePage), dialog(dialog)
+FlamePage::FlamePage(NewInstanceDialog* dialog, QWidget* parent)
+    : QWidget(parent), ui(new Ui::FlamePage), dialog(dialog), m_fetch_progress(this, false)
 {
     ui->setupUi(this);
     connect(ui->searchButton, &QPushButton::clicked, this, &FlamePage::triggerSearch);
@@ -65,6 +66,12 @@ FlamePage::FlamePage(NewInstanceDialog* dialog, QWidget* parent) : QWidget(paren
     m_search_timer.setSingleShot(true);
 
     connect(&m_search_timer, &QTimer::timeout, this, &FlamePage::triggerSearch);
+
+    m_fetch_progress.hideIfInactive(true);
+    m_fetch_progress.setFixedHeight(24);
+    m_fetch_progress.progressFormat("");
+
+    ui->gridLayout->addWidget(&m_fetch_progress, 2, 0, 1, ui->gridLayout->columnCount());
 
     // index is used to set the sorting with the curseforge api
     ui->sortByBox->addItem(tr("Sort by Featured"));
@@ -124,6 +131,7 @@ void FlamePage::openedImpl()
 void FlamePage::triggerSearch()
 {
     listModel->searchWithTerm(ui->searchEdit->text(), ui->sortByBox->currentIndex());
+    m_fetch_progress.watch(listModel->activeSearchJob().get());
 }
 
 void FlamePage::onSelectionChanged(QModelIndex curr, [[maybe_unused]] QModelIndex prev)

--- a/launcher/ui/pages/modplatform/flame/FlamePage.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.cpp
@@ -61,6 +61,11 @@ FlamePage::FlamePage(NewInstanceDialog* dialog, QWidget* parent) : QWidget(paren
     ui->versionSelectionBox->view()->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     ui->versionSelectionBox->view()->parentWidget()->setMaximumHeight(300);
 
+    m_search_timer.setTimerType(Qt::TimerType::CoarseTimer);
+    m_search_timer.setSingleShot(true);
+
+    connect(&m_search_timer, &QTimer::timeout, this, &FlamePage::triggerSearch);
+
     // index is used to set the sorting with the curseforge api
     ui->sortByBox->addItem(tr("Sort by Featured"));
     ui->sortByBox->addItem(tr("Sort by Popularity"));
@@ -90,6 +95,11 @@ bool FlamePage::eventFilter(QObject* watched, QEvent* event)
             triggerSearch();
             keyEvent->accept();
             return true;
+        } else {
+            if (m_search_timer.isActive())
+                m_search_timer.stop();
+
+            m_search_timer.start(350);
         }
     }
     return QWidget::eventFilter(watched, event);

--- a/launcher/ui/pages/modplatform/flame/FlamePage.h
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.h
@@ -41,6 +41,7 @@
 #include <modplatform/flame/FlamePackIndex.h>
 #include <QTimer>
 #include "ui/pages/BasePage.h"
+#include "ui/widgets/ProgressWidget.h"
 
 namespace Ui {
 class FlamePage;
@@ -86,6 +87,8 @@ class FlamePage : public QWidget, public BasePage {
     Flame::IndexedPack current;
 
     int m_selected_version_index = -1;
+
+    ProgressWidget m_fetch_progress;
 
     // Used to do instant searching with a delay to cache quick changes
     QTimer m_search_timer;

--- a/launcher/ui/pages/modplatform/flame/FlamePage.h
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.h
@@ -39,7 +39,7 @@
 
 #include <Application.h>
 #include <modplatform/flame/FlamePackIndex.h>
-#include "tasks/Task.h"
+#include <QTimer>
 #include "ui/pages/BasePage.h"
 
 namespace Ui {
@@ -86,4 +86,7 @@ class FlamePage : public QWidget, public BasePage {
     Flame::IndexedPack current;
 
     int m_selected_version_index = -1;
+
+    // Used to do instant searching with a delay to cache quick changes
+    QTimer m_search_timer;
 };

--- a/launcher/ui/pages/modplatform/flame/FlamePage.ui
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.ui
@@ -47,7 +47,7 @@
      </item>
     </layout>
    </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <layout class="QHBoxLayout">
      <item>
       <widget class="QListView" name="packView">
@@ -77,7 +77,7 @@
      </item>
     </layout>
    </item>
-   <item row="3" column="0">
+   <item row="4" column="0">
     <layout class="QHBoxLayout">
      <item>
       <widget class="QComboBox" name="sortByBox"/>

--- a/launcher/ui/pages/modplatform/import_ftb/ImportFTBPage.h
+++ b/launcher/ui/pages/modplatform/import_ftb/ImportFTBPage.h
@@ -53,12 +53,15 @@ class ImportFTBPage : public QWidget, public BasePage {
     void suggestCurrent();
     void onPackSelectionChanged(Modpack* pack = nullptr);
    private slots:
+    void onSortingSelectionChanged(QString data);
     void onPublicPackSelectionChanged(QModelIndex first, QModelIndex second);
+    void triggerSearch();
 
    private:
     bool initialized = false;
     Modpack selected;
     ListModel* listModel = nullptr;
+    FilterModel* currentModel = nullptr;
 
     NewInstanceDialog* dialog = nullptr;
     Ui::ImportFTBPage* ui = nullptr;

--- a/launcher/ui/pages/modplatform/import_ftb/ImportFTBPage.ui
+++ b/launcher/ui/pages/modplatform/import_ftb/ImportFTBPage.ui
@@ -10,8 +10,8 @@
     <height>1011</height>
    </rect>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout">
-   <item>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="1">
     <widget class="QTreeView" name="modpackList">
      <property name="maximumSize">
       <size>
@@ -20,6 +20,54 @@
       </size>
      </property>
     </widget>
+   </item>
+   <item row="0" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLineEdit" name="searchEdit">
+       <property name="placeholderText">
+        <string>Search and filter...</string>
+       </property>
+       <property name="clearButtonEnabled">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButton">
+       <property name="text">
+        <string>Search</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QComboBox" name="sortByBox">
+       <property name="minimumSize">
+        <size>
+         <width>265</width>
+         <height>0</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/launcher/ui/pages/modplatform/import_ftb/ListModel.cpp
+++ b/launcher/ui/pages/modplatform/import_ftb/ListModel.cpp
@@ -23,7 +23,9 @@
 #include <QIcon>
 #include <QProcessEnvironment>
 #include "FileSystem.h"
+#include "StringUtils.h"
 #include "modplatform/import_ftb/PackHelpers.h"
+#include "ui/widgets/ProjectItem.h"
 
 namespace FTBImportAPP {
 
@@ -71,18 +73,99 @@ QVariant ListModel::data(const QModelIndex& index, int role) const
     }
 
     auto pack = modpacks.at(pos);
-    if (role == Qt::DisplayRole) {
-        return pack.name;
-    } else if (role == Qt::DecorationRole) {
-        return pack.icon;
-    } else if (role == Qt::UserRole) {
-        QVariant v;
-        v.setValue(pack);
-        return v;
-    } else if (role == Qt::ToolTipRole) {
-        return tr("Minecraft %1").arg(pack.mcVersion);
+    if (role == Qt::ToolTipRole) {
     }
 
-    return QVariant();
+    switch (role) {
+        case Qt::ToolTipRole:
+            return tr("Minecraft %1").arg(pack.mcVersion);
+        case Qt::DecorationRole:
+            return pack.icon;
+        case Qt::UserRole: {
+            QVariant v;
+            v.setValue(pack);
+            return v;
+        }
+        case Qt::DisplayRole:
+            return pack.name;
+        case Qt::SizeHintRole:
+            return QSize(0, 58);
+        // Custom data
+        case UserDataTypes::TITLE:
+            return pack.name;
+        case UserDataTypes::DESCRIPTION:
+            return tr("Minecraft %1").arg(pack.mcVersion);
+        case UserDataTypes::SELECTED:
+            return false;
+        case UserDataTypes::INSTALLED:
+            return false;
+        default:
+            break;
+    }
+
+    return {};
+}
+
+FilterModel::FilterModel(QObject* parent) : QSortFilterProxyModel(parent)
+{
+    currentSorting = Sorting::ByGameVersion;
+    sortings.insert(tr("Sort by Name"), Sorting::ByName);
+    sortings.insert(tr("Sort by Game Version"), Sorting::ByGameVersion);
+}
+
+bool FilterModel::lessThan(const QModelIndex& left, const QModelIndex& right) const
+{
+    Modpack leftPack = sourceModel()->data(left, Qt::UserRole).value<Modpack>();
+    Modpack rightPack = sourceModel()->data(right, Qt::UserRole).value<Modpack>();
+
+    if (currentSorting == Sorting::ByGameVersion) {
+        Version lv(leftPack.mcVersion);
+        Version rv(rightPack.mcVersion);
+        return lv < rv;
+
+    } else if (currentSorting == Sorting::ByName) {
+        return StringUtils::naturalCompare(leftPack.name, rightPack.name, Qt::CaseSensitive) >= 0;
+    }
+
+    // UHM, some inavlid value set?!
+    qWarning() << "Invalid sorting set!";
+    return true;
+}
+
+bool FilterModel::filterAcceptsRow([[maybe_unused]] int sourceRow, [[maybe_unused]] const QModelIndex& sourceParent) const
+{
+    if (searchTerm.isEmpty()) {
+        return true;
+    }
+    QModelIndex index = sourceModel()->index(sourceRow, 0, sourceParent);
+    Modpack pack = sourceModel()->data(index, Qt::UserRole).value<Modpack>();
+    return pack.name.contains(searchTerm, Qt::CaseInsensitive);
+}
+
+void FilterModel::setSearchTerm(const QString term)
+{
+    searchTerm = term.trimmed();
+    invalidate();
+}
+
+const QMap<QString, FilterModel::Sorting> FilterModel::getAvailableSortings()
+{
+    return sortings;
+}
+
+QString FilterModel::translateCurrentSorting()
+{
+    return sortings.key(currentSorting);
+}
+
+void FilterModel::setSorting(Sorting s)
+{
+    currentSorting = s;
+    invalidate();
+}
+
+FilterModel::Sorting FilterModel::getCurrentSorting()
+{
+    return currentSorting;
 }
 }  // namespace FTBImportAPP

--- a/launcher/ui/pages/modplatform/import_ftb/ListModel.h
+++ b/launcher/ui/pages/modplatform/import_ftb/ListModel.h
@@ -20,10 +20,32 @@
 
 #include <QAbstractListModel>
 #include <QIcon>
+#include <QSortFilterProxyModel>
 #include <QVariant>
 #include "modplatform/import_ftb/PackHelpers.h"
 
 namespace FTBImportAPP {
+
+class FilterModel : public QSortFilterProxyModel {
+    Q_OBJECT
+   public:
+    FilterModel(QObject* parent = Q_NULLPTR);
+    enum Sorting { ByName, ByGameVersion };
+    const QMap<QString, Sorting> getAvailableSortings();
+    QString translateCurrentSorting();
+    void setSorting(Sorting sorting);
+    Sorting getCurrentSorting();
+    void setSearchTerm(QString term);
+
+   protected:
+    bool filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const override;
+    bool lessThan(const QModelIndex& left, const QModelIndex& right) const override;
+
+   private:
+    QMap<QString, Sorting> sortings;
+    Sorting currentSorting;
+    QString searchTerm;
+};
 
 class ListModel : public QAbstractListModel {
     Q_OBJECT

--- a/launcher/ui/pages/modplatform/legacy_ftb/ListModel.h
+++ b/launcher/ui/pages/modplatform/legacy_ftb/ListModel.h
@@ -25,6 +25,7 @@ class FilterModel : public QSortFilterProxyModel {
     QString translateCurrentSorting();
     void setSorting(Sorting sorting);
     Sorting getCurrentSorting();
+    void setSearchTerm(QString term);
 
    protected:
     bool filterAcceptsRow(int sourceRow, const QModelIndex& sourceParent) const override;
@@ -33,6 +34,7 @@ class FilterModel : public QSortFilterProxyModel {
    private:
     QMap<QString, Sorting> sortings;
     Sorting currentSorting;
+    QString searchTerm;
 };
 
 class ListModel : public QAbstractListModel {

--- a/launcher/ui/pages/modplatform/legacy_ftb/Page.cpp
+++ b/launcher/ui/pages/modplatform/legacy_ftb/Page.cpp
@@ -35,6 +35,7 @@
  */
 
 #include "Page.h"
+#include "ui/widgets/ProjectItem.h"
 #include "ui_Page.h"
 
 #include <QInputDialog>
@@ -110,6 +111,8 @@ Page::Page(NewInstanceDialog* dialog, QWidget* parent) : QWidget(parent), dialog
     connect(ui->sortByBox, &QComboBox::currentTextChanged, this, &Page::onSortingSelectionChanged);
     connect(ui->versionSelectionBox, &QComboBox::currentTextChanged, this, &Page::onVersionSelectionItemChanged);
 
+    connect(ui->searchEdit, &QLineEdit::textChanged, this, &Page::triggerSearch);
+
     connect(ui->publicPackList->selectionModel(), &QItemSelectionModel::currentChanged, this, &Page::onPublicPackSelectionChanged);
     connect(ui->thirdPartyPackList->selectionModel(), &QItemSelectionModel::currentChanged, this, &Page::onThirdPartyPackSelectionChanged);
     connect(ui->privatePackList->selectionModel(), &QItemSelectionModel::currentChanged, this, &Page::onPrivatePackSelectionChanged);
@@ -125,6 +128,9 @@ Page::Page(NewInstanceDialog* dialog, QWidget* parent) : QWidget(parent), dialog
     ui->thirdPartyPackList->selectionModel()->reset();
     ui->privatePackList->selectionModel()->reset();
 
+    ui->publicPackList->setItemDelegate(new ProjectItemDelegate(this));
+    ui->thirdPartyPackList->setItemDelegate(new ProjectItemDelegate(this));
+    ui->privatePackList->setItemDelegate(new ProjectItemDelegate(this));
     onTabChanged(ui->tabWidget->currentIndex());
 }
 
@@ -319,6 +325,8 @@ void Page::onTabChanged(int tab)
         currentModpackInfo = ui->publicPackDescription;
     }
 
+    triggerSearch();
+
     currentList->selectionModel()->reset();
     QModelIndex idx = currentList->currentIndex();
     if (idx.isValid()) {
@@ -356,6 +364,11 @@ void Page::onRemovePackClicked()
     ftbPrivatePacks->remove(pack.packCode);
     privateListModel->remove(row);
     onPackSelectionChanged();
+}
+
+void Page::triggerSearch()
+{
+    currentModel->setSearchTerm(ui->searchEdit->text());
 }
 
 }  // namespace LegacyFTB

--- a/launcher/ui/pages/modplatform/legacy_ftb/Page.h
+++ b/launcher/ui/pages/modplatform/legacy_ftb/Page.h
@@ -43,7 +43,6 @@
 #include "QObjectPtr.h"
 #include "modplatform/legacy_ftb/PackFetchTask.h"
 #include "modplatform/legacy_ftb/PackHelpers.h"
-#include "tasks/Task.h"
 #include "ui/pages/BasePage.h"
 
 class NewInstanceDialog;
@@ -56,8 +55,6 @@ class Page;
 
 class ListModel;
 class FilterModel;
-class PrivatePackListModel;
-class PrivatePackFilterModel;
 class PrivatePackManager;
 
 class Page : public QWidget, public BasePage {
@@ -97,6 +94,8 @@ class Page : public QWidget, public BasePage {
 
     void onAddPackClicked();
     void onRemovePackClicked();
+
+    void triggerSearch();
 
    private:
     FilterModel* currentModel = nullptr;

--- a/launcher/ui/pages/modplatform/legacy_ftb/Page.ui
+++ b/launcher/ui/pages/modplatform/legacy_ftb/Page.ui
@@ -10,8 +10,29 @@
     <height>602</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
+  <layout class="QGridLayout" name="gridLayout_5">
+   <item row="0" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLineEdit" name="searchEdit">
+       <property name="placeholderText">
+        <string>Search and filter...</string>
+       </property>
+       <property name="clearButtonEnabled">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="pushButton">
+       <property name="text">
+        <string>Search</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="4" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
       <number>0</number>
@@ -36,9 +57,9 @@
        </item>
        <item row="0" column="1">
         <widget class="QTextBrowser" name="publicPackDescription">
-           <property name="openExternalLinks">
-            <bool>true</bool>
-           </property>
+         <property name="openExternalLinks">
+          <bool>true</bool>
+         </property>
         </widget>
        </item>
       </layout>
@@ -50,10 +71,10 @@
       <layout class="QGridLayout" name="gridLayout_3">
        <item row="0" column="1">
         <widget class="QTextBrowser" name="thirdPartyPackDescription">
-               <property name="openExternalLinks">
-            <bool>true</bool>
-           </property>
-          </widget>
+         <property name="openExternalLinks">
+          <bool>true</bool>
+         </property>
+        </widget>
        </item>
        <item row="0" column="0">
         <widget class="QTreeView" name="thirdPartyPackList">
@@ -104,16 +125,16 @@
        </item>
        <item row="0" column="1" rowspan="3">
         <widget class="QTextBrowser" name="privatePackDescription">
-           <property name="openExternalLinks">
-            <bool>true</bool>
-           </property>
-          </widget>
+         <property name="openExternalLinks">
+          <bool>true</bool>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>
     </widget>
    </item>
-   <item>
+   <item row="5" column="0">
     <layout class="QGridLayout" name="gridLayout_4">
      <item row="0" column="1">
       <widget class="QLabel" name="label">

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
@@ -38,8 +38,8 @@
 
 #include "BuildConfig.h"
 #include "Json.h"
-#include "minecraft/MinecraftInstance.h"
-#include "minecraft/PackProfile.h"
+#include "modplatform/modrinth/ModrinthAPI.h"
+#include "net/NetJob.h"
 #include "ui/widgets/ProjectItem.h"
 
 #include "net/ApiDownload.h"
@@ -130,7 +130,28 @@ bool ModpackListModel::setData(const QModelIndex& index, const QVariant& value, 
 
 void ModpackListModel::performPaginatedSearch()
 {
-    // TODO: Move to standalone API
+    if (hasActiveSearchJob())
+        return;
+
+    if (currentSearchTerm.startsWith("#")) {
+        auto projectId = currentSearchTerm.removeFirst();
+        if (!projectId.isEmpty()) {
+            ResourceAPI::ProjectInfoCallbacks callbacks;
+
+            // Use defaults if no callbacks are set
+            if (!callbacks.on_fail)
+                callbacks.on_fail = [this](QString reason) { searchRequestFailed(reason); };
+
+            if (!callbacks.on_succeed)
+                callbacks.on_succeed = [this](auto& doc, auto pack) { searchRequestForOneSucceeded(doc); };
+            static const ModrinthAPI api;
+            if (auto job = api.getProjectInfo({ projectId }, std::move(callbacks)); job) {
+                jobPtr = job;
+                jobPtr->start();
+            }
+            return;
+        }
+    }  // TODO: Move to standalone API
     auto netJob = makeShared<NetJob>("Modrinth::SearchModpack", APPLICATION->network());
     auto searchAllUrl = QString(BuildConfig.MODRINTH_PROD_URL +
                                 "/search?"
@@ -167,16 +188,17 @@ void ModpackListModel::performPaginatedSearch()
 
 void ModpackListModel::refresh()
 {
-    if (jobPtr) {
+    if (hasActiveSearchJob()) {
         jobPtr->abort();
         searchState = ResetRequested;
         return;
-    } else {
-        beginResetModel();
-        modpacks.clear();
-        endResetModel();
-        searchState = None;
     }
+
+    beginResetModel();
+    modpacks.clear();
+    endResetModel();
+    searchState = None;
+
     nextSearchOffset = 0;
     performPaginatedSearch();
 }
@@ -307,9 +329,29 @@ void ModpackListModel::searchRequestFinished(QJsonDocument& doc_all)
     endInsertRows();
 }
 
+void ModpackListModel::searchRequestForOneSucceeded(QJsonDocument& doc)
+{
+    jobPtr.reset();
+
+    auto packObj = doc.object();
+
+    Modrinth::Modpack pack;
+    try {
+        Modrinth::loadIndexedPack(pack, packObj);
+        pack.id = Json::ensureString(packObj, "id", pack.id);
+    } catch (const JSONValidationError& e) {
+        qWarning() << "Error while loading mod from " << m_parent->debugName() << ": " << e.cause();
+        return;
+    }
+
+    beginInsertRows(QModelIndex(), modpacks.size(), modpacks.size() + 1);
+    modpacks.append({ pack });
+    endInsertRows();
+}
+
 void ModpackListModel::searchRequestFailed(QString reason)
 {
-    auto failed_action = jobPtr->getFailedActions().at(0);
+    auto failed_action = dynamic_cast<NetJob*>(jobPtr.get())->getFailedActions().at(0);
     if (!failed_action->m_reply) {
         // Network error
         QMessageBox::critical(nullptr, tr("Error"), tr("A network error occurred. Could not load modpacks."));

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
@@ -138,12 +138,8 @@ void ModpackListModel::performPaginatedSearch()
         if (!projectId.isEmpty()) {
             ResourceAPI::ProjectInfoCallbacks callbacks;
 
-            // Use defaults if no callbacks are set
-            if (!callbacks.on_fail)
-                callbacks.on_fail = [this](QString reason) { searchRequestFailed(reason); };
-
-            if (!callbacks.on_succeed)
-                callbacks.on_succeed = [this](auto& doc, auto& pack) { searchRequestForOneSucceeded(doc); };
+            callbacks.on_fail = [this](QString reason) { searchRequestFailed(reason); };
+            callbacks.on_succeed = [this](auto& doc, auto& pack) { searchRequestForOneSucceeded(doc); };
             static const ModrinthAPI api;
             if (auto job = api.getProjectInfo({ projectId }, std::move(callbacks)); job) {
                 jobPtr = job;

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
@@ -134,7 +134,7 @@ void ModpackListModel::performPaginatedSearch()
         return;
 
     if (currentSearchTerm.startsWith("#")) {
-        auto projectId = currentSearchTerm.removeFirst();
+        auto projectId = currentSearchTerm.mid(1);
         if (!projectId.isEmpty()) {
             ResourceAPI::ProjectInfoCallbacks callbacks;
 

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
@@ -143,7 +143,7 @@ void ModpackListModel::performPaginatedSearch()
                 callbacks.on_fail = [this](QString reason) { searchRequestFailed(reason); };
 
             if (!callbacks.on_succeed)
-                callbacks.on_succeed = [this](auto& doc, auto pack) { searchRequestForOneSucceeded(doc); };
+                callbacks.on_succeed = [this](auto& doc, auto& pack) { searchRequestForOneSucceeded(doc); };
             static const ModrinthAPI api;
             if (auto job = api.getProjectInfo({ projectId }, std::move(callbacks)); job) {
                 jobPtr = job;

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModel.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModel.h
@@ -73,6 +73,8 @@ class ModpackListModel : public QAbstractListModel {
     void refresh();
     void searchWithTerm(const QString& term, const int sort);
 
+    [[nodiscard]] bool hasActiveSearchJob() const { return jobPtr && jobPtr->isRunning(); }
+
     void getLogo(const QString& logo, const QString& logoUrl, LogoCallback callback);
 
     inline auto canFetchMore(const QModelIndex& parent) const -> bool override
@@ -83,6 +85,7 @@ class ModpackListModel : public QAbstractListModel {
    public slots:
     void searchRequestFinished(QJsonDocument& doc_all);
     void searchRequestFailed(QString reason);
+    void searchRequestForOneSucceeded(QJsonDocument&);
 
    protected slots:
 
@@ -111,7 +114,7 @@ class ModpackListModel : public QAbstractListModel {
     int nextSearchOffset = 0;
     enum SearchState { None, CanPossiblyFetchMore, ResetRequested, Finished } searchState = None;
 
-    NetJob::Ptr jobPtr;
+    Task::Ptr jobPtr;
 
     std::shared_ptr<QByteArray> m_all_response = std::make_shared<QByteArray>();
     QByteArray m_specific_response;

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModel.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModel.h
@@ -74,6 +74,7 @@ class ModpackListModel : public QAbstractListModel {
     void searchWithTerm(const QString& term, const int sort);
 
     [[nodiscard]] bool hasActiveSearchJob() const { return jobPtr && jobPtr->isRunning(); }
+    [[nodiscard]] Task::Ptr activeSearchJob() { return hasActiveSearchJob() ? jobPtr : nullptr; }
 
     void getLogo(const QString& logo, const QString& logoUrl, LogoCallback callback);
 

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
@@ -64,6 +64,11 @@ ModrinthPage::ModrinthPage(NewInstanceDialog* dialog, QWidget* parent) : QWidget
     ui->versionSelectionBox->view()->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     ui->versionSelectionBox->view()->parentWidget()->setMaximumHeight(300);
 
+    m_search_timer.setTimerType(Qt::TimerType::CoarseTimer);
+    m_search_timer.setSingleShot(true);
+
+    connect(&m_search_timer, &QTimer::timeout, this, &ModrinthPage::triggerSearch);
+
     ui->sortByBox->addItem(tr("Sort by Relevance"));
     ui->sortByBox->addItem(tr("Sort by Total Downloads"));
     ui->sortByBox->addItem(tr("Sort by Follows"));
@@ -102,6 +107,11 @@ bool ModrinthPage::eventFilter(QObject* watched, QEvent* event)
             this->triggerSearch();
             keyEvent->accept();
             return true;
+        } else {
+            if (m_search_timer.isActive())
+                m_search_timer.stop();
+
+            m_search_timer.start(350);
         }
     }
     return QObject::eventFilter(watched, event);

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
@@ -52,7 +52,8 @@
 #include <QKeyEvent>
 #include <QPushButton>
 
-ModrinthPage::ModrinthPage(NewInstanceDialog* dialog, QWidget* parent) : QWidget(parent), ui(new Ui::ModrinthPage), dialog(dialog)
+ModrinthPage::ModrinthPage(NewInstanceDialog* dialog, QWidget* parent)
+    : QWidget(parent), ui(new Ui::ModrinthPage), dialog(dialog), m_fetch_progress(this, false)
 {
     ui->setupUi(this);
 
@@ -68,6 +69,12 @@ ModrinthPage::ModrinthPage(NewInstanceDialog* dialog, QWidget* parent) : QWidget
     m_search_timer.setSingleShot(true);
 
     connect(&m_search_timer, &QTimer::timeout, this, &ModrinthPage::triggerSearch);
+
+    m_fetch_progress.hideIfInactive(true);
+    m_fetch_progress.setFixedHeight(24);
+    m_fetch_progress.progressFormat("");
+
+    ui->gridLayout->addWidget(&m_fetch_progress, 2, 0, 1, ui->gridLayout->columnCount());
 
     ui->sortByBox->addItem(tr("Sort by Relevance"));
     ui->sortByBox->addItem(tr("Sort by Total Downloads"));
@@ -319,6 +326,7 @@ void ModrinthPage::suggestCurrent()
 void ModrinthPage::triggerSearch()
 {
     m_model->searchWithTerm(ui->searchEdit->text(), ui->sortByBox->currentIndex());
+    m_fetch_progress.watch(m_model->activeSearchJob().get());
 }
 
 void ModrinthPage::onVersionSelectionChanged(QString version)

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.h
@@ -42,6 +42,7 @@
 
 #include "modplatform/modrinth/ModrinthPackManifest.h"
 
+#include <QTimer>
 #include <QWidget>
 
 namespace Ui {
@@ -88,4 +89,7 @@ class ModrinthPage : public QWidget, public BasePage {
 
     Modrinth::Modpack current;
     QString selectedVersion;
+
+    // Used to do instant searching with a delay to cache quick changes
+    QTimer m_search_timer;
 };

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.h
@@ -41,6 +41,7 @@
 #include "ui/pages/BasePage.h"
 
 #include "modplatform/modrinth/ModrinthPackManifest.h"
+#include "ui/widgets/ProgressWidget.h"
 
 #include <QTimer>
 #include <QWidget>
@@ -89,6 +90,8 @@ class ModrinthPage : public QWidget, public BasePage {
 
     Modrinth::Modpack current;
     QString selectedVersion;
+
+    ProgressWidget m_fetch_progress;
 
     // Used to do instant searching with a delay to cache quick changes
     QTimer m_search_timer;

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.ui
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.ui
@@ -10,8 +10,8 @@
     <height>600</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout">
-   <item>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
     <widget class="QLabel" name="label_2">
      <property name="font">
       <font>
@@ -29,7 +29,7 @@
      </property>
     </widget>
    </item>
-   <item>
+   <item row="1" column="0">
     <layout class="QHBoxLayout">
      <item>
       <widget class="QLineEdit" name="searchEdit">
@@ -47,7 +47,7 @@
      </item>
     </layout>
    </item>
-   <item>
+   <item row="3" column="0">
     <layout class="QHBoxLayout">
      <item>
       <widget class="QListView" name="packView">
@@ -77,7 +77,7 @@
      </item>
     </layout>
    </item>
-   <item>
+   <item row="4" column="0">
     <layout class="QHBoxLayout">
      <item>
       <widget class="QComboBox" name="sortByBox"/>

--- a/launcher/ui/pages/modplatform/technic/TechnicModel.h
+++ b/launcher/ui/pages/modplatform/technic/TechnicModel.h
@@ -58,6 +58,8 @@ class ListModel : public QAbstractListModel {
     void getLogo(const QString& logo, const QString& logoUrl, LogoCallback callback);
     void searchWithTerm(const QString& term);
 
+    [[nodiscard]] bool hasActiveSearchJob() const { return jobPtr && jobPtr->isRunning(); }
+
    private slots:
     void searchRequestFinished();
     void searchRequestFailed();

--- a/launcher/ui/pages/modplatform/technic/TechnicModel.h
+++ b/launcher/ui/pages/modplatform/technic/TechnicModel.h
@@ -59,6 +59,7 @@ class ListModel : public QAbstractListModel {
     void searchWithTerm(const QString& term);
 
     [[nodiscard]] bool hasActiveSearchJob() const { return jobPtr && jobPtr->isRunning(); }
+    [[nodiscard]] Task::Ptr activeSearchJob() { return hasActiveSearchJob() ? jobPtr : nullptr; }
 
    private slots:
     void searchRequestFinished();

--- a/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
+++ b/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
@@ -34,6 +34,7 @@
  */
 
 #include "TechnicPage.h"
+#include "ui/widgets/ProjectItem.h"
 #include "ui_TechnicPage.h"
 
 #include <QKeyEvent>
@@ -59,8 +60,15 @@ TechnicPage::TechnicPage(NewInstanceDialog* dialog, QWidget* parent) : QWidget(p
     model = new Technic::ListModel(this);
     ui->packView->setModel(model);
 
+    m_search_timer.setTimerType(Qt::TimerType::CoarseTimer);
+    m_search_timer.setSingleShot(true);
+
+    connect(&m_search_timer, &QTimer::timeout, this, &TechnicPage::triggerSearch);
+
     connect(ui->packView->selectionModel(), &QItemSelectionModel::currentChanged, this, &TechnicPage::onSelectionChanged);
     connect(ui->versionSelectionBox, &QComboBox::currentTextChanged, this, &TechnicPage::onVersionSelectionChanged);
+
+    ui->packView->setItemDelegate(new ProjectItemDelegate(this));
 }
 
 bool TechnicPage::eventFilter(QObject* watched, QEvent* event)
@@ -71,6 +79,11 @@ bool TechnicPage::eventFilter(QObject* watched, QEvent* event)
             triggerSearch();
             keyEvent->accept();
             return true;
+        } else {
+            if (m_search_timer.isActive())
+                m_search_timer.stop();
+
+            m_search_timer.start(350);
         }
     }
     return QWidget::eventFilter(watched, event);

--- a/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
+++ b/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
@@ -52,7 +52,8 @@
 
 #include "net/ApiDownload.h"
 
-TechnicPage::TechnicPage(NewInstanceDialog* dialog, QWidget* parent) : QWidget(parent), ui(new Ui::TechnicPage), dialog(dialog)
+TechnicPage::TechnicPage(NewInstanceDialog* dialog, QWidget* parent)
+    : QWidget(parent), ui(new Ui::TechnicPage), dialog(dialog), m_fetch_progress(this, false)
 {
     ui->setupUi(this);
     connect(ui->searchButton, &QPushButton::clicked, this, &TechnicPage::triggerSearch);
@@ -64,6 +65,12 @@ TechnicPage::TechnicPage(NewInstanceDialog* dialog, QWidget* parent) : QWidget(p
     m_search_timer.setSingleShot(true);
 
     connect(&m_search_timer, &QTimer::timeout, this, &TechnicPage::triggerSearch);
+
+    m_fetch_progress.hideIfInactive(true);
+    m_fetch_progress.setFixedHeight(24);
+    m_fetch_progress.progressFormat("");
+
+    ui->gridLayout->addWidget(&m_fetch_progress, 2, 0, 1, ui->gridLayout->columnCount());
 
     connect(ui->packView->selectionModel(), &QItemSelectionModel::currentChanged, this, &TechnicPage::onSelectionChanged);
     connect(ui->versionSelectionBox, &QComboBox::currentTextChanged, this, &TechnicPage::onVersionSelectionChanged);
@@ -113,6 +120,7 @@ void TechnicPage::openedImpl()
 void TechnicPage::triggerSearch()
 {
     model->searchWithTerm(ui->searchEdit->text());
+    m_fetch_progress.watch(model->activeSearchJob().get());
 }
 
 void TechnicPage::onSelectionChanged(QModelIndex first, [[maybe_unused]] QModelIndex second)

--- a/launcher/ui/pages/modplatform/technic/TechnicPage.h
+++ b/launcher/ui/pages/modplatform/technic/TechnicPage.h
@@ -42,6 +42,7 @@
 #include "TechnicData.h"
 #include "net/NetJob.h"
 #include "ui/pages/BasePage.h"
+#include "ui/widgets/ProgressWidget.h"
 
 namespace Ui {
 class TechnicPage;
@@ -91,6 +92,8 @@ class TechnicPage : public QWidget, public BasePage {
 
     NetJob::Ptr jobPtr;
     std::shared_ptr<QByteArray> response = std::make_shared<QByteArray>();
+
+    ProgressWidget m_fetch_progress;
 
     // Used to do instant searching with a delay to cache quick changes
     QTimer m_search_timer;

--- a/launcher/ui/pages/modplatform/technic/TechnicPage.h
+++ b/launcher/ui/pages/modplatform/technic/TechnicPage.h
@@ -35,12 +35,12 @@
 
 #pragma once
 
+#include <QTimer>
 #include <QWidget>
 
 #include <Application.h>
 #include "TechnicData.h"
 #include "net/NetJob.h"
-#include "tasks/Task.h"
 #include "ui/pages/BasePage.h"
 
 namespace Ui {
@@ -91,4 +91,7 @@ class TechnicPage : public QWidget, public BasePage {
 
     NetJob::Ptr jobPtr;
     std::shared_ptr<QByteArray> response = std::make_shared<QByteArray>();
+
+    // Used to do instant searching with a delay to cache quick changes
+    QTimer m_search_timer;
 };

--- a/launcher/ui/pages/modplatform/technic/TechnicPage.ui
+++ b/launcher/ui/pages/modplatform/technic/TechnicPage.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="3" column="0" colspan="2">
+   <item row="4" column="0" colspan="2">
     <layout class="QGridLayout" name="gridLayout_3">
      <item row="0" column="2">
       <widget class="QComboBox" name="versionSelectionBox"/>
@@ -44,7 +44,7 @@
      </item>
     </layout>
    </item>
-   <item row="2" column="0" colspan="2">
+   <item row="3" column="0" colspan="2">
     <layout class="QGridLayout" name="gridLayout_2">
      <item row="0" column="0">
       <widget class="QListView" name="packView">

--- a/launcher/ui/widgets/ProjectItem.cpp
+++ b/launcher/ui/widgets/ProjectItem.cpp
@@ -34,8 +34,8 @@ void ProjectItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& o
             icon_width = icon_size.width();
             icon_height = icon_size.height();
 
-            icon_x_margin = (rect.height() - icon_width) / 2;
             icon_y_margin = (rect.height() - icon_height) / 2;
+            icon_x_margin = icon_y_margin;  // use same margins for consistency
         }
 
         // Centralize icon with a margin to separate from the other elements


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
fixes #1239
fixes #401
fixes #843

Done
- [x] search bar and button available on all providers
- [x] instant search for all providers(flame,modrinth,technic) 
- [x] modpack name and below description present for all providers (technic doesn't like descriptions)
- [x] you prefix your search term with `#` then followed by the project id will allow you to view the mentioned project(as this is no filter if the project is a modpack or a mod will have the potential danger to display mods in modpack import and also other resources)

I'm not gonna implement the preserving of the search text over different providers.
