### PR TITLE
feat:neoforge can download forge mods

### DIFF
--- a/launcher/modplatform/flame/FlameAPI.h
+++ b/launcher/modplatform/flame/FlameAPI.h
@@ -47,9 +47,10 @@ class FlameAPI : public NetworkResourceAPI {
             return 4;
         // TODO: remove this once Quilt drops official Fabric support
         if (loaders & Quilt)  // NOTE: Most if not all Fabric mods should work *currently*
-            return 4;         // FIXME: implement multiple loaders filter
-        if (loaders & NeoForge)
-            return 6;
+            return 4;         // FIXME: implement multiple loaders filter (this should be 5)
+        // TODO: remove this once NeoForge drops official Forge support
+        if (loaders & NeoForge)  // NOTE: Most if not all Forge mods should work *currently*
+            return 1;            // FIXME: implement multiple loaders filter (this should be 6)
         return 0;
     }
 

--- a/launcher/modplatform/modrinth/ModrinthAPI.h
+++ b/launcher/modplatform/modrinth/ModrinthAPI.h
@@ -43,6 +43,8 @@ class ModrinthAPI : public NetworkResourceAPI {
                 l << getModLoaderString(loader);
             }
         }
+        if ((types & NeoForge) && (~types & Forge))  // Add Forge if NeoForge is in use, if Forge isn't already there
+            l << getModLoaderString(Forge);
         if ((types & Quilt) && (~types & Fabric))  // Add Fabric if Quilt is in use, if Fabric isn't already there
             l << getModLoaderString(Fabric);
         return l;


### PR DESCRIPTION
Parent PR: #1498 

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
Until we implement multiple loaders filter(for flame provider) or neoforge drops forge support we should consider using the same approach that we use for fabric and quilt.
And yes I know that curseforge has added a new parameter to the search API that you can specify multiple loader types.
But it has yet to implement the same functionality for the get versions API.
