### PR TITLE
Fix various list interactions

### DIFF
--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -415,7 +415,7 @@ Qt::ItemFlags AccountList::flags(const QModelIndex& index) const
 
 bool AccountList::setData(const QModelIndex& idx, const QVariant& value, int role)
 {
-    if (idx.row() < 0 || idx.row() >= rowCount(idx) || !idx.isValid()) {
+    if (idx.row() < 0 || idx.row() >= rowCount(idx.parent()) || !idx.isValid()) {
         return false;
     }
 
@@ -423,7 +423,8 @@ bool AccountList::setData(const QModelIndex& idx, const QVariant& value, int rol
         if (value == Qt::Checked) {
             MinecraftAccountPtr account = at(idx.row());
             setDefaultAccount(account);
-        }
+        } else if (m_defaultAccount == at(idx.row()))
+            setDefaultAccount(nullptr);
     }
 
     emit dataChanged(idx, index(idx.row(), columnCount(QModelIndex()) - 1));

--- a/launcher/ui/pages/global/AccountListPage.cpp
+++ b/launcher/ui/pages/global/AccountListPage.cpp
@@ -85,6 +85,8 @@ AccountListPage::AccountListPage(QWidget* parent) : QMainWindow(parent), ui(new 
     connect(selectionModel, &QItemSelectionModel::selectionChanged,
             [this]([[maybe_unused]] const QItemSelection& sel, [[maybe_unused]] const QItemSelection& dsel) { updateButtonStates(); });
     connect(ui->listView, &VersionListView::customContextMenuRequested, this, &AccountListPage::ShowContextMenu);
+    connect(ui->listView, &VersionListView::activated, this,
+            [this](const QModelIndex& index) { m_accounts->setDefaultAccount(m_accounts->at(index.row())); });
 
     connect(m_accounts.get(), &AccountList::listChanged, this, &AccountListPage::listChanged);
     connect(m_accounts.get(), &AccountList::listActivityChanged, this, &AccountListPage::listChanged);

--- a/launcher/ui/pages/instance/ExternalResourcesPage.cpp
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.cpp
@@ -152,6 +152,7 @@ void ExternalResourcesPage::retranslate()
 void ExternalResourcesPage::itemActivated(const QModelIndex&)
 {
     auto selection = m_filterModel->mapSelectionToSource(ui->treeView->selectionModel()->selection());
+    m_model->setResourceEnabled(selection.indexes(), EnableAction::TOGGLE);
 }
 
 void ExternalResourcesPage::filterTextChanged(const QString& newContents)

--- a/launcher/ui/pages/instance/VersionPage.cpp
+++ b/launcher/ui/pages/instance/VersionPage.cpp
@@ -166,14 +166,17 @@ VersionPage::VersionPage(MinecraftInstance* inst, QWidget* parent) : QMainWindow
     ui->packageView->setSelectionMode(QAbstractItemView::SingleSelection);
     ui->packageView->setContextMenuPolicy(Qt::CustomContextMenu);
 
-    connect(ui->packageView->selectionModel(), &QItemSelectionModel::currentChanged, this, &VersionPage::versionCurrent);
     auto smodel = ui->packageView->selectionModel();
+    connect(smodel, &QItemSelectionModel::currentChanged, this, &VersionPage::versionCurrent);
     connect(smodel, &QItemSelectionModel::currentChanged, this, &VersionPage::packageCurrent);
-
     connect(m_profile.get(), &PackProfile::minecraftChanged, this, &VersionPage::updateVersionControls);
     updateVersionControls();
     preselect(0);
     connect(ui->packageView, &ModListView::customContextMenuRequested, this, &VersionPage::showContextMenu);
+    connect(ui->packageView, &QAbstractItemView::activated, this, [this](const QModelIndex& index) {
+        auto component = m_profile->getComponent(index.row());
+        component->setEnabled(!component->isEnabled());
+    });
     connect(ui->filterEdit, &QLineEdit::textChanged, this, &VersionPage::onFilterTextChanged);
 }
 


### PR DESCRIPTION
- Double-click to toggle instance components.
- Restore double-click to toggle resources - this was removed by mistake.
- Fix clicking on checkbox to select account - also allow deselection - and double-clicking to select account.
