### PR TITLE
added check for valid query items in curse url install

### DIFF
--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -932,6 +932,11 @@ void MainWindow::processURLs(QList<QUrl> urls)
                 // format of url curseforge://install?addonId=IDHERE&fileId=IDHERE
                 QUrlQuery query(url);
 
+                if (query.allQueryItemValues("addonId").isEmpty() || query.allQueryItemValues("fileId").isEmpty()) {
+                    qDebug() << "Invalid curseforge link:" << url;
+                    continue;
+                }
+
                 auto addonId = query.allQueryItemValues("addonId")[0];
                 auto fileId = query.allQueryItemValues("fileId")[0];
 


### PR DESCRIPTION
Parent PR: #981 

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
This fixes a crash with the curseforge URL handler where if `addonId` or `fileId` is missing from a given link the app crashes.
e.g. `prismlauncher 'curseforge://install?addonId=486989'`