### PR TITLE
Add support for multiple mod loader filters for CurseForge

### DIFF
--- a/launcher/minecraft/ComponentUpdateTask.cpp
+++ b/launcher/minecraft/ComponentUpdateTask.cpp
@@ -2,14 +2,14 @@
 
 #include "Component.h"
 #include "ComponentUpdateTask_p.h"
-#include "OneSixVersionFormat.h"
 #include "PackProfile.h"
 #include "PackProfile_p.h"
 #include "Version.h"
 #include "cassert"
 #include "meta/Index.h"
 #include "meta/Version.h"
-#include "meta/VersionList.h"
+#include "minecraft/OneSixVersionFormat.h"
+#include "minecraft/ProfileUtils.h"
 #include "net/Mode.h"
 
 #include "Application.h"

--- a/launcher/minecraft/PackProfile.cpp
+++ b/launcher/minecraft/PackProfile.cpp
@@ -62,11 +62,11 @@
 #include "Application.h"
 #include "modplatform/ResourceAPI.h"
 
-static const QMap<QString, ResourceAPI::ModLoaderType> modloaderMapping{ { "net.neoforged", ResourceAPI::NeoForge },
-                                                                         { "net.minecraftforge", ResourceAPI::Forge },
-                                                                         { "net.fabricmc.fabric-loader", ResourceAPI::Fabric },
-                                                                         { "org.quiltmc.quilt-loader", ResourceAPI::Quilt },
-                                                                         { "com.mumfrey.liteloader", ResourceAPI::LiteLoader } };
+static const QMap<QString, ModPlatform::ModLoaderType> modloaderMapping{ { "net.neoforged", ModPlatform::NeoForge },
+                                                                         { "net.minecraftforge", ModPlatform::Forge },
+                                                                         { "net.fabricmc.fabric-loader", ModPlatform::Fabric },
+                                                                         { "org.quiltmc.quilt-loader", ModPlatform::Quilt },
+                                                                         { "com.mumfrey.liteloader", ModPlatform::LiteLoader } };
 
 PackProfile::PackProfile(MinecraftInstance* instance) : QAbstractListModel()
 {
@@ -990,12 +990,12 @@ void PackProfile::disableInteraction(bool disable)
     }
 }
 
-std::optional<ResourceAPI::ModLoaderTypes> PackProfile::getModLoaders()
+std::optional<ModPlatform::ModLoaderTypes> PackProfile::getModLoaders()
 {
-    ResourceAPI::ModLoaderTypes result;
+    ModPlatform::ModLoaderTypes result;
     bool has_any_loader = false;
 
-    QMapIterator<QString, ResourceAPI::ModLoaderType> i(modloaderMapping);
+    QMapIterator<QString, ModPlatform::ModLoaderType> i(modloaderMapping);
 
     while (i.hasNext()) {
         i.next();

--- a/launcher/minecraft/PackProfile.cpp
+++ b/launcher/minecraft/PackProfile.cpp
@@ -58,9 +58,8 @@
 #include "ComponentUpdateTask.h"
 #include "PackProfile.h"
 #include "PackProfile_p.h"
-
-#include "Application.h"
-#include "modplatform/ResourceAPI.h"
+#include "minecraft/mod/Mod.h"
+#include "modplatform/ModIndex.h"
 
 static const QMap<QString, ModPlatform::ModLoaderType> modloaderMapping{ { "net.neoforged", ModPlatform::NeoForge },
                                                                          { "net.minecraftforge", ModPlatform::Forge },
@@ -1008,4 +1007,19 @@ std::optional<ModPlatform::ModLoaderTypes> PackProfile::getModLoaders()
     if (!has_any_loader)
         return {};
     return result;
+}
+
+std::optional<ModPlatform::ModLoaderTypes> PackProfile::getSupportedModLoaders()
+{
+    auto loadersOpt = getModLoaders();
+    if (!loadersOpt.has_value())
+        return loadersOpt;
+    auto loaders = loadersOpt.value();
+    // TODO: remove this or add version condition once Quilt drops official Fabric support
+    if (loaders & ModPlatform::Quilt)
+        loaders |= ModPlatform::Fabric;
+    // TODO: remove this or add version condition once NeoForge drops official Forge support
+    if (loaders & ModPlatform::NeoForge)
+        loaders |= ModPlatform::Forge;
+    return loaders;
 }

--- a/launcher/minecraft/PackProfile.h
+++ b/launcher/minecraft/PackProfile.h
@@ -44,6 +44,7 @@
 #include <QList>
 #include <QString>
 #include <memory>
+#include <optional>
 
 #include "Component.h"
 #include "LaunchProfile.h"

--- a/launcher/minecraft/PackProfile.h
+++ b/launcher/minecraft/PackProfile.h
@@ -146,7 +146,7 @@ class PackProfile : public QAbstractListModel {
     // todo(merged): is this the best approach
     void appendComponent(ComponentPtr component);
 
-    std::optional<ResourceAPI::ModLoaderTypes> getModLoaders();
+    std::optional<ModPlatform::ModLoaderTypes> getModLoaders();
 
    private:
     void scheduleSave();

--- a/launcher/minecraft/PackProfile.h
+++ b/launcher/minecraft/PackProfile.h
@@ -45,13 +45,9 @@
 #include <QString>
 #include <memory>
 
-#include "BaseVersion.h"
 #include "Component.h"
 #include "LaunchProfile.h"
-#include "Library.h"
-#include "MojangDownloadInfo.h"
-#include "ProfileUtils.h"
-#include "modplatform/ResourceAPI.h"
+#include "modplatform/ModIndex.h"
 #include "net/Mode.h"
 
 class MinecraftInstance;
@@ -147,6 +143,8 @@ class PackProfile : public QAbstractListModel {
     void appendComponent(ComponentPtr component);
 
     std::optional<ModPlatform::ModLoaderTypes> getModLoaders();
+    // this returns aditional loaders(Quilt supports fabric and NeoForge supports Forge)
+    std::optional<ModPlatform::ModLoaderTypes> getSupportedModLoaders();
 
    private:
     void scheduleSave();

--- a/launcher/minecraft/mod/tasks/GetModDependenciesTask.cpp
+++ b/launcher/minecraft/mod/tasks/GetModDependenciesTask.cpp
@@ -41,7 +41,8 @@ static Version mcVersion(BaseInstance* inst)
 
 static ModPlatform::ModLoaderTypes mcLoaders(BaseInstance* inst)
 {
-    return static_cast<MinecraftInstance*>(inst)->getPackProfile()->getModLoaders().value();
+    return static_cast<MinecraftInstance*>(inst)->getPackProfile()->getSupportedModLoaders().value_or(
+        ModPlatform::ModLoaderTypes::fromInt(0));
 }
 
 GetModDependenciesTask::GetModDependenciesTask(QObject* parent,

--- a/launcher/minecraft/mod/tasks/GetModDependenciesTask.cpp
+++ b/launcher/minecraft/mod/tasks/GetModDependenciesTask.cpp
@@ -201,6 +201,7 @@ Task::Ptr GetModDependenciesTask::prepareDependencyTask(const ModPlatform::Depen
                         return;
                     }
                 }
+                removePack(dep.addonId);
                 qWarning() << "Error while reading mod version empty ";
                 qDebug() << doc;
                 return;

--- a/launcher/minecraft/mod/tasks/GetModDependenciesTask.cpp
+++ b/launcher/minecraft/mod/tasks/GetModDependenciesTask.cpp
@@ -39,7 +39,7 @@ static Version mcVersion(BaseInstance* inst)
     return static_cast<MinecraftInstance*>(inst)->getPackProfile()->getComponent("net.minecraft")->getVersion();
 }
 
-static ResourceAPI::ModLoaderTypes mcLoaders(BaseInstance* inst)
+static ModPlatform::ModLoaderTypes mcLoaders(BaseInstance* inst)
 {
     return static_cast<MinecraftInstance*>(inst)->getPackProfile()->getModLoaders().value();
 }
@@ -75,7 +75,7 @@ void GetModDependenciesTask::prepare()
 ModPlatform::Dependency GetModDependenciesTask::getOverride(const ModPlatform::Dependency& dep,
                                                             const ModPlatform::ResourceProvider providerName)
 {
-    if (auto isQuilt = m_loaderType & ResourceAPI::Quilt; isQuilt || m_loaderType & ResourceAPI::Fabric) {
+    if (auto isQuilt = m_loaderType & ModPlatform::Quilt; isQuilt || m_loaderType & ModPlatform::Fabric) {
         auto overide = ModPlatform::getOverrideDeps();
         auto over = std::find_if(overide.cbegin(), overide.cend(), [dep, providerName, isQuilt](auto o) {
             return o.provider == providerName && dep.addonId == (isQuilt ? o.fabric : o.quilt);
@@ -191,7 +191,7 @@ Task::Ptr GetModDependenciesTask::prepareDependencyTask(const ModPlatform::Depen
             }
             pDep->version = provider.mod->loadDependencyVersions(dep, arr);
             if (!pDep->version.addonId.isValid()) {
-                if (m_loaderType & ResourceAPI::Quilt) {  // falback for quilt
+                if (m_loaderType & ModPlatform::Quilt) {  // falback for quilt
                     auto overide = ModPlatform::getOverrideDeps();
                     auto over = std::find_if(overide.cbegin(), overide.cend(),
                                              [dep, provider](auto o) { return o.provider == provider.name && dep.addonId == o.quilt; });

--- a/launcher/minecraft/mod/tasks/GetModDependenciesTask.cpp
+++ b/launcher/minecraft/mod/tasks/GetModDependenciesTask.cpp
@@ -41,8 +41,7 @@ static Version mcVersion(BaseInstance* inst)
 
 static ModPlatform::ModLoaderTypes mcLoaders(BaseInstance* inst)
 {
-    return static_cast<MinecraftInstance*>(inst)->getPackProfile()->getSupportedModLoaders().value_or(
-        ModPlatform::ModLoaderTypes::fromInt(0));
+    return static_cast<MinecraftInstance*>(inst)->getPackProfile()->getSupportedModLoaders().value();
 }
 
 GetModDependenciesTask::GetModDependenciesTask(QObject* parent,

--- a/launcher/minecraft/mod/tasks/GetModDependenciesTask.h
+++ b/launcher/minecraft/mod/tasks/GetModDependenciesTask.h
@@ -80,5 +80,5 @@ class GetModDependenciesTask : public SequentialTask {
     Provider m_modrinth_provider;
 
     Version m_version;
-    ResourceAPI::ModLoaderTypes m_loaderType;
+    ModPlatform::ModLoaderTypes m_loaderType;
 };

--- a/launcher/modplatform/CheckUpdateTask.h
+++ b/launcher/modplatform/CheckUpdateTask.h
@@ -14,7 +14,7 @@ class CheckUpdateTask : public Task {
    public:
     CheckUpdateTask(QList<Mod*>& mods,
                     std::list<Version>& mcVersions,
-                    std::optional<ResourceAPI::ModLoaderTypes> loaders,
+                    std::optional<ModPlatform::ModLoaderTypes> loaders,
                     std::shared_ptr<ModFolderModel> mods_folder)
         : Task(nullptr), m_mods(mods), m_game_versions(mcVersions), m_loaders(loaders), m_mods_folder(mods_folder){};
 
@@ -53,7 +53,7 @@ class CheckUpdateTask : public Task {
    protected:
     QList<Mod*>& m_mods;
     std::list<Version>& m_game_versions;
-    std::optional<ResourceAPI::ModLoaderTypes> m_loaders;
+    std::optional<ModPlatform::ModLoaderTypes> m_loaders;
     std::shared_ptr<ModFolderModel> m_mods_folder;
 
     std::vector<UpdatableMod> m_updatable;

--- a/launcher/modplatform/ModIndex.cpp
+++ b/launcher/modplatform/ModIndex.cpp
@@ -83,4 +83,25 @@ QString getMetaURL(ResourceProvider provider, QVariant projectID)
            projectID.toString();
 }
 
+auto getModLoaderString(ModLoaderType type) -> const QString
+{
+    switch (type) {
+        case NeoForge:
+            return "neoforge";
+        case Forge:
+            return "forge";
+        case Cauldron:
+            return "cauldron";
+        case LiteLoader:
+            return "liteloader";
+        case Fabric:
+            return "fabric";
+        case Quilt:
+            return "quilt";
+        default:
+            break;
+    }
+    return "";
+}
+
 }  // namespace ModPlatform

--- a/launcher/modplatform/ModIndex.h
+++ b/launcher/modplatform/ModIndex.h
@@ -30,6 +30,9 @@ class QIODevice;
 
 namespace ModPlatform {
 
+enum ModLoaderType { NeoForge = 1 << 0, Forge = 1 << 1, Cauldron = 1 << 2, LiteLoader = 1 << 3, Fabric = 1 << 4, Quilt = 1 << 5 };
+Q_DECLARE_FLAGS(ModLoaderTypes, ModLoaderType)
+
 enum class ResourceProvider { MODRINTH, FLAME };
 
 enum class ResourceType { MOD, RESOURCE_PACK, SHADER_PACK };
@@ -128,7 +131,6 @@ struct IndexedPack {
         return std::any_of(versions.constBegin(), versions.constEnd(), [](auto const& v) { return v.is_currently_selected; });
     }
 };
-QString getMetaURL(ResourceProvider provider, QVariant projectID);
 
 struct OverrideDep {
     QString quilt;
@@ -147,6 +149,8 @@ inline auto getOverrideDeps() -> QList<OverrideDep>
 }
 
 QString getMetaURL(ResourceProvider provider, QVariant projectID);
+
+auto getModLoaderString(ModLoaderType type) -> const QString;
 
 }  // namespace ModPlatform
 

--- a/launcher/modplatform/ModIndex.h
+++ b/launcher/modplatform/ModIndex.h
@@ -152,6 +152,12 @@ QString getMetaURL(ResourceProvider provider, QVariant projectID);
 
 auto getModLoaderString(ModLoaderType type) -> const QString;
 
+constexpr bool hasSingleModLoaderSelected(ModLoaderTypes l) noexcept
+{
+    auto x = static_cast<int>(l);
+    return x && !(x & (x - 1));
+}
+
 }  // namespace ModPlatform
 
 Q_DECLARE_METATYPE(ModPlatform::IndexedPack)

--- a/launcher/modplatform/ModIndex.h
+++ b/launcher/modplatform/ModIndex.h
@@ -73,7 +73,7 @@ struct IndexedVersion {
     QString downloadUrl;
     QString date;
     QString fileName;
-    QStringList loaders = {};
+    ModLoaderTypes loaders = {};
     QString hash_type;
     QString hash;
     bool is_preferred = true;

--- a/launcher/modplatform/ResourceAPI.h
+++ b/launcher/modplatform/ResourceAPI.h
@@ -54,9 +54,6 @@ class ResourceAPI {
    public:
     virtual ~ResourceAPI() = default;
 
-    enum ModLoaderType { NeoForge = 1 << 0, Forge = 1 << 1, Cauldron = 1 << 2, LiteLoader = 1 << 3, Fabric = 1 << 4, Quilt = 1 << 5 };
-    Q_DECLARE_FLAGS(ModLoaderTypes, ModLoaderType)
-
     struct SortingMethod {
         // The index of the sorting method. Used to allow for arbitrary ordering in the list of methods.
         // Used by Flame in the API request.
@@ -74,7 +71,7 @@ class ResourceAPI {
 
         std::optional<QString> search;
         std::optional<SortingMethod> sorting;
-        std::optional<ModLoaderTypes> loaders;
+        std::optional<ModPlatform::ModLoaderTypes> loaders;
         std::optional<std::list<Version> > versions;
     };
     struct SearchCallbacks {
@@ -87,7 +84,7 @@ class ResourceAPI {
         ModPlatform::IndexedPack pack;
 
         std::optional<std::list<Version> > mcVersions;
-        std::optional<ModLoaderTypes> loaders;
+        std::optional<ModPlatform::ModLoaderTypes> loaders;
 
         VersionSearchArgs(VersionSearchArgs const&) = default;
         void operator=(VersionSearchArgs other)
@@ -114,7 +111,7 @@ class ResourceAPI {
     struct DependencySearchArgs {
         ModPlatform::Dependency dependency;
         Version mcVersion;
-        ModLoaderTypes loader;
+        ModPlatform::ModLoaderTypes loader;
     };
 
     struct DependencySearchCallbacks {
@@ -159,27 +156,6 @@ class ResourceAPI {
     {
         qWarning() << "TODO";
         return nullptr;
-    }
-
-    static auto getModLoaderString(ModLoaderType type) -> const QString
-    {
-        switch (type) {
-            case NeoForge:
-                return "neoforge";
-            case Forge:
-                return "forge";
-            case Cauldron:
-                return "cauldron";
-            case LiteLoader:
-                return "liteloader";
-            case Fabric:
-                return "fabric";
-            case Quilt:
-                return "quilt";
-            default:
-                break;
-        }
-        return "";
     }
 
    protected:

--- a/launcher/modplatform/flame/FileResolvingTask.cpp
+++ b/launcher/modplatform/flame/FileResolvingTask.cpp
@@ -154,7 +154,7 @@ void Flame::FileResolvingTask::modrinthCheckFinished()
         // If there's more than one mod loader for this version, we can't know for sure
         // which file is relative to each loader, so it's best to not use any one and
         // let the user download it manually.
-        if (std::bitset<8>(file.loaders.toInt()).count() <= 1) {
+        if (std::bitset<8>(file.loaders).count() <= 1) {
             out->url = file.downloadUrl;
             qDebug() << "Found alternative on modrinth " << out->fileName;
         } else {

--- a/launcher/modplatform/flame/FileResolvingTask.cpp
+++ b/launcher/modplatform/flame/FileResolvingTask.cpp
@@ -1,6 +1,5 @@
 #include "FileResolvingTask.h"
 
-#include <bit>
 #include "Json.h"
 #include "modplatform/ModIndex.h"
 #include "net/ApiDownload.h"

--- a/launcher/modplatform/flame/FileResolvingTask.cpp
+++ b/launcher/modplatform/flame/FileResolvingTask.cpp
@@ -103,7 +103,7 @@ void Flame::FileResolvingTask::netJobFinished()
                 auto url = QString("https://api.modrinth.com/v2/version_file/%1?algorithm=sha1").arg(hash);
                 auto output = std::make_shared<QByteArray>();
                 auto dl = Net::ApiDownload::makeByteArray(QUrl(url), output);
-                QObject::connect(dl.get(), &Net::Download::succeeded, [&out]() { out.resolved = true; });
+                QObject::connect(dl.get(), &Net::ApiDownload::succeeded, [&out]() { out.resolved = true; });
 
                 m_checkJob->addNetAction(dl);
                 blockedProjects.insert(&out, output);
@@ -176,7 +176,7 @@ void Flame::FileResolvingTask::modrinthCheckFinished()
             auto url = QString("https://api.curseforge.com/v1/mods/%1").arg(projectId);
             auto dl = Net::ApiDownload::makeByteArray(url, output);
             qDebug() << "Fetching url slug for file:" << mod->fileName;
-            QObject::connect(dl.get(), &Net::Download::succeeded, [block, index, output]() {
+            QObject::connect(dl.get(), &Net::ApiDownload::succeeded, [block, index, output]() {
                 auto mod = block->at(index);  // use the shared_ptr so it is captured and only freed when we are done
                 auto json = QJsonDocument::fromJson(*output);
                 auto base =

--- a/launcher/modplatform/flame/FileResolvingTask.cpp
+++ b/launcher/modplatform/flame/FileResolvingTask.cpp
@@ -1,7 +1,8 @@
 #include "FileResolvingTask.h"
 
-#include <bitset>
+#include <bit>
 #include "Json.h"
+#include "modplatform/ModIndex.h"
 #include "net/ApiDownload.h"
 #include "net/ApiUpload.h"
 #include "net/Upload.h"
@@ -135,6 +136,11 @@ void Flame::FileResolvingTask::netJobFinished()
     m_checkJob->start();
 }
 
+constexpr bool has_single_bit(int x) noexcept
+{
+    return x && !(x & (x - 1));
+}
+
 void Flame::FileResolvingTask::modrinthCheckFinished()
 {
     setProgress(2, 3);
@@ -154,7 +160,7 @@ void Flame::FileResolvingTask::modrinthCheckFinished()
         // If there's more than one mod loader for this version, we can't know for sure
         // which file is relative to each loader, so it's best to not use any one and
         // let the user download it manually.
-        if (std::bitset<8>(file.loaders).count() <= 1) {
+        if (!file.loaders || has_single_bit(file.loaders)) {
             out->url = file.downloadUrl;
             qDebug() << "Found alternative on modrinth " << out->fileName;
         } else {

--- a/launcher/modplatform/flame/FileResolvingTask.cpp
+++ b/launcher/modplatform/flame/FileResolvingTask.cpp
@@ -135,11 +135,6 @@ void Flame::FileResolvingTask::netJobFinished()
     m_checkJob->start();
 }
 
-constexpr bool has_single_bit(int x) noexcept
-{
-    return x && !(x & (x - 1));
-}
-
 void Flame::FileResolvingTask::modrinthCheckFinished()
 {
     setProgress(2, 3);
@@ -159,7 +154,7 @@ void Flame::FileResolvingTask::modrinthCheckFinished()
         // If there's more than one mod loader for this version, we can't know for sure
         // which file is relative to each loader, so it's best to not use any one and
         // let the user download it manually.
-        if (!file.loaders || has_single_bit(file.loaders)) {
+        if (!file.loaders || hasSingleModLoaderSelected(file.loaders)) {
             out->url = file.downloadUrl;
             qDebug() << "Found alternative on modrinth " << out->fileName;
         } else {

--- a/launcher/modplatform/flame/FileResolvingTask.cpp
+++ b/launcher/modplatform/flame/FileResolvingTask.cpp
@@ -1,5 +1,6 @@
 #include "FileResolvingTask.h"
 
+#include <bitset>
 #include "Json.h"
 #include "net/ApiDownload.h"
 #include "net/ApiUpload.h"
@@ -153,7 +154,7 @@ void Flame::FileResolvingTask::modrinthCheckFinished()
         // If there's more than one mod loader for this version, we can't know for sure
         // which file is relative to each loader, so it's best to not use any one and
         // let the user download it manually.
-        if (file.loaders.size() <= 1) {
+        if (std::bitset<8>(file.loaders.toInt()).count() <= 1) {
             out->url = file.downloadUrl;
             qDebug() << "Found alternative on modrinth " << out->fileName;
         } else {

--- a/launcher/modplatform/flame/FlameAPI.cpp
+++ b/launcher/modplatform/flame/FlameAPI.cpp
@@ -6,7 +6,6 @@
 #include "FlameModIndex.h"
 
 #include "Application.h"
-#include "BuildConfig.h"
 #include "Json.h"
 #include "net/ApiDownload.h"
 #include "net/ApiUpload.h"
@@ -131,19 +130,13 @@ auto FlameAPI::getLatestVersion(VersionSearchArgs&& args) -> ModPlatform::Indexe
             auto obj = Json::requireObject(doc);
             auto arr = Json::requireArray(obj, "data");
 
-            QJsonObject latest_file_obj;
-            ModPlatform::IndexedVersion ver_tmp;
-
             for (auto file : arr) {
                 auto file_obj = Json::requireObject(file);
                 auto file_tmp = FlameMod::loadIndexedPackVersion(file_obj);
-                if (file_tmp.date > ver_tmp.date) {
-                    ver_tmp = file_tmp;
-                    latest_file_obj = file_obj;
-                }
+                if (file_tmp.date > ver.date && (!args.loaders.has_value() || args.loaders.value() & file_tmp.loaders))
+                    ver = file_tmp;
             }
 
-            ver = FlameMod::loadIndexedPackVersion(latest_file_obj);
         } catch (Json::JsonException& e) {
             qCritical() << "Failed to parse response from a version request.";
             qCritical() << e.what();

--- a/launcher/modplatform/flame/FlameAPI.cpp
+++ b/launcher/modplatform/flame/FlameAPI.cpp
@@ -133,7 +133,7 @@ auto FlameAPI::getLatestVersion(VersionSearchArgs&& args) -> ModPlatform::Indexe
             for (auto file : arr) {
                 auto file_obj = Json::requireObject(file);
                 auto file_tmp = FlameMod::loadIndexedPackVersion(file_obj);
-                if (file_tmp.date > ver.date && (!args.loaders.has_value() || args.loaders.value() & file_tmp.loaders))
+                if (file_tmp.date > ver.date && (!args.loaders.has_value() || !file_tmp.loaders || args.loaders.value() & file_tmp.loaders))
                     ver = file_tmp;
             }
 

--- a/launcher/modplatform/flame/FlameAPI.h
+++ b/launcher/modplatform/flame/FlameAPI.h
@@ -24,7 +24,10 @@ class FlameAPI : public NetworkResourceAPI {
 
     [[nodiscard]] auto getSortingMethods() const -> QList<ResourceAPI::SortingMethod> override;
 
-    static inline auto validateModLoaders(ModLoaderTypes loaders) -> bool { return loaders & (NeoForge | Forge | Fabric | Quilt); }
+    static inline auto validateModLoaders(ModPlatform::ModLoaderTypes loaders) -> bool
+    {
+        return loaders & (ModPlatform::NeoForge | ModPlatform::Forge | ModPlatform::Fabric | ModPlatform::Quilt);
+    }
 
    private:
     static int getClassId(ModPlatform::ResourceType type)
@@ -38,19 +41,19 @@ class FlameAPI : public NetworkResourceAPI {
         }
     }
 
-    static int getMappedModLoader(ModLoaderTypes loaders)
+    static int getMappedModLoader(ModPlatform::ModLoaderTypes loaders)
     {
         // https://docs.curseforge.com/?http#tocS_ModLoaderType
-        if (loaders & Forge)
+        if (loaders & ModPlatform::Forge)
             return 1;
-        if (loaders & Fabric)
+        if (loaders & ModPlatform::Fabric)
             return 4;
         // TODO: remove this once Quilt drops official Fabric support
-        if (loaders & Quilt)  // NOTE: Most if not all Fabric mods should work *currently*
-            return 4;         // FIXME: implement multiple loaders filter (this should be 5)
+        if (loaders & ModPlatform::Quilt)  // NOTE: Most if not all Fabric mods should work *currently*
+            return 4;                      // FIXME: implement multiple loaders filter (this should be 5)
         // TODO: remove this once NeoForge drops official Forge support
-        if (loaders & NeoForge)  // NOTE: Most if not all Forge mods should work *currently*
-            return 1;            // FIXME: implement multiple loaders filter (this should be 6)
+        if (loaders & ModPlatform::NeoForge)  // NOTE: Most if not all Forge mods should work *currently*
+            return 1;                         // FIXME: implement multiple loaders filter (this should be 6)
         return 0;
     }
 
@@ -93,7 +96,7 @@ class FlameAPI : public NetworkResourceAPI {
         if (args.loaders.has_value()) {
             int mappedModLoader = getMappedModLoader(args.loaders.value());
 
-            if (args.loaders.value() & Quilt) {
+            if (args.loaders.value() & ModPlatform::Quilt) {
                 auto overide = ModPlatform::getOverrideDeps();
                 auto over = std::find_if(overide.cbegin(), overide.cend(), [addonId](auto dep) {
                     return dep.provider == ModPlatform::ResourceProvider::FLAME && addonId == dep.quilt;
@@ -113,7 +116,7 @@ class FlameAPI : public NetworkResourceAPI {
     {
         auto mappedModLoader = getMappedModLoader(args.loader);
         auto addonId = args.dependency.addonId.toString();
-        if (args.loader & Quilt) {
+        if (args.loader & ModPlatform::Quilt) {
             auto overide = ModPlatform::getOverrideDeps();
             auto over = std::find_if(overide.cbegin(), overide.cend(), [addonId](auto dep) {
                 return dep.provider == ModPlatform::ResourceProvider::FLAME && addonId == dep.quilt;

--- a/launcher/modplatform/flame/FlameAPI.h
+++ b/launcher/modplatform/flame/FlameAPI.h
@@ -58,6 +58,7 @@ class FlameAPI : public NetworkResourceAPI {
             case ModPlatform::NeoForge:
                 return 6;
         }
+        return 0;
     }
 
     static auto getModLoaderStrings(const ModPlatform::ModLoaderTypes types) -> const QStringList

--- a/launcher/modplatform/flame/FlameAPI.h
+++ b/launcher/modplatform/flame/FlameAPI.h
@@ -41,18 +41,23 @@ class FlameAPI : public NetworkResourceAPI {
         }
     }
 
-    static int getMappedModLoader(ModPlatform::ModLoaderTypes loaders)
+    static int getMappedModLoader(ModPlatform::ModLoaderType loaders)
     {
         // https://docs.curseforge.com/?http#tocS_ModLoaderType
-        if (loaders & ModPlatform::Forge)
-            return 1;
-        if (loaders & ModPlatform::Fabric)
-            return 4;
-        if (loaders & ModPlatform::Quilt)
-            return 5;
-        if (loaders & ModPlatform::NeoForge)
-            return 6;
-        return 0;
+        switch (loaders) {
+            case ModPlatform::Forge:
+                return 1;
+            case ModPlatform::Cauldron:
+                return 2;
+            case ModPlatform::LiteLoader:
+                return 3;
+            case ModPlatform::Fabric:
+                return 4;
+            case ModPlatform::Quilt:
+                return 5;
+            case ModPlatform::NeoForge:
+                return 6;
+        }
     }
 
     static auto getModLoaderStrings(const ModPlatform::ModLoaderTypes types) -> const QStringList

--- a/launcher/modplatform/flame/FlameAPI.h
+++ b/launcher/modplatform/flame/FlameAPI.h
@@ -101,30 +101,16 @@ class FlameAPI : public NetworkResourceAPI {
     [[nodiscard]] std::optional<QString> getVersionsURL(VersionSearchArgs const& args) const override
     {
         auto addonId = args.pack.addonId.toString();
-        QString url{ QString("https://api.curseforge.com/v1/mods/%1/files?pageSize=10000&").arg(addonId) };
+        QString url = QString("https://api.curseforge.com/v1/mods/%1/files?pageSize=10000").arg(addonId);
 
-        QStringList get_parameters;
         if (args.mcVersions.has_value())
-            get_parameters.append(QString("gameVersion=%1").arg(args.mcVersions.value().front().toString()));
-        return url + get_parameters.join('&');
+            url += QString("&gameVersion=%1").arg(args.mcVersions.value().front().toString());
+        return url;
     };
 
     [[nodiscard]] std::optional<QString> getDependencyURL(DependencySearchArgs const& args) const override
     {
-        auto mappedModLoader = getMappedModLoader(args.loader);
         auto addonId = args.dependency.addonId.toString();
-        if (args.loader & ModPlatform::Quilt) {
-            auto overide = ModPlatform::getOverrideDeps();
-            auto over = std::find_if(overide.cbegin(), overide.cend(), [addonId](auto dep) {
-                return dep.provider == ModPlatform::ResourceProvider::FLAME && addonId == dep.quilt;
-            });
-            if (over != overide.cend()) {
-                mappedModLoader = 5;
-            }
-        }
-        return QString("https://api.curseforge.com/v1/mods/%1/files?pageSize=10000&gameVersion=%2&modLoaderType=%3")
-            .arg(addonId)
-            .arg(args.mcVersion.toString())
-            .arg(mappedModLoader);
+        return QString("https://api.curseforge.com/v1/mods/%1/files?pageSize=10000&gameVersion=%2").arg(addonId, args.mcVersion.toString());
     };
 };

--- a/launcher/modplatform/flame/FlameAPI.h
+++ b/launcher/modplatform/flame/FlameAPI.h
@@ -111,12 +111,23 @@ class FlameAPI : public NetworkResourceAPI {
 
         if (args.mcVersions.has_value())
             url += QString("&gameVersion=%1").arg(args.mcVersions.value().front().toString());
+
+        if (args.loaders.has_value() && ModPlatform::hasSingleModLoaderSelected(args.loaders.value())) {
+            int mappedModLoader = getMappedModLoader(static_cast<ModPlatform::ModLoaderType>(static_cast<int>(args.loaders.value())));
+            url += QString("&modLoaderType=%1").arg(mappedModLoader);
+        }
         return url;
     };
 
     [[nodiscard]] std::optional<QString> getDependencyURL(DependencySearchArgs const& args) const override
     {
         auto addonId = args.dependency.addonId.toString();
-        return QString("https://api.curseforge.com/v1/mods/%1/files?pageSize=10000&gameVersion=%2").arg(addonId, args.mcVersion.toString());
+        auto url =
+            QString("https://api.curseforge.com/v1/mods/%1/files?pageSize=10000&gameVersion=%2").arg(addonId, args.mcVersion.toString());
+        if (args.loader && ModPlatform::hasSingleModLoaderSelected(args.loader)) {
+            int mappedModLoader = getMappedModLoader(static_cast<ModPlatform::ModLoaderType>(static_cast<int>(args.loader)));
+            url += QString("&modLoaderType=%1").arg(mappedModLoader);
+        }
+        return url;
     };
 };

--- a/launcher/modplatform/flame/FlameCheckUpdate.cpp
+++ b/launcher/modplatform/flame/FlameCheckUpdate.cpp
@@ -5,13 +5,11 @@
 #include <MurmurHash2.h>
 #include <memory>
 
-#include "FileSystem.h"
 #include "Json.h"
 
 #include "ResourceDownloadTask.h"
 
 #include "minecraft/mod/ModFolderModel.h"
-#include "minecraft/mod/ResourceFolderModel.h"
 
 #include "net/ApiDownload.h"
 

--- a/launcher/modplatform/flame/FlameCheckUpdate.h
+++ b/launcher/modplatform/flame/FlameCheckUpdate.h
@@ -10,7 +10,7 @@ class FlameCheckUpdate : public CheckUpdateTask {
    public:
     FlameCheckUpdate(QList<Mod*>& mods,
                      std::list<Version>& mcVersions,
-                     std::optional<ResourceAPI::ModLoaderTypes> loaders,
+                     std::optional<ModPlatform::ModLoaderTypes> loaders,
                      std::shared_ptr<ModFolderModel> mods_folder)
         : CheckUpdateTask(mods, mcVersions, loaders, mods_folder)
     {}

--- a/launcher/modplatform/flame/FlameModIndex.cpp
+++ b/launcher/modplatform/flame/FlameModIndex.cpp
@@ -115,6 +115,19 @@ auto FlameMod::loadIndexedPackVersion(QJsonObject& obj, bool load_changelog) -> 
 
         if (str.contains('.'))
             file.mcVersion.append(str);
+        auto loader = str.toLower();
+        if (loader == "neoforge")
+            file.loaders |= ModPlatform::NeoForge;
+        if (loader == "forge")
+            file.loaders |= ModPlatform::Forge;
+        if (loader == "cauldron")
+            file.loaders |= ModPlatform::Cauldron;
+        if (loader == "liteloader")
+            file.loaders |= ModPlatform::LiteLoader;
+        if (loader == "fabric")
+            file.loaders |= ModPlatform::Fabric;
+        if (loader == "quilt")
+            file.loaders |= ModPlatform::Quilt;
     }
 
     file.addonId = Json::requireInteger(obj, "modId");

--- a/launcher/modplatform/flame/FlameModIndex.cpp
+++ b/launcher/modplatform/flame/FlameModIndex.cpp
@@ -211,5 +211,7 @@ ModPlatform::IndexedVersion FlameMod::loadDependencyVersions(const ModPlatform::
         return a.date > b.date;
     };
     std::sort(versions.begin(), versions.end(), orderSortPredicate);
-    return versions.front();
+    if (versions.size() != 0)
+        return versions.front();
+    return {};
 }

--- a/launcher/modplatform/flame/FlameModIndex.cpp
+++ b/launcher/modplatform/flame/FlameModIndex.cpp
@@ -81,6 +81,7 @@ void FlameMod::loadIndexedPackVersions(ModPlatform::IndexedPack& pack,
     QVector<ModPlatform::IndexedVersion> unsortedVersions;
     auto profile = (dynamic_cast<const MinecraftInstance*>(inst))->getPackProfile();
     QString mcVersion = profile->getComponentVersion("net.minecraft");
+    auto loaders = profile->getSupportedModLoaders();
 
     for (auto versionIter : arr) {
         auto obj = versionIter.toObject();
@@ -89,7 +90,8 @@ void FlameMod::loadIndexedPackVersions(ModPlatform::IndexedPack& pack,
         if (!file.addonId.isValid())
             file.addonId = pack.addonId;
 
-        if (file.fileId.isValid())  // Heuristic to check if the returned value is valid
+        if (file.fileId.isValid() &&
+            (!loaders.has_value() || loaders.value() & file.loaders))  // Heuristic to check if the returned value is valid
             unsortedVersions.append(file);
     }
 
@@ -186,8 +188,11 @@ auto FlameMod::loadIndexedPackVersion(QJsonObject& obj, bool load_changelog) -> 
     return file;
 }
 
-ModPlatform::IndexedVersion FlameMod::loadDependencyVersions(const ModPlatform::Dependency& m, QJsonArray& arr)
+ModPlatform::IndexedVersion FlameMod::loadDependencyVersions(const ModPlatform::Dependency& m, QJsonArray& arr, const BaseInstance* inst)
 {
+    auto profile = (dynamic_cast<const MinecraftInstance*>(inst))->getPackProfile();
+    QString mcVersion = profile->getComponentVersion("net.minecraft");
+    auto loaders = profile->getSupportedModLoaders();
     QVector<ModPlatform::IndexedVersion> versions;
     for (auto versionIter : arr) {
         auto obj = versionIter.toObject();
@@ -196,7 +201,8 @@ ModPlatform::IndexedVersion FlameMod::loadDependencyVersions(const ModPlatform::
         if (!file.addonId.isValid())
             file.addonId = m.addonId;
 
-        if (file.fileId.isValid())  // Heuristic to check if the returned value is valid
+        if (file.fileId.isValid() &&
+            (!loaders.has_value() || loaders.value() & file.loaders))  // Heuristic to check if the returned value is valid
             versions.append(file);
     }
 

--- a/launcher/modplatform/flame/FlameModIndex.cpp
+++ b/launcher/modplatform/flame/FlameModIndex.cpp
@@ -91,7 +91,7 @@ void FlameMod::loadIndexedPackVersions(ModPlatform::IndexedPack& pack,
             file.addonId = pack.addonId;
 
         if (file.fileId.isValid() &&
-            (!loaders.has_value() || loaders.value() & file.loaders))  // Heuristic to check if the returned value is valid
+            (!loaders.has_value() || !file.loaders || loaders.value() & file.loaders))  // Heuristic to check if the returned value is valid
             unsortedVersions.append(file);
     }
 
@@ -202,7 +202,7 @@ ModPlatform::IndexedVersion FlameMod::loadDependencyVersions(const ModPlatform::
             file.addonId = m.addonId;
 
         if (file.fileId.isValid() &&
-            (!loaders.has_value() || loaders.value() & file.loaders))  // Heuristic to check if the returned value is valid
+            (!loaders.has_value() || !file.loaders || loaders.value() & file.loaders))  // Heuristic to check if the returned value is valid
             versions.append(file);
     }
 

--- a/launcher/modplatform/flame/FlameModIndex.h
+++ b/launcher/modplatform/flame/FlameModIndex.h
@@ -19,5 +19,5 @@ void loadIndexedPackVersions(ModPlatform::IndexedPack& pack,
                              const shared_qobject_ptr<QNetworkAccessManager>& network,
                              const BaseInstance* inst);
 auto loadIndexedPackVersion(QJsonObject& obj, bool load_changelog = false) -> ModPlatform::IndexedVersion;
-auto loadDependencyVersions(const ModPlatform::Dependency& m, QJsonArray& arr) -> ModPlatform::IndexedVersion;
+auto loadDependencyVersions(const ModPlatform::Dependency& m, QJsonArray& arr, const BaseInstance* inst) -> ModPlatform::IndexedVersion;
 }  // namespace FlameMod

--- a/launcher/modplatform/helpers/NetworkResourceAPI.cpp
+++ b/launcher/modplatform/helpers/NetworkResourceAPI.cpp
@@ -131,7 +131,7 @@ Task::Ptr NetworkResourceAPI::getDependencyVersion(DependencySearchArgs&& args, 
     auto netJob = makeShared<NetJob>(QString("%1::Dependency").arg(args.dependency.addonId.toString()), APPLICATION->network());
     auto response = std::make_shared<QByteArray>();
 
-    netJob->addNetAction(Net::Download::makeByteArray(versions_url, response));
+    netJob->addNetAction(Net::ApiDownload::makeByteArray(versions_url, response));
 
     QObject::connect(netJob.get(), &NetJob::succeeded, [=] {
         QJsonParseError parse_error{};

--- a/launcher/modplatform/import_ftb/PackHelpers.cpp
+++ b/launcher/modplatform/import_ftb/PackHelpers.cpp
@@ -60,19 +60,19 @@ Modpack parseDirectory(QString path)
             auto name = Json::requireString(obj, "name", "name");
             auto version = Json::requireString(obj, "version", "version");
             if (name == "neoforge") {
-                modpack.loaderType = ResourceAPI::NeoForge;
+                modpack.loaderType = ModPlatform::NeoForge;
                 modpack.version = version;
                 break;
             } else if (name == "forge") {
-                modpack.loaderType = ResourceAPI::Forge;
+                modpack.loaderType = ModPlatform::Forge;
                 modpack.version = version;
                 break;
             } else if (name == "fabric") {
-                modpack.loaderType = ResourceAPI::Fabric;
+                modpack.loaderType = ModPlatform::Fabric;
                 modpack.version = version;
                 break;
             } else if (name == "quilt") {
-                modpack.loaderType = ResourceAPI::Quilt;
+                modpack.loaderType = ModPlatform::Quilt;
                 modpack.version = version;
                 break;
             }

--- a/launcher/modplatform/import_ftb/PackHelpers.h
+++ b/launcher/modplatform/import_ftb/PackHelpers.h
@@ -39,7 +39,7 @@ struct Modpack {
     // not needed for instance creation
     QVariant jvmArgs;
 
-    std::optional<ResourceAPI::ModLoaderType> loaderType;
+    std::optional<ModPlatform::ModLoaderType> loaderType;
     QString loaderVersion;
 
     QIcon icon;

--- a/launcher/modplatform/import_ftb/PackInstallTask.cpp
+++ b/launcher/modplatform/import_ftb/PackInstallTask.cpp
@@ -68,25 +68,25 @@ void PackInstallTask::copySettings()
     auto modloader = m_pack.loaderType;
     if (modloader.has_value())
         switch (modloader.value()) {
-            case ResourceAPI::NeoForge: {
+            case ModPlatform::NeoForge: {
                 components->setComponentVersion("net.neoforged", m_pack.version, true);
                 break;
             }
-            case ResourceAPI::Forge: {
+            case ModPlatform::Forge: {
                 components->setComponentVersion("net.minecraftforge", m_pack.version, true);
                 break;
             }
-            case ResourceAPI::Fabric: {
+            case ModPlatform::Fabric: {
                 components->setComponentVersion("net.fabricmc.fabric-loader", m_pack.version, true);
                 break;
             }
-            case ResourceAPI::Quilt: {
+            case ModPlatform::Quilt: {
                 components->setComponentVersion("org.quiltmc.quilt-loader", m_pack.version, true);
                 break;
             }
-            case ResourceAPI::Cauldron:
+            case ModPlatform::Cauldron:
                 break;
-            case ResourceAPI::LiteLoader:
+            case ModPlatform::LiteLoader:
                 break;
         }
     components->saveNow();

--- a/launcher/modplatform/modrinth/ModrinthAPI.cpp
+++ b/launcher/modplatform/modrinth/ModrinthAPI.cpp
@@ -41,7 +41,7 @@ Task::Ptr ModrinthAPI::currentVersions(const QStringList& hashes, QString hash_f
 Task::Ptr ModrinthAPI::latestVersion(QString hash,
                                      QString hash_format,
                                      std::optional<std::list<Version>> mcVersions,
-                                     std::optional<ModLoaderTypes> loaders,
+                                     std::optional<ModPlatform::ModLoaderTypes> loaders,
                                      std::shared_ptr<QByteArray> response)
 {
     auto netJob = makeShared<NetJob>(QString("Modrinth::GetLatestVersion"), APPLICATION->network());
@@ -71,7 +71,7 @@ Task::Ptr ModrinthAPI::latestVersion(QString hash,
 Task::Ptr ModrinthAPI::latestVersions(const QStringList& hashes,
                                       QString hash_format,
                                       std::optional<std::list<Version>> mcVersions,
-                                      std::optional<ModLoaderTypes> loaders,
+                                      std::optional<ModPlatform::ModLoaderTypes> loaders,
                                       std::shared_ptr<QByteArray> response)
 {
     auto netJob = makeShared<NetJob>(QString("Modrinth::GetLatestVersions"), APPLICATION->network());

--- a/launcher/modplatform/modrinth/ModrinthAPI.h
+++ b/launcher/modplatform/modrinth/ModrinthAPI.h
@@ -19,13 +19,13 @@ class ModrinthAPI : public NetworkResourceAPI {
     auto latestVersion(QString hash,
                        QString hash_format,
                        std::optional<std::list<Version>> mcVersions,
-                       std::optional<ModLoaderTypes> loaders,
+                       std::optional<ModPlatform::ModLoaderTypes> loaders,
                        std::shared_ptr<QByteArray> response) -> Task::Ptr;
 
     auto latestVersions(const QStringList& hashes,
                         QString hash_format,
                         std::optional<std::list<Version>> mcVersions,
-                        std::optional<ModLoaderTypes> loaders,
+                        std::optional<ModPlatform::ModLoaderTypes> loaders,
                         std::shared_ptr<QByteArray> response) -> Task::Ptr;
 
     Task::Ptr getProjects(QStringList addonIds, std::shared_ptr<QByteArray> response) const override;
@@ -35,22 +35,24 @@ class ModrinthAPI : public NetworkResourceAPI {
 
     inline auto getAuthorURL(const QString& name) const -> QString { return "https://modrinth.com/user/" + name; };
 
-    static auto getModLoaderStrings(const ModLoaderTypes types) -> const QStringList
+    static auto getModLoaderStrings(const ModPlatform::ModLoaderTypes types) -> const QStringList
     {
         QStringList l;
-        for (auto loader : { NeoForge, Forge, Fabric, Quilt, LiteLoader }) {
+        for (auto loader :
+             { ModPlatform::NeoForge, ModPlatform::Forge, ModPlatform::Fabric, ModPlatform::Quilt, ModPlatform::LiteLoader }) {
             if (types & loader) {
                 l << getModLoaderString(loader);
             }
         }
-        if ((types & NeoForge) && (~types & Forge))  // Add Forge if NeoForge is in use, if Forge isn't already there
-            l << getModLoaderString(Forge);
-        if ((types & Quilt) && (~types & Fabric))  // Add Fabric if Quilt is in use, if Fabric isn't already there
-            l << getModLoaderString(Fabric);
+        if ((types & ModPlatform::NeoForge) &&
+            (~types & ModPlatform::Forge))  // Add Forge if NeoForge is in use, if Forge isn't already there
+            l << getModLoaderString(ModPlatform::Forge);
+        if ((types & ModPlatform::Quilt) && (~types & ModPlatform::Fabric))  // Add Fabric if Quilt is in use, if Fabric isn't already there
+            l << getModLoaderString(ModPlatform::Fabric);
         return l;
     }
 
-    static auto getModLoaderFilters(ModLoaderTypes types) -> const QString
+    static auto getModLoaderFilters(ModPlatform::ModLoaderTypes types) -> const QString
     {
         QStringList l;
         for (auto loader : getModLoaderStrings(types)) {
@@ -143,9 +145,9 @@ class ModrinthAPI : public NetworkResourceAPI {
         return s.isEmpty() ? QString() : s;
     }
 
-    static inline auto validateModLoaders(ModLoaderTypes loaders) -> bool
+    static inline auto validateModLoaders(ModPlatform::ModLoaderTypes loaders) -> bool
     {
-        return loaders & (NeoForge | Forge | Fabric | Quilt | LiteLoader);
+        return loaders & (ModPlatform::NeoForge | ModPlatform::Forge | ModPlatform::Fabric | ModPlatform::Quilt | ModPlatform::LiteLoader);
     }
 
     [[nodiscard]] std::optional<QString> getDependencyURL(DependencySearchArgs const& args) const override

--- a/launcher/modplatform/modrinth/ModrinthAPI.h
+++ b/launcher/modplatform/modrinth/ModrinthAPI.h
@@ -44,11 +44,6 @@ class ModrinthAPI : public NetworkResourceAPI {
                 l << getModLoaderString(loader);
             }
         }
-        if ((types & ModPlatform::NeoForge) &&
-            (~types & ModPlatform::Forge))  // Add Forge if NeoForge is in use, if Forge isn't already there
-            l << getModLoaderString(ModPlatform::Forge);
-        if ((types & ModPlatform::Quilt) && (~types & ModPlatform::Fabric))  // Add Fabric if Quilt is in use, if Fabric isn't already there
-            l << getModLoaderString(ModPlatform::Fabric);
         return l;
     }
 

--- a/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
+++ b/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
@@ -11,7 +11,6 @@
 #include "tasks/ConcurrentTask.h"
 
 #include "minecraft/mod/ModFolderModel.h"
-#include "minecraft/mod/ResourceFolderModel.h"
 
 static ModrinthAPI api;
 static ModPlatform::ProviderCapabilities ProviderCaps;

--- a/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
+++ b/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
@@ -111,11 +111,11 @@ void ModrinthCheckUpdate::executeTask()
                 // so we may want to filter it
                 QString loader_filter;
                 if (m_loaders.has_value()) {
-                    static auto flags = { ResourceAPI::ModLoaderType::NeoForge, ResourceAPI::ModLoaderType::Forge,
-                                          ResourceAPI::ModLoaderType::Fabric, ResourceAPI::ModLoaderType::Quilt };
+                    static auto flags = { ModPlatform::ModLoaderType::NeoForge, ModPlatform::ModLoaderType::Forge,
+                                          ModPlatform::ModLoaderType::Fabric, ModPlatform::ModLoaderType::Quilt };
                     for (auto flag : flags) {
                         if (m_loaders.value().testFlag(flag)) {
-                            loader_filter = api.getModLoaderString(flag);
+                            loader_filter = ModPlatform::getModLoaderString(flag);
                             break;
                         }
                     }

--- a/launcher/modplatform/modrinth/ModrinthCheckUpdate.h
+++ b/launcher/modplatform/modrinth/ModrinthCheckUpdate.h
@@ -10,7 +10,7 @@ class ModrinthCheckUpdate : public CheckUpdateTask {
    public:
     ModrinthCheckUpdate(QList<Mod*>& mods,
                         std::list<Version>& mcVersions,
-                        std::optional<ResourceAPI::ModLoaderTypes> loaders,
+                        std::optional<ModPlatform::ModLoaderTypes> loaders,
                         std::shared_ptr<ModFolderModel> mods_folder)
         : CheckUpdateTask(mods, mcVersions, loaders, mods_folder)
     {}

--- a/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
@@ -134,7 +134,18 @@ auto Modrinth::loadIndexedPackVersion(QJsonObject& obj, QString preferred_hash_t
     }
     auto loaders = Json::requireArray(obj, "loaders");
     for (auto loader : loaders) {
-        file.loaders.append(loader.toString());
+        if (loader == "neoforge")
+            file.loaders |= ModPlatform::NeoForge;
+        if (loader == "forge")
+            file.loaders |= ModPlatform::Forge;
+        if (loader == "cauldron")
+            file.loaders |= ModPlatform::Cauldron;
+        if (loader == "liteloader")
+            file.loaders |= ModPlatform::LiteLoader;
+        if (loader == "fabric")
+            file.loaders |= ModPlatform::Fabric;
+        if (loader == "quilt")
+            file.loaders |= ModPlatform::Quilt;
     }
     file.version = Json::requireString(obj, "name");
     file.version_number = Json::requireString(obj, "version_number");

--- a/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
@@ -105,7 +105,7 @@ void Modrinth::loadIndexedPackVersions(ModPlatform::IndexedPack& pack, QJsonArra
         auto file = loadIndexedPackVersion(obj);
 
         if (file.fileId.isValid() &&
-            (!loaders.has_value() || loaders.value() & file.loaders))  // Heuristic to check if the returned value is valid
+            (!loaders.has_value() || !file.loaders || loaders.value() & file.loaders))  // Heuristic to check if the returned value is valid
             unsortedVersions.append(file);
     }
     auto orderSortPredicate = [](const ModPlatform::IndexedVersion& a, const ModPlatform::IndexedVersion& b) -> bool {
@@ -242,7 +242,7 @@ auto Modrinth::loadDependencyVersions([[maybe_unused]] const ModPlatform::Depend
         auto file = loadIndexedPackVersion(obj);
 
         if (file.fileId.isValid() &&
-            (!loaders.has_value() || loaders.value() & file.loaders))  // Heuristic to check if the returned value is valid
+            (!loaders.has_value() || !file.loaders || loaders.value() & file.loaders))  // Heuristic to check if the returned value is valid
             versions.append(file);
     }
     auto orderSortPredicate = [](const ModPlatform::IndexedVersion& a, const ModPlatform::IndexedVersion& b) -> bool {

--- a/launcher/modplatform/modrinth/ModrinthPackIndex.h
+++ b/launcher/modplatform/modrinth/ModrinthPackIndex.h
@@ -26,11 +26,8 @@ namespace Modrinth {
 
 void loadIndexedPack(ModPlatform::IndexedPack& m, QJsonObject& obj);
 void loadExtraPackData(ModPlatform::IndexedPack& m, QJsonObject& obj);
-void loadIndexedPackVersions(ModPlatform::IndexedPack& pack,
-                             QJsonArray& arr,
-                             const shared_qobject_ptr<QNetworkAccessManager>& network,
-                             const BaseInstance* inst);
+void loadIndexedPackVersions(ModPlatform::IndexedPack& pack, QJsonArray& arr, const BaseInstance* inst);
 auto loadIndexedPackVersion(QJsonObject& obj, QString hash_type = "sha512", QString filename_prefer = "") -> ModPlatform::IndexedVersion;
-auto loadDependencyVersions(const ModPlatform::Dependency& m, QJsonArray& arr) -> ModPlatform::IndexedVersion;
+auto loadDependencyVersions(const ModPlatform::Dependency& m, QJsonArray& arr, const BaseInstance* inst) -> ModPlatform::IndexedVersion;
 
 }  // namespace Modrinth

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -43,7 +43,6 @@
 #include "FileSystem.h"
 
 #include "MainWindow.h"
-#include "ui/dialogs/ExportToModListDialog.h"
 #include "ui_MainWindow.h"
 
 #include <QDir>
@@ -90,17 +89,14 @@
 #include <news/NewsChecker.h>
 #include <tools/BaseProfiler.h>
 #include <updater/ExternalUpdater.h>
-#include "InstancePageProvider.h"
 #include "InstanceWindow.h"
-#include "JavaCommon.h"
-#include "LaunchController.h"
 
 #include "ui/dialogs/AboutDialog.h"
 #include "ui/dialogs/CopyInstanceDialog.h"
 #include "ui/dialogs/CustomMessageBox.h"
-#include "ui/dialogs/EditAccountDialog.h"
 #include "ui/dialogs/ExportInstanceDialog.h"
 #include "ui/dialogs/ExportPackDialog.h"
+#include "ui/dialogs/ExportToModListDialog.h"
 #include "ui/dialogs/IconPickerDialog.h"
 #include "ui/dialogs/ImportResourceDialog.h"
 #include "ui/dialogs/NewInstanceDialog.h"
@@ -113,9 +109,13 @@
 #include "ui/themes/ThemeManager.h"
 #include "ui/widgets/LabeledToolButton.h"
 
+#include "minecraft/PackProfile.h"
+#include "minecraft/VersionFile.h"
 #include "minecraft/WorldList.h"
 #include "minecraft/mod/ModFolderModel.h"
+#include "minecraft/mod/ResourcePackFolderModel.h"
 #include "minecraft/mod/ShaderPackFolderModel.h"
+#include "minecraft/mod/TexturePackFolderModel.h"
 #include "minecraft/mod/tasks/LocalResourceParse.h"
 
 #include "modplatform/flame/FlameAPI.h"
@@ -123,7 +123,6 @@
 #include "KonamiCode.h"
 
 #include "InstanceCopyTask.h"
-#include "InstanceImportTask.h"
 
 #include "Json.h"
 

--- a/launcher/ui/dialogs/ModUpdateDialog.cpp
+++ b/launcher/ui/dialogs/ModUpdateDialog.cpp
@@ -30,7 +30,7 @@ static std::list<Version> mcVersions(BaseInstance* inst)
     return { static_cast<MinecraftInstance*>(inst)->getPackProfile()->getComponent("net.minecraft")->getVersion() };
 }
 
-static std::optional<ResourceAPI::ModLoaderTypes> mcLoaders(BaseInstance* inst)
+static std::optional<ModPlatform::ModLoaderTypes> mcLoaders(BaseInstance* inst)
 {
     return { static_cast<MinecraftInstance*>(inst)->getPackProfile()->getModLoaders() };
 }

--- a/launcher/ui/dialogs/ModUpdateDialog.cpp
+++ b/launcher/ui/dialogs/ModUpdateDialog.cpp
@@ -5,8 +5,6 @@
 #include "ScrollMessageBox.h"
 #include "ui_ReviewMessageBox.h"
 
-#include "FileSystem.h"
-#include "Json.h"
 #include "Markdown.h"
 
 #include "tasks/ConcurrentTask.h"
@@ -32,7 +30,7 @@ static std::list<Version> mcVersions(BaseInstance* inst)
 
 static std::optional<ModPlatform::ModLoaderTypes> mcLoaders(BaseInstance* inst)
 {
-    return { static_cast<MinecraftInstance*>(inst)->getPackProfile()->getModLoaders() };
+    return { static_cast<MinecraftInstance*>(inst)->getPackProfile()->getSupportedModLoaders() };
 }
 
 ModUpdateDialog::ModUpdateDialog(QWidget* parent,

--- a/launcher/ui/dialogs/ResourceDownloadDialog.cpp
+++ b/launcher/ui/dialogs/ResourceDownloadDialog.cpp
@@ -279,7 +279,7 @@ QList<BasePage*> ModDownloadDialog::getPages()
 {
     QList<BasePage*> pages;
 
-    auto loaders = static_cast<MinecraftInstance*>(m_instance)->getPackProfile()->getModLoaders().value();
+    auto loaders = static_cast<MinecraftInstance*>(m_instance)->getPackProfile()->getSupportedModLoaders().value();
 
     if (ModrinthAPI::validateModLoaders(loaders))
         pages.append(ModrinthModPage::create(this, *m_instance));

--- a/launcher/ui/pages/modplatform/ModModel.cpp
+++ b/launcher/ui/pages/modplatform/ModModel.cpp
@@ -33,7 +33,7 @@ ResourceAPI::SearchArgs ModModel::createSearchArguments()
 
     auto sort = getCurrentSortingMethodByIndex();
 
-    return { ModPlatform::ResourceType::MOD, m_next_search_offset, m_search_term, sort, profile->getModLoaders(), versions };
+    return { ModPlatform::ResourceType::MOD, m_next_search_offset, m_search_term, sort, profile->getSupportedModLoaders(), versions };
 }
 
 ResourceAPI::VersionSearchArgs ModModel::createVersionsArguments(QModelIndex& entry)
@@ -48,7 +48,7 @@ ResourceAPI::VersionSearchArgs ModModel::createVersionsArguments(QModelIndex& en
     if (!m_filter->versions.empty())
         versions = m_filter->versions;
 
-    return { pack, versions, profile->getModLoaders() };
+    return { pack, versions, profile->getSupportedModLoaders() };
 }
 
 ResourceAPI::ProjectInfoArgs ModModel::createInfoArguments(QModelIndex& entry)

--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -124,7 +124,7 @@ void ModPage::updateVersionList()
         auto version = current_pack->versions[i];
         bool valid = false;
         for (auto& mcVer : m_filter->versions) {
-            if (validateVersion(version, mcVer.toString(), packProfile->getModLoaders())) {
+            if (validateVersion(version, mcVer.toString(), packProfile->getSupportedModLoaders())) {
                 valid = true;
                 break;
             }

--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -124,7 +124,6 @@ void ModPage::updateVersionList()
         auto version = current_pack->versions[i];
         bool valid = false;
         for (auto& mcVer : m_filter->versions) {
-            // NOTE: Flame doesn't care about loader, so passing it changes nothing.
             if (validateVersion(version, mcVer.toString(), packProfile->getModLoaders())) {
                 valid = true;
                 break;

--- a/launcher/ui/pages/modplatform/ModPage.h
+++ b/launcher/ui/pages/modplatform/ModPage.h
@@ -55,7 +55,7 @@ class ModPage : public ResourcePage {
 
     virtual auto validateVersion(ModPlatform::IndexedVersion& ver,
                                  QString mineVer,
-                                 std::optional<ResourceAPI::ModLoaderTypes> loaders = {}) const -> bool = 0;
+                                 std::optional<ModPlatform::ModLoaderTypes> loaders = {}) const -> bool = 0;
 
     [[nodiscard]] bool supportsFiltering() const override { return true; };
     auto getFilter() const -> const std::shared_ptr<ModFilterWidget::Filter> { return m_filter; }

--- a/launcher/ui/pages/modplatform/ShaderPackPage.cpp
+++ b/launcher/ui/pages/modplatform/ShaderPackPage.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include "ShaderPackPage.h"
+#include "modplatform/ModIndex.h"
 #include "ui_ResourcePage.h"
 
 #include "ShaderPackModel.h"
@@ -48,7 +49,7 @@ void ShaderPackResourcePage::addResourceToPage(ModPlatform::IndexedPack::Ptr pac
                                                const std::shared_ptr<ResourceFolderModel> base_model)
 {
     QString custom_target_folder;
-    if (version.loaders.contains(QStringLiteral("canvas")))
+    if (version.loaders & ModPlatform::Cauldron)
         custom_target_folder = QStringLiteral("resourcepacks");
     m_model->addPack(pack, version, base_model, false, custom_target_folder);
 }

--- a/launcher/ui/pages/modplatform/flame/FlameResourceModels.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameResourceModels.cpp
@@ -31,7 +31,7 @@ void FlameModModel::loadIndexedPackVersions(ModPlatform::IndexedPack& m, QJsonAr
 
 auto FlameModModel::loadDependencyVersions(const ModPlatform::Dependency& m, QJsonArray& arr) -> ModPlatform::IndexedVersion
 {
-    return FlameMod::loadDependencyVersions(m, arr);
+    return FlameMod::loadDependencyVersions(m, arr, &m_base_instance);
 }
 
 auto FlameModModel::documentToArray(QJsonDocument& obj) const -> QJsonArray

--- a/launcher/ui/pages/modplatform/flame/FlameResourcePages.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameResourcePages.cpp
@@ -70,7 +70,8 @@ auto FlameModPage::validateVersion(ModPlatform::IndexedVersion& ver,
                                    QString mineVer,
                                    std::optional<ModPlatform::ModLoaderTypes> loaders) const -> bool
 {
-    return ver.mcVersion.contains(mineVer) && !ver.downloadUrl.isEmpty() && (!loaders.has_value() || loaders.value() & ver.loaders);
+    return ver.mcVersion.contains(mineVer) && !ver.downloadUrl.isEmpty() &&
+           (!loaders.has_value() || !ver.loaders || loaders.value() & ver.loaders);
 }
 
 bool FlameModPage::optedOut(ModPlatform::IndexedVersion& ver) const

--- a/launcher/ui/pages/modplatform/flame/FlameResourcePages.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameResourcePages.cpp
@@ -68,7 +68,7 @@ FlameModPage::FlameModPage(ModDownloadDialog* dialog, BaseInstance& instance) : 
 
 auto FlameModPage::validateVersion(ModPlatform::IndexedVersion& ver,
                                    QString mineVer,
-                                   std::optional<ResourceAPI::ModLoaderTypes> loaders) const -> bool
+                                   std::optional<ModPlatform::ModLoaderTypes> loaders) const -> bool
 {
     Q_UNUSED(loaders);
     return ver.mcVersion.contains(mineVer) && !ver.downloadUrl.isEmpty();

--- a/launcher/ui/pages/modplatform/flame/FlameResourcePages.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameResourcePages.cpp
@@ -70,8 +70,7 @@ auto FlameModPage::validateVersion(ModPlatform::IndexedVersion& ver,
                                    QString mineVer,
                                    std::optional<ModPlatform::ModLoaderTypes> loaders) const -> bool
 {
-    Q_UNUSED(loaders);
-    return ver.mcVersion.contains(mineVer) && !ver.downloadUrl.isEmpty();
+    return ver.mcVersion.contains(mineVer) && !ver.downloadUrl.isEmpty() && (!loaders.has_value() || loaders.value() & ver.loaders);
 }
 
 bool FlameModPage::optedOut(ModPlatform::IndexedVersion& ver) const

--- a/launcher/ui/pages/modplatform/flame/FlameResourcePages.h
+++ b/launcher/ui/pages/modplatform/flame/FlameResourcePages.h
@@ -95,7 +95,7 @@ class FlameModPage : public ModPage {
 
     bool validateVersion(ModPlatform::IndexedVersion& ver,
                          QString mineVer,
-                         std::optional<ResourceAPI::ModLoaderTypes> loaders = {}) const override;
+                         std::optional<ModPlatform::ModLoaderTypes> loaders = {}) const override;
     bool optedOut(ModPlatform::IndexedVersion& ver) const override;
 
     void openUrl(const QUrl& url) override;

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthResourceModels.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthResourceModels.cpp
@@ -39,12 +39,12 @@ void ModrinthModModel::loadExtraPackInfo(ModPlatform::IndexedPack& m, QJsonObjec
 
 void ModrinthModModel::loadIndexedPackVersions(ModPlatform::IndexedPack& m, QJsonArray& arr)
 {
-    ::Modrinth::loadIndexedPackVersions(m, arr, APPLICATION->network(), &m_base_instance);
+    ::Modrinth::loadIndexedPackVersions(m, arr, &m_base_instance);
 }
 
 auto ModrinthModModel::loadDependencyVersions(const ModPlatform::Dependency& m, QJsonArray& arr) -> ModPlatform::IndexedVersion
 {
-    return ::Modrinth::loadDependencyVersions(m, arr);
+    return ::Modrinth::loadDependencyVersions(m, arr, &m_base_instance);
 }
 
 auto ModrinthModModel::documentToArray(QJsonDocument& obj) const -> QJsonArray
@@ -66,7 +66,7 @@ void ModrinthResourcePackModel::loadExtraPackInfo(ModPlatform::IndexedPack& m, Q
 
 void ModrinthResourcePackModel::loadIndexedPackVersions(ModPlatform::IndexedPack& m, QJsonArray& arr)
 {
-    ::Modrinth::loadIndexedPackVersions(m, arr, APPLICATION->network(), &m_base_instance);
+    ::Modrinth::loadIndexedPackVersions(m, arr, &m_base_instance);
 }
 
 auto ModrinthResourcePackModel::documentToArray(QJsonDocument& obj) const -> QJsonArray
@@ -88,7 +88,7 @@ void ModrinthTexturePackModel::loadExtraPackInfo(ModPlatform::IndexedPack& m, QJ
 
 void ModrinthTexturePackModel::loadIndexedPackVersions(ModPlatform::IndexedPack& m, QJsonArray& arr)
 {
-    ::Modrinth::loadIndexedPackVersions(m, arr, APPLICATION->network(), &m_base_instance);
+    ::Modrinth::loadIndexedPackVersions(m, arr, &m_base_instance);
 }
 
 auto ModrinthTexturePackModel::documentToArray(QJsonDocument& obj) const -> QJsonArray
@@ -110,7 +110,7 @@ void ModrinthShaderPackModel::loadExtraPackInfo(ModPlatform::IndexedPack& m, QJs
 
 void ModrinthShaderPackModel::loadIndexedPackVersions(ModPlatform::IndexedPack& m, QJsonArray& arr)
 {
-    ::Modrinth::loadIndexedPackVersions(m, arr, APPLICATION->network(), &m_base_instance);
+    ::Modrinth::loadIndexedPackVersions(m, arr, &m_base_instance);
 }
 
 auto ModrinthShaderPackModel::documentToArray(QJsonDocument& obj) const -> QJsonArray

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.cpp
@@ -65,7 +65,7 @@ ModrinthModPage::ModrinthModPage(ModDownloadDialog* dialog, BaseInstance& instan
 
 auto ModrinthModPage::validateVersion(ModPlatform::IndexedVersion& ver,
                                       QString mineVer,
-                                      std::optional<ResourceAPI::ModLoaderTypes> loaders) const -> bool
+                                      std::optional<ModPlatform::ModLoaderTypes> loaders) const -> bool
 {
     auto loaderCompatible = !loaders.has_value();
 

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.cpp
@@ -67,19 +67,7 @@ auto ModrinthModPage::validateVersion(ModPlatform::IndexedVersion& ver,
                                       QString mineVer,
                                       std::optional<ModPlatform::ModLoaderTypes> loaders) const -> bool
 {
-    auto loaderCompatible = !loaders.has_value();
-
-    if (!loaderCompatible) {
-        auto loaderStrings = ModrinthAPI::getModLoaderStrings(loaders.value());
-        for (auto remoteLoader : ver.loaders) {
-            if (loaderStrings.contains(remoteLoader)) {
-                loaderCompatible = true;
-                break;
-            }
-        }
-    }
-
-    return ver.mcVersion.contains(mineVer) && loaderCompatible;
+    return ver.mcVersion.contains(mineVer) && (!loaders.has_value() || loaders.value() & ver.loaders);
 }
 
 ModrinthResourcePackPage::ModrinthResourcePackPage(ResourcePackDownloadDialog* dialog, BaseInstance& instance)

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.cpp
@@ -67,7 +67,7 @@ auto ModrinthModPage::validateVersion(ModPlatform::IndexedVersion& ver,
                                       QString mineVer,
                                       std::optional<ModPlatform::ModLoaderTypes> loaders) const -> bool
 {
-    return ver.mcVersion.contains(mineVer) && (!loaders.has_value() || loaders.value() & ver.loaders);
+    return ver.mcVersion.contains(mineVer) && (!loaders.has_value() || !ver.loaders || loaders.value() & ver.loaders);
 }
 
 ModrinthResourcePackPage::ModrinthResourcePackPage(ResourcePackDownloadDialog* dialog, BaseInstance& instance)

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.h
@@ -93,7 +93,7 @@ class ModrinthModPage : public ModPage {
 
     [[nodiscard]] inline auto helpPage() const -> QString override { return "Mod-platform"; }
 
-    auto validateVersion(ModPlatform::IndexedVersion& ver, QString mineVer, std::optional<ResourceAPI::ModLoaderTypes> loaders = {}) const
+    auto validateVersion(ModPlatform::IndexedVersion& ver, QString mineVer, std::optional<ModPlatform::ModLoaderTypes> loaders = {}) const
         -> bool override;
 };
 


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
fixes #1217
This also fixes some forgotten conflicts(use of Download instead of ApiDownload) caused by net refactor PR.
This one doesn't let the user filter by a specific loader but at least we can now support quilt+fabric and neoforge+forge using the flame API.
Hopefully, this is clean enough.