### PR TITLE
fix: remove -Wextra-semi

### DIFF
--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -75,7 +75,6 @@ function(
     set(CLANG_WARNINGS
         -Wall
         -Wextra # reasonable and standard
-        -Wextra-semi # Warn about semicolon after in-class function definition.
         -Wshadow # warn the user if a variable declaration shadows one from a parent context
         -Wnon-virtual-dtor # warn the user if a class with virtual functions has a non-virtual destructor. This helps
         # catch hard to track down memory errors


### PR DESCRIPTION
Parent PR: #1107

this flag is unavailable on gcc versions < 8. we could detect the
version of the compiler here, but i don't think we lose much in this
flags removal and this is a simpler option

Signed-off-by: seth <getchoo@tuta.io>