### PR TITLE
[Linux] Filter source in Nix Flake & add controller support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -89,6 +89,21 @@
         "type": "github"
       }
     },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1693833173,
+        "narHash": "sha256-hlMABKrGbEiJD5dwUSfnw1CQ3bG7KKwDV+Nx3bEZd7U=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "ac030bd9ba98e318e1f4c4328d60766ade8ebe8b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1693626178,
@@ -156,6 +171,7 @@
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
         "libnbtplusplus": "libnbtplusplus",
+        "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs",
         "pre-commit-hooks": "pre-commit-hooks"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -20,12 +20,14 @@
     };
   };
 
-  outputs = inputs:
-    inputs.flake-parts.lib.mkFlake
-    {inherit inputs;}
-    {
+  outputs = {
+    flake-parts,
+    pre-commit-hooks,
+    ...
+  } @ inputs:
+    flake-parts.lib.mkFlake {inherit inputs;} {
       imports = [
-        inputs.pre-commit-hooks.flakeModule
+        pre-commit-hooks.flakeModule
 
         ./nix/dev.nix
         ./nix/distribution.nix

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,7 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
+    nix-filter.url = "github:numtide/nix-filter";
     pre-commit-hooks = {
       url = "github:cachix/pre-commit-hooks.nix";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/nix/distribution.nix
+++ b/nix/distribution.nix
@@ -9,7 +9,7 @@
     ...
   }: {
     packages = let
-      ourPackages = lib.fix (final: self.overlays.default ({inherit (pkgs) darwin;} // final) pkgs);
+      ourPackages = lib.fix (final: self.overlays.default final pkgs);
     in {
       inherit
         (ourPackages)
@@ -29,16 +29,21 @@
       # common args for prismlauncher evaluations
       unwrappedArgs = {
         inherit (inputs) libnbtplusplus;
-        inherit (final.darwin.apple_sdk.frameworks) Cocoa;
+        inherit ((final.darwin or prev.darwin).apple_sdk.frameworks) Cocoa;
         inherit self version;
       };
     in {
       prismlauncher-qt5-unwrapped = prev.libsForQt5.callPackage ./pkg unwrappedArgs;
+
       prismlauncher-qt5 = prev.libsForQt5.callPackage ./pkg/wrapper.nix {
         prismlauncher-unwrapped = final.prismlauncher-qt5-unwrapped;
       };
+
       prismlauncher-unwrapped = prev.qt6Packages.callPackage ./pkg unwrappedArgs;
-      prismlauncher = prev.qt6Packages.callPackage ./pkg/wrapper.nix {inherit (final) prismlauncher-unwrapped;};
+
+      prismlauncher = prev.qt6Packages.callPackage ./pkg/wrapper.nix {
+        inherit (final) prismlauncher-unwrapped;
+      };
     };
   };
 }

--- a/nix/distribution.nix
+++ b/nix/distribution.nix
@@ -26,11 +26,27 @@
     overlays.default = final: prev: let
       version = builtins.substring 0 8 self.lastModifiedDate or "dirty";
 
+      filteredSelf = inputs.nix-filter.lib.filter {
+        root = ../.;
+        include = [
+          "buildconfig"
+          "cmake"
+          "launcher"
+          "libraries"
+          "program_info"
+          "tests"
+          ../COPYING.md
+          ../CMakeLists.txt
+        ];
+      };
+
       # common args for prismlauncher evaluations
       unwrappedArgs = {
+        self = filteredSelf;
+
         inherit (inputs) libnbtplusplus;
         inherit ((final.darwin or prev.darwin).apple_sdk.frameworks) Cocoa;
-        inherit self version;
+        inherit version;
       };
     in {
       prismlauncher-qt5-unwrapped = prev.libsForQt5.callPackage ./pkg unwrappedArgs;

--- a/nix/pkg/default.nix
+++ b/nix/pkg/default.nix
@@ -58,6 +58,7 @@ assert lib.assertMsg (stdenv.isLinux || !gamemodeSupport) "gamemodeSupport is on
     dontWrapQtApps = true;
 
     meta = with lib; {
+      mainProgram = "prismlauncher";
       homepage = "https://prismlauncher.org/";
       description = "A free, open source launcher for Minecraft";
       longDescription = ''

--- a/nix/pkg/wrapper.nix
+++ b/nix/pkg/wrapper.nix
@@ -18,9 +18,11 @@
   flite,
   mesa-demos,
   udev,
+  libusb1,
   msaClientID ? null,
   gamemodeSupport ? stdenv.isLinux,
   textToSpeechSupport ? stdenv.isLinux,
+  controllerSupport ? stdenv.isLinux,
   jdks ? [jdk17 jdk8],
   additionalLibs ? [],
   additionalPrograms ? [],
@@ -71,6 +73,7 @@ in
         ]
         ++ lib.optional gamemodeSupport gamemode.lib
         ++ lib.optional textToSpeechSupport flite
+        ++ lib.optional controllerSupport libusb1
         ++ additionalLibs;
 
       runtimePrograms =


### PR DESCRIPTION
this is a follow up on #1574, cleaning up a bit of how we handle the `packages` output. concatenating `darwin` and the fixed point was a little weird, and i find the `or` to be a lot cleaner (plus i imagine it helps eval time a little too :p). the `input` argument is also now expanded and matched, which makes the main `flake.nix` look a bit neater imo

now the main point: source filtering. this uses numtide's [nix-filter](https://github.com/numtide/nix-filter) library, which helps us further reduce unnecessary rebuilds. i tried to not bring another library in, but frankly it would've added a lot to our flake and `nix-filter` is very lightweight as is

this also includes changes in nixpkgs, namely the addition of `meta.mainProgram` for functions like `lib.getExe` and `libusb1` for controller support, similar to our flatpak
