### PR TITLE
Skip folders when updating mods

### DIFF
--- a/launcher/ui/dialogs/ModUpdateDialog.cpp
+++ b/launcher/ui/dialogs/ModUpdateDialog.cpp
@@ -237,7 +237,6 @@ auto ModUpdateDialog::ensureMetadata() -> bool
             continue;
 
         if (candidate->type() == ResourceType::FOLDER) {
-            m_failed_metadata.append({ candidate, tr("This is a folder.") });
             continue;
         }
 

--- a/launcher/ui/dialogs/ModUpdateDialog.cpp
+++ b/launcher/ui/dialogs/ModUpdateDialog.cpp
@@ -236,6 +236,11 @@ auto ModUpdateDialog::ensureMetadata() -> bool
         if (skip_rest)
             continue;
 
+        if (candidate->type() == ResourceType::FOLDER) {
+            m_failed_metadata.append({ candidate, tr("This is a folder.") });
+            continue;
+        }
+
         if (confirm_rest) {
             addToTmp(candidate, provider_rest);
             should_try_others.insert(candidate->internal_id(), try_others_rest);


### PR DESCRIPTION
Previously the mod updater would fail, reporting "The mod updater was aborted!", when trying to update a folder.
Now it will display the message like other failures and allow other mods to be updated.

