### PR TITLE
Added version check for neoforge filter

### DIFF
--- a/launcher/minecraft/PackProfile.cpp
+++ b/launcher/minecraft/PackProfile.cpp
@@ -1018,8 +1018,8 @@ std::optional<ModPlatform::ModLoaderTypes> PackProfile::getSupportedModLoaders()
     // TODO: remove this or add version condition once Quilt drops official Fabric support
     if (loaders & ModPlatform::Quilt)
         loaders |= ModPlatform::Fabric;
-    // TODO: remove this or add version condition once NeoForge drops official Forge support
-    if (loaders & ModPlatform::NeoForge)
+    Version instance_ver{ getComponentVersion("net.minecraft") };
+    if (instance_ver <= Version("1.20.1") && loaders & ModPlatform::NeoForge)
         loaders |= ModPlatform::Forge;
     return loaders;
 }

--- a/launcher/minecraft/PackProfile.cpp
+++ b/launcher/minecraft/PackProfile.cpp
@@ -1018,7 +1018,7 @@ std::optional<ModPlatform::ModLoaderTypes> PackProfile::getSupportedModLoaders()
     // TODO: remove this or add version condition once Quilt drops official Fabric support
     if (loaders & ModPlatform::Quilt)
         loaders |= ModPlatform::Fabric;
-    if (getComponentVersion("net.minecraft") == "1.20.1" && loaders & ModPlatform::NeoForge)
+    if (getComponentVersion("net.minecraft") == "1.20.1" && (loaders & ModPlatform::NeoForge))
         loaders |= ModPlatform::Forge;
     return loaders;
 }

--- a/launcher/minecraft/PackProfile.cpp
+++ b/launcher/minecraft/PackProfile.cpp
@@ -1018,8 +1018,7 @@ std::optional<ModPlatform::ModLoaderTypes> PackProfile::getSupportedModLoaders()
     // TODO: remove this or add version condition once Quilt drops official Fabric support
     if (loaders & ModPlatform::Quilt)
         loaders |= ModPlatform::Fabric;
-    Version instance_ver{ getComponentVersion("net.minecraft") };
-    if (instance_ver <= Version("1.20.1") && loaders & ModPlatform::NeoForge)
+    if (getComponentVersion("net.minecraft") == "1.20.1" && loaders & ModPlatform::NeoForge)
         loaders |= ModPlatform::Forge;
     return loaders;
 }

--- a/tests/Version_test.cpp
+++ b/tests/Version_test.cpp
@@ -55,6 +55,8 @@ class VersionTest : public QObject {
                                               << "2.2.0" << true << false;
         QTest::newRow("lessThan, two-digit") << "1.41"
                                              << "1.42" << true << false;
+        QTest::newRow("lessThan, snapshot") << "1.20.0-rc2"
+                                            << "1.20.1" << true << false;
 
         QTest::newRow("greaterThan, explicit 1") << "1.2.1"
                                                  << "1.2.0" << false << false;
@@ -72,6 +74,8 @@ class VersionTest : public QObject {
                                                  << "1.2" << false << false;
         QTest::newRow("greaterThan, two-digit") << "1.42"
                                                 << "1.41" << false << false;
+        QTest::newRow("greaterThan, snapshot") << "1.20.2-rc2"
+                                               << "1.20.1" << false << false;
     }
 
    private slots:


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->

Made the neoforge loaders filter dependent on the instance version.
Currently, 1.20.1 is compatible with the forge, but with 1.20.2 the compatibility is dropped.