### PR TITLE
fixed quilt dependencies

### DIFF
--- a/launcher/minecraft/mod/tasks/GetModDependenciesTask.cpp
+++ b/launcher/minecraft/mod/tasks/GetModDependenciesTask.cpp
@@ -94,7 +94,7 @@ QList<ModPlatform::Dependency> GetModDependenciesTask::getDependenciesForVersion
     for (auto ver_dep : version.dependencies) {
         if (ver_dep.type != ModPlatform::DependencyType::REQUIRED)
             continue;
-
+        ver_dep = getOverride(ver_dep, providerName);
         auto isOnlyVersion = providerName == ModPlatform::ResourceProvider::MODRINTH && ver_dep.addonId.toString().isEmpty();
         if (auto dep = std::find_if(c_dependencies.begin(), c_dependencies.end(),
                                     [&ver_dep, isOnlyVersion](const ModPlatform::Dependency& i) {
@@ -127,7 +127,7 @@ QList<ModPlatform::Dependency> GetModDependenciesTask::getDependenciesForVersion
             dep != m_pack_dependencies.end())  // check loaded dependencies
             continue;
 
-        c_dependencies.append(getOverride(ver_dep, providerName));
+        c_dependencies.append(ver_dep);
     }
     return c_dependencies;
 }


### PR DESCRIPTION
Parent PR: #1263
resolves the issue mentioned on Discord by having multiple quilt APIs as dependencies: https://discord.com/channels/1031648380885147709/1031823065937629267/1159007547542483014
How to test:
- download a quilt pack like additive( an older version so we have mods to update)
- update the mods on that instance
- you should have only one of any Quilt API or quilt kotlin Libraries mods to download(not one for each mod)  