### PR TITLE
[Linux] Add more Java installation directories

### DIFF
--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -403,6 +403,14 @@ QList<QString> JavaUtils::FindJavaPaths()
     scanJavaDirs("/opt/jdks");
     // flatpak
     scanJavaDirs("/app/jdk");
+
+    auto home = qEnvironmentVariable("HOME");
+
+    // javas downloaded by IntelliJ
+    scanJavaDirs(FS::PathCombine(home, ".jdks"));
+    // javas downloaded by sdkman
+    scanJavaDirs(FS::PathCombine(home, ".sdkman/candidates/java"));
+
     javas = addJavasFromEnv(javas);
     javas.removeDuplicates();
     return javas;


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
This PR adds a few more standard locations into which JDKs may be installed. While these aren't global installation targets, I do feel like they are common enough to warrant inclusion into the search path.


