### PR TITLE
removed windows legacy builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,18 +55,6 @@ jobs:
             vcvars_arch: 'amd64_x86'
 
           - os: windows-2022
-            name: "Windows-MSVC-Legacy"
-            msystem: ''
-            architecture: 'win32'
-            vcvars_arch: 'amd64_x86'
-            qt_ver: 5
-            qt_host: windows
-            qt_arch: 'win32_msvc2019'
-            qt_version: '5.15.2'
-            qt_modules: ''
-            qt_tools: 'tools_openssl_x86'
-
-          - os: windows-2022
             name: "Windows-MSVC"
             msystem: ''
             architecture: 'x64'

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -3,10 +3,9 @@ name: Build Application and Make Release
 on:
   push:
     tags:
-      - '*'
+      - "*"
 
 jobs:
-
   build_release:
     name: Build Release
     uses: ./.github/workflows/build.yml
@@ -28,8 +27,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          submodules: 'true'
-          path: 'PrismLauncher-source'
+          submodules: "true"
+          path: "PrismLauncher-source"
       - name: Download artifacts
         uses: actions/download-artifact@v3
       - name: Grab and store version
@@ -95,9 +94,6 @@ jobs:
             PrismLauncher-Windows-MinGW-w64-${{ env.VERSION }}.zip
             PrismLauncher-Windows-MinGW-w64-Portable-${{ env.VERSION }}.zip
             PrismLauncher-Windows-MinGW-w64-Setup-${{ env.VERSION }}.exe
-            PrismLauncher-Windows-MSVC-Legacy-${{ env.VERSION }}.zip
-            PrismLauncher-Windows-MSVC-Legacy-Portable-${{ env.VERSION }}.zip
-            PrismLauncher-Windows-MSVC-Legacy-Setup-${{ env.VERSION }}.exe
             PrismLauncher-Windows-MSVC-arm64-${{ env.VERSION }}.zip
             PrismLauncher-Windows-MSVC-arm64-Portable-${{ env.VERSION }}.zip
             PrismLauncher-Windows-MSVC-arm64-Setup-${{ env.VERSION }}.exe


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
@DioEgizio this is what you meant here: https://discord.com/channels/1031648380885147709/1031823065937629267/1159574441265733672 ?

\* I can confirm that that build doesn't work anymore