### PR TITLE
Autodetect Java bundled with official launcher

### DIFF
--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -335,7 +335,7 @@ QList<QString> JavaUtils::FindJavaPaths()
         }
     }
 
-    javas.append(getMinecraftJavaBundle());
+    candidates.append(getMinecraftJavaBundle());
     candidates = addJavasFromEnv(candidates);
     candidates.removeDuplicates();
     return candidates;

--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -335,6 +335,7 @@ QList<QString> JavaUtils::FindJavaPaths()
         }
     }
 
+    javas.append(getMinecraftJavaBundle());
     candidates = addJavasFromEnv(candidates);
     candidates.removeDuplicates();
     return candidates;
@@ -360,6 +361,7 @@ QList<QString> JavaUtils::FindJavaPaths()
         javas.append(systemLibraryJVMDir.absolutePath() + "/" + java + "/Contents/Home/bin/java");
         javas.append(systemLibraryJVMDir.absolutePath() + "/" + java + "/Contents/Commands/java");
     }
+    javas.append(getMinecraftJavaBundle());
     javas = addJavasFromEnv(javas);
     javas.removeDuplicates();
     return javas;
@@ -411,6 +413,7 @@ QList<QString> JavaUtils::FindJavaPaths()
     // javas downloaded by sdkman
     scanJavaDirs(FS::PathCombine(home, ".sdkman/candidates/java"));
 
+    javas.append(getMinecraftJavaBundle());
     javas = addJavasFromEnv(javas);
     javas.removeDuplicates();
     return javas;
@@ -423,6 +426,7 @@ QList<QString> JavaUtils::FindJavaPaths()
     QList<QString> javas;
     javas.append(this->GetDefaultJava()->path);
 
+    javas.append(getMinecraftJavaBundle());
     return addJavasFromEnv(javas);
 }
 #endif
@@ -430,4 +434,43 @@ QList<QString> JavaUtils::FindJavaPaths()
 QString JavaUtils::getJavaCheckPath()
 {
     return APPLICATION->getJarPath("JavaCheck.jar");
+}
+
+QStringList getMinecraftJavaBundle()
+{
+    QString partialPath;
+    QString executable = "java";
+#if defined(Q_OS_OSX)
+    partialPath = FS::PathCombine(QDir::homePath(), "Library/Application Support");
+#elif defined(Q_OS_WIN32)
+    partialPath = QProcessEnvironment::systemEnvironment().value("LOCALAPPDATA", "");
+    executable += "w.exe";
+#else
+    partialPath = QDir::homePath();
+#endif
+    auto minecraftPath = FS::PathCombine(partialPath, ".minecraft", "runtime");
+    QStringList javas;
+    QStringList processpaths{ minecraftPath };
+
+    while (!processpaths.isEmpty()) {
+        auto dirPath = processpaths.takeFirst();
+        QDir dir(dirPath);
+        if (!dir.exists())
+            continue;
+        auto entries = dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
+        auto binFound = false;
+        for (auto& entry : entries) {
+            if (entry.baseName() == "bin") {
+                javas.append(FS::PathCombine(entry.canonicalFilePath(), executable));
+                binFound = true;
+                break;
+            }
+        }
+        if (!binFound) {
+            for (auto& entry : entries) {
+                processpaths << entry.canonicalFilePath();
+            }
+        }
+    }
+    return javas;
 }

--- a/launcher/java/JavaUtils.h
+++ b/launcher/java/JavaUtils.h
@@ -26,6 +26,7 @@
 
 QString stripVariableEntries(QString name, QString target, QString remove);
 QProcessEnvironment CleanEnviroment();
+QStringList getMinecraftJavaBundle();
 
 class JavaUtils : public QObject {
     Q_OBJECT


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
fixes #1665

With this, the autodetect should also get the Minecraft installed java.
How to test:
- have Minecraft launcher and have a java installed through it (it's done automatically once you start the game from what I tested)
- open Prism and navigate to java settings
- Push Auto-detect
- in the list should appear the java from  Minecraft launcher

It's more apparent if you do not have any other java on your system.