### PR TITLE
Fix wrong account selection

### DIFF
--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -106,7 +106,7 @@ void LaunchController::decideAccount()
     // Select the account to use. If the instance has a specific account set, that will be used. Otherwise, the default account will be used
     auto instanceAccountId = m_instance->settings()->get("InstanceAccountId").toString();
     auto instanceAccountIndex = accounts->findAccountByProfileId(instanceAccountId);
-    if (instanceAccountIndex == -1) {
+    if (instanceAccountIndex == -1 || instanceAccountId.isEmpty()) {
         m_accountToUse = accounts->defaultAccount();
     } else {
         m_accountToUse = accounts->at(instanceAccountIndex);


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
fixes #1576

This doesn't warn the user that they have a Microsoft account that doesn't own Minecraft(we already have that in place)
This just ensures that if you have an account that doesn't own Minecraft the default account is respected.
Also if you select the account that doesn't own Minecraft as your default account you will still get the error saying that the account doesn't own Minecraft.