### PR TITLE
fixed code signing for appImage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -501,7 +501,7 @@ jobs:
             export SIGN=1
             export SIGN_KEY=${{ secrets.GPG_PRIVATE_KEY_ID }}
             mkdir -p ~/.gnupg/
-            printf "$GPG_PRIVATE_KEY" | base64 --decode > ~/.gnupg/private.key
+            echo "$GPG_PRIVATE_KEY" > ~/.gnupg/private.key
             gpg --import ~/.gnupg/private.key
           else
             echo ":warning: Skipped code signing for Linux AppImage, as gpg key was not present." >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Parent PR: #1268

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
It looks like on the main repo we already have the `GPG_PRIVATE_KEY` private key already defined, but is not in base64 as I initially intended.
This fixes the failing build: by replacing printf and base64 decode with a simple echo 