### PR TITLE
Only build updater when correct conditions are met

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,6 +347,11 @@ add_subdirectory(program_info)
 ####################################### Install layout #######################################
 
 set(Launcher_ENABLE_UPDATER NO)
+set(Launcher_BUILD_UPDATER NO)
+
+if (NOT APPLE AND (NOT Launcher_UPDATER_GITHUB_REPO STREQUAL "" AND NOT Launcher_BUILD_ARTIFACT STREQUAL ""))
+	set(Launcher_BUILD_UPDATER YES)
+endif()
 
 if(NOT (UNIX AND APPLE))
     # Install "portable.txt" if selected component is "portable"

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -1306,7 +1306,7 @@ install(TARGETS ${Launcher_Name}
     FRAMEWORK DESTINATION ${FRAMEWORK_DEST_DIR} COMPONENT Runtime
 )
 
-if(NOT APPLE OR (DEFINED Launcher_BUILD_UPDATER AND Launcher_BUILD_UPDATER))
+if(Launcher_BUILD_UPDATER)
     # Updater
     add_library(prism_updater_logic STATIC ${PRISMUPDATER_SOURCES} ${TASKS_SOURCES} ${PRISMUPDATER_UI})
     target_include_directories(prism_updater_logic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
this prevents the updater basically being built by default on all platforms besides mac; it follows the same logic as the internal variable we set in buildconfig
this probably could've been done without keeping the unused variable, but i think it's for the best we make this option apparent for anyone looking through our build options