### PR TITLE
enabled GenericManagedPackPage for all non managed packs

### DIFF
--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
@@ -289,7 +289,7 @@ bool ModrinthCreationTask::createInstance()
         // Only change the name if it didn't use a custom name, so that the previous custom name
         // is preserved, but if we're using the original one, we update the version string.
         // NOTE: This needs to come before the copyManagedPack call!
-        if (inst->name().contains(inst->getManagedPackVersionName())) {
+        if (inst->name().contains(inst->getManagedPackVersionName()) && inst->name() != instance.name()) {
             if (askForChangingInstanceName(m_parent, inst->name(), instance.name()) == InstanceNameChange::ShouldChange)
                 inst->setName(instance.name());
         }

--- a/launcher/ui/pages/instance/ManagedPackPage.cpp
+++ b/launcher/ui/pages/instance/ManagedPackPage.cpp
@@ -144,7 +144,7 @@ QString ManagedPackPage::displayName() const
 {
     auto type = m_inst->getManagedPackType();
     if (type.isEmpty())
-        return "PrismPack";
+        return "Generic";
     if (type == "flame")
         type = "CurseForge";
     return type.replace(0, 1, type[0].toUpper());
@@ -357,6 +357,8 @@ void ModrinthManagedPackPage::update()
 void ModrinthManagedPackPage::updateFromFile()
 {
     auto output = QFileDialog::getOpenFileUrl(this, tr("Choose update file"), QDir::homePath(), "Modrinth pack (*.mrpack *.zip)");
+    if (output.isEmpty())
+        return;
     QMap<QString, QString> extra_info;
     extra_info.insert("pack_id", m_inst->getManagedPackID());
     extra_info.insert("pack_version_id", QString());
@@ -520,6 +522,8 @@ void FlameManagedPackPage::update()
 void FlameManagedPackPage::updateFromFile()
 {
     auto output = QFileDialog::getOpenFileUrl(this, tr("Choose update file"), QDir::homePath(), "CurseForge pack (*.zip)");
+    if (output.isEmpty())
+        return;
 
     QMap<QString, QString> extra_info;
     extra_info.insert("pack_id", m_inst->getManagedPackID());
@@ -550,8 +554,6 @@ GenericManagedPackPage::GenericManagedPackPage(BaseInstance* inst, InstanceWindo
 {
     connect(ui->updateFromFileButton, &QPushButton::clicked, this, &GenericManagedPackPage::updateFromFile);
 
-    ui->changelogTextBrowser->setText(m_inst->notes());
-    ui->packName->setText(m_inst->name());
     ui->packVersion->hide();
     ui->packVersionLabel->hide();
     ui->packOrigin->hide();
@@ -562,9 +564,18 @@ GenericManagedPackPage::GenericManagedPackPage(BaseInstance* inst, InstanceWindo
     ui->updateFromFileButton->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
 }
 
+void GenericManagedPackPage::parseManagedPack()
+{
+    ui->packName->setText(m_inst->name());
+    ui->changelogTextBrowser->setText(m_inst->notes());
+}
+
 void GenericManagedPackPage::updateFromFile()
 {
-    auto output = QFileDialog::getOpenFileUrl(this, tr("Choose update file"), QDir::homePath(), "Prism pack (*.mrpack *.zip)");
+    auto output =
+        QFileDialog::getOpenFileUrl(this, tr("Choose update file"), QDir::homePath(), "Modrinth/CurseForge pack (*.mrpack *.zip)");
+    if (output.isEmpty())
+        return;
     QMap<QString, QString> extra_info;
     extra_info.insert("pack_id", m_inst->getManagedPackID());
     extra_info.insert("pack_version_id", QString());

--- a/launcher/ui/pages/instance/ManagedPackPage.cpp
+++ b/launcher/ui/pages/instance/ManagedPackPage.cpp
@@ -142,12 +142,7 @@ void ManagedPackPage::openedImpl()
 
 QString ManagedPackPage::displayName() const
 {
-    auto type = m_inst->getManagedPackType();
-    if (type.isEmpty())
-        return "Pack Manager";
-    if (type == "flame")
-        type = "CurseForge";
-    return type.replace(0, 1, type[0].toUpper());
+    return "Modpack";
 }
 
 QIcon ManagedPackPage::icon() const

--- a/launcher/ui/pages/instance/ManagedPackPage.cpp
+++ b/launcher/ui/pages/instance/ManagedPackPage.cpp
@@ -135,14 +135,24 @@ void ManagedPackPage::openedImpl()
     ui->packName->setText(m_inst->getManagedPackName());
     ui->packVersion->setText(m_inst->getManagedPackVersionName());
     ui->packOrigin->setText(tr("Website: <a href=%1>%2</a>    |    Pack ID: %3    |    Version ID: %4")
-                                .arg(url(), displayName(), m_inst->getManagedPackID(), m_inst->getManagedPackVersionID()));
+                                .arg(url(), providerName(), m_inst->getManagedPackID(), m_inst->getManagedPackVersionID()));
 
     parseManagedPack();
 }
 
+QString ManagedPackPage::providerName() const
+{
+    auto type = m_inst->getManagedPackType();
+    if (type.isEmpty())
+        return {};
+    if (type == "flame")
+        type = "CurseForge";
+    return type.replace(0, 1, type[0].toUpper());
+}
+
 QString ManagedPackPage::displayName() const
 {
-    return "Modpack";
+    return tr("Modpack");
 }
 
 QIcon ManagedPackPage::icon() const

--- a/launcher/ui/pages/instance/ManagedPackPage.cpp
+++ b/launcher/ui/pages/instance/ManagedPackPage.cpp
@@ -144,7 +144,7 @@ QString ManagedPackPage::displayName() const
 {
     auto type = m_inst->getManagedPackType();
     if (type.isEmpty())
-        return "Generic";
+        return "Pack Manager";
     if (type == "flame")
         type = "CurseForge";
     return type.replace(0, 1, type[0].toUpper());
@@ -153,7 +153,7 @@ QString ManagedPackPage::displayName() const
 QIcon ManagedPackPage::icon() const
 {
     auto type = m_inst->getManagedPackType();
-    return APPLICATION->getThemedIcon(type.isEmpty() ? "prismlauncher" : type);
+    return APPLICATION->getThemedIcon(type.isEmpty() ? "checkupdate" : type);
 }
 
 QString ManagedPackPage::helpPage() const

--- a/launcher/ui/pages/instance/ManagedPackPage.h
+++ b/launcher/ui/pages/instance/ManagedPackPage.h
@@ -105,6 +105,8 @@ class GenericManagedPackPage final : public ManagedPackPage {
     ~GenericManagedPackPage() override = default;
 
     [[nodiscard]] bool shouldDisplay() const override;
+    void parseManagedPack() override;
+   public slots:
     void updateFromFile() override;
 };
 

--- a/launcher/ui/pages/instance/ManagedPackPage.h
+++ b/launcher/ui/pages/instance/ManagedPackPage.h
@@ -43,6 +43,8 @@ class ManagedPackPage : public QWidget, public BasePage {
     [[nodiscard]] QString id() const override { return "managed_pack"; }
     [[nodiscard]] bool shouldDisplay() const override;
 
+    QString providerName() const;
+
     void openedImpl() override;
 
     bool apply() override { return true; }

--- a/launcher/ui/pages/instance/ManagedPackPage.h
+++ b/launcher/ui/pages/instance/ManagedPackPage.h
@@ -101,13 +101,11 @@ class GenericManagedPackPage final : public ManagedPackPage {
     Q_OBJECT
 
    public:
-    GenericManagedPackPage(BaseInstance* inst, InstanceWindow* instance_window, QWidget* parent = nullptr)
-        : ManagedPackPage(inst, instance_window, parent)
-    {}
+    GenericManagedPackPage(BaseInstance* inst, InstanceWindow* instance_window, QWidget* parent = nullptr);
     ~GenericManagedPackPage() override = default;
 
-    // TODO: We may want to show this page with some useful info at some point.
-    [[nodiscard]] bool shouldDisplay() const override { return false; };
+    [[nodiscard]] bool shouldDisplay() const override;
+    void updateFromFile() override;
 };
 
 class ModrinthManagedPackPage final : public ManagedPackPage {


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
Parrent PR: https://github.com/PrismLauncher/PrismLauncher/pull/1405
should fix: https://github.com/PrismLauncher/PrismLauncher/issues/1394#issuecomment-1767449001
From that comment looks like I did not fix the original issue just extended the functionality of the managed packs(downloaded through prism from modrinth/curseforge)
This PR aims to have a generic managed pack page for all non-managed packs, allowing the user to update them using files.
How to test:
- download a modrinth pack( an older version)
- install it using the mrpack file
- download a newer version of the pack(outside of prism)
- click edit instance on the created instance
- you should have a new tab named `Pack Manager`(I'm bad at names; feel free to suggest one)
- entering that page you will be greeted with:
    - the pack name(the name of the instance)
    - a big button with upload from file
    - a changelog that reflects the notes content
- click on the upload from the file 
- select the new version
- profit


Also fixes #1731