### PR TITLE
replace x11 socket with fallback-x11

### DIFF
--- a/flatpak/org.prismlauncher.PrismLauncher.yml
+++ b/flatpak/org.prismlauncher.PrismLauncher.yml
@@ -9,7 +9,7 @@ sdk-extensions:
 command: prismlauncher
 finish-args:
   - --share=ipc
-  - --socket=x11
+  - --socket=fallback-x11
   - --socket=wayland
   - --device=all
   - --share=network


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
fixes #1674
and copies: https://github.com/flathub/net.davidotek.pupgui2/pull/24

This should work but as I do not use flatpack I have no idea if it works or not.
This is just a copy of the mentioned PR(but for prism)
For more info about this please have a look through the linked PR(there is a great documentation on that there)
