### PR TITLE
fix: java memory not set on initial setup

### DIFF
--- a/launcher/ui/setupwizard/JavaWizardPage.cpp
+++ b/launcher/ui/setupwizard/JavaWizardPage.cpp
@@ -64,8 +64,7 @@ bool JavaWizardPage::validatePage()
         }
         case JavaSettingsWidget::ValidationStatus::AllOK: {
             settings->set("JavaPath", m_java_widget->javaPath());
-            return true;
-        }
+        } /* fallthrough */
         case JavaSettingsWidget::ValidationStatus::JavaBad: {
             // Memory
             auto s = APPLICATION->settings();


### PR DESCRIPTION
Parent PR: #1128

fixes #1683

I added this to the milestone as is a huge thing for new users(and the fix is small)