### PR TITLE
Localize account type in account list

### DIFF
--- a/cmake/CompilerWarnings.cmake
+++ b/cmake/CompilerWarnings.cmake
@@ -68,6 +68,8 @@ function(
         /w14906 # string literal cast to 'LPWSTR'
         /w14928 # illegal copy-initialization; more than one user-defined conversion has been implicitly applied
         /permissive- # standards conformance mode for MSVC compiler.
+
+        /we4062 # forbid omitting a possible value of an enum in a switch statement
     )
   endif()
 
@@ -93,6 +95,8 @@ function(
         # in a lot of noise. This warning is only notifying us that clang is emulating the GCC behaviour
         # instead of the exact standard wording so we can safely ignore it
         -Wno-gnu-zero-variadic-macro-arguments
+
+        -Werror=switch # forbid omitting a possible value of an enum in a switch statement
     )
   endif()
 
@@ -104,6 +108,8 @@ function(
         -Wduplicated-branches # warn if if / else branches have duplicated code
         -Wlogical-op # warn about logical operations being used where bitwise were probably wanted
         -Wuseless-cast # warn if you perform a cast to the same type
+
+        -Werror=switch # forbid omitting a possible value of an enum in a switch statement
     )
   endif()
 
@@ -128,6 +134,8 @@ function(
     -Woverloaded-virtual
     -Wuseless-cast
     -Wextra-semi
+
+    -Werror=switch # forbid omitting a possible value of an enum in a switch statement
   )
 
   target_compile_options(

--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -36,6 +36,7 @@
 
 #include "LaunchController.h"
 #include "Application.h"
+#include "minecraft/auth/AccountData.h"
 #include "minecraft/auth/AccountList.h"
 
 #include "ui/InstanceWindow.h"
@@ -161,7 +162,7 @@ void LaunchController::login()
         m_accountToUse->fillSession(m_session);
 
         // Launch immediately in true offline mode
-        if (m_accountToUse->isOffline()) {
+        if (m_accountToUse->accountType() == AccountType::Offline) {
             launchInstance();
             return;
         }

--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -283,9 +283,15 @@ QVariant AccountList::data(const QModelIndex& index, int role) const
                     return account->accountDisplayString();
 
                 case TypeColumn: {
-                    auto typeStr = account->typeString();
-                    typeStr[0] = typeStr[0].toUpper();
-                    return typeStr;
+                    switch (account->accountType()) {
+                        case AccountType::MSA: {
+                            return tr("MSA", "Account type");
+                        }
+                        case AccountType::Offline: {
+                            return tr("Offline", "Account type");
+                        }
+                    }
+                    return tr("Unknown", "Account type");
                 }
 
                 case StatusColumn: {

--- a/launcher/minecraft/auth/MinecraftAccount.cpp
+++ b/launcher/minecraft/auth/MinecraftAccount.cpp
@@ -52,6 +52,7 @@
 
 #include "flows/MSA.h"
 #include "flows/Offline.h"
+#include "minecraft/auth/AccountData.h"
 
 MinecraftAccount::MinecraftAccount(QObject* parent) : QObject(parent)
 {
@@ -185,7 +186,7 @@ void MinecraftAccount::authFailed(QString reason)
             // NOTE: this doesn't do much. There was an error of some sort.
         } break;
         case AccountTaskState::STATE_FAILED_HARD: {
-            if (isMSA()) {
+            if (accountType() == AccountType::MSA) {
                 data.msaToken.token = QString();
                 data.msaToken.refresh_token = QString();
                 data.msaToken.validity = Katabasis::Validity::None;

--- a/launcher/minecraft/auth/MinecraftAccount.h
+++ b/launcher/minecraft/auth/MinecraftAccount.h
@@ -118,9 +118,7 @@ class MinecraftAccount : public QObject, public Usable {
 
     bool isActive() const;
 
-    bool isMSA() const { return data.type == AccountType::MSA; }
-
-    bool isOffline() const { return data.type == AccountType::Offline; }
+    [[nodiscard]] AccountType accountType() const noexcept { return data.type; }
 
     bool ownsMinecraft() const { return data.minecraftEntitlement.ownsMinecraft; }
 

--- a/launcher/ui/pages/global/AccountListPage.cpp
+++ b/launcher/ui/pages/global/AccountListPage.cpp
@@ -35,6 +35,7 @@
  */
 
 #include "AccountListPage.h"
+#include "minecraft/auth/AccountData.h"
 #include "ui_AccountListPage.h"
 
 #include <QItemSelectionModel>
@@ -215,7 +216,7 @@ void AccountListPage::updateButtonStates()
         QModelIndex selected = selection.first();
         MinecraftAccountPtr account = selected.data(AccountList::PointerRole).value<MinecraftAccountPtr>();
         accountIsReady = !account->isActive();
-        accountIsOnline = !account->isOffline();
+        accountIsOnline = account->accountType() != AccountType::Offline;
     }
     ui->actionRemove->setEnabled(accountIsReady);
     ui->actionSetDefault->setEnabled(accountIsReady);


### PR DESCRIPTION
This PR fixes an issue where the account type (MSA or offline) in the account list view was not translated.

Before:
<img width="828" alt="account_type_before" src="https://github.com/PrismLauncher/PrismLauncher/assets/56512186/60d4b363-d30f-4e39-9601-54111bfc07e7">

After:
<img width="828" alt="account_type_after" src="https://github.com/PrismLauncher/PrismLauncher/assets/56512186/8b45f6a0-99a0-4b3e-be83-0b63afc6bf7a">

Note: I mucked around a bit in `launcher/minecraft/auth/MinecraftAccount.h`, replacing the two `isMSA()` and `isOffline()` functions with one `accountType()` function. If those changes aren't desirable for whatever reason I can revert them.