### PR TITLE
[Windows] Remove Windows 7/8 support from app manifest

### DIFF
--- a/program_info/prismlauncher.manifest.in
+++ b/program_info/prismlauncher.manifest.in
@@ -16,12 +16,6 @@
   <description>Custom Minecraft launcher for managing multiple installs.</description>
   <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
     <application>
-      <!--The ID below indicates app support for Windows 7 -->
-      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
-      <!--The ID below indicates app support for Windows 8 -->
-      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
-      <!--The ID below indicates app support for Windows 8.1 -->
-      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
       <!--The ID below indicates app support for Windows 10/11 -->
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
     </application>


### PR DESCRIPTION
With 8.0 windows legacy support was dropped, this just removes it from the manifest

Request for PR: https://discord.com/channels/1031648380885147709/1167762562155303014/1167786210824036452
