### PR TITLE
Localize sorting options for resource and shader packs

### DIFF
--- a/launcher/modplatform/flame/FlameAPI.cpp
+++ b/launcher/modplatform/flame/FlameAPI.cpp
@@ -208,17 +208,15 @@ Task::Ptr FlameAPI::getFile(const QString& addonId, const QString& fileId, std::
     return netJob;
 }
 
-// https://docs.curseforge.com/?python#tocS_ModsSearchSortField
-static QList<ResourceAPI::SortingMethod> s_sorts = { { 1, "Featured", QObject::tr("Sort by Featured") },
-                                                     { 2, "Popularity", QObject::tr("Sort by Popularity") },
-                                                     { 3, "LastUpdated", QObject::tr("Sort by Last Updated") },
-                                                     { 4, "Name", QObject::tr("Sort by Name") },
-                                                     { 5, "Author", QObject::tr("Sort by Author") },
-                                                     { 6, "TotalDownloads", QObject::tr("Sort by Downloads") },
-                                                     { 7, "Category", QObject::tr("Sort by Category") },
-                                                     { 8, "GameVersion", QObject::tr("Sort by Game Version") } };
-
 QList<ResourceAPI::SortingMethod> FlameAPI::getSortingMethods() const
 {
-    return s_sorts;
+    // https://docs.curseforge.com/?python#tocS_ModsSearchSortField
+    return { { 1, "Featured", QObject::tr("Sort by Featured") },
+             { 2, "Popularity", QObject::tr("Sort by Popularity") },
+             { 3, "LastUpdated", QObject::tr("Sort by Last Updated") },
+             { 4, "Name", QObject::tr("Sort by Name") },
+             { 5, "Author", QObject::tr("Sort by Author") },
+             { 6, "TotalDownloads", QObject::tr("Sort by Downloads") },
+             { 7, "Category", QObject::tr("Sort by Category") },
+             { 8, "GameVersion", QObject::tr("Sort by Game Version") } };
 }

--- a/launcher/modplatform/modrinth/ModrinthAPI.cpp
+++ b/launcher/modplatform/modrinth/ModrinthAPI.cpp
@@ -111,14 +111,12 @@ Task::Ptr ModrinthAPI::getProjects(QStringList addonIds, std::shared_ptr<QByteAr
     return netJob;
 }
 
-// https://docs.modrinth.com/api-spec/#tag/projects/operation/searchProjects
-static QList<ResourceAPI::SortingMethod> s_sorts = { { 1, "relevance", QObject::tr("Sort by Relevance") },
-                                                     { 2, "downloads", QObject::tr("Sort by Downloads") },
-                                                     { 3, "follows", QObject::tr("Sort by Follows") },
-                                                     { 4, "newest", QObject::tr("Sort by Last Updated") },
-                                                     { 5, "updated", QObject::tr("Sort by Newest") } };
-
 QList<ResourceAPI::SortingMethod> ModrinthAPI::getSortingMethods() const
 {
-    return s_sorts;
+    // https://docs.modrinth.com/api-spec/#tag/projects/operation/searchProjects
+    return { { 1, "relevance", QObject::tr("Sort by Relevance") },
+             { 2, "downloads", QObject::tr("Sort by Downloads") },
+             { 3, "follows", QObject::tr("Sort by Follows") },
+             { 4, "newest", QObject::tr("Sort by Last Updated") },
+             { 5, "updated", QObject::tr("Sort by Newest") } };
 }


### PR DESCRIPTION
This PR fixes an issue where the sorting options (sort by popularity, sort by name, etc.) when downloading resource and shader packs from CurseForge or Modrinth were not being properly translated.

This is because the display strings were being stored in a static variable, loaded once at the start of the program, when they should be dynamic.

Before:
<img width="647" alt="sorting_before" src="https://github.com/PrismLauncher/PrismLauncher/assets/56512186/fe03c9c1-8e91-4329-8c8b-886adf03dbfe">

After:
<img width="648" alt="sorting_after" src="https://github.com/PrismLauncher/PrismLauncher/assets/56512186/50c6ba09-c341-4940-b961-2ff23e78cbd7">
