### PR TITLE
Remove top-level `const` qualifiers in function declarations

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,4 +1,5 @@
 Checks:
   - modernize-use-using
+  - readability-avoid-const-params-in-decls
 
 SystemHeaders: false

--- a/launcher/DataMigrationTask.h
+++ b/launcher/DataMigrationTask.h
@@ -18,7 +18,7 @@
 class DataMigrationTask : public Task {
     Q_OBJECT
    public:
-    explicit DataMigrationTask(QObject* parent, const QString& sourcePath, const QString& targetPath, const IPathMatcher::Ptr pathmatcher);
+    explicit DataMigrationTask(QObject* parent, const QString& sourcePath, const QString& targetPath, IPathMatcher::Ptr pathmatcher);
     ~DataMigrationTask() override = default;
 
    protected:

--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -59,7 +59,7 @@
 
 #include <quazip/quazipdir.h>
 
-InstanceImportTask::InstanceImportTask(const QUrl sourceUrl, QWidget* parent, QMap<QString, QString>&& extra_info)
+InstanceImportTask::InstanceImportTask(const QUrl& sourceUrl, QWidget* parent, QMap<QString, QString>&& extra_info)
     : m_sourceUrl(sourceUrl), m_extra_info(extra_info), m_parent(parent)
 {}
 

--- a/launcher/InstanceImportTask.h
+++ b/launcher/InstanceImportTask.h
@@ -54,7 +54,7 @@ class FileResolvingTask;
 class InstanceImportTask : public InstanceTask {
     Q_OBJECT
    public:
-    explicit InstanceImportTask(const QUrl sourceUrl, QWidget* parent = nullptr, QMap<QString, QString>&& extra_info = {});
+    explicit InstanceImportTask(const QUrl& sourceUrl, QWidget* parent = nullptr, QMap<QString, QString>&& extra_info = {});
 
     bool abort() override;
     const QVector<Flame::File>& getBlockedFiles() const { return m_blockedMods; }

--- a/launcher/MMCZip.cpp
+++ b/launcher/MMCZip.cpp
@@ -50,7 +50,7 @@
 
 namespace MMCZip {
 // ours
-bool mergeZipFiles(QuaZip* into, QFileInfo from, QSet<QString>& contained, const FilterFunction filter)
+bool mergeZipFiles(QuaZip* into, QFileInfo from, QSet<QString>& contained, const FilterFunction& filter)
 {
     QuaZip modZip(from.filePath());
     modZip.open(QuaZip::mdUnzip);

--- a/launcher/MMCZip.h
+++ b/launcher/MMCZip.h
@@ -60,7 +60,7 @@ using FilterFunction = std::function<bool(const QString&)>;
 /**
  * Merge two zip files, using a filter function
  */
-bool mergeZipFiles(QuaZip* into, QFileInfo from, QSet<QString>& contained, const FilterFunction filter = nullptr);
+bool mergeZipFiles(QuaZip* into, QFileInfo from, QSet<QString>& contained, const FilterFunction& filter = nullptr);
 
 /**
  * Compress directory, by providing a list of files to compress

--- a/launcher/RecursiveFileSystemWatcher.h
+++ b/launcher/RecursiveFileSystemWatcher.h
@@ -13,7 +13,7 @@ class RecursiveFileSystemWatcher : public QObject {
     QDir rootDir() const { return m_root; }
 
     // WARNING: setting this to true may be bad for performance
-    void setWatchFiles(const bool watchFiles);
+    void setWatchFiles(bool watchFiles);
     bool watchFiles() const { return m_watchFiles; }
 
     void setMatcher(IPathMatcher::Ptr matcher) { m_matcher = matcher; }

--- a/launcher/ResourceDownloadTask.h
+++ b/launcher/ResourceDownloadTask.h
@@ -32,7 +32,7 @@ class ResourceDownloadTask : public SequentialTask {
    public:
     explicit ResourceDownloadTask(ModPlatform::IndexedPack::Ptr pack,
                                   ModPlatform::IndexedVersion version,
-                                  const std::shared_ptr<ResourceFolderModel> packs,
+                                  std::shared_ptr<ResourceFolderModel> packs,
                                   bool is_indexed = true,
                                   QString custom_target_folder = {});
     const QString& getFilename() const { return m_pack_version.fileName; }

--- a/launcher/VersionProxyModel.h
+++ b/launcher/VersionProxyModel.h
@@ -28,7 +28,7 @@ class VersionProxyModel : public QAbstractProxyModel {
 
     const FilterMap& filters() const;
     const QString& search() const;
-    void setFilter(const BaseVersionList::ModelRoles column, Filter* filter);
+    void setFilter(BaseVersionList::ModelRoles column, Filter* filter);
     void setSearch(const QString& search);
     void clearFilters();
     QModelIndex getRecommended() const;

--- a/launcher/icons/IconList.h
+++ b/launcher/icons/IconList.h
@@ -67,7 +67,7 @@ class IconList : public QAbstractListModel {
     virtual Qt::ItemFlags flags(const QModelIndex& index) const override;
 
     bool addThemeIcon(const QString& key);
-    bool addIcon(const QString& key, const QString& name, const QString& path, const IconType type);
+    bool addIcon(const QString& key, const QString& name, const QString& path, IconType type);
     void saveIcon(const QString& key, const QString& path, const char* format) const;
     bool deleteIcon(const QString& key);
     bool trashIcon(const QString& key);

--- a/launcher/meta/Index.h
+++ b/launcher/meta/Index.h
@@ -55,6 +55,6 @@ class Index : public QAbstractListModel, public BaseEntity {
     QVector<VersionList::Ptr> m_lists;
     QHash<QString, VersionList::Ptr> m_uids;
 
-    void connectVersionList(const int row, const VersionList::Ptr& list);
+    void connectVersionList(int row, const VersionList::Ptr& list);
 };
 }  // namespace Meta

--- a/launcher/meta/Version.h
+++ b/launcher/meta/Version.h
@@ -64,7 +64,7 @@ class Version : public QObject, public BaseVersion, public BaseEntity {
 
    public:  // for usage by format parsers only
     void setType(const QString& type);
-    void setTime(const qint64 time);
+    void setTime(qint64 time);
     void setRequires(const Meta::RequireSet& reqs, const Meta::RequireSet& conflicts);
     void setVolatile(bool volatile_);
     void setRecommended(bool recommended);

--- a/launcher/meta/VersionList.h
+++ b/launcher/meta/VersionList.h
@@ -79,7 +79,7 @@ class VersionList : public BaseVersionList, public BaseEntity {
 
     Version::Ptr m_recommended;
 
-    void setupAddedVersion(const int row, const Version::Ptr& version);
+    void setupAddedVersion(int row, const Version::Ptr& version);
 };
 }  // namespace Meta
 Q_DECLARE_METATYPE(Meta::VersionList::Ptr)

--- a/launcher/minecraft/OneSixVersionFormat.h
+++ b/launcher/minecraft/OneSixVersionFormat.h
@@ -9,7 +9,7 @@
 class OneSixVersionFormat {
    public:
     // version files / profile patches
-    static VersionFilePtr versionFileFromJson(const QJsonDocument& doc, const QString& filename, const bool requireOrder);
+    static VersionFilePtr versionFileFromJson(const QJsonDocument& doc, const QString& filename, bool requireOrder);
     static QJsonDocument versionFileToJson(const VersionFilePtr& patch);
 
     // libraries

--- a/launcher/minecraft/PackProfile.cpp
+++ b/launcher/minecraft/PackProfile.cpp
@@ -430,7 +430,7 @@ bool PackProfile::remove(const int index)
     return true;
 }
 
-bool PackProfile::remove(const QString id)
+bool PackProfile::remove(const QString& id)
 {
     int i = 0;
     for (auto patch : d->components) {

--- a/launcher/minecraft/PackProfile.h
+++ b/launcher/minecraft/PackProfile.h
@@ -89,13 +89,13 @@ class PackProfile : public QAbstractListModel {
 
     enum MoveDirection { MoveUp, MoveDown };
     /// move component file # up or down the list
-    void move(const int index, const MoveDirection direction);
+    void move(int index, MoveDirection direction);
 
     /// remove component file # - including files/records
-    bool remove(const int index);
+    bool remove(int index);
 
     /// remove component file by id - including files/records
-    bool remove(const QString id);
+    bool remove(const QString& id);
 
     bool customize(int index);
 

--- a/launcher/minecraft/ProfileUtils.cpp
+++ b/launcher/minecraft/ProfileUtils.cpp
@@ -140,7 +140,7 @@ VersionFilePtr parseJsonFile(const QFileInfo& fileInfo, const bool requireOrder)
     return guardedParseJson(doc, fileInfo.completeBaseName(), fileInfo.absoluteFilePath(), requireOrder);
 }
 
-bool saveJsonFile(const QJsonDocument doc, const QString& filename)
+bool saveJsonFile(const QJsonDocument& doc, const QString& filename)
 {
     auto data = doc.toJson();
     QSaveFile jsonFile(filename);

--- a/launcher/minecraft/ProfileUtils.h
+++ b/launcher/minecraft/ProfileUtils.h
@@ -47,10 +47,10 @@ bool readOverrideOrders(QString path, PatchOrder& order);
 bool writeOverrideOrders(QString path, const PatchOrder& order);
 
 /// Parse a version file in JSON format
-VersionFilePtr parseJsonFile(const QFileInfo& fileInfo, const bool requireOrder);
+VersionFilePtr parseJsonFile(const QFileInfo& fileInfo, bool requireOrder);
 
 /// Save a JSON file (in any format)
-bool saveJsonFile(const QJsonDocument doc, const QString& filename);
+bool saveJsonFile(const QJsonDocument& doc, const QString& filename);
 
 /// Remove LWJGL from a patch file. This is applied to all Mojang-like profile files.
 void removeLwjglFromPatch(VersionFilePtr patch);

--- a/launcher/minecraft/auth/AccountList.h
+++ b/launcher/minecraft/auth/AccountList.h
@@ -75,7 +75,7 @@ class AccountList : public QAbstractListModel {
     virtual Qt::ItemFlags flags(const QModelIndex& index) const override;
     virtual bool setData(const QModelIndex& index, const QVariant& value, int role) override;
 
-    void addAccount(const MinecraftAccountPtr account);
+    void addAccount(MinecraftAccountPtr account);
     void removeAccount(QModelIndex index);
     int findAccountByProfileId(const QString& profileId) const;
     MinecraftAccountPtr getAccountByProfileName(const QString& profileName) const;

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -45,7 +45,7 @@ ResourceFolderModel::~ResourceFolderModel()
         QCoreApplication::processEvents();
 }
 
-bool ResourceFolderModel::startWatching(const QStringList paths)
+bool ResourceFolderModel::startWatching(const QStringList& paths)
 {
     if (m_is_watching)
         return false;
@@ -64,7 +64,7 @@ bool ResourceFolderModel::startWatching(const QStringList paths)
     return m_is_watching;
 }
 
-bool ResourceFolderModel::stopWatching(const QStringList paths)
+bool ResourceFolderModel::stopWatching(const QStringList& paths)
 {
     if (!m_is_watching)
         return false;

--- a/launcher/minecraft/mod/ResourceFolderModel.h
+++ b/launcher/minecraft/mod/ResourceFolderModel.h
@@ -39,14 +39,14 @@ class ResourceFolderModel : public QAbstractListModel {
      *  Returns whether starting to watch all the paths was successful.
      *  If one or more fails, it returns false.
      */
-    bool startWatching(const QStringList paths);
+    bool startWatching(const QStringList& paths);
 
     /** Stops watching the paths for changes.
      *
      *  Returns whether stopping to watch all the paths was successful.
      *  If one or more fails, it returns false.
      */
-    bool stopWatching(const QStringList paths);
+    bool stopWatching(const QStringList& paths);
 
     /* Helper methods for subclasses, using a predetermined list of paths. */
     virtual bool startWatching() { return startWatching({ m_dir.absolutePath() }); }

--- a/launcher/minecraft/mod/tasks/GetModDependenciesTask.cpp
+++ b/launcher/minecraft/mod/tasks/GetModDependenciesTask.cpp
@@ -238,7 +238,7 @@ Task::Ptr GetModDependenciesTask::prepareDependencyTask(const ModPlatform::Depen
     return tasks;
 }
 
-void GetModDependenciesTask::removePack(const QVariant addonId)
+void GetModDependenciesTask::removePack(const QVariant& addonId)
 {
     auto pred = [addonId](const std::shared_ptr<PackDependency>& v) { return v->pack->addonId == addonId; };
 #if QT_VERSION >= QT_VERSION_CHECK(6, 1, 0)

--- a/launcher/minecraft/mod/tasks/GetModDependenciesTask.h
+++ b/launcher/minecraft/mod/tasks/GetModDependenciesTask.h
@@ -65,13 +65,13 @@ class GetModDependenciesTask : public SequentialTask {
     QHash<QString, QStringList> getRequiredBy();
 
    protected slots:
-    Task::Ptr prepareDependencyTask(const ModPlatform::Dependency&, const ModPlatform::ResourceProvider, int);
+    Task::Ptr prepareDependencyTask(const ModPlatform::Dependency&, ModPlatform::ResourceProvider, int);
     QList<ModPlatform::Dependency> getDependenciesForVersion(const ModPlatform::IndexedVersion&,
-                                                             const ModPlatform::ResourceProvider providerName);
+                                                             ModPlatform::ResourceProvider providerName);
     void prepare();
     Task::Ptr getProjectInfoTask(std::shared_ptr<PackDependency> pDep);
-    ModPlatform::Dependency getOverride(const ModPlatform::Dependency&, const ModPlatform::ResourceProvider providerName);
-    void removePack(const QVariant addonId);
+    ModPlatform::Dependency getOverride(const ModPlatform::Dependency&, ModPlatform::ResourceProvider providerName);
+    void removePack(const QVariant& addonId);
 
    private:
     QList<std::shared_ptr<PackDependency>> m_pack_dependencies;

--- a/launcher/modplatform/modrinth/ModrinthPackExportTask.h
+++ b/launcher/modplatform/modrinth/ModrinthPackExportTask.h
@@ -68,7 +68,7 @@ class ModrinthPackExportTask : public Task {
     void collectFiles();
     void collectHashes();
     void makeApiRequest();
-    void parseApiResponse(const std::shared_ptr<QByteArray> response);
+    void parseApiResponse(std::shared_ptr<QByteArray> response);
     void buildZip();
 
     QByteArray generateIndex();

--- a/launcher/modplatform/technic/TechnicPackProcessor.h
+++ b/launcher/modplatform/technic/TechnicPackProcessor.h
@@ -33,6 +33,6 @@ class TechnicPackProcessor : public QObject {
              const QString& instIcon,
              const QString& stagingPath,
              const QString& minecraftVersion = QString(),
-             const bool isSolder = false);
+             bool isSolder = false);
 };
 }  // namespace Technic

--- a/launcher/ui/dialogs/ModUpdateDialog.h
+++ b/launcher/ui/dialogs/ModUpdateDialog.h
@@ -16,10 +16,7 @@ class ConcurrentTask;
 class ModUpdateDialog final : public ReviewMessageBox {
     Q_OBJECT
    public:
-    explicit ModUpdateDialog(QWidget* parent,
-                             BaseInstance* instance,
-                             const std::shared_ptr<ModFolderModel> mod_model,
-                             QList<Mod*>& search_for);
+    explicit ModUpdateDialog(QWidget* parent, BaseInstance* instance, std::shared_ptr<ModFolderModel> mod_model, QList<Mod*>& search_for);
 
     void checkCandidates();
 

--- a/launcher/ui/dialogs/ResourceDownloadDialog.h
+++ b/launcher/ui/dialogs/ResourceDownloadDialog.h
@@ -50,7 +50,7 @@ class ResourceDownloadDialog : public QDialog, public BasePageProvider {
    public:
     using DownloadTaskPtr = shared_qobject_ptr<ResourceDownloadTask>;
 
-    ResourceDownloadDialog(QWidget* parent, const std::shared_ptr<ResourceFolderModel> base_model);
+    ResourceDownloadDialog(QWidget* parent, std::shared_ptr<ResourceFolderModel> base_model);
 
     void initializeContainer();
     void connectButtons();

--- a/launcher/ui/instanceview/InstanceView.h
+++ b/launcher/ui/instanceview/InstanceView.h
@@ -65,7 +65,7 @@ class InstanceView : public QAbstractItemView {
     /// get the model index at the specified visual point
     virtual QModelIndex indexAt(const QPoint& point) const override;
     QString groupNameAt(const QPoint& point);
-    void setSelection(const QRect& rect, const QItemSelectionModel::SelectionFlags commands) override;
+    void setSelection(const QRect& rect, QItemSelectionModel::SelectionFlags commands) override;
 
     virtual int horizontalOffset() const override;
     virtual int verticalOffset() const override;

--- a/launcher/ui/pages/instance/OtherLogsPage.h
+++ b/launcher/ui/pages/instance/OtherLogsPage.h
@@ -65,7 +65,7 @@ class OtherLogsPage : public QWidget, public BasePage {
 
    private slots:
     void populateSelectLogBox();
-    void on_selectLogBox_currentIndexChanged(const int index);
+    void on_selectLogBox_currentIndexChanged(int index);
     void on_btnReload_clicked();
     void on_btnPaste_clicked();
     void on_btnCopy_clicked();
@@ -78,7 +78,7 @@ class OtherLogsPage : public QWidget, public BasePage {
     void findPreviousActivated();
 
    private:
-    void setControlsEnabled(const bool enabled);
+    void setControlsEnabled(bool enabled);
 
    private:
     Ui::OtherLogsPage* ui;

--- a/launcher/ui/pages/modplatform/ModPage.h
+++ b/launcher/ui/pages/modplatform/ModPage.h
@@ -49,9 +49,7 @@ class ModPage : public ResourcePage {
 
     [[nodiscard]] QMap<QString, QString> urlHandlers() const override;
 
-    void addResourceToPage(ModPlatform::IndexedPack::Ptr,
-                           ModPlatform::IndexedVersion&,
-                           const std::shared_ptr<ResourceFolderModel>) override;
+    void addResourceToPage(ModPlatform::IndexedPack::Ptr, ModPlatform::IndexedVersion&, std::shared_ptr<ResourceFolderModel>) override;
 
     virtual auto validateVersion(ModPlatform::IndexedVersion& ver,
                                  QString mineVer,

--- a/launcher/ui/pages/modplatform/ResourceModel.h
+++ b/launcher/ui/pages/modplatform/ResourceModel.h
@@ -88,7 +88,7 @@ class ResourceModel : public QAbstractListModel {
 
     void addPack(ModPlatform::IndexedPack::Ptr pack,
                  ModPlatform::IndexedVersion& version,
-                 const std::shared_ptr<ResourceFolderModel> packs,
+                 std::shared_ptr<ResourceFolderModel> packs,
                  bool is_indexed = false,
                  QString custom_target_folder = {});
     void removePack(const QString& rem);

--- a/launcher/ui/pages/modplatform/ResourcePage.h
+++ b/launcher/ui/pages/modplatform/ResourcePage.h
@@ -78,7 +78,7 @@ class ResourcePage : public QWidget, public BasePage {
     void addResourceToDialog(ModPlatform::IndexedPack::Ptr, ModPlatform::IndexedVersion&);
     void removeResourceFromDialog(const QString& pack_name);
     virtual void removeResourceFromPage(const QString& name);
-    virtual void addResourceToPage(ModPlatform::IndexedPack::Ptr, ModPlatform::IndexedVersion&, const std::shared_ptr<ResourceFolderModel>);
+    virtual void addResourceToPage(ModPlatform::IndexedPack::Ptr, ModPlatform::IndexedVersion&, std::shared_ptr<ResourceFolderModel>);
 
     QList<DownloadTaskPtr> selectedPacks() { return m_model->selectedPacks(); }
     bool hasSelectedPacks() { return !(m_model->selectedPacks().isEmpty()); }

--- a/launcher/ui/pages/modplatform/ShaderPackPage.h
+++ b/launcher/ui/pages/modplatform/ShaderPackPage.h
@@ -38,9 +38,7 @@ class ShaderPackResourcePage : public ResourcePage {
 
     [[nodiscard]] bool supportsFiltering() const override { return false; };
 
-    void addResourceToPage(ModPlatform::IndexedPack::Ptr,
-                           ModPlatform::IndexedVersion&,
-                           const std::shared_ptr<ResourceFolderModel>) override;
+    void addResourceToPage(ModPlatform::IndexedPack::Ptr, ModPlatform::IndexedVersion&, std::shared_ptr<ResourceFolderModel>) override;
 
     [[nodiscard]] QMap<QString, QString> urlHandlers() const override;
 

--- a/launcher/ui/pages/modplatform/flame/FlameModel.h
+++ b/launcher/ui/pages/modplatform/flame/FlameModel.h
@@ -38,7 +38,7 @@ class ListModel : public QAbstractListModel {
     void fetchMore(const QModelIndex& parent) override;
 
     void getLogo(const QString& logo, const QString& logoUrl, LogoCallback callback);
-    void searchWithTerm(const QString& term, const int sort);
+    void searchWithTerm(const QString& term, int sort);
 
     [[nodiscard]] bool hasActiveSearchJob() const { return jobPtr && jobPtr->isRunning(); }
     [[nodiscard]] Task::Ptr activeSearchJob() { return hasActiveSearchJob() ? jobPtr : nullptr; }

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModel.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModel.h
@@ -71,7 +71,7 @@ class ModpackListModel : public QAbstractListModel {
     /* Ask the API for more information */
     void fetchMore(const QModelIndex& parent) override;
     void refresh();
-    void searchWithTerm(const QString& term, const int sort);
+    void searchWithTerm(const QString& term, int sort);
 
     [[nodiscard]] bool hasActiveSearchJob() const { return jobPtr && jobPtr->isRunning(); }
     [[nodiscard]] Task::Ptr activeSearchJob() { return hasActiveSearchJob() ? jobPtr : nullptr; }

--- a/launcher/ui/widgets/LanguageSelectionWidget.cpp
+++ b/launcher/ui/widgets/LanguageSelectionWidget.cpp
@@ -76,7 +76,7 @@ void LanguageSelectionWidget::languageRowChanged(const QModelIndex& current, con
     translations->updateLanguage(key);
 }
 
-void LanguageSelectionWidget::languageSettingChanged(const Setting&, const QVariant)
+void LanguageSelectionWidget::languageSettingChanged(const Setting&, const QVariant&)
 {
     auto translations = APPLICATION->translations();
     auto index = translations->selectedIndex();

--- a/launcher/ui/widgets/LanguageSelectionWidget.h
+++ b/launcher/ui/widgets/LanguageSelectionWidget.h
@@ -34,7 +34,7 @@ class LanguageSelectionWidget : public QWidget {
 
    protected slots:
     void languageRowChanged(const QModelIndex& current, const QModelIndex& previous);
-    void languageSettingChanged(const Setting&, const QVariant);
+    void languageSettingChanged(const Setting&, const QVariant&);
 
    private:
     QVBoxLayout* verticalLayout = nullptr;


### PR DESCRIPTION
In most cases I simply removed the `const`, but in a few I changed the parameter to a `const` reference (when it was more than a simple `int` or `enum`, for example). Also introduced a clang-tidy check for this.