### PR TITLE
Add button to disable resolving dependencies when installing mods

### DIFF
--- a/launcher/ui/dialogs/ModUpdateDialog.cpp
+++ b/launcher/ui/dialogs/ModUpdateDialog.cpp
@@ -435,6 +435,9 @@ void ModUpdateDialog::appendMod(CheckUpdateTask::UpdatableMod const& info, QStri
                 reqItem->insertChildren(i++, { reqItem });
             }
         }
+
+        ui->toggleDepsButton->show();
+        m_deps << item_top;
     }
 
     auto changelog_item = new QTreeWidgetItem(item_top);

--- a/launcher/ui/dialogs/ReviewMessageBox.cpp
+++ b/launcher/ui/dialogs/ReviewMessageBox.cpp
@@ -13,6 +13,7 @@ ReviewMessageBox::ReviewMessageBox(QWidget* parent, [[maybe_unused]] QString con
     auto back_button = ui->buttonBox->button(QDialogButtonBox::Cancel);
     back_button->setText(tr("Back"));
 
+    ui->toggleDepsButton->hide();
     ui->modTreeWidget->header()->setSectionResizeMode(0, QHeaderView::Stretch);
     ui->modTreeWidget->header()->setStretchLastSection(false);
     ui->modTreeWidget->header()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
@@ -75,6 +76,8 @@ void ReviewMessageBox::appendResource(ResourceInformation&& info)
         }
 
         itemTop->insertChildren(childIndx++, { requiredByItem });
+        ui->toggleDepsButton->show();
+        m_deps << itemTop;
     }
 
     auto versionTypeItem = new QTreeWidgetItem(itemTop);
@@ -108,3 +111,10 @@ void ReviewMessageBox::retranslateUi(QString resources_name)
     ui->explainLabel->setText(tr("You're about to download the following %1:").arg(resources_name));
     ui->onlyCheckedLabel->setText(tr("Only %1 with a check will be downloaded!").arg(resources_name));
 }
+void ReviewMessageBox::on_toggleDepsButton_clicked()
+{
+    m_deps_checked = !m_deps_checked;
+    auto state = m_deps_checked ? Qt::Checked : Qt::Unchecked;
+    for (auto dep : m_deps)
+        dep->setCheckState(0, state);
+};

--- a/launcher/ui/dialogs/ReviewMessageBox.h
+++ b/launcher/ui/dialogs/ReviewMessageBox.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QDialog>
+#include <QTreeWidgetItem>
 
 namespace Ui {
 class ReviewMessageBox;
@@ -28,8 +29,14 @@ class ReviewMessageBox : public QDialog {
 
     ~ReviewMessageBox() override;
 
+   protected slots:
+    void on_toggleDepsButton_clicked();
+
    protected:
     ReviewMessageBox(QWidget* parent, const QString& title, const QString& icon);
 
     Ui::ReviewMessageBox* ui;
+
+    QList<QTreeWidgetItem*> m_deps;
+    bool m_deps_checked = true;
 };

--- a/launcher/ui/dialogs/ReviewMessageBox.ui
+++ b/launcher/ui/dialogs/ReviewMessageBox.ui
@@ -44,14 +44,19 @@
     </widget>
    </item>
    <item row="1" column="0">
-    <widget class="QLabel" name="explainLabel">
-    </widget>
+    <widget class="QLabel" name="explainLabel"/>
    </item>
    <item row="5" column="0" rowspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QLabel" name="onlyCheckedLabel">
+      <widget class="QPushButton" name="toggleDepsButton">
+       <property name="text">
+        <string>Toggle Dependencies</string>
+       </property>
       </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="onlyCheckedLabel"/>
      </item>
      <item>
       <widget class="QDialogButtonBox" name="buttonBox">


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
Similar to: https://github.com/PrismLauncher/PrismLauncher/pull/1746
fixes #1818
But this is on the review message widget and allows the user to deselect(toggle) all dependencies