### PR TITLE
Fix crash with mod icon caching

### DIFF
--- a/launcher/MTPixmapCache.h
+++ b/launcher/MTPixmapCache.h
@@ -102,7 +102,7 @@ class PixmapCache final : public QObject {
     bool _markCacheMissByEviciton()
     {
         static constexpr int maxInt = std::numeric_limits<int>::max();
-        static constexpr uint oneMB = 1000;
+        static constexpr uint step = 10240;
         static constexpr int oneSecond = 1000;
 
         auto now = QTime::currentTime();
@@ -117,7 +117,7 @@ class PixmapCache final : public QObject {
         m_last_cache_miss_by_eviciton = now;
         if (m_consecutive_fast_evicitons >= m_consecutive_fast_evicitons_threshold) {
             // increase the cache size
-            uint newSize = _cacheLimit() + oneMB;
+            uint newSize = _cacheLimit() + step;
             if (newSize >= maxInt) {  // increase it until you overflow :D
                 newSize = maxInt;
                 qDebug() << m_consecutive_fast_evicitons

--- a/launcher/MTPixmapCache.h
+++ b/launcher/MTPixmapCache.h
@@ -101,7 +101,7 @@ class PixmapCache final : public QObject {
      */
     bool _markCacheMissByEviciton()
     {
-        static constexpr int maxInt = std::numeric_limits<int>::max();
+        static constexpr uint maxInt = static_cast<uint>(std::numeric_limits<int>::max());
         static constexpr uint step = 10240;
         static constexpr int oneSecond = 1000;
 
@@ -123,8 +123,8 @@ class PixmapCache final : public QObject {
                 qDebug() << m_consecutive_fast_evicitons
                          << tr("pixmap cache misses by eviction happened too fast, doing nothing as the cache size reached it's limit");
             } else {
-                qDebug() << m_consecutive_fast_evicitons << tr("pixmap cache misses by eviction happened too fast, doubling cache size to")
-                         << static_cast<int>(newSize);
+                qDebug() << m_consecutive_fast_evicitons
+                         << tr("pixmap cache misses by eviction happened too fast, increasing cache size to") << static_cast<int>(newSize);
             }
             _setCacheLimit(static_cast<int>(newSize));
             m_consecutive_fast_evicitons = 0;

--- a/launcher/MTPixmapCache.h
+++ b/launcher/MTPixmapCache.h
@@ -101,10 +101,14 @@ class PixmapCache final : public QObject {
      */
     bool _markCacheMissByEviciton()
     {
+        static constexpr int maxInt = std::numeric_limits<int>::max();
+        static constexpr uint oneMB = 1000;
+        static constexpr int oneSecond = 1000;
+
         auto now = QTime::currentTime();
         if (!m_last_cache_miss_by_eviciton.isNull()) {
             auto diff = m_last_cache_miss_by_eviciton.msecsTo(now);
-            if (diff < 1000) {  // less than a second ago
+            if (diff < oneSecond) {  // less than a second ago
                 ++m_consecutive_fast_evicitons;
             } else {
                 m_consecutive_fast_evicitons = 0;
@@ -112,10 +116,10 @@ class PixmapCache final : public QObject {
         }
         m_last_cache_miss_by_eviciton = now;
         if (m_consecutive_fast_evicitons >= m_consecutive_fast_evicitons_threshold) {
-            // double the cache size
-            auto newSize = _cacheLimit() * 2ll;
-            if (newSize >= std::numeric_limits<int>::max()) {  // double it until you overflow :D
-                newSize = std::numeric_limits<int>::max();
+            // increase the cache size
+            uint newSize = _cacheLimit() + oneMB;
+            if (newSize >= maxInt) {  // increase it until you overflow :D
+                newSize = maxInt;
                 qDebug() << m_consecutive_fast_evicitons
                          << tr("pixmap cache misses by eviction happened too fast, doing nothing as the cache size reached it's limit");
             } else {

--- a/launcher/MTPixmapCache.h
+++ b/launcher/MTPixmapCache.h
@@ -113,7 +113,13 @@ class PixmapCache final : public QObject {
         if (m_consecutive_fast_evicitons >= m_consecutive_fast_evicitons_threshold) {
             // double the cache size
             auto newSize = _cacheLimit() * 2;
-            qDebug() << m_consecutive_fast_evicitons << "pixmap cache misses by eviction happened too fast, doubling cache size to"
+            if (newSize <= 0) {  // double it until you overflow :D
+                qDebug() << m_consecutive_fast_evicitons
+                         << tr("pixmap cache misses by eviction happened too fast, doing nothing as the cache size reached it's limit");
+                m_consecutive_fast_evicitons = 0;
+                return true;
+            }
+            qDebug() << m_consecutive_fast_evicitons << tr("pixmap cache misses by eviction happened too fast, doubling cache size to")
                      << newSize;
             _setCacheLimit(newSize);
             m_consecutive_fast_evicitons = 0;

--- a/launcher/MTPixmapCache.h
+++ b/launcher/MTPixmapCache.h
@@ -113,7 +113,7 @@ class PixmapCache final : public QObject {
         m_last_cache_miss_by_eviciton = now;
         if (m_consecutive_fast_evicitons >= m_consecutive_fast_evicitons_threshold) {
             // double the cache size
-            auto newSize = _cacheLimit() * 2.L;
+            auto newSize = _cacheLimit() * 2ll;
             if (newSize >= std::numeric_limits<int>::max()) {  // double it until you overflow :D
                 newSize = std::numeric_limits<int>::max();
                 qDebug() << m_consecutive_fast_evicitons


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
How to reproduce:
- download multiple large instances( more mods better they can be the same)
- view the mods page for each one of them
- after closing all edit instances windows
- repeat the second and third steps until the UI doesn't respond

Small note I was able to reproduce this with three instances with 800+ mods
Here is the link to the discord message that started this: https://discord.com/channels/1031648380885147709/1118165588200657006/1169052911200903288 if they ever do an issue on GitHub link it to this ticket