### PR TITLE
[Windows] Autodetect Java from the Microsoft Store version of the official launcher

### DIFF
--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -34,6 +34,7 @@
  */
 
 #include <QDir>
+#include <QFileInfo>
 #include <QString>
 #include <QStringList>
 
@@ -440,18 +441,26 @@ QStringList getMinecraftJavaBundle()
 {
     QString partialPath;
     QString executable = "java";
+    QStringList processpaths;
 #if defined(Q_OS_OSX)
     partialPath = FS::PathCombine(QDir::homePath(), "Library/Application Support");
 #elif defined(Q_OS_WIN32)
     partialPath = QProcessEnvironment::systemEnvironment().value("LOCALAPPDATA", "");
     executable += "w.exe";
+
+    // add the following to the search
+    // C:\Users\USERNAME\AppData\Local\Packages\Microsoft.4297127D64EC6_8wekyb3d8bbwe\LocalCache\Local\runtime
+    auto minecraftInstaltionPath =
+        FS::PathCombine(QFileInfo(partialPath).absolutePath(), "Local", "Packages", "Microsoft.4297127D64EC6_8wekyb3d8bbwe");
+    minecraftInstaltionPath = FS::PathCombine(minecraftInstaltionPath, "LocalCache", "Local", "runtime");
+    processpaths << minecraftInstaltionPath;
 #else
     partialPath = QDir::homePath();
 #endif
-    auto minecraftPath = FS::PathCombine(partialPath, ".minecraft", "runtime");
-    QStringList javas;
-    QStringList processpaths{ minecraftPath };
+    auto minecraftDataPath = FS::PathCombine(partialPath, ".minecraft", "runtime");
+    processpaths << minecraftDataPath;
 
+    QStringList javas;
     while (!processpaths.isEmpty()) {
         auto dirPath = processpaths.takeFirst();
         QDir dir(dirPath);

--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -448,12 +448,12 @@ QStringList getMinecraftJavaBundle()
     partialPath = QProcessEnvironment::systemEnvironment().value("LOCALAPPDATA", "");
     executable += "w.exe";
 
-    // add the following to the search
+    // add the microsoft store version of the launcher to the search. the current path is:
     // C:\Users\USERNAME\AppData\Local\Packages\Microsoft.4297127D64EC6_8wekyb3d8bbwe\LocalCache\Local\runtime
-    auto minecraftInstaltionPath =
+    auto minecraftMSStorePath =
         FS::PathCombine(QFileInfo(partialPath).absolutePath(), "Local", "Packages", "Microsoft.4297127D64EC6_8wekyb3d8bbwe");
-    minecraftInstaltionPath = FS::PathCombine(minecraftInstaltionPath, "LocalCache", "Local", "runtime");
-    processpaths << minecraftInstaltionPath;
+    minecraftMSStorePath = FS::PathCombine(minecraftMSStorePath, "LocalCache", "Local", "runtime");
+    processpaths << minecraftMSStorePath;
 #else
     partialPath = QDir::homePath();
 #endif


### PR DESCRIPTION
fixes #1835
issue reported: Minecraft java detection not working on windows: https://discord.com/channels/1031648380885147709/1167762562155303014/1171227351774937150
Microsoft uses two paths for this:
- on UNIX inside the .minecraft data dir
- on Windows is where Minecraft is installed.
