### PR TITLE
Improve name and tooltip of mod dependency management option

### DIFF
--- a/launcher/ui/pages/global/LauncherPage.ui
+++ b/launcher/ui/pages/global/LauncherPage.ui
@@ -189,10 +189,10 @@
            <item>
            <widget class="QCheckBox" name="dependenciesDisableBtn">
             <property name="toolTip">
-             <string>Disable automatically checking and installation of mod dependencies.</string>
+             <string>Disable the automatic detection, installation, and updating of mod dependencies.</string>
             </property>
             <property name="text">
-             <string>Do not install mod dependencies</string>
+             <string>Disable automatic mod dependency management</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Tiny PR to improve the name and tooltip of the setting that disables the automatic mod dependency management introduced in Prism 8.0.

Currently the option and tooltip make it sound like it only applies to installing mods via Prism, when in reality this option also impacts updating mods, as new mods dependencies will also be detected and installed there.

This also fixes the tooltip sounding weird, and the name is also more consistent with the rest of the options.
