### PR TITLE
Add random and slideshow modes to Catpacks

### DIFF
--- a/launcher/ui/instanceview/InstanceView.cpp
+++ b/launcher/ui/instanceview/InstanceView.cpp
@@ -465,7 +465,7 @@ void InstanceView::paintEvent([[maybe_unused]] QPaintEvent* event)
             widWidth = m_catPixmap.width();
         if (m_catPixmap.height() < widHeight)
             widHeight = m_catPixmap.height();
-        auto pixmap = m_catPixmap.scaled(widWidth, widHeight, Qt::KeepAspectRatio);
+        auto pixmap = m_catPixmap.scaled(widWidth, widHeight, Qt::KeepAspectRatio, Qt::SmoothTransformation);
         QRect rectOfPixmap = pixmap.rect();
         rectOfPixmap.moveBottomRight(this->viewport()->rect().bottomRight());
         painter.drawPixmap(rectOfPixmap.topLeft(), pixmap);

--- a/launcher/ui/themes/CatPack.cpp
+++ b/launcher/ui/themes/CatPack.cpp
@@ -36,7 +36,10 @@
 #include "ui/themes/CatPack.h"
 #include <QDate>
 #include <QDir>
+#include <QDirIterator>
 #include <QFileInfo>
+#include <QImageReader>
+#include <QRandomGenerator>
 #include "FileSystem.h"
 #include "Json.h"
 
@@ -79,7 +82,7 @@ JsonCatPack::JsonCatPack(QFileInfo& manifestInfo) : BasicCatPack(manifestInfo.di
     auto doc = Json::requireDocument(manifestInfo.absoluteFilePath(), "CatPack JSON file");
     const auto root = doc.object();
     m_name = Json::requireString(root, "name", "Catpack name");
-    m_defaultPath = FS::PathCombine(path, Json::requireString(root, "default", "Default Cat"));
+    m_default_path = FS::PathCombine(path, Json::requireString(root, "default", "Default Cat"));
     auto variants = Json::ensureArray(root, "variants", QJsonArray(), "Catpack Variants");
     for (auto v : variants) {
         auto variant = Json::ensureObject(v, QJsonObject(), "Cat variant");
@@ -117,5 +120,21 @@ QString JsonCatPack::path(QDate now)
         if (startDate <= now && now <= endDate)
             return var.path;
     }
-    return m_defaultPath;
+    auto dInfo = QFileInfo(m_default_path);
+    if (!dInfo.isDir())
+        return m_default_path;
+
+    QStringList supportedImageFormats;
+    for (auto format : QImageReader::supportedImageFormats()) {
+        supportedImageFormats.append("*." + format);
+    }
+
+    auto files = QDir(m_default_path).entryInfoList(supportedImageFormats, QDir::Files, QDir::Name);
+    if (files.length() == 0)
+        return "";
+    auto idx = now.dayOfYear() % files.length();
+    auto isRandom = dInfo.fileName().compare("random", Qt::CaseInsensitive) == 0;
+    if (isRandom)
+        idx = QRandomGenerator::global()->bounded(0, files.length());
+    return files[idx].absoluteFilePath();
 }

--- a/launcher/ui/themes/CatPack.cpp
+++ b/launcher/ui/themes/CatPack.cpp
@@ -132,7 +132,7 @@ QString JsonCatPack::path(QDate now)
     auto files = QDir(m_default_path).entryInfoList(supportedImageFormats, QDir::Files, QDir::Name);
     if (files.length() == 0)
         return "";
-    auto idx = now.dayOfYear() % files.length();
+    auto idx = (now.dayOfYear() - 1) % files.length();
     auto isRandom = dInfo.fileName().compare("random", Qt::CaseInsensitive) == 0;
     if (isRandom)
         idx = QRandomGenerator::global()->bounded(0, files.length());

--- a/launcher/ui/themes/CatPack.h
+++ b/launcher/ui/themes/CatPack.h
@@ -87,6 +87,6 @@ class JsonCatPack : public BasicCatPack {
     QString path(QDate now);
 
    private:
-    QString m_defaultPath;
+    QString m_default_path;
     QList<Variant> m_variants;
 };

--- a/launcher/ui/themes/ThemeManager.cpp
+++ b/launcher/ui/themes/ThemeManager.cpp
@@ -178,8 +178,8 @@ QList<ITheme*> ThemeManager::getValidApplicationThemes()
 QList<CatPack*> ThemeManager::getValidCatPacks()
 {
     QList<CatPack*> ret;
-    ret.reserve(m_catPacks.size());
-    for (auto&& [id, theme] : m_catPacks) {
+    ret.reserve(m_cat_packs.size());
+    for (auto&& [id, theme] : m_cat_packs) {
         ret.append(theme.get());
     }
     return ret;
@@ -244,8 +244,8 @@ void ThemeManager::applyCurrentlySelectedTheme(bool initial)
 
 QString ThemeManager::getCatPack(QString catName)
 {
-    auto catIter = m_catPacks.find(!catName.isEmpty() ? catName : APPLICATION->settings()->get("BackgroundCat").toString());
-    if (catIter != m_catPacks.end()) {
+    auto catIter = m_cat_packs.find(!catName.isEmpty() ? catName : APPLICATION->settings()->get("BackgroundCat").toString());
+    if (catIter != m_cat_packs.end()) {
         auto& catPack = catIter->second;
         themeDebugLog() << "applying catpack" << catPack->id();
         return catPack->path();
@@ -253,14 +253,14 @@ QString ThemeManager::getCatPack(QString catName)
         themeWarningLog() << "Tried to get invalid catPack:" << catName;
     }
 
-    return m_catPacks.begin()->second->path();
+    return m_cat_packs.begin()->second->path();
 }
 
 QString ThemeManager::addCatPack(std::unique_ptr<CatPack> catPack)
 {
     QString id = catPack->id();
-    if (m_catPacks.find(id) == m_catPacks.end())
-        m_catPacks.emplace(id, std::move(catPack));
+    if (m_cat_packs.find(id) == m_cat_packs.end())
+        m_cat_packs.emplace(id, std::move(catPack));
     else
         themeWarningLog() << "CatPack(" << id << ") not added to prevent id duplication";
     return id;

--- a/launcher/ui/themes/ThemeManager.h
+++ b/launcher/ui/themes/ThemeManager.h
@@ -61,7 +61,7 @@ class ThemeManager {
     QDir m_iconThemeFolder{ "iconthemes" };
     QDir m_applicationThemeFolder{ "themes" };
     QDir m_catPacksFolder{ "catpacks" };
-    std::map<QString, std::unique_ptr<CatPack>> m_catPacks;
+    std::map<QString, std::unique_ptr<CatPack>> m_cat_packs;
 
     void initializeThemes();
     void initializeCatPacks();


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
fixes #693
fixes #1820 
and hopefully fixes #1816 (needs testing)

So here are the additions to the catpacks:
- if the default path points to a directory then we will display one cat per day from that directory in a slideshow manner (the files are sorted alphabetically then the file index is chosen by the following formula `theDayOfTheYear % numFiles`)
- if that directory is named `random` (case insensitive) then a new cat is selected on each prism restart or cat button toggle 
- make sure we apply smooth transformation when scaling of the cat
