### PR TITLE
Ignore dependencies that can not be found

### DIFF
--- a/launcher/minecraft/mod/tasks/GetModDependenciesTask.cpp
+++ b/launcher/minecraft/mod/tasks/GetModDependenciesTask.cpp
@@ -137,10 +137,11 @@ Task::Ptr GetModDependenciesTask::getProjectInfoTask(std::shared_ptr<PackDepende
     auto provider = pDep->pack->provider == m_flame_provider.name ? m_flame_provider : m_modrinth_provider;
     auto responseInfo = std::make_shared<QByteArray>();
     auto info = provider.api->getProject(pDep->pack->addonId.toString(), responseInfo);
-    QObject::connect(info.get(), &NetJob::succeeded, [responseInfo, provider, pDep] {
+    QObject::connect(info.get(), &NetJob::succeeded, [this, responseInfo, provider, pDep] {
         QJsonParseError parse_error{};
         QJsonDocument doc = QJsonDocument::fromJson(*responseInfo, &parse_error);
         if (parse_error.error != QJsonParseError::NoError) {
+            removePack(pDep->pack->addonId);
             qWarning() << "Error while parsing JSON response for mod info at " << parse_error.offset
                        << " reason: " << parse_error.errorString();
             qDebug() << *responseInfo;
@@ -151,6 +152,7 @@ Task::Ptr GetModDependenciesTask::getProjectInfoTask(std::shared_ptr<PackDepende
                                                                              : Json::requireObject(doc);
             provider.mod->loadIndexedPack(*pDep->pack, obj);
         } catch (const JSONValidationError& e) {
+            removePack(pDep->pack->addonId);
             qDebug() << doc;
             qWarning() << "Error while reading mod info: " << e.cause();
         }
@@ -211,11 +213,13 @@ Task::Ptr GetModDependenciesTask::prepareDependencyTask(const ModPlatform::Depen
             pDep->pack->versionsLoaded = true;
 
         } catch (const JSONValidationError& e) {
+            removePack(dep.addonId);
             qDebug() << doc;
             qWarning() << "Error while reading mod version: " << e.cause();
             return;
         }
         if (level == 0) {
+            removePack(dep.addonId);
             qWarning() << "Dependency cycle exceeded";
             return;
         }


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
Reported by hound.22 on discord.
Some mods may have dependencies that are no longer on the provider.
Here is the one that was found: https://modrinth.com/mod/tweakermore/version/mc1.20.1-v3.15.0
This PR just removes the dependency from the list if it gets any JSON error.