### PR TITLE
Add warning when updating mods while the game is running

### DIFF
--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -460,9 +460,9 @@ bool ResourceFolderModel::setData(const QModelIndex& index, [[maybe_unused]] con
     if (role == Qt::CheckStateRole) {
         if (m_instance != nullptr && m_instance->isRunning()) {
             auto response =
-                CustomMessageBox::selectable(nullptr, "Confirm toggle",
-                                             "If you enable/disable this resource while the game is running it may crash your game.\n"
-                                             "Are you sure you want to do this?",
+                CustomMessageBox::selectable(nullptr, tr("Confirm toggle"),
+                                             tr("If you enable/disable this resource while the game is running it may crash your game.\n"
+                                                "Are you sure you want to do this?"),
                                              QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No, QMessageBox::No)
                     ->exec();
 

--- a/launcher/ui/dialogs/ChooseProviderDialog.h
+++ b/launcher/ui/dialogs/ChooseProviderDialog.h
@@ -13,7 +13,6 @@ enum class ResourceProvider;
 
 class Mod;
 class NetJob;
-class ModUpdateDialog;
 
 class ChooseProviderDialog : public QDialog {
     Q_OBJECT

--- a/launcher/ui/pages/instance/ExternalResourcesPage.cpp
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.cpp
@@ -252,9 +252,9 @@ void ExternalResourcesPage::removeItem()
 void ExternalResourcesPage::removeItems(const QItemSelection& selection)
 {
     if (m_instance != nullptr && m_instance->isRunning()) {
-        auto response = CustomMessageBox::selectable(this, "Confirm Delete",
-                                                     "If you remove this resource while the game is running it may crash your game.\n"
-                                                     "Are you sure you want to do this?",
+        auto response = CustomMessageBox::selectable(this, tr("Confirm Delete"),
+                                                     tr("If you remove this resource while the game is running it may crash your game.\n"
+                                                        "Are you sure you want to do this?"),
                                                      QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No, QMessageBox::No)
                             ->exec();
 
@@ -273,9 +273,9 @@ void ExternalResourcesPage::enableItem()
 void ExternalResourcesPage::disableItem()
 {
     if (m_instance != nullptr && m_instance->isRunning()) {
-        auto response = CustomMessageBox::selectable(this, "Confirm disable",
-                                                     "If you disable this resource while the game is running it may crash your game.\n"
-                                                     "Are you sure you want to do this?",
+        auto response = CustomMessageBox::selectable(this, tr("Confirm disable"),
+                                                     tr("If you disable this resource while the game is running it may crash your game.\n"
+                                                        "Are you sure you want to do this?"),
                                                      QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No, QMessageBox::No)
                             ->exec();
 

--- a/launcher/ui/pages/instance/ModFolderPage.cpp
+++ b/launcher/ui/pages/instance/ModFolderPage.cpp
@@ -150,9 +150,9 @@ bool ModFolderPage::onSelectionChanged(const QModelIndex& current, [[maybe_unuse
 void ModFolderPage::removeItems(const QItemSelection& selection)
 {
     if (m_instance != nullptr && m_instance->isRunning()) {
-        auto response = CustomMessageBox::selectable(this, "Confirm Delete",
-                                                     "If you remove mods while the game is running it may crash your game.\n"
-                                                     "Are you sure you want to do this?",
+        auto response = CustomMessageBox::selectable(this, tr("Confirm Delete"),
+                                                     tr("If you remove mods while the game is running it may crash your game.\n"
+                                                        "Are you sure you want to do this?"),
                                                      QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No, QMessageBox::No)
                             ->exec();
 
@@ -217,6 +217,17 @@ void ModFolderPage::updateMods()
     if (APPLICATION->settings()->get("ModMetadataDisabled").toBool()) {
         QMessageBox::critical(this, tr("Error"), tr("Mod updates are unavailable when metadata is disabled!"));
         return;
+    }
+    if (m_instance != nullptr && m_instance->isRunning()) {
+        auto response = CustomMessageBox::selectable(this, tr("Confirm Update"),
+                                                     tr("If you update mods while the game is running may cause mod duplication.\n"
+                                                        "The old files may not be deleted as they are in use.\n"
+                                                        "Are you sure you want to do this?"),
+                                                     QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No, QMessageBox::No)
+                            ->exec();
+
+        if (response != QMessageBox::Yes)
+            return;
     }
     auto selection = m_filterModel->mapSelectionToSource(ui->treeView->selectionModel()->selection()).indexes();
 

--- a/launcher/ui/pages/instance/ModFolderPage.cpp
+++ b/launcher/ui/pages/instance/ModFolderPage.cpp
@@ -240,12 +240,13 @@ void ModFolderPage::updateMods(bool includeDeps)
         return;
     }
     if (m_instance != nullptr && m_instance->isRunning()) {
-        auto response = CustomMessageBox::selectable(this, tr("Confirm Update"),
-                                                     tr("If you update mods while the game is running may cause mod duplication and game crashes.\n"
-                                                        "The old files may not be deleted as they are in use.\n"
-                                                        "Are you sure you want to do this?"),
-                                                     QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No, QMessageBox::No)
-                            ->exec();
+        auto response =
+            CustomMessageBox::selectable(this, tr("Confirm Update"),
+                                         tr("If you update mods while the game is running may cause mod duplication and game crashes.\n"
+                                            "The old files may not be deleted as they are in use.\n"
+                                            "Are you sure you want to do this?"),
+                                         QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No, QMessageBox::No)
+                ->exec();
 
         if (response != QMessageBox::Yes)
             return;

--- a/launcher/ui/pages/instance/ModFolderPage.cpp
+++ b/launcher/ui/pages/instance/ModFolderPage.cpp
@@ -220,7 +220,7 @@ void ModFolderPage::updateMods()
     }
     if (m_instance != nullptr && m_instance->isRunning()) {
         auto response = CustomMessageBox::selectable(this, tr("Confirm Update"),
-                                                     tr("If you update mods while the game is running may cause mod duplication.\n"
+                                                     tr("If you update mods while the game is running may cause mod duplication and game crashes.\n"
                                                         "The old files may not be deleted as they are in use.\n"
                                                         "Are you sure you want to do this?"),
                                                      QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No, QMessageBox::No)


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
fixes #1851
By adding a confirmation dialog while the instance is running.
Small additions added `tr` to other warnings that are displayed while running.