### PR TITLE
Fix resetting settings when saving

### DIFF
--- a/launcher/InstanceCopyTask.cpp
+++ b/launcher/InstanceCopyTask.cpp
@@ -142,9 +142,8 @@ void InstanceCopyTask::copyFinished()
     if (!m_keepPlaytime) {
         inst->resetTimePlayed();
     }
-    if (m_useLinks)
-        inst->addLinkedInstanceId(m_origInstance->id());
     if (m_useLinks) {
+        inst->addLinkedInstanceId(m_origInstance->id());
         auto allowed_symlinks_file = QFileInfo(FS::PathCombine(inst->gameRoot(), "allowed_symlinks.txt"));
 
         QByteArray allowed_symlinks;

--- a/launcher/settings/INIFile.cpp
+++ b/launcher/settings/INIFile.cpp
@@ -54,6 +54,7 @@ bool INIFile::saveFile(QString fileName)
         insert("ConfigVersion", "1.2");
     QSettings _settings_obj{ fileName, QSettings::Format::IniFormat };
     _settings_obj.setFallbacksEnabled(false);
+    _settings_obj.clear();
 
     for (Iterator iter = begin(); iter != end(); iter++)
         _settings_obj.setValue(iter.key(), iter.value());


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
fixes #1856
And most probably other issues where the setting was reset but persisted on save.