### PR TITLE
[Linux] Sync nightly Flatpak manifest with Flathub

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -594,7 +594,7 @@ jobs:
   flatpak:
     runs-on: ubuntu-latest
     container:
-      image: bilelmoussaoui/flatpak-github-actions:kde-5.15-22.08
+      image: bilelmoussaoui/flatpak-github-actions:kde-5.15-23.08
       options: --privileged
     steps:
       - name: Checkout

--- a/flatpak/org.prismlauncher.PrismLauncher.yml
+++ b/flatpak/org.prismlauncher.PrismLauncher.yml
@@ -1,6 +1,6 @@
 id: org.prismlauncher.PrismLauncher
 runtime: org.kde.Platform
-runtime-version: "5.15-22.08"
+runtime-version: "5.15-23.08"
 sdk: org.kde.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk17
@@ -113,6 +113,9 @@ modules:
           version-query: .tag_name
           url-query: .tarball_url
           timestamp-query: .published_at
+      # from https://github.com/flathub/net.gaijin.WarThunder/blob/7ea6f7a9f84b9c77150c003a7059dc03f8dcbc7f/gamemode.patch
+      - type: patch
+        path: patches/gamemode.patch
     cleanup:
       - /include
       - /lib/pkgconfig

--- a/flatpak/patches/gamemode.patch
+++ b/flatpak/patches/gamemode.patch
@@ -1,0 +1,12 @@
+diff -ruN a/common/common-pidfds.c b/common/common-pidfds.c
+--- a/common/common-pidfds.c	2021-02-18 20:00:12.000000000 +0100
++++ b/common/common-pidfds.c	2023-09-07 08:57:42.954362763 +0200
+@@ -58,6 +58,8 @@
+ {
+ 	return (int)syscall(__NR_pidfd_open, pid, flags);
+ }
++#else
++#include <sys/pidfd.h>
+ #endif
+ 
+ /* pidfd functions */


### PR DESCRIPTION
This syncs our local Flatpak build with [downstream](https://github.com/flathub/org.prismlauncher.PrismLauncher).