### PR TITLE
chore: disable x86_64-darwin in garnix

### DIFF
--- a/garnix.yaml
+++ b/garnix.yaml
@@ -1,5 +1,6 @@
 builds:
-  exclude: []
+  exclude:
+    - "*.x86_64-darwin.*"
   include:
     - "checks.x86_64-linux.*"
     - "devShells.*.*"


### PR DESCRIPTION
this is currently broken on garnix's end, but hopefully we will be able to enable this again in the future
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
