### PR TITLE
Fixed the maximized option on the newer Minecraft versions

### DIFF
--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -411,3 +411,8 @@ void BaseInstance::updateRuntimeContext()
 {
     // NOOP
 }
+
+bool BaseInstance::isLegacy()
+{
+    return traits().contains("legacyLaunch") || traits().contains("alphaLaunch");
+}

--- a/launcher/BaseInstance.h
+++ b/launcher/BaseInstance.h
@@ -269,6 +269,8 @@ class BaseInstance : public QObject, public std::enable_shared_from_this<BaseIns
     bool removeLinkedInstanceId(const QString& id);
     bool isLinkedToInstanceId(const QString& id) const;
 
+    bool isLegacy();
+
    protected:
     void changeStatus(Status newStatus);
 

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -91,6 +91,9 @@
 #include "tools/BaseProfiler.h"
 
 #include <QActionGroup>
+#include <QMainWindow>
+#include <QScreen>
+#include <QWindow>
 
 #ifdef Q_OS_LINUX
 #include "MangoHud.h"
@@ -752,11 +755,29 @@ QString MinecraftInstance::createLaunchScript(AuthSessionPtr session, MinecraftT
     // window size, title and state, legacy
     {
         QString windowParams;
-        if (settings()->get("LaunchMaximized").toBool())
-            windowParams = "maximized";
-        else
+        if (settings()->get("LaunchMaximized").toBool()) {
+            // FIXME doesn't support maximisation
+            if (getLauncher() == "standard") {
+                auto screen = QGuiApplication::primaryScreen();
+                auto screenGeometry = screen->availableSize();
+
+                // small hack to get the widow decorations
+                for (auto w : QApplication::topLevelWidgets()) {
+                    auto mainWindow = qobject_cast<QMainWindow*>(w);
+                    if (mainWindow) {
+                        screenGeometry = screenGeometry.shrunkBy(mainWindow->windowHandle()->frameMargins());
+                        break;
+                    }
+                }
+
+                windowParams = QString("%1x%2").arg(screenGeometry.width()).arg(screenGeometry.height());
+            } else {
+                windowParams = "maximized";
+            }
+        } else {
             windowParams =
                 QString("%1x%2").arg(settings()->get("MinecraftWinWidth").toInt()).arg(settings()->get("MinecraftWinHeight").toInt());
+        }
         launchScript += "windowTitle " + windowTitle() + "\n";
         launchScript += "windowParams " + windowParams + "\n";
     }

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -533,7 +533,7 @@ QStringList MinecraftInstance::javaArguments()
 QString MinecraftInstance::getLauncher()
 {
     // use legacy launcher if the traits are set
-    if (traits().contains("legacyLaunch") || traits().contains("alphaLaunch"))
+    if (isLegacy())
         return "legacy";
 
     return "standard";
@@ -757,7 +757,7 @@ QString MinecraftInstance::createLaunchScript(AuthSessionPtr session, MinecraftT
         QString windowParams;
         if (settings()->get("LaunchMaximized").toBool()) {
             // FIXME doesn't support maximisation
-            if (getLauncher() == "standard") {
+            if (!isLegacy()) {
                 auto screen = QGuiApplication::primaryScreen();
                 auto screenGeometry = screen->availableSize();
 

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -765,7 +765,12 @@ QString MinecraftInstance::createLaunchScript(AuthSessionPtr session, MinecraftT
                 for (auto w : QApplication::topLevelWidgets()) {
                     auto mainWindow = qobject_cast<QMainWindow*>(w);
                     if (mainWindow) {
-                        screenGeometry = screenGeometry.shrunkBy(mainWindow->windowHandle()->frameMargins());
+                        auto m = mainWindow->windowHandle()->frameMargins();
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+                        screenGeometry = screenGeometry.shrunkBy(m);
+#else
+                        screenGeometry = { screenGeometry.width() - m.left() - m.right(), screenGeometry.height() - m.top() - m.bottom() };
+#endif
                         break;
                     }
                 }

--- a/launcher/ui/pages/global/MinecraftPage.ui
+++ b/launcher/ui/pages/global/MinecraftPage.ui
@@ -56,6 +56,16 @@
            </widget>
           </item>
           <item>
+           <widget class="QLabel" name="maximizedWarning">
+            <property name="toolTip">
+             <string>On newer versions the game only supports resolution. In order to simulate the maximized behaviour the current implementation approximates the maximum display size.</string>
+            </property>
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; color:#f5c211;&quot;&gt;Warning&lt;/span&gt;&lt;span style=&quot; color:#f5c211;&quot;&gt;: On the newer Minecraft versions the start maximized option is not fully supported.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <layout class="QGridLayout" name="gridLayoutWindowSize">
             <item row="1" column="0">
              <widget class="QLabel" name="labelWindowHeight">

--- a/launcher/ui/pages/instance/InstanceSettingsPage.cpp
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.cpp
@@ -323,6 +323,7 @@ void InstanceSettingsPage::loadSettings()
     // Window Size
     ui->windowSizeGroupBox->setChecked(m_settings->get("OverrideWindow").toBool());
     ui->maximizedCheckBox->setChecked(m_settings->get("LaunchMaximized").toBool());
+    ui->maximizedWarning->setVisible(m_settings->get("LaunchMaximized").toBool() && !m_instance->isLegacy());
     ui->windowWidthSpinBox->setValue(m_settings->get("MinecraftWinWidth").toInt());
     ui->windowHeightSpinBox->setValue(m_settings->get("MinecraftWinHeight").toInt());
 

--- a/launcher/ui/pages/instance/InstanceSettingsPage.ui
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.ui
@@ -36,7 +36,7 @@
    <item>
     <widget class="QTabWidget" name="settingsTabs">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="minecraftPage">
       <attribute name="title">
@@ -282,6 +282,16 @@
            <widget class="QCheckBox" name="maximizedCheckBox">
             <property name="text">
              <string>Start Minecraft maximized</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="maximizedWarning">
+            <property name="toolTip">
+             <string>The base game only supports resolution. In order to simulate the maximized behaviour the current implementation approximates the maximum display size..</string>
+            </property>
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; color:#f5c211;&quot;&gt;Warning&lt;/span&gt;&lt;span style=&quot; color:#f5c211;&quot;&gt;: The maximized option may not be fully supported for the current minecraft version.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
            </widget>
           </item>

--- a/libraries/launcher/org/prismlauncher/launcher/impl/StandardLauncher.java
+++ b/libraries/launcher/org/prismlauncher/launcher/impl/StandardLauncher.java
@@ -57,13 +57,6 @@ package org.prismlauncher.launcher.impl;
 import org.prismlauncher.utils.Parameters;
 import org.prismlauncher.utils.ReflectionUtils;
 
-import java.awt.Dimension;
-import java.awt.GraphicsConfiguration;
-import java.awt.GraphicsDevice;
-import java.awt.GraphicsEnvironment;
-import java.awt.Insets;
-import java.awt.Rectangle;
-import java.awt.Toolkit;
 import java.lang.invoke.MethodHandle;
 import java.util.Collections;
 import java.util.List;
@@ -83,25 +76,10 @@ public final class StandardLauncher extends AbstractLauncher {
     @Override
     public void launch() throws Throwable {
         // window size, title and state
-        // FIXME doesn't support maximisation
-        if (!maximize) {
-            gameArgs.add("--width");
-            gameArgs.add(Integer.toString(width));
-            gameArgs.add("--height");
-            gameArgs.add(Integer.toString(height));
-        } else {
-            try {
-                // Dimension rct = Toolkit.getDefaultToolkit().getScreenSize();
-                Rectangle rct = getDefaultDeviceBounds();
-
-                gameArgs.add("--width");
-                gameArgs.add(Integer.toString(rct.width));
-                gameArgs.add("--height");
-                gameArgs.add(Integer.toString(rct.height));
-            } catch (Exception e) {
-                //  If for some reason the get fails just continue without seting the dimensions
-            }
-        }
+        gameArgs.add("--width");
+        gameArgs.add(Integer.toString(width));
+        gameArgs.add("--height");
+        gameArgs.add(Integer.toString(height));
 
         if (serverAddress != null) {
             if (quickPlayMultiplayerSupported) {
@@ -122,19 +100,5 @@ public final class StandardLauncher extends AbstractLauncher {
         // find and invoke the main method
         MethodHandle method = ReflectionUtils.findMainMethod(mainClassName);
         method.invokeExact(gameArgs.toArray(new String[0]));
-    }
-
-    private static Rectangle getDefaultDeviceBounds() {
-        GraphicsDevice gd = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice();
-        GraphicsConfiguration gc = gd.getDefaultConfiguration();
-
-        Rectangle bounds = gc.getBounds();
-        Insets insets = Toolkit.getDefaultToolkit().getScreenInsets(gc);
-        bounds.x += insets.left;
-        bounds.y += insets.top;
-        bounds.width -= (insets.left + insets.right);
-        bounds.height -= (insets.top + insets.bottom);
-
-        return bounds;
     }
 }

--- a/libraries/launcher/org/prismlauncher/launcher/impl/StandardLauncher.java
+++ b/libraries/launcher/org/prismlauncher/launcher/impl/StandardLauncher.java
@@ -57,6 +57,13 @@ package org.prismlauncher.launcher.impl;
 import org.prismlauncher.utils.Parameters;
 import org.prismlauncher.utils.ReflectionUtils;
 
+import java.awt.Dimension;
+import java.awt.GraphicsConfiguration;
+import java.awt.GraphicsDevice;
+import java.awt.GraphicsEnvironment;
+import java.awt.Insets;
+import java.awt.Rectangle;
+import java.awt.Toolkit;
 import java.lang.invoke.MethodHandle;
 import java.util.Collections;
 import java.util.List;
@@ -82,6 +89,18 @@ public final class StandardLauncher extends AbstractLauncher {
             gameArgs.add(Integer.toString(width));
             gameArgs.add("--height");
             gameArgs.add(Integer.toString(height));
+        } else {
+            try {
+                // Dimension rct = Toolkit.getDefaultToolkit().getScreenSize();
+                Rectangle rct = getDefaultDeviceBounds();
+
+                gameArgs.add("--width");
+                gameArgs.add(Integer.toString(rct.width));
+                gameArgs.add("--height");
+                gameArgs.add(Integer.toString(rct.height));
+            } catch (Exception e) {
+                //  If for some reason the get fails just continue without seting the dimensions
+            }
         }
 
         if (serverAddress != null) {
@@ -103,5 +122,19 @@ public final class StandardLauncher extends AbstractLauncher {
         // find and invoke the main method
         MethodHandle method = ReflectionUtils.findMainMethod(mainClassName);
         method.invokeExact(gameArgs.toArray(new String[0]));
+    }
+
+    private static Rectangle getDefaultDeviceBounds() {
+        GraphicsDevice gd = GraphicsEnvironment.getLocalGraphicsEnvironment().getDefaultScreenDevice();
+        GraphicsConfiguration gc = gd.getDefaultConfiguration();
+
+        Rectangle bounds = gc.getBounds();
+        Insets insets = Toolkit.getDefaultToolkit().getScreenInsets(gc);
+        bounds.x += insets.left;
+        bounds.y += insets.top;
+        bounds.width -= (insets.left + insets.right);
+        bounds.height -= (insets.top + insets.bottom);
+
+        return bounds;
     }
 }


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
fixes #181
closes #292
Works on my machine but I would want to test it against other platforms
This doesn't really start it in maximized mode but just sets the game width and height to the maximum possible value.
~Warning I'm entirely sure that `java.awt` stuff is in the default java installation(I haven't worked with java for a long time)~