### PR TITLE
[macOS] Fix instance update dialog

### DIFF
--- a/launcher/InstanceTask.cpp
+++ b/launcher/InstanceTask.cpp
@@ -2,6 +2,8 @@
 
 #include "ui/dialogs/CustomMessageBox.h"
 
+#include <QPushButton>
+
 InstanceNameChange askForChangingInstanceName(QWidget* parent, const QString& old_name, const QString& new_name)
 {
     auto dialog =
@@ -27,16 +29,15 @@ ShouldUpdate askIfShouldUpdate(QWidget* parent, QString original_version_name)
             "separate instance, or update the existing one?\n\nNOTE: Make sure you made a backup of your important instance data before "
             "updating, as worlds can be corrupted and some configuration may be lost (due to pack overrides).")
             .arg(original_version_name),
-        QMessageBox::Information, QMessageBox::Ok | QMessageBox::Reset | QMessageBox::Abort);
-    info->setButtonText(QMessageBox::Ok, QObject::tr("Update existing instance"));
-    info->setButtonText(QMessageBox::Abort, QObject::tr("Create new instance"));
-    info->setButtonText(QMessageBox::Reset, QObject::tr("Cancel"));
+        QMessageBox::Information, QMessageBox::Cancel);
+    QAbstractButton* update = info->addButton(QObject::tr("Update existing instance"), QMessageBox::AcceptRole);
+    QAbstractButton* skip = info->addButton(QObject::tr("Create new instance"), QMessageBox::ResetRole);
 
     info->exec();
 
-    if (info->clickedButton() == info->button(QMessageBox::Ok))
+    if (info->clickedButton() == update)
         return ShouldUpdate::Update;
-    if (info->clickedButton() == info->button(QMessageBox::Abort))
+    if (info->clickedButton() == skip)
         return ShouldUpdate::SkipUpdating;
     return ShouldUpdate::Cancel;
 }


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
hopefully fixes #1910(partially)
I hope I fixed the button texts by replacing the deprecated function (`setButtonText`).
I could not find anywhere why the dialogs look so different between distros(but I suspect it is a mac thing), so I resolved myself by just updating the buttons' text.
This needs to be tested on mac.
 