### PR TITLE
Minor spelling fixes

### DIFF
--- a/launcher/minecraft/mod/tasks/GetModDependenciesTask.cpp
+++ b/launcher/minecraft/mod/tasks/GetModDependenciesTask.cpp
@@ -183,7 +183,7 @@ Task::Ptr GetModDependenciesTask::prepareDependencyTask(const ModPlatform::Depen
     ResourceAPI::DependencySearchArgs args = { dep, m_version, m_loaderType };
     ResourceAPI::DependencySearchCallbacks callbacks;
     callbacks.on_fail = [](QString reason, int) {
-        qCritical() << tr("A network error occurred. Could not load project dependenies:%1").arg(reason);
+        qCritical() << tr("A network error occurred. Could not load project dependencies:%1").arg(reason);
     };
     callbacks.on_succeed = [dep, provider, pDep, level, this](auto& doc, [[maybe_unused]] auto& pack) {
         try {

--- a/launcher/ui/pages/instance/ModFolderPage.cpp
+++ b/launcher/ui/pages/instance/ModFolderPage.cpp
@@ -242,7 +242,7 @@ void ModFolderPage::updateMods(bool includeDeps)
     if (m_instance != nullptr && m_instance->isRunning()) {
         auto response =
             CustomMessageBox::selectable(this, tr("Confirm Update"),
-                                         tr("If you update mods while the game is running may cause mod duplication and game crashes.\n"
+                                         tr("Updating mods while the game is running may cause mod duplication and game crashes.\n"
                                             "The old files may not be deleted as they are in use.\n"
                                             "Are you sure you want to do this?"),
                                          QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No, QMessageBox::No)

--- a/launcher/ui/pages/modplatform/ResourceModel.cpp
+++ b/launcher/ui/pages/modplatform/ResourceModel.cpp
@@ -238,7 +238,7 @@ void ResourceModel::loadEntry(QModelIndex& entry)
             callbacks.on_abort = [this] {
                 if (!s_running_models.constFind(this).value())
                     return;
-                qCritical() << tr("The request was abborted for an unknown reason");
+                qCritical() << tr("The request was aborted for an unknown reason");
             };
 
         if (auto job = m_api->getProjectInfo(std::move(args), std::move(callbacks)); job)


### PR DESCRIPTION
Just some minor spelling fixes.
(Also, from this commit onwards, I'll only sign with `lumiscosity` instead of `maple!`, hopefully that doesn't cause issues...)

Signed-off-by: lumiscosity <averyrudelphe@gmail.com>