### PR TITLE
Enhancement: Game Log "wrap lines" setting state saved globally

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -601,6 +601,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         m_settings->registerSetting("AutoCloseConsole", false);
         m_settings->registerSetting("ShowConsoleOnError", true);
         m_settings->registerSetting("LogPrePostOutput", true);
+        m_settings->registerSetting("LineWrap", true);
 
         // Window Size
         m_settings->registerSetting({ "LaunchMaximized", "MCWindowMaximize" }, false);

--- a/launcher/launch/LogModel.cpp
+++ b/launcher/launch/LogModel.cpp
@@ -140,12 +140,12 @@ void LogModel::setOverflowMessage(const QString& overflowMessage)
 
 void LogModel::setLineWrap(bool state)
 {
-    if (m_lineWrap != state) {
-        m_lineWrap = state;
+    if (APPLICATION->settings()->get("LineWrap") != state) {
+        APPLICATION->settings()->set("LineWrap",state);
     }
 }
 
-bool LogModel::wrapLines() const
+bool LogModel::wrapLines()
 {
-    return m_lineWrap;
+    return APPLICATION->settings()->get("LineWrap");
 }

--- a/launcher/launch/LogModel.h
+++ b/launcher/launch/LogModel.h
@@ -26,7 +26,7 @@ class LogModel : public QAbstractListModel {
     void setOverflowMessage(const QString& overflowMessage);
 
     void setLineWrap(bool state);
-    bool wrapLines() const;
+    bool wrapLines();
 
     enum Roles { LevelRole = Qt::UserRole };
 
@@ -46,7 +46,6 @@ class LogModel : public QAbstractListModel {
     bool m_stopOnOverflow = false;
     QString m_overflowMessage = "OVERFLOW";
     bool m_suspended = false;
-    bool m_lineWrap = true;
 
    private:
     Q_DISABLE_COPY(LogModel)


### PR DESCRIPTION
This changes the functionality of the "Wrap Lines" checkbox setting in the Minecraft Log ui into a globally saved setting.

This addresses #484 , so users do not need to repeatedly check the box with their preference at every launch. Which can get very annoying when troubleshooting.


Note: I only have a beginners understanding of cpp, and was unable to have the project itself build with the time I had available, it all seems correct to me, though I've possibly missed some beginner level issue.

6 lines changed in 3 files

Signed-off-by: Traben <ben.trabant@gmail.com>