### PR TITLE
[Linux/MacOS] Replace nix-filter with lib.fileset

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -91,21 +91,6 @@
         "type": "github"
       }
     },
-    "nix-filter": {
-      "locked": {
-        "lastModified": 1705332318,
-        "narHash": "sha256-kcw1yFeJe9N4PjQji9ZeX47jg0p9A0DuU4djKvg1a7I=",
-        "owner": "numtide",
-        "repo": "nix-filter",
-        "rev": "3449dc925982ad46246cfc36469baf66e1b64f17",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "nix-filter",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1705697961,
@@ -155,7 +140,6 @@
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
         "libnbtplusplus": "libnbtplusplus",
-        "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs",
         "pre-commit-hooks": "pre-commit-hooks"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,6 @@
       url = "github:hercules-ci/flake-parts";
       inputs.nixpkgs-lib.follows = "nixpkgs";
     };
-    nix-filter.url = "github:numtide/nix-filter";
     pre-commit-hooks = {
       url = "github:cachix/pre-commit-hooks.nix";
       inputs = {

--- a/nix/distribution.nix
+++ b/nix/distribution.nix
@@ -26,24 +26,8 @@
     overlays.default = final: prev: let
       version = builtins.substring 0 8 self.lastModifiedDate or "dirty";
 
-      filteredSelf = inputs.nix-filter.lib.filter {
-        root = ../.;
-        include = [
-          "buildconfig"
-          "cmake"
-          "launcher"
-          "libraries"
-          "program_info"
-          "tests"
-          ../COPYING.md
-          ../CMakeLists.txt
-        ];
-      };
-
       # common args for prismlauncher evaluations
       unwrappedArgs = {
-        self = filteredSelf;
-
         inherit (inputs) libnbtplusplus;
         inherit ((final.darwin or prev.darwin).apple_sdk.frameworks) Cocoa;
         inherit version;

--- a/nix/pkg/default.nix
+++ b/nix/pkg/default.nix
@@ -16,7 +16,6 @@
   gamemode,
   msaClientID ? null,
   gamemodeSupport ? stdenv.isLinux,
-  self,
   version,
   libnbtplusplus,
 }:
@@ -25,7 +24,19 @@ assert lib.assertMsg (stdenv.isLinux || !gamemodeSupport) "gamemodeSupport is on
     pname = "prismlauncher-unwrapped";
     inherit version;
 
-    src = lib.cleanSource self;
+    src = lib.fileset.toSource {
+      root = ../../.;
+      fileset = lib.fileset.unions (map (fileName: ../../${fileName}) [
+        "buildconfig"
+        "cmake"
+        "launcher"
+        "libraries"
+        "program_info"
+        "tests"
+        "COPYING.md"
+        "CMakeLists.txt"
+      ]);
+    };
 
     nativeBuildInputs = [extra-cmake-modules cmake jdk17 ninja canonicalize-jars-hook];
     buildInputs =


### PR DESCRIPTION
with our own use of `map`, this is basically a drop-in replacement for
nix-filter, but already in nixpkgs!

Signed-off-by: seth <getchoo@tuta.io>

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
