### PR TITLE
Access Home folder and Removable drives for Flatpak

### DIFF
--- a/flatpak/org.prismlauncher.PrismLauncher.yml
+++ b/flatpak/org.prismlauncher.PrismLauncher.yml
@@ -14,6 +14,11 @@ finish-args:
   - --device=all
   - --share=network
   - --socket=pulseaudio
+    # Home folder
+  - --filesystem=home
+    # Removable drives
+  - --filesystem=/mnt
+  - --filesystem=/media
     # for Discord RPC mods
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
     # Mod drag&drop


### PR DESCRIPTION
Attempting to add proper support for the user's home directory and connected removable storage.
Currently, the Flatpak version of Prism Launcher does not recognize the user's home directory correctly.
Furthermore, it cannot recognize removable devices.
On Arch, This problem renders the built-in file manager rather unhelpful, as it cannot view these locations, nor can it read nor write to them.
On Debian 12, I receive a message that states that the location was granted temporarily, and might (and does) break when Prism is restarted.
This lack of proper recognition of these locations is rather inconvenient for customizing the instance path, among other use cases.
This is, by default, intentional behavior for a flatpak, I believe as a safety measure to enforce the sandboxing system.  In flatpaks, these locations need to be manually enabled.
This fork is intended to enable these filesystems for the user such that the built-in file manager can connect to them.
The end goal of this, for me, is to be able to load a Minecraft instance (as created by Prism on another computer) from a removable device, and have that configuration be reliably accessible by the client after configuring the link.
**This initial post requires testing.**