### PR TITLE
[Linux/MacOS] Improve usability of flake with stable Nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,14 +1,4 @@
-(
-  import
-  (
-    let
-      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
-    in
-      fetchTarball {
-        url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
-        sha256 = lock.nodes.flake-compat.locked.narHash;
-      }
-  )
-  {src = ./.;}
-)
-.defaultNix
+{system ? builtins.currentSystem, ...}: let
+  flake = import ./nix/compat.nix;
+in
+  assert (flake.packages ? "${system}") || builtins.throw "${system} not supported! Please use the overlay"; flake.packages.${system}

--- a/nix/README.md
+++ b/nix/README.md
@@ -189,6 +189,9 @@ The wrapped packages (`prismlauncher` and `prismlauncher-qt5`) offer some build 
 The following parameters can be overridden:
 
 - `msaClientID` (default: `null`, requires full rebuild!) Client ID used for Microsoft Authentication
-- `gamemodeSupport` (default: `true`) Turn on/off support for [Feral GameMode](https://github.com/FeralInteractive/gamemode)
+- `gamemodeSupport` (default: `true`, requires full rebuild!) Turn on/off support for [Feral GameMode](https://github.com/FeralInteractive/gamemode). Only available for Linux
+- `withWaylandGLFW` (default: `false`) Turn on/off unstable, native GLFW patched to run Minecraft on Wayland. Only available on Linux, see [this](pkg/wrapper.nix#L30) comment for more.
+- `textToSpeechSupport` (default: `stdenv.isLinux`) Turn on/off support for narrator. Only has an effect on Linux
+- `controllerSupport` (default: `stdenv.isLinux`) Turn on/off support for controllers; useful for mods. Only has an effect on Linux
 - `jdks` (default: `[ jdk17 jdk8 ]`) Java runtimes added to `PRISMLAUNCHER_JAVA_PATHS` variable
-- `additionalLibs` (default: `[ ]`) Additional libraries that will be added to `LD_LIBRARY_PATH`
+- `additionalLibs` (default: `[ ]`) Additional libraries that will be added to `LD_LIBRARY_PATH`. Only has an effect on Linux

--- a/nix/README.md
+++ b/nix/README.md
@@ -130,21 +130,34 @@ Example (NixOS):
 }
 ```
 
-### Using the overlay (`fetchTarball`)
+### Using the overlay (stable Nix)
 
-We use flake-compat to allow using this Flake on a system that doesn't use flakes.
+We offer standard Nix expressions and a channel to allow using this flake on a system that doesn't use flakes.
+
+To add the channel:
+
+```shell
+nix-channel --add https://github.com/PrismLauncher/PrismLauncher/archive/develop.tar.gz prismlauncher
+
+nix-channel --update prismlauncher
+```
 
 Example:
 
 ```nix
-{pkgs, ...}: {
-  nixpkgs.overlays = [(import (builtins.fetchTarball "https://github.com/PrismLauncher/PrismLauncher/archive/develop.tar.gz" + "/overlays.nix"))];
+{pkgs, ...}: let
+  # with channels
+  prismOverlay = import <prismlauncher/overlay.nix>;
+  # with fetchTarball
+  prismOverlay = import (builtins.fetchTarball "https://github.com/PrismLauncher/PrismLauncher/archive/develop.tar.gz" + "/overlay.nix");
+in {
+  nixpkgs.overlays = [prismOverlay];
 
   environment.systemPackages = [pkgs.prismlauncher];
 }
 ```
 
-### Installing the package directly (`fetchTarball`)
+### Installing the package directly (stable Nix)
 
 Alternatively, if you don't want to use an overlay, you can install Prism Launcher directly by installing the `prismlauncher` package.
 This way the installed package is fully reproducible.
@@ -152,8 +165,11 @@ This way the installed package is fully reproducible.
 Example:
 
 ```nix
-{
-  environment.systemPackages = [(import (builtins.fetchTarball "https://github.com/PrismLauncher/PrismLauncher/archive/develop.tar.gz") {}).prismlauncher];
+let
+  prismlauncher = import <prismlauncher> {};
+  prismlauncher = import (builtins.fetchTarball "https://github.com/PrismLauncher/PrismLauncher/archive/develop.tar.gz") {};
+in {
+  environment.systemPackages = [prismlauncher.prismlauncher];
 }
 ```
 
@@ -164,10 +180,6 @@ You can add this repository as a channel and install its packages that way.
 Example:
 
 ```shell
-nix-channel --add https://github.com/PrismLauncher/PrismLauncher/archive/develop.tar.gz prismlauncher
-
-nix-channel --update prismlauncher
-
 nix-env -iA prismlauncher.prismlauncher
 ```
 

--- a/nix/README.md
+++ b/nix/README.md
@@ -15,7 +15,6 @@ to temporarily enable it when using `nix` commands.
 Example (NixOS):
 
 ```nix
-{...}:
 {
   nix.settings = {
     trusted-substituters = [
@@ -118,7 +117,6 @@ If you want to avoid rebuilds you may add the garnix cache to your substitutors.
 Example (NixOS):
 
 ```nix
-{...}:
 {
   nix.settings = {
     trusted-substituters = [
@@ -140,7 +138,7 @@ Example:
 
 ```nix
 {pkgs, ...}: {
-  nixpkgs.overlays = [(import (builtins.fetchTarball "https://github.com/PrismLauncher/PrismLauncher/archive/develop.tar.gz")).overlays.default];
+  nixpkgs.overlays = [(import (builtins.fetchTarball "https://github.com/PrismLauncher/PrismLauncher/archive/develop.tar.gz" + "/overlays.nix"))];
 
   environment.systemPackages = [pkgs.prismlauncher];
 }
@@ -154,8 +152,8 @@ This way the installed package is fully reproducible.
 Example:
 
 ```nix
-{pkgs, ...}: {
-  environment.systemPackages = [(import (builtins.fetchTarball "https://github.com/PrismLauncher/PrismLauncher/archive/develop.tar.gz")).packages.${pkgs.system}.prismlauncher];
+{
+  environment.systemPackages = [(import (builtins.fetchTarball "https://github.com/PrismLauncher/PrismLauncher/archive/develop.tar.gz") {}).prismlauncher];
 }
 ```
 

--- a/nix/compat.nix
+++ b/nix/compat.nix
@@ -1,0 +1,14 @@
+(
+  import
+  (
+    let
+      lock = builtins.fromJSON (builtins.readFile ../flake.lock);
+    in
+      fetchTarball {
+        url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+        sha256 = lock.nodes.flake-compat.locked.narHash;
+      }
+  )
+  {src = ../.;}
+)
+.defaultNix

--- a/nix/distribution.nix
+++ b/nix/distribution.nix
@@ -18,32 +18,29 @@
         prismlauncher-unwrapped
         prismlauncher
         ;
+
       default = ourPackages.prismlauncher;
     };
   };
 
-  flake = {
-    overlays.default = final: prev: let
-      version = builtins.substring 0 8 self.lastModifiedDate or "dirty";
+  flake.overlays.default = final: prev: let
+    # common args for prismlauncher evaluations
+    unwrappedArgs = {
+      version = builtins.substring 0 7 self.rev or "dirty";
+      inherit (inputs) libnbtplusplus;
+      inherit ((final.darwin or prev.darwin).apple_sdk.frameworks) Cocoa;
+    };
+  in {
+    prismlauncher-qt5-unwrapped = prev.libsForQt5.callPackage ./pkg unwrappedArgs;
 
-      # common args for prismlauncher evaluations
-      unwrappedArgs = {
-        inherit (inputs) libnbtplusplus;
-        inherit ((final.darwin or prev.darwin).apple_sdk.frameworks) Cocoa;
-        inherit version;
-      };
-    in {
-      prismlauncher-qt5-unwrapped = prev.libsForQt5.callPackage ./pkg unwrappedArgs;
+    prismlauncher-qt5 = prev.libsForQt5.callPackage ./pkg/wrapper.nix {
+      prismlauncher-unwrapped = final.prismlauncher-qt5-unwrapped;
+    };
 
-      prismlauncher-qt5 = prev.libsForQt5.callPackage ./pkg/wrapper.nix {
-        prismlauncher-unwrapped = final.prismlauncher-qt5-unwrapped;
-      };
+    prismlauncher-unwrapped = prev.qt6Packages.callPackage ./pkg unwrappedArgs;
 
-      prismlauncher-unwrapped = prev.qt6Packages.callPackage ./pkg unwrappedArgs;
-
-      prismlauncher = prev.qt6Packages.callPackage ./pkg/wrapper.nix {
-        inherit (final) prismlauncher-unwrapped;
-      };
+    prismlauncher = prev.qt6Packages.callPackage ./pkg/wrapper.nix {
+      inherit (final) prismlauncher-unwrapped;
     };
   };
 }

--- a/nix/distribution.nix
+++ b/nix/distribution.nix
@@ -3,24 +3,11 @@
   self,
   ...
 }: {
-  perSystem = {
-    lib,
-    pkgs,
-    ...
-  }: {
+  perSystem = {pkgs, ...}: {
     packages = let
-      ourPackages = lib.fix (final: self.overlays.default final pkgs);
-    in {
-      inherit
-        (ourPackages)
-        prismlauncher-qt5-unwrapped
-        prismlauncher-qt5
-        prismlauncher-unwrapped
-        prismlauncher
-        ;
-
-      default = ourPackages.prismlauncher;
-    };
+      ourPackages = self.overlays.default (pkgs // ourPackages) pkgs;
+    in
+      ourPackages // {default = ourPackages.prismlauncher;};
   };
 
   flake.overlays.default = final: prev: let
@@ -28,7 +15,7 @@
     unwrappedArgs = {
       version = builtins.substring 0 7 self.rev or "dirty";
       inherit (inputs) libnbtplusplus;
-      inherit ((final.darwin or prev.darwin).apple_sdk.frameworks) Cocoa;
+      inherit (final.darwin.apple_sdk.frameworks) Cocoa;
     };
   in {
     prismlauncher-qt5-unwrapped = prev.libsForQt5.callPackage ./pkg unwrappedArgs;

--- a/nix/pkg/default.nix
+++ b/nix/pkg/default.nix
@@ -20,7 +20,7 @@
   libnbtplusplus,
 }:
 assert lib.assertMsg (stdenv.isLinux || !gamemodeSupport) "gamemodeSupport is only available on Linux";
-  stdenv.mkDerivation rec {
+  stdenv.mkDerivation {
     pname = "prismlauncher-unwrapped";
     inherit version;
 
@@ -78,8 +78,7 @@ assert lib.assertMsg (stdenv.isLinux || !gamemodeSupport) "gamemodeSupport is on
         their associated options with a simple interface.
       '';
       platforms = with platforms; linux ++ darwin;
-      changelog = "https://github.com/PrismLauncher/PrismLauncher/releases/tag/${version}";
       license = licenses.gpl3Only;
-      maintainers = with maintainers; [minion3665 Scrumplex getchoo];
+      maintainers = with maintainers; [Scrumplex getchoo];
     };
   }

--- a/overlay.nix
+++ b/overlay.nix
@@ -1,0 +1,1 @@
+(import ./nix/compat.nix).overlays.default


### PR DESCRIPTION
this improves the consumptiom experience of the flake with the stable `nix-` commands. while still using flake-compat in the background, `system` is taken care of and `overlay.nix` is provided as a standard way to use the overlay with `fetchTarball`/a channel. the docs have also been updated to mention channels more, as they should usually be used over `fetchTarball`

...now that i say that maybe we should add `niv` instructions one day 🤔

dependent on #2061
