### PR TITLE
Revert "Use `minecraft` instead of `.minecraft` for better accessibility"

### DIFF
--- a/launcher/InstanceCopyTask.cpp
+++ b/launcher/InstanceCopyTask.cpp
@@ -43,10 +43,10 @@ void InstanceCopyTask::executeTask()
         QFileInfo dotMCDir(FS::PathCombine(m_stagingPath, ".minecraft"));
 
         QString staging_mc_dir;
-        if (dotMCDir.exists() && !mcDir.exists())
-            staging_mc_dir = dotMCDir.filePath();
-        else
+        if (mcDir.exists() && !dotMCDir.exists())
             staging_mc_dir = mcDir.filePath();
+        else
+            staging_mc_dir = dotMCDir.filePath();
 
         FS::copy savesCopy(FS::PathCombine(m_origInstance->gameRoot(), "saves"), FS::PathCombine(staging_mc_dir, "saves"));
         savesCopy.followSymlinks(true);

--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -164,8 +164,8 @@ void InstanceImportTask::processZipPack()
     } else if (technicFound) {
         // process as Technic pack
         qDebug() << "Technic:" << technicFound;
-        extractDir.mkpath("minecraft");
-        extractDir.cd("minecraft");
+        extractDir.mkpath(".minecraft");
+        extractDir.cd(".minecraft");
         m_modpackType = ModpackType::Technic;
     } else {
         QStringList paths_to_ignore{ "overrides/" };

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -292,10 +292,10 @@ QString MinecraftInstance::gameRoot() const
     QFileInfo mcDir(FS::PathCombine(instanceRoot(), "minecraft"));
     QFileInfo dotMCDir(FS::PathCombine(instanceRoot(), ".minecraft"));
 
-    if (dotMCDir.exists() && !mcDir.exists())
-        return dotMCDir.filePath();
-    else
+    if (mcDir.exists() && !dotMCDir.exists())
         return mcDir.filePath();
+    else
+        return dotMCDir.filePath();
 }
 
 QString MinecraftInstance::binRoot() const

--- a/launcher/modplatform/import_ftb/PackInstallTask.cpp
+++ b/launcher/modplatform/import_ftb/PackInstallTask.cpp
@@ -37,7 +37,7 @@ void PackInstallTask::executeTask()
     progress(1, 2);
 
     m_copyFuture = QtConcurrent::run(QThreadPool::globalInstance(), [this] {
-        FS::copy folderCopy(m_pack.path, FS::PathCombine(m_stagingPath, "minecraft"));
+        FS::copy folderCopy(m_pack.path, FS::PathCombine(m_stagingPath, ".minecraft"));
         folderCopy.followSymlinks(true);
         return folderCopy();
     });

--- a/launcher/modplatform/legacy_ftb/PackInstallTask.cpp
+++ b/launcher/modplatform/legacy_ftb/PackInstallTask.cpp
@@ -137,7 +137,7 @@ void PackInstallTask::install()
     QDir unzipMcDir(m_stagingPath + "/unzip/minecraft");
     if (unzipMcDir.exists()) {
         // ok, found minecraft dir, move contents to instance dir
-        if (!QDir().rename(m_stagingPath + "/unzip/minecraft", m_stagingPath + "/minecraft")) {
+        if (!QDir().rename(m_stagingPath + "/unzip/minecraft", m_stagingPath + "/.minecraft")) {
             emitFailed(tr("Failed to move unzipped Minecraft!"));
             return;
         }
@@ -155,7 +155,7 @@ void PackInstallTask::install()
     bool fallback = true;
 
     // handle different versions
-    QFile packJson(m_stagingPath + "/minecraft/pack.json");
+    QFile packJson(m_stagingPath + "/.minecraft/pack.json");
     QDir jarmodDir = QDir(m_stagingPath + "/unzip/instMods");
     if (packJson.exists()) {
         packJson.open(QIODevice::ReadOnly | QIODevice::Text);

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
@@ -173,7 +173,7 @@ bool ModrinthCreationTask::createInstance()
     FS::ensureFilePathExists(new_index_place);
     QFile::rename(index_path, new_index_place);
 
-    auto mcPath = FS::PathCombine(m_stagingPath, "minecraft");
+    auto mcPath = FS::PathCombine(m_stagingPath, ".minecraft");
 
     auto override_path = FS::PathCombine(m_stagingPath, "overrides");
     if (QFile::exists(override_path)) {
@@ -234,7 +234,7 @@ bool ModrinthCreationTask::createInstance()
 
     m_files_job.reset(new NetJob(tr("Mod Download Modrinth"), APPLICATION->network()));
 
-    auto root_modpack_path = FS::PathCombine(m_stagingPath, "minecraft");
+    auto root_modpack_path = FS::PathCombine(m_stagingPath, ".minecraft");
     auto root_modpack_url = QUrl::fromLocalFile(root_modpack_path);
 
     for (auto file : m_files) {

--- a/launcher/modplatform/technic/SingleZipPackInstallTask.cpp
+++ b/launcher/modplatform/technic/SingleZipPackInstallTask.cpp
@@ -62,7 +62,7 @@ void Technic::SingleZipPackInstallTask::downloadSucceeded()
     m_abortable = false;
 
     setStatus(tr("Extracting modpack"));
-    QDir extractDir(FS::PathCombine(m_stagingPath, "minecraft"));
+    QDir extractDir(FS::PathCombine(m_stagingPath, ".minecraft"));
     qDebug() << "Attempting to create instance from" << m_archivePath;
 
     // open the zip and find relevant files in it

--- a/launcher/modplatform/technic/SolderPackInstallTask.cpp
+++ b/launcher/modplatform/technic/SolderPackInstallTask.cpp
@@ -140,7 +140,7 @@ void Technic::SolderPackInstallTask::downloadSucceeded()
     m_filesNetJob.reset();
     m_extractFuture = QtConcurrent::run([this]() {
         int i = 0;
-        QString extractDir = FS::PathCombine(m_stagingPath, "minecraft");
+        QString extractDir = FS::PathCombine(m_stagingPath, ".minecraft");
         FS::ensureFolderPathExists(extractDir);
 
         while (m_modCount > i) {

--- a/launcher/modplatform/technic/TechnicPackProcessor.cpp
+++ b/launcher/modplatform/technic/TechnicPackProcessor.cpp
@@ -33,7 +33,7 @@ void Technic::TechnicPackProcessor::run(SettingsObjectPtr globalSettings,
                                         const QString& minecraftVersion,
                                         [[maybe_unused]] const bool isSolder)
 {
-    QString minecraftPath = FS::PathCombine(stagingPath, "minecraft");
+    QString minecraftPath = FS::PathCombine(stagingPath, ".minecraft");
     QString configPath = FS::PathCombine(stagingPath, "instance.cfg");
     auto instanceSettings = std::make_shared<INISettingsObject>(configPath);
     MinecraftInstance instance(globalSettings, instanceSettings, stagingPath);


### PR DESCRIPTION
Reverts PrismLauncher/PrismLauncher#2050