### PR TITLE
Improve Minecraft log performance

### DIFF
--- a/launcher/ui/widgets/LogView.cpp
+++ b/launcher/ui/widgets/LogView.cpp
@@ -36,6 +36,7 @@
 #include "LogView.h"
 #include <QScrollBar>
 #include <QTextBlock>
+#include <QTextDocumentFragment>
 
 LogView::LogView(QWidget* parent) : QPlainTextEdit(parent)
 {
@@ -117,6 +118,9 @@ void LogView::rowsAboutToBeInserted(const QModelIndex& parent, int first, int la
 
 void LogView::rowsInserted(const QModelIndex& parent, int first, int last)
 {
+    QTextDocument document;
+    QTextCursor cursor(&document);
+
     for (int i = first; i <= last; i++) {
         auto idx = m_model->index(i, 0, parent);
         auto text = m_model->data(idx, Qt::DisplayRole).toString();
@@ -133,11 +137,16 @@ void LogView::rowsInserted(const QModelIndex& parent, int first, int last)
         if (bg.isValid()) {
             format.setBackground(bg.value<QColor>());
         }
-        auto workCursor = textCursor();
-        workCursor.movePosition(QTextCursor::End);
-        workCursor.insertText(text, format);
-        workCursor.insertBlock();
+        cursor.movePosition(QTextCursor::End);
+        cursor.insertText(text, format);
+        cursor.insertBlock();
     }
+
+    QTextDocumentFragment fragment(&document);
+    QTextCursor workCursor = textCursor();
+    workCursor.movePosition(QTextCursor::End);
+    workCursor.insertFragment(fragment);
+
     if (m_scroll && !m_scrolling) {
         m_scrolling = true;
         QMetaObject::invokeMethod(this, "scrollToBottom", Qt::QueuedConnection);


### PR DESCRIPTION
fix #463 (at least make the opening time much more bearable)

I also wanted to limit the refresh rate of the page to stop it from freezing when doing e.g. `while true; do echo test; done`, however that seemed difficult to get right. I wonder how Konsole for example stops this from happening though