### PR TITLE
Reduced temporary instance folder name

### DIFF
--- a/launcher/InstanceList.cpp
+++ b/launcher/InstanceList.cpp
@@ -38,6 +38,7 @@
 #include <QDir>
 #include <QDirIterator>
 #include <QFile>
+#include <QFileInfo>
 #include <QFileSystemWatcher>
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -933,8 +934,12 @@ Task* InstanceList::wrapInstanceTask(InstanceTask* task)
 
 QString InstanceList::getStagedInstancePath()
 {
-    QString key = QUuid::createUuid().toString(QUuid::WithoutBraces);
     QString tempDir = ".LAUNCHER_TEMP/";
+    auto tempPath = FS::PathCombine(m_instDir, tempDir);
+    if (QFileInfo::exists(tempPath)) {
+        FS::deletePath(tempPath);  // clean the path to prevent any collisions
+    }
+    QString key = QUuid::createUuid().toString(QUuid::WithoutBraces).left(6);  // reduce the size from 36 to 6
     QString relPath = FS::PathCombine(tempDir, key);
     QDir rootPath(m_instDir);
     auto path = FS::PathCombine(m_instDir, relPath);
@@ -942,7 +947,6 @@ QString InstanceList::getStagedInstancePath()
         return QString();
     }
 #ifdef Q_OS_WIN32
-    auto tempPath = FS::PathCombine(m_instDir, tempDir);
     SetFileAttributesA(tempPath.toStdString().c_str(), FILE_ATTRIBUTE_HIDDEN | FILE_ATTRIBUTE_NOT_CONTENT_INDEXED);
 #endif
     return path;

--- a/program_info/prismlauncher.manifest.in
+++ b/program_info/prismlauncher.manifest.in
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+        <ws2:longPathAware>true</ws2:longPathAware>
+    </windowsSettings>
+  </application>
   <assemblyIdentity name="PrismLauncher.Application.1" type="win32" version="@Launcher_VERSION_NAME4@" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
Related to: https://discord.com/channels/1031648380885147709/1031823065937629267/1210190497793187921

As discussed there it may be that the issues regarding modpack download were because of a too-long file path.
This PR tries to reduce that path with 30 characters.
The mentioned solution to use a temporary folder was disregarded as to move the instance back prism would need to copy the files instead of moving them( due to the fact the paths are on different drives/mount points).

This PR will also clean the temporary directory each time we create a new instance to ensure that there are no path collisions and no artifacts from some failed attempts.
