### PR TITLE
Several fixes for staging instances

### DIFF
--- a/launcher/InstanceList.cpp
+++ b/launcher/InstanceList.cpp
@@ -907,7 +907,11 @@ class InstanceStaging : public Task {
         emitFailed(reason);
     }
 
-    void childAborted() { emitAborted(); }
+    void childAborted()
+    {
+        m_parent->destroyStagingPath(m_stagingPath);
+        emitAborted();
+    }
 
    private:
     InstanceList* m_parent;

--- a/launcher/InstanceList.cpp
+++ b/launcher/InstanceList.cpp
@@ -38,6 +38,7 @@
 #include <QDir>
 #include <QDirIterator>
 #include <QFile>
+#include <QFileInfo>
 #include <QFileSystemWatcher>
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -933,8 +934,12 @@ Task* InstanceList::wrapInstanceTask(InstanceTask* task)
 
 QString InstanceList::getStagedInstancePath()
 {
-    QString key = QUuid::createUuid().toString(QUuid::WithoutBraces);
     QString tempDir = ".LAUNCHER_TEMP/";
+    auto tempPath = FS::PathCombine(m_instDir, tempDir);
+    if (QFileInfo::exists(tempPath)) {
+        FS::deletePath(tempPath);  // clean the path to prevent any collisions
+    }
+    QString key = QUuid::createUuid().toString(QUuid::WithoutBraces).left(6);  // reduce the size from 36 to 6
     QString relPath = FS::PathCombine(tempDir, key);
     QDir rootPath(m_instDir);
     auto path = FS::PathCombine(m_instDir, relPath);
@@ -942,7 +947,6 @@ QString InstanceList::getStagedInstancePath()
         return QString();
     }
 #ifdef Q_OS_WIN32
-    auto tempPath = FS::PathCombine(m_instDir, tempDir);
     SetFileAttributesA(tempPath.toStdString().c_str(), FILE_ATTRIBUTE_HIDDEN | FILE_ATTRIBUTE_NOT_CONTENT_INDEXED);
 #endif
     return path;

--- a/launcher/InstanceList.cpp
+++ b/launcher/InstanceList.cpp
@@ -938,11 +938,15 @@ Task* InstanceList::wrapInstanceTask(InstanceTask* task)
 
 QString InstanceList::getStagedInstancePath()
 {
-    const QString tempRoot = FS::PathCombine(m_instDir, ".LAUNCHER_TEMP");
+    const QString tempRoot = FS::PathCombine(m_instDir, ".tmp");
 
     QString result;
+    int tries = 0;
 
     do {
+        if (++tries > 256)
+            return {};
+
         const QString key = QUuid::createUuid().toString(QUuid::Id128).left(6);
         result = FS::PathCombine(tempRoot, key);
     } while (QFileInfo::exists(result));

--- a/launcher/InstanceList.cpp
+++ b/launcher/InstanceList.cpp
@@ -848,7 +848,8 @@ class InstanceStaging : public Task {
     const unsigned maxBackoff = 16;
 
    public:
-    InstanceStaging(InstanceList* parent, InstanceTask* child, SettingsObjectPtr settings) : m_parent(parent), backoff(minBackoff, maxBackoff)
+    InstanceStaging(InstanceList* parent, InstanceTask* child, SettingsObjectPtr settings)
+        : m_parent(parent), backoff(minBackoff, maxBackoff)
     {
         m_stagingPath = parent->getStagedInstancePath();
 
@@ -958,7 +959,7 @@ QString InstanceList::getStagedInstancePath()
     if (!QDir::current().mkpath(result))
         return {};
 #ifdef Q_OS_WIN32
-    SetFileAttributesA(tempPath.toStdString().c_str(), FILE_ATTRIBUTE_HIDDEN | FILE_ATTRIBUTE_NOT_CONTENT_INDEXED);
+    SetFileAttributesA(tempRoot.toStdString().c_str(), FILE_ATTRIBUTE_HIDDEN | FILE_ATTRIBUTE_NOT_CONTENT_INDEXED);
 #endif
     return result;
 }

--- a/launcher/InstanceList.cpp
+++ b/launcher/InstanceList.cpp
@@ -848,11 +848,15 @@ class InstanceStaging : public Task {
     const unsigned maxBackoff = 16;
 
    public:
-    InstanceStaging(InstanceList* parent, InstanceTask* child) : m_parent(parent), backoff(minBackoff, maxBackoff)
+    InstanceStaging(InstanceList* parent, InstanceTask* child, SettingsObjectPtr settings) : m_parent(parent), backoff(minBackoff, maxBackoff)
     {
         m_stagingPath = parent->getStagedInstancePath();
 
         m_child.reset(child);
+
+        m_child->setStagingPath(m_stagingPath);
+        m_child->setParentSettings(std::move(settings));
+
         connect(child, &Task::succeeded, this, &InstanceStaging::childSucceeded);
         connect(child, &Task::failed, this, &InstanceStaging::childFailed);
         connect(child, &Task::aborted, this, &InstanceStaging::childAborted);
@@ -933,7 +937,7 @@ class InstanceStaging : public Task {
 
 Task* InstanceList::wrapInstanceTask(InstanceTask* task)
 {
-    return new InstanceStaging(this, task);
+    return new InstanceStaging(this, task, m_globalSettings);
 }
 
 QString InstanceList::getStagedInstancePath()

--- a/program_info/prismlauncher.manifest.in
+++ b/program_info/prismlauncher.manifest.in
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings xmlns:ws2="http://schemas.microsoft.com/SMI/2016/WindowsSettings">
+        <ws2:longPathAware>true</ws2:longPathAware>
+    </windowsSettings>
+  </application>
   <assemblyIdentity name="PrismLauncher.Application.1" type="win32" version="@Launcher_VERSION_NAME4@" />
   <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>


### PR DESCRIPTION
- Fixes #2108. This was caused by a limitation in Windows, there's not much we can do apart from try to pick a shorter filename.
- Displays an error if the staging folder cannot be made
- Cleans up staging folder if import is aborted