### PR TITLE
Add totalTimePlayed for FTBApp import

### DIFF
--- a/launcher/modplatform/import_ftb/PackHelpers.cpp
+++ b/launcher/modplatform/import_ftb/PackHelpers.cpp
@@ -43,6 +43,7 @@ Modpack parseDirectory(QString path)
         modpack.version = Json::requireString(root, "version", "version");
         modpack.mcVersion = Json::requireString(root, "mcVersion", "mcVersion");
         modpack.jvmArgs = Json::ensureVariant(root, "jvmArgs", {}, "jvmArgs");
+        modpack.totalPlayTime = Json::requireInteger(root, "totalPlayTime", "totalPlayTime");
     } catch (const Exception& e) {
         qDebug() << "Couldn't load ftb instance json: " << e.cause();
         return {};

--- a/launcher/modplatform/import_ftb/PackHelpers.h
+++ b/launcher/modplatform/import_ftb/PackHelpers.h
@@ -36,6 +36,7 @@ struct Modpack {
     QString name;
     QString version;
     QString mcVersion;
+    int totalPlayTime;
     // not needed for instance creation
     QVariant jvmArgs;
 

--- a/launcher/modplatform/import_ftb/PackInstallTask.cpp
+++ b/launcher/modplatform/import_ftb/PackInstallTask.cpp
@@ -55,6 +55,7 @@ void PackInstallTask::copySettings()
     instanceSettings->suspendSave();
     MinecraftInstance instance(m_globalSettings, instanceSettings, m_stagingPath);
     instance.settings()->set("InstanceType", "OneSix");
+    instance.settings()->set("totalTimePlayed", m_pack.totalPlayTime / 1000);
 
     if (m_pack.jvmArgs.isValid() && !m_pack.jvmArgs.toString().isEmpty()) {
         instance.settings()->set("OverrideJavaArgs", true);


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
Just found after imported instance from FTB App, the totalPalyTime becomes 0.

This patch add `totalPlayTime` after import instance from FTB App. Also tried add `lastLaunchTime`, but seems Prism Launch can't show it because FTB App don't have `LastPlayedTime`, so I give up for `lastLaunchTime`. 
