### PR TITLE
Fix a typo

### DIFF
--- a/launcher/MMCZip.cpp
+++ b/launcher/MMCZip.cpp
@@ -463,7 +463,7 @@ auto ExportToZipTask::exportZip() -> ZipResult
 
         auto absolute = file.absoluteFilePath();
         auto relative = m_dir.relativeFilePath(absolute);
-        setStatus("Compresing: " + relative);
+        setStatus("Compressing: " + relative);
         setProgress(m_progress + 1, m_progressTotal);
         if (m_follow_symlinks) {
             if (file.isSymLink())


### PR DESCRIPTION
This PR only corrects a small typo that I found while exporting my instance as a zip. Thus, I created this small PR directly to not forget about it.