### PR TITLE
Use UTF-8 for ZIP creation

### DIFF
--- a/launcher/MMCZip.cpp
+++ b/launcher/MMCZip.cpp
@@ -119,6 +119,7 @@ bool compressDirFiles(QuaZip* zip, QString dir, QFileInfoList files, bool follow
 bool compressDirFiles(QString fileCompressed, QString dir, QFileInfoList files, bool followSymlinks)
 {
     QuaZip zip(fileCompressed);
+    zip.setUtf8Enabled(true);
     QDir().mkpath(QFileInfo(fileCompressed).absolutePath());
     if (!zip.open(QuaZip::mdCreate)) {
         QFile::remove(fileCompressed);
@@ -141,6 +142,7 @@ bool compressDirFiles(QString fileCompressed, QString dir, QFileInfoList files, 
 bool createModdedJar(QString sourceJarPath, QString targetJarPath, const QList<Mod*>& mods)
 {
     QuaZip zipOut(targetJarPath);
+    zipOut.setUtf8Enabled(true);
     if (!zipOut.open(QuaZip::mdCreate)) {
         QFile::remove(targetJarPath);
         qCritical() << "Failed to open the minecraft.jar for modding";

--- a/launcher/MMCZip.h
+++ b/launcher/MMCZip.h
@@ -163,6 +163,7 @@ class ExportToZipTask : public Task {
         , m_follow_symlinks(followSymlinks)
     {
         setAbortable(true);
+        m_output.setUtf8Enabled(true);
     };
     ExportToZipTask(QString outputPath, QString dir, QFileInfoList files, QString destinationPrefix = "", bool followSymlinks = false)
         : ExportToZipTask(outputPath, QDir(dir), files, destinationPrefix, followSymlinks){};


### PR DESCRIPTION
Fix #2187 
Fix #1497 
Technically does not, this does fix Prism creating invalid packs which can't be imported, but that issue refers to a pack failing to import which isn't technically valid (CF ignores the encoding error).