### PR TITLE
Fix crash on non-latin instance name

### DIFF
--- a/launcher/FileSystem.cpp
+++ b/launcher/FileSystem.cpp
@@ -1585,4 +1585,44 @@ uintmax_t hardLinkCount(const QString& path)
     return count;
 }
 
+#ifdef Q_OS_WIN
+// returns 8.3 file format from long path
+QString shortPathName(const QString& file)
+{
+    auto input = file.toStdWString();
+    std::wstring output;
+    long length = GetShortPathNameW(input.c_str(), NULL, 0);
+    if (length == 0)
+        return {};
+    // NOTE: this resizing might seem weird...
+    // when GetShortPathNameW fails, it returns length including null character
+    // when it succeeds, it returns length excluding null character
+    // See: https://msdn.microsoft.com/en-us/library/windows/desktop/aa364989(v=vs.85).aspx
+    output.resize(length);
+    if (GetShortPathNameW(input.c_str(), (LPWSTR)output.c_str(), length) == 0)
+        return {};
+    output.resize(length - 1);
+    QString ret = QString::fromStdWString(output);
+    return ret;
+}
+
+// if the string survives roundtrip through local 8bit encoding...
+bool fitsInLocal8bit(const QString& string)
+{
+    return string == QString::fromLocal8Bit(string.toLocal8Bit());
+}
+
+QString getPathNameInLocal8bit(const QString& file)
+{
+    if (!fitsInLocal8bit(file)) {
+        auto path = shortPathName(file);
+        if (!path.isEmpty()) {
+            return path;
+        }
+        // in case shortPathName fails just return the path as is
+    }
+    return file;
+}
+#endif
+
 }  // namespace FS

--- a/launcher/FileSystem.h
+++ b/launcher/FileSystem.h
@@ -551,4 +551,8 @@ bool canLink(const QString& src, const QString& dst);
 
 uintmax_t hardLinkCount(const QString& path);
 
+#ifdef Q_OS_WIN
+QString getPathNameInLocal8bit(const QString& file);
+#endif
+
 }  // namespace FS

--- a/launcher/InstanceImportTask.h
+++ b/launcher/InstanceImportTask.h
@@ -47,9 +47,6 @@
 #include <optional>
 
 class QuaZip;
-namespace Flame {
-class FileResolvingTask;
-}
 
 class InstanceImportTask : public InstanceTask {
     Q_OBJECT
@@ -79,7 +76,6 @@ class InstanceImportTask : public InstanceTask {
 
    private: /* data */
     NetJob::Ptr m_filesNetJob;
-    shared_qobject_ptr<Flame::FileResolvingTask> m_modIdResolver;
     QUrl m_sourceUrl;
     QString m_archivePath;
     bool m_downloadRequired = false;

--- a/launcher/java/JavaChecker.cpp
+++ b/launcher/java/JavaChecker.cpp
@@ -55,6 +55,9 @@ void JavaChecker::performCheck()
         qDebug() << "Java checker library could not be found. Please check your installation.";
         return;
     }
+#ifdef Q_OS_WIN
+    checkerJar = FS::getPathNameInLocal8bit(checkerJar);
+#endif
 
     QStringList args;
 

--- a/launcher/minecraft/launch/ExtractNatives.cpp
+++ b/launcher/minecraft/launch/ExtractNatives.cpp
@@ -79,6 +79,7 @@ void ExtractNatives::executeTask()
     auto settings = minecraftInstance->settings();
 
     auto outputPath = minecraftInstance->getNativePath();
+    FS::ensureFolderPathExists(outputPath);
     auto javaVersion = minecraftInstance->getJavaVersion();
     bool jniHackEnabled = javaVersion.major() >= 8;
     for (const auto& source : toExtract) {

--- a/launcher/minecraft/launch/ExtractNatives.h
+++ b/launcher/minecraft/launch/ExtractNatives.h
@@ -16,8 +16,6 @@
 #pragma once
 
 #include <launch/LaunchStep.h>
-#include <memory>
-#include "minecraft/auth/AuthSession.h"
 
 // FIXME: temporary wrapper for existing task.
 class ExtractNatives : public LaunchStep {

--- a/launcher/minecraft/launch/LauncherPartLaunch.cpp
+++ b/launcher/minecraft/launch/LauncherPartLaunch.cpp
@@ -74,15 +74,35 @@ QString shortPathName(const QString& file)
     auto input = file.toStdWString();
     std::wstring output;
     long length = GetShortPathNameW(input.c_str(), NULL, 0);
+    if (length == 0)
+        return {};
     // NOTE: this resizing might seem weird...
     // when GetShortPathNameW fails, it returns length including null character
     // when it succeeds, it returns length excluding null character
     // See: https://msdn.microsoft.com/en-us/library/windows/desktop/aa364989(v=vs.85).aspx
     output.resize(length);
-    GetShortPathNameW(input.c_str(), (LPWSTR)output.c_str(), length);
+    if (GetShortPathNameW(input.c_str(), (LPWSTR)output.c_str(), length) == 0)
+        return {};
     output.resize(length - 1);
     QString ret = QString::fromStdWString(output);
     return ret;
+}
+
+QString getShortPathName(const QString& file)
+{
+    auto path = shortPathName(file);
+    if (!path.isEmpty())
+        return path;
+    // the path can not be getted due to the file/folder not existing
+    // so create the parrent folder
+    // and assume that we can concatenate the short path of the parent folder with the file name
+    // usually the 8 bit characters are in the instance name not in the name of the end files/folders we need
+    FS::ensureFilePathExists(file);
+    QFileInfo a(file);
+    auto partialShortPath = shortPathName(a.path());
+    if (!partialShortPath.isEmpty())
+        return FS::PathCombine(partialShortPath, a.fileName());
+    return file;
 }
 #endif
 
@@ -137,7 +157,7 @@ void LauncherPartLaunch::executeTask()
     auto natPath = minecraftInstance->getNativePath();
 #ifdef Q_OS_WIN
     if (!fitsInLocal8bit(natPath)) {
-        args << "-Djava.library.path=" + shortPathName(natPath);
+        args << "-Djava.library.path=" + getShortPathName(natPath);
     } else {
         args << "-Djava.library.path=" + natPath;
     }
@@ -150,7 +170,7 @@ void LauncherPartLaunch::executeTask()
     QStringList processed;
     for (auto& item : classPath) {
         if (!fitsInLocal8bit(item)) {
-            processed << shortPathName(item);
+            processed << getShortPathName(item);
         } else {
             processed << item;
         }

--- a/launcher/minecraft/launch/LauncherPartLaunch.cpp
+++ b/launcher/minecraft/launch/LauncherPartLaunch.cpp
@@ -88,20 +88,15 @@ QString shortPathName(const QString& file)
     return ret;
 }
 
-QString getShortPathName(const QString& file)
+QString getPathNameInLocal8bit(const QString& file)
 {
-    auto path = shortPathName(file);
-    if (!path.isEmpty())
-        return path;
-    // the path can not be getted due to the file/folder not existing
-    // so create the parrent folder
-    // and assume that we can concatenate the short path of the parent folder with the file name
-    // usually the 8 bit characters are in the instance name not in the name of the end files/folders we need
-    FS::ensureFilePathExists(file);
-    QFileInfo a(file);
-    auto partialShortPath = shortPathName(a.path());
-    if (!partialShortPath.isEmpty())
-        return FS::PathCombine(partialShortPath, a.fileName());
+    if (!fitsInLocal8bit(file)) {
+        auto path = shortPathName(file);
+        if (!path.isEmpty()) {
+            return path;
+        }
+        // in case shortPathName fails just return the path as is
+    }
     return file;
 }
 #endif
@@ -156,24 +151,15 @@ void LauncherPartLaunch::executeTask()
 
     auto natPath = minecraftInstance->getNativePath();
 #ifdef Q_OS_WIN
-    if (!fitsInLocal8bit(natPath)) {
-        args << "-Djava.library.path=" + getShortPathName(natPath);
-    } else {
-        args << "-Djava.library.path=" + natPath;
-    }
-#else
-    args << "-Djava.library.path=" + natPath;
+    natPath = getPathNameInLocal8bit(natPath);
 #endif
+    args << "-Djava.library.path=" + natPath;
 
     args << "-cp";
 #ifdef Q_OS_WIN
     QStringList processed;
     for (auto& item : classPath) {
-        if (!fitsInLocal8bit(item)) {
-            processed << getShortPathName(item);
-        } else {
-            processed << item;
-        }
+        processed << getPathNameInLocal8bit(item);
     }
     args << processed.join(';');
 #else


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
fixes #1659
fixes #131
No, I did not test this, but I'm 100% sure that this doesn't produce a crash if the shortNamePath fails in any way, maybe it just doesn't start the instance.
~~And for safety, I also added a check when the user creates a new instance.~~
I tested it on wine and it works with my patch