### PR TITLE
chore: update to Qt 6.7.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
             qt_ver: 6
             qt_host: windows
             qt_arch: ''
-            qt_version: '6.6.2'
+            qt_version: '6.7.0'
             qt_modules: 'qt5compat qtimageformats'
             qt_tools: ''
 
@@ -88,7 +88,7 @@ jobs:
             qt_ver: 6
             qt_host: windows
             qt_arch: 'win64_msvc2019_arm64'
-            qt_version: '6.6.2'
+            qt_version: '6.7.0'
             qt_modules: 'qt5compat qtimageformats'
             qt_tools: ''
 
@@ -98,7 +98,7 @@ jobs:
             qt_ver: 6
             qt_host: mac
             qt_arch: ''
-            qt_version: '6.6.2'
+            qt_version: '6.7.0'
             qt_modules: 'qt5compat qtimageformats'
             qt_tools: ''
 


### PR DESCRIPTION
this updates the windows and macOS builds to [Qt 6.7](https://www.qt.io/blog/qt-6.7-released).
Between the many things this [improves svg support](https://www.qt.io/blog/qt-svg-not-so-1.2-tiny-any-more), and adds a new windows11 theme. It's far from perfect but way better than windowsvista, and has support for dark mode.
Some screenshots:
Light: 
![Screenshot 2024-04-02 214712](https://github.com/PrismLauncher/PrismLauncher/assets/83089242/570ed9b7-e1a0-43c1-9dbe-2555802684da)

Dark:
![Screenshot 2024-04-02 214439](https://github.com/PrismLauncher/PrismLauncher/assets/83089242/c75f2786-0836-4681-81be-35f7b4f2d8ea)
![Screenshot 2024-04-02 214505](https://github.com/PrismLauncher/PrismLauncher/assets/83089242/b3c9462e-4b2a-4325-88d7-fee2734255f9)

