### PR TITLE
fix: update flatpak manifest for java 21

### DIFF
--- a/flatpak/org.prismlauncher.PrismLauncher.yml
+++ b/flatpak/org.prismlauncher.PrismLauncher.yml
@@ -3,6 +3,7 @@ runtime: org.kde.Platform
 runtime-version: 5.15-23.08
 sdk: org.kde.Sdk
 sdk-extensions:
+  - org.freedesktop.Sdk.Extension.openjdk21
   - org.freedesktop.Sdk.Extension.openjdk17
   - org.freedesktop.Sdk.Extension.openjdk8
 
@@ -50,6 +51,8 @@ modules:
     buildsystem: simple
     build-commands:
       - mkdir -p /app/jdk/
+      - /usr/lib/sdk/openjdk21/install.sh
+      - mv /app/jre /app/jdk/21
       - /usr/lib/sdk/openjdk17/install.sh
       - mv /app/jre /app/jdk/17
       - /usr/lib/sdk/openjdk8/install.sh


### PR DESCRIPTION
backport of https://github.com/flathub/org.prismlauncher.PrismLauncher/pull/54 for our CI builds

