### PR TITLE
Replace invalid characters when extracting ZIP

### DIFF
--- a/launcher/FileSystem.cpp
+++ b/launcher/FileSystem.cpp
@@ -801,15 +801,24 @@ QString NormalizePath(QString path)
     }
 }
 
-QString badFilenameChars = "\"\\/?<>:;*|!+\r\n";
+static const QString BAD_PATH_CHARS = "\"?<>:;*|!+\r\n";
+static const QString BAD_FILENAME_CHARS = BAD_PATH_CHARS + "\\/";
 
 QString RemoveInvalidFilenameChars(QString string, QChar replaceWith)
 {
-    for (int i = 0; i < string.length(); i++) {
-        if (badFilenameChars.contains(string[i])) {
+    for (int i = 0; i < string.length(); i++)
+        if (string.at(i).toLatin1() < ' ' || BAD_FILENAME_CHARS.contains(string.at(i)))
             string[i] = replaceWith;
-        }
-    }
+
+    return string;
+}
+
+QString RemoveInvalidPathChars(QString string, QChar replaceWith)
+{
+    for (int i = 0; i < string.length(); i++)
+        if (string.at(i) < ' ' || BAD_PATH_CHARS.contains(string.at(i)))
+            string[i] = replaceWith;
+
     return string;
 }
 

--- a/launcher/FileSystem.h
+++ b/launcher/FileSystem.h
@@ -342,6 +342,8 @@ QString NormalizePath(QString path);
 
 QString RemoveInvalidFilenameChars(QString string, QChar replaceWith = '-');
 
+QString RemoveInvalidPathChars(QString string, QChar replaceWith = '-');
+
 QString DirNameFromString(QString string, QString inDir = ".");
 
 /// Checks if the a given Path contains "!"

--- a/launcher/MMCZip.cpp
+++ b/launcher/MMCZip.cpp
@@ -286,10 +286,13 @@ std::optional<QStringList> extractSubDir(QuaZip* zip, const QString& subdir, con
 
     do {
         QString file_name = zip->getCurrentFileName();
+#ifdef Q_OS_WIN
+        file_name = FS::RemoveInvalidPathChars(file_name);
+#endif
         if (!file_name.startsWith(subdir))
             continue;
 
-        auto relative_file_name = QDir::fromNativeSeparators(file_name.remove(0, subdir.size()));
+        auto relative_file_name = QDir::fromNativeSeparators(file_name.mid(subdir.size()));
         auto original_name = relative_file_name;
 
         // Fix subdirs/files ending with a / getting transformed into absolute paths


### PR DESCRIPTION
This mimics CurseForge app's behaviour
Fixes #564
(The pack in that issue was actually had bad filename encoding so the pack will have `-` instead of §, unfortunately i don't think there's a way around this)

Maybe Linux also needs characters replacing? Is it possible for a zip filename to contain a null byte?