### PR TITLE
Fix unicode characters being invalid in filenames

### DIFF
--- a/launcher/FileSystem.cpp
+++ b/launcher/FileSystem.cpp
@@ -807,7 +807,7 @@ static const QString BAD_FILENAME_CHARS = BAD_PATH_CHARS + "\\/";
 QString RemoveInvalidFilenameChars(QString string, QChar replaceWith)
 {
     for (int i = 0; i < string.length(); i++)
-        if (string.at(i).toLatin1() < ' ' || BAD_FILENAME_CHARS.contains(string.at(i)))
+        if (string.at(i) < ' ' || BAD_FILENAME_CHARS.contains(string.at(i)))
             string[i] = replaceWith;
 
     return string;


### PR DESCRIPTION
Parent PR: #2275
I was messing around with different methods to get it to build on Qt 5 and left this by mistake.
Edit: this is worse than I thought, it replaces all unicode characters 😆 
