### PR TITLE
Fix crash on invalid CurseForge link on import

### DIFF
--- a/launcher/ui/pages/modplatform/ImportPage.cpp
+++ b/launcher/ui/pages/modplatform/ImportPage.cpp
@@ -123,6 +123,10 @@ void ImportPage::updateState()
             // need to find the download link for the modpack
             // format of url curseforge://install?addonId=IDHERE&fileId=IDHERE
             QUrlQuery query(url);
+            if (query.allQueryItemValues("addonId").isEmpty() || query.allQueryItemValues("fileId").isEmpty()) {
+                qDebug() << "Invalid curseforge link:" << url;
+                return;
+            }
             auto addonId = query.allQueryItemValues("addonId")[0];
             auto fileId = query.allQueryItemValues("fileId")[0];
             auto array = std::make_shared<QByteArray>();


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
fixes #2290