### PR TITLE
Remove old version variants in instance creation

### DIFF
--- a/launcher/ui/pages/modplatform/CustomPage.cpp
+++ b/launcher/ui/pages/modplatform/CustomPage.cpp
@@ -55,7 +55,6 @@ CustomPage::CustomPage(NewInstanceDialog* dialog, QWidget* parent) : QWidget(par
     connect(ui->alphaFilter, &QCheckBox::stateChanged, this, &CustomPage::filterChanged);
     connect(ui->betaFilter, &QCheckBox::stateChanged, this, &CustomPage::filterChanged);
     connect(ui->snapshotFilter, &QCheckBox::stateChanged, this, &CustomPage::filterChanged);
-    connect(ui->oldSnapshotFilter, &QCheckBox::stateChanged, this, &CustomPage::filterChanged);
     connect(ui->releaseFilter, &QCheckBox::stateChanged, this, &CustomPage::filterChanged);
     connect(ui->experimentsFilter, &QCheckBox::stateChanged, this, &CustomPage::filterChanged);
     connect(ui->refreshBtn, &QPushButton::clicked, this, &CustomPage::refresh);
@@ -96,13 +95,11 @@ void CustomPage::filterChanged()
 {
     QStringList out;
     if (ui->alphaFilter->isChecked())
-        out << "(old_alpha)";
+        out << "(alpha)";
     if (ui->betaFilter->isChecked())
-        out << "(old_beta)";
+        out << "(beta)";
     if (ui->snapshotFilter->isChecked())
         out << "(snapshot)";
-    if (ui->oldSnapshotFilter->isChecked())
-        out << "(old_snapshot)";
     if (ui->releaseFilter->isChecked())
         out << "(release)";
     if (ui->experimentsFilter->isChecked())

--- a/launcher/ui/pages/modplatform/CustomPage.ui
+++ b/launcher/ui/pages/modplatform/CustomPage.ui
@@ -94,16 +94,6 @@
             </widget>
            </item>
            <item>
-            <widget class="QCheckBox" name="oldSnapshotFilter">
-             <property name="text">
-              <string>Old Snapshots</string>
-             </property>
-             <property name="checkable">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QCheckBox" name="betaFilter">
              <property name="text">
               <string>Betas</string>
@@ -286,7 +276,6 @@
   <tabstop>tabWidget</tabstop>
   <tabstop>releaseFilter</tabstop>
   <tabstop>snapshotFilter</tabstop>
-  <tabstop>oldSnapshotFilter</tabstop>
   <tabstop>betaFilter</tabstop>
   <tabstop>alphaFilter</tabstop>
   <tabstop>experimentsFilter</tabstop>


### PR DESCRIPTION
This should make things more simple to view and set. The existence of `old_*` is frankly unnecessary. There is no "newer" alpha or beta, and in the case of snapshot, the distinction is insignificant to the end users.

More to the point, the current search regex includes `old_snapshot` when looking up regular snapshots, which makes the thing pointless.
~blocked by: https://github.com/PrismLauncher/meta/pull/43~