### PR TITLE
Fix application close with file dialog

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -225,6 +225,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
 
     // Don't quit on hiding the last window
     this->setQuitOnLastWindowClosed(false);
+    this->setQuitLockEnabled(false);
 
     // Commandline parsing
     QCommandLineParser parser;


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
fixes #2214
This only does the suggestion mentioned here: https://github.com/PrismLauncher/PrismLauncher/issues/2214#issuecomment-2043954310 
as a tldr: Qt6 introduced something that closes the app once the last QEventLoopLocker closes and they expect the applications to add that line to fix it.
This happens when the filedialog open is KFileDialog(aka only on systems that have plasma 6)

