### PR TITLE
Fix modrinth pack update

### DIFF
--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
@@ -20,6 +20,7 @@
 #include "ui/pages/modplatform/OptionalModDialog.h"
 
 #include <QAbstractButton>
+#include <QFileInfo>
 #include <vector>
 
 bool ModrinthCreationTask::abort()
@@ -58,6 +59,7 @@ bool ModrinthCreationTask::updateInstance()
         return false;
 
     auto version_name = inst->getManagedPackVersionName();
+    m_root_path = QFileInfo(inst->gameRoot()).fileName();
     auto version_str = !version_name.isEmpty() ? tr(" (version %1)").arg(version_name) : "";
 
     if (shouldConfirmUpdate()) {
@@ -173,7 +175,7 @@ bool ModrinthCreationTask::createInstance()
     FS::ensureFilePathExists(new_index_place);
     QFile::rename(index_path, new_index_place);
 
-    auto mcPath = FS::PathCombine(m_stagingPath, "minecraft");
+    auto mcPath = FS::PathCombine(m_stagingPath, m_root_path);
 
     auto override_path = FS::PathCombine(m_stagingPath, "overrides");
     if (QFile::exists(override_path)) {
@@ -234,7 +236,7 @@ bool ModrinthCreationTask::createInstance()
 
     m_files_job.reset(new NetJob(tr("Mod Download Modrinth"), APPLICATION->network()));
 
-    auto root_modpack_path = FS::PathCombine(m_stagingPath, "minecraft");
+    auto root_modpack_path = FS::PathCombine(m_stagingPath, m_root_path);
     auto root_modpack_url = QUrl::fromLocalFile(root_modpack_path);
 
     for (auto file : m_files) {

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.h
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.h
@@ -46,4 +46,6 @@ class ModrinthCreationTask final : public InstanceCreationTask {
     NetJob::Ptr m_files_job;
 
     std::optional<InstancePtr> m_instance;
+
+    QString m_root_path = "minecraft";
 };


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
fixes #2299
This was introduced in https://github.com/PrismLauncher/PrismLauncher/commit/f54ac25614b62b0a43d014d8b47f9faee8112d12
Steps to reproduce:
- using 8.2 create an instance of fabulously optimized from modrinth, but not the latest version as we need to update it
- open that instance and create a world
- close instance and prism
- using the latest build update the instance
- try to play it (you get a crash or you will not have the world created previously)

What happens: instead of overwriting the old folder it creates a new one.