### PR TITLE
Rename object name "userInterfaceTab" from "generalTab"

### DIFF
--- a/launcher/ui/pages/global/LauncherPage.ui
+++ b/launcher/ui/pages/global/LauncherPage.ui
@@ -237,7 +237,7 @@
         </widget>
        </item>
        <item>
-        <spacer name="verticalSpacer_2">
+        <spacer name="verticalSpacer_FeaturesTab">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
@@ -251,7 +251,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="generalTab">
+     <widget class="QWidget" name="userInterfaceTab">
       <attribute name="title">
        <string>User Interface</string>
       </attribute>
@@ -374,7 +374,7 @@
         </widget>
        </item>
        <item>
-        <spacer name="generalTabSpacer">
+        <spacer name="verticalSpacer_UserInterfaceTab">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>


### PR DESCRIPTION
The "User Interface" tab was innacurately named "General" which I just went in and fixed.

This also renamed the object for respective vertical spacers.

Signed-off-by: SolidStateDj <solidstatedj@proton.me>

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
