### PR TITLE
Add Gradle Toolchains to java scan list

### DIFF
--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -413,6 +413,8 @@ QList<QString> JavaUtils::FindJavaPaths()
     scanJavaDirs(FS::PathCombine(home, ".jdks"));
     // javas downloaded by sdkman
     scanJavaDirs(FS::PathCombine(home, ".sdkman/candidates/java"));
+    // javas downloaded by gradle (toolchains)
+    scanJavaDirs(FS::PathCombine(home, ".gradle/jdks"));
 
     javas.append(getMinecraftJavaBundle());
     javas = addJavasFromEnv(javas);


### PR DESCRIPTION
more jdk scanning. in my case it's a bit overkill and will show every single version of java. 
but, if the others are on the list, this should be as well.