### PR TITLE
Fix Minecraft Launcher runtime detection on Windows and macOS

### DIFF
--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -446,16 +446,16 @@ QStringList getMinecraftJavaBundle()
 #if defined(Q_OS_OSX)
     processpaths << FS::PathCombine(QDir::homePath(), FS::PathCombine("Library", "Application Support", "minecraft", "runtime"));
 #elif defined(Q_OS_WIN32)
-    QString partialPath = QProcessEnvironment::systemEnvironment().value("LOCALAPPDATA", "");
-    processpaths << FS::PathCombine(partialPath, ".minecraft", "runtime");
+    auto appDataPath = QProcessEnvironment::systemEnvironment().value("AppData", "");
+    processpaths << FS::PathCombine(QFileInfo(appDataPath).absolutePath(), ".minecraft", "runtime");
     executable += "w.exe";
 
     // add the microsoft store version of the launcher to the search. the current path is:
     // C:\Users\USERNAME\AppData\Local\Packages\Microsoft.4297127D64EC6_8wekyb3d8bbwe\LocalCache\Local\runtime
+    auto localAppDataPath = QProcessEnvironment::systemEnvironment().value("LOCALAPPDATA", "");
     auto minecraftMSStorePath =
-        FS::PathCombine(QFileInfo(partialPath).absolutePath(), "Local", "Packages", "Microsoft.4297127D64EC6_8wekyb3d8bbwe");
-    minecraftMSStorePath = FS::PathCombine(minecraftMSStorePath, "LocalCache", "Local", "runtime");
-    processpaths << minecraftMSStorePath;
+        FS::PathCombine(QFileInfo(localAppDataPath).absolutePath(), "Local", "Packages", "Microsoft.4297127D64EC6_8wekyb3d8bbwe");
+    processpaths << FS::PathCombine(minecraftMSStorePath, "LocalCache", "Local", "runtime");
 #else
     processpaths << FS::PathCombine(QDir::homePath(), ".minecraft", "runtime");
 #endif

--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -441,13 +441,13 @@ QString JavaUtils::getJavaCheckPath()
 
 QStringList getMinecraftJavaBundle()
 {
-    QString partialPath;
     QString executable = "java";
     QStringList processpaths;
 #if defined(Q_OS_OSX)
-    partialPath = FS::PathCombine(QDir::homePath(), "Library/Application Support");
+    processpaths << FS::PathCombine(QDir::homePath(), FS::PathCombine("Library", "Application Support", "minecraft", "runtime"));
 #elif defined(Q_OS_WIN32)
-    partialPath = QProcessEnvironment::systemEnvironment().value("LOCALAPPDATA", "");
+    QString partialPath = QProcessEnvironment::systemEnvironment().value("LOCALAPPDATA", "");
+    processpaths << FS::PathCombine(partialPath, ".minecraft", "runtime");
     executable += "w.exe";
 
     // add the microsoft store version of the launcher to the search. the current path is:
@@ -457,10 +457,8 @@ QStringList getMinecraftJavaBundle()
     minecraftMSStorePath = FS::PathCombine(minecraftMSStorePath, "LocalCache", "Local", "runtime");
     processpaths << minecraftMSStorePath;
 #else
-    partialPath = QDir::homePath();
+    processpaths << FS::PathCombine(QDir::homePath(), ".minecraft", "runtime");
 #endif
-    auto minecraftDataPath = FS::PathCombine(partialPath, ".minecraft", "runtime");
-    processpaths << minecraftDataPath;
 
     QStringList javas;
     while (!processpaths.isEmpty()) {

--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -446,9 +446,10 @@ QStringList getMinecraftJavaBundle()
 #if defined(Q_OS_OSX)
     processpaths << FS::PathCombine(QDir::homePath(), FS::PathCombine("Library", "Application Support", "minecraft", "runtime"));
 #elif defined(Q_OS_WIN32)
-    auto appDataPath = QProcessEnvironment::systemEnvironment().value("AppData", "");
-    processpaths << FS::PathCombine(QFileInfo(appDataPath).absolutePath(), ".minecraft", "runtime");
     executable += "w.exe";
+
+    auto appDataPath = QProcessEnvironment::systemEnvironment().value("APPDATA", "");
+    processpaths << FS::PathCombine(QFileInfo(appDataPath).absolutePath(), ".minecraft", "runtime");
 
     // add the microsoft store version of the launcher to the search. the current path is:
     // C:\Users\USERNAME\AppData\Local\Packages\Microsoft.4297127D64EC6_8wekyb3d8bbwe\LocalCache\Local\runtime

--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -455,7 +455,7 @@ QStringList getMinecraftJavaBundle()
     // C:\Users\USERNAME\AppData\Local\Packages\Microsoft.4297127D64EC6_8wekyb3d8bbwe\LocalCache\Local\runtime
     auto localAppDataPath = QProcessEnvironment::systemEnvironment().value("LOCALAPPDATA", "");
     auto minecraftMSStorePath =
-        FS::PathCombine(QFileInfo(localAppDataPath).absolutePath(), "Local", "Packages", "Microsoft.4297127D64EC6_8wekyb3d8bbwe");
+        FS::PathCombine(QFileInfo(localAppDataPath).absolutePath(), "Packages", "Microsoft.4297127D64EC6_8wekyb3d8bbwe");
     processpaths << FS::PathCombine(minecraftMSStorePath, "LocalCache", "Local", "runtime");
 #else
     processpaths << FS::PathCombine(QDir::homePath(), ".minecraft", "runtime");


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
fixes #2332