### PR TITLE
Remove server side decorations FIXME and document why it's needed

### DIFF
--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -231,7 +231,8 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWi
         setInstanceActionsEnabled(false);
 
         // add a close button at the end of the main toolbar when running on gamescope / steam deck
-        // FIXME: detect if we don't have server side decorations instead
+        // this is only needed on gamescope because it defaults to an X11/XWayland session and
+        // does not implement decorations
         if (qgetenv("XDG_CURRENT_DESKTOP") == "gamescope") {
             ui->mainToolBar->addAction(ui->actionCloseWindow);
         }


### PR DESCRIPTION
gamescope defaults to an X11 session but does not implement Server Side Decorations which Qt expects to be available.

Launching gamescope with `--expose-wayland` makes it start a Wayland session, where Qt queries xdg decorations and falls back to Client Side Decorations.

@Scrumplex there is no real solution to this outside of either doing CSD all the time or having this gamescope specific hack