### PR TITLE
Fix CurseForge export caused by UTF-8 issues

### DIFF
--- a/launcher/MMCZip.h
+++ b/launcher/MMCZip.h
@@ -154,7 +154,12 @@ bool collectFileListRecursively(const QString& rootDir, const QString& subDir, Q
 #if defined(LAUNCHER_APPLICATION)
 class ExportToZipTask : public Task {
    public:
-    ExportToZipTask(QString outputPath, QDir dir, QFileInfoList files, QString destinationPrefix = "", bool followSymlinks = false)
+    ExportToZipTask(QString outputPath,
+                    QDir dir,
+                    QFileInfoList files,
+                    QString destinationPrefix = "",
+                    bool followSymlinks = false,
+                    bool utf8Enabled = false)
         : m_output_path(outputPath)
         , m_output(outputPath)
         , m_dir(dir)
@@ -163,10 +168,15 @@ class ExportToZipTask : public Task {
         , m_follow_symlinks(followSymlinks)
     {
         setAbortable(true);
-        m_output.setUtf8Enabled(true);
+        m_output.setUtf8Enabled(utf8Enabled);
     };
-    ExportToZipTask(QString outputPath, QString dir, QFileInfoList files, QString destinationPrefix = "", bool followSymlinks = false)
-        : ExportToZipTask(outputPath, QDir(dir), files, destinationPrefix, followSymlinks){};
+    ExportToZipTask(QString outputPath,
+                    QString dir,
+                    QFileInfoList files,
+                    QString destinationPrefix = "",
+                    bool followSymlinks = false,
+                    bool utf8Enabled = false)
+        : ExportToZipTask(outputPath, QDir(dir), files, destinationPrefix, followSymlinks, utf8Enabled){};
 
     virtual ~ExportToZipTask() = default;
 

--- a/launcher/modplatform/flame/FlamePackExportTask.cpp
+++ b/launcher/modplatform/flame/FlamePackExportTask.cpp
@@ -201,7 +201,7 @@ void FlamePackExportTask::makeApiRequest()
                        << " reason: " << parseError.errorString();
             qWarning() << *response;
 
-            failed(parseError.errorString());
+            emitFailed(parseError.errorString());
             return;
         }
 
@@ -213,6 +213,7 @@ void FlamePackExportTask::makeApiRequest()
             if (dataArr.isEmpty()) {
                 qWarning() << "No matches found for fingerprint search!";
 
+                getProjectsInfo();
                 return;
             }
             for (auto match : dataArr) {
@@ -243,9 +244,9 @@ void FlamePackExportTask::makeApiRequest()
             qDebug() << doc;
         }
         pendingHashes.clear();
+        getProjectsInfo();
     });
-    connect(task.get(), &Task::finished, this, &FlamePackExportTask::getProjectsInfo);
-    connect(task.get(), &NetJob::failed, this, &FlamePackExportTask::emitFailed);
+    connect(task.get(), &NetJob::failed, this, &FlamePackExportTask::getProjectsInfo);
     task->start();
 }
 
@@ -279,7 +280,7 @@ void FlamePackExportTask::getProjectsInfo()
             qWarning() << "Error while parsing JSON response from CurseForge projects task at " << parseError.offset
                        << " reason: " << parseError.errorString();
             qWarning() << *response;
-            failed(parseError.errorString());
+            emitFailed(parseError.errorString());
             return;
         }
 
@@ -333,7 +334,7 @@ void FlamePackExportTask::buildZip()
     setStatus(tr("Adding files..."));
     setProgress(4, 5);
 
-    auto zipTask = makeShared<MMCZip::ExportToZipTask>(output, gameRoot, files, "overrides/", true);
+    auto zipTask = makeShared<MMCZip::ExportToZipTask>(output, gameRoot, files, "overrides/", true, false);
     zipTask->addExtraFile("manifest.json", generateIndex());
     zipTask->addExtraFile("modlist.html", generateHTML());
 

--- a/launcher/modplatform/modrinth/ModrinthPackExportTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackExportTask.cpp
@@ -200,7 +200,7 @@ void ModrinthPackExportTask::buildZip()
 {
     setStatus(tr("Adding files..."));
 
-    auto zipTask = makeShared<MMCZip::ExportToZipTask>(output, gameRoot, files, "overrides/", true);
+    auto zipTask = makeShared<MMCZip::ExportToZipTask>(output, gameRoot, files, "overrides/", true, true);
     zipTask->addExtraFile("modrinth.index.json", generateIndex());
 
     zipTask->setExcludeFiles(resolvedFiles.keys());

--- a/launcher/ui/dialogs/ExportInstanceDialog.cpp
+++ b/launcher/ui/dialogs/ExportInstanceDialog.cpp
@@ -146,7 +146,7 @@ void ExportInstanceDialog::doExport()
         return;
     }
 
-    auto task = makeShared<MMCZip::ExportToZipTask>(output, m_instance->instanceRoot(), files, "", true);
+    auto task = makeShared<MMCZip::ExportToZipTask>(output, m_instance->instanceRoot(), files, "", true, true);
 
     connect(task.get(), &Task::failed, this,
             [this, output](QString reason) { CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show(); });


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
Parent PR: #2225
This should fix a crash when you try to export without the internet ( the changes made to launcher/modplatform/flame/FlamePackExportTask.cpp). This happens when trying to get the project info for the files that don't have metadata and that task fails.

The second part of this PR is the change made to launcher/MMCZip.h introduced in the mentioned PR. CurseForge doesn't like the zip files generated with that flag. So I made it configurable: Modrinth and Prism export with it enabled and CurseForge disabled.

As both issues closed by #2225 were related to Modrinth export I will presume that this doesn't happen on CurseForge, or at least my change will not create other regresions. 