### PR TITLE
Remove prebuilt system tarballs on Linux, bundle Qt with Linux portable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -490,14 +490,6 @@ jobs:
             ":warning: Skipped code signing for Windows, as certificate was not present." >> $env:GITHUB_STEP_SUMMARY
           }
 
-      - name: Package (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          cmake --install ${{ env.BUILD_DIR }} --prefix ${{ env.INSTALL_DIR }}
-          for l in $(find ${{ env.INSTALL_DIR }} -type f); do l=${l#$(pwd)/}; l=${l#${{ env.INSTALL_DIR }}/}; l=${l#./}; echo $l; done > ${{ env.INSTALL_DIR }}/manifest.txt
-          cd ${{ env.INSTALL_DIR }}
-          tar --owner root --group root -czf ../PrismLauncher.tar.gz *
-
       - name: Package (Linux, portable)
         if: runner.os == 'Linux'
         run: |
@@ -590,26 +582,12 @@ jobs:
           name: PrismLauncher-${{ matrix.name }}-Setup-${{ env.VERSION }}-${{ inputs.build_type }}
           path: PrismLauncher-Setup.exe
 
-      - name: Upload binary tarball (Linux, Qt 5)
-        if: runner.os == 'Linux' && matrix.qt_ver != 6
-        uses: actions/upload-artifact@v4
-        with:
-          name: PrismLauncher-${{ runner.os }}-Qt5-${{ env.VERSION }}-${{ inputs.build_type }}
-          path: PrismLauncher.tar.gz
-
       - name: Upload binary tarball (Linux, portable, Qt 5)
         if: runner.os == 'Linux' && matrix.qt_ver != 6
         uses: actions/upload-artifact@v4
         with:
           name: PrismLauncher-${{ runner.os }}-Qt5-Portable-${{ env.VERSION }}-${{ inputs.build_type }}
           path: PrismLauncher-portable.tar.gz
-
-      - name: Upload binary tarball (Linux, Qt 6)
-        if: runner.os == 'Linux' && matrix.qt_ver !=5
-        uses: actions/upload-artifact@v4
-        with:
-          name: PrismLauncher-${{ runner.os }}-Qt6-${{ env.VERSION }}-${{ inputs.build_type }}
-          path: PrismLauncher.tar.gz
 
       - name: Upload binary tarball (Linux, portable, Qt 6)
         if: runner.os == 'Linux' && matrix.qt_ver != 5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,10 @@ jobs:
         include:
           - os: ubuntu-20.04
             qt_ver: 5
+            qt_host: linux
+            qt_arch: ""
+            qt_version: "5.12.8"
+            qt_modules: ""
 
           - os: ubuntu-20.04
             qt_ver: 6
@@ -61,7 +65,6 @@ jobs:
             qt_arch: ""
             qt_version: "6.2.4"
             qt_modules: "qt5compat qtimageformats"
-            qt_tools: ""
 
           - os: windows-2022
             name: "Windows-MinGW-w64"
@@ -78,7 +81,6 @@ jobs:
             qt_arch: ''
             qt_version: '6.7.0'
             qt_modules: 'qt5compat qtimageformats'
-            qt_tools: ''
 
           - os: windows-2022
             name: "Windows-MSVC-arm64"
@@ -90,7 +92,6 @@ jobs:
             qt_arch: 'win64_msvc2019_arm64'
             qt_version: '6.7.0'
             qt_modules: 'qt5compat qtimageformats'
-            qt_tools: ''
 
           - os: macos-12
             name: macOS
@@ -100,7 +101,6 @@ jobs:
             qt_arch: ''
             qt_version: '6.7.0'
             qt_modules: 'qt5compat qtimageformats'
-            qt_tools: ''
 
           - os: macos-12
             name: macOS-Legacy
@@ -109,7 +109,6 @@ jobs:
             qt_host: mac
             qt_version: "5.15.2"
             qt_modules: ""
-            qt_tools: ""
 
     runs-on: ${{ matrix.os }}
 
@@ -207,11 +206,6 @@ jobs:
           brew update
           brew install ninja extra-cmake-modules
 
-      - name: Install Qt (Linux)
-        if: runner.os == 'Linux' && matrix.qt_ver != 6
-        run: |
-          sudo apt-get -y install qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libqt5core5a libqt5network5 libqt5gui5 qtwayland5
-
       - name: Install host Qt (Windows MSVC arm64)
         if: runner.os == 'Windows' && matrix.architecture == 'arm64'
         uses: jurplel/install-qt-action@v3
@@ -223,20 +217,18 @@ jobs:
           target: "desktop"
           arch: ""
           modules: ${{ matrix.qt_modules }}
-          tools: ${{ matrix.qt_tools }}
           cache: ${{ inputs.is_qt_cached }}
           cache-key-prefix: host-qt-arm64-windows
           dir: ${{ github.workspace }}\HostQt
           set-env: false
 
-      - name: Install Qt (macOS, Linux, Qt 6 & Windows MSVC)
-        if: runner.os == 'Linux' && matrix.qt_ver == 6 || runner.os == 'macOS' || (runner.os == 'Windows' && matrix.msystem == '')
+      - name: Install Qt (macOS, Linux & Windows MSVC)
+        if: matrix.msystem == ''
         uses: jurplel/install-qt-action@v3
         with:
           aqtversion: "==3.1.*"
           py7zrversion: ">=0.20.2"
           version: ${{ matrix.qt_version }}
-          host: ${{ matrix.qt_host }}
           target: "desktop"
           arch: ${{ matrix.qt_arch }}
           modules: ${{ matrix.qt_modules }}
@@ -432,12 +424,6 @@ jobs:
         run: |
           cmake --install ${{ env.BUILD_DIR }} --config ${{ inputs.build_type }}
 
-          cd ${{ env.INSTALL_DIR }}
-          if ("${{ matrix.qt_ver }}" -eq "5")
-          {
-            Copy-Item ${{ runner.workspace }}/Qt/Tools/OpenSSL/Win_x86/bin/libcrypto-1_1.dll -Destination libcrypto-1_1.dll
-            Copy-Item ${{ runner.workspace }}/Qt/Tools/OpenSSL/Win_x86/bin/libssl-1_1.dll -Destination libssl-1_1.dll
-          }
           cd ${{ github.workspace }}
 
           Get-ChildItem ${{ env.INSTALL_DIR }} -Recurse | ForEach FullName | Resolve-Path -Relative | %{ $_.TrimStart('.\') } | %{ $_.TrimStart('${{ env.INSTALL_DIR }}') } | %{ $_.TrimStart('\') } | Out-File -FilePath ${{ env.INSTALL_DIR }}/manifest.txt

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -210,7 +210,7 @@ jobs:
       - name: Install Qt (Linux)
         if: runner.os == 'Linux' && matrix.qt_ver != 6
         run: |
-          sudo apt-get -y install qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libqt5core5a libqt5network5 libqt5gui5
+          sudo apt-get -y install qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libqt5core5a libqt5network5 libqt5gui5 qtwayland5
 
       - name: Install host Qt (Windows MSVC arm64)
         if: runner.os == 'Windows' && matrix.architecture == 'arm64'
@@ -490,20 +490,6 @@ jobs:
             ":warning: Skipped code signing for Windows, as certificate was not present." >> $env:GITHUB_STEP_SUMMARY
           }
 
-      - name: Package (Linux, portable)
-        if: runner.os == 'Linux'
-        run: |
-          cmake --install ${{ env.BUILD_DIR }} --prefix ${{ env.INSTALL_PORTABLE_DIR }}
-          cmake --install ${{ env.BUILD_DIR }} --prefix ${{ env.INSTALL_PORTABLE_DIR }} --component portable
-
-          # workaround to make portable installs to work on fedora
-          mkdir  ${{ env.INSTALL_PORTABLE_DIR }}/lib
-          cp /lib/x86_64-linux-gnu/libbz2.so.1.0 ${{ env.INSTALL_PORTABLE_DIR }}/lib
-
-          for l in $(find ${{ env.INSTALL_PORTABLE_DIR }} -type f); do l=${l#$(pwd)/}; l=${l#${{ env.INSTALL_PORTABLE_DIR }}/}; l=${l#./}; echo $l; done > ${{ env.INSTALL_PORTABLE_DIR }}/manifest.txt
-          cd ${{ env.INSTALL_PORTABLE_DIR }}
-          tar -czf ../PrismLauncher-portable.tar.gz *
-
       - name: Package AppImage (Linux)
         if: runner.os == 'Linux' && matrix.qt_ver != 5
         shell: bash
@@ -549,6 +535,25 @@ jobs:
           ./linuxdeploy-x86_64.AppImage --appdir ${{ env.INSTALL_APPIMAGE_DIR }} --output appimage --plugin qt -i ${{ env.INSTALL_APPIMAGE_DIR }}/usr/share/icons/hicolor/scalable/apps/org.prismlauncher.PrismLauncher.svg
 
           mv "PrismLauncher-Linux-x86_64.AppImage" "PrismLauncher-Linux-${{ env.VERSION }}-${{ inputs.build_type }}-x86_64.AppImage"
+
+      - name: Package (Linux, portable)
+        if: runner.os == 'Linux'
+        run: |
+          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_PORTABLE_DIR }} -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DENABLE_LTO=ON -DLauncher_BUILD_PLATFORM=official -DCMAKE_C_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DLauncher_QT_VERSION_MAJOR=${{ matrix.qt_ver }} -DLauncher_BUILD_ARTIFACT=Linux-Qt${{ matrix.qt_ver }} -DINSTALL_BUNDLE=full -G Ninja
+          cmake --install ${{ env.BUILD_DIR }}
+          cmake --install ${{ env.BUILD_DIR }} --component portable
+
+          mkdir  ${{ env.INSTALL_PORTABLE_DIR }}/lib
+          cp /lib/x86_64-linux-gnu/libbz2.so.1.0 ${{ env.INSTALL_PORTABLE_DIR }}/lib
+          cp /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0 ${{ env.INSTALL_PORTABLE_DIR }}/lib
+          cp /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 ${{ env.INSTALL_PORTABLE_DIR }}/lib
+          cp /usr/lib/x86_64-linux-gnu/libssl.so.1.1 ${{ env.INSTALL_PORTABLE_DIR }}/lib
+          cp /usr/lib/x86_64-linux-gnu/libffi.so.7 ${{ env.INSTALL_PORTABLE_DIR }}/lib
+          mv ${{ env.INSTALL_PORTABLE_DIR }}/bin/*.so* ${{ env.INSTALL_PORTABLE_DIR }}/lib
+
+          for l in $(find ${{ env.INSTALL_PORTABLE_DIR }} -type f); do l=${l#$(pwd)/}; l=${l#${{ env.INSTALL_PORTABLE_DIR }}/}; l=${l#./}; echo $l; done > ${{ env.INSTALL_PORTABLE_DIR }}/manifest.txt
+          cd ${{ env.INSTALL_PORTABLE_DIR }}
+          tar -czf ../PrismLauncher-portable.tar.gz *
 
       ##
       # UPLOAD BUILDS

--- a/.github/workflows/trigger_release.yml
+++ b/.github/workflows/trigger_release.yml
@@ -46,9 +46,7 @@ jobs:
         run: |
           mv ${{ github.workspace }}/PrismLauncher-source PrismLauncher-${{ env.VERSION }}
           mv PrismLauncher-Linux-Qt6-Portable*/PrismLauncher-portable.tar.gz PrismLauncher-Linux-Qt6-Portable-${{ env.VERSION }}.tar.gz
-          mv PrismLauncher-Linux-Qt6*/PrismLauncher.tar.gz PrismLauncher-Linux-Qt6-${{ env.VERSION }}.tar.gz
           mv PrismLauncher-Linux-Qt5-Portable*/PrismLauncher-portable.tar.gz PrismLauncher-Linux-Qt5-Portable-${{ env.VERSION }}.tar.gz
-          mv PrismLauncher-Linux-Qt5*/PrismLauncher.tar.gz PrismLauncher-Linux-Qt5-${{ env.VERSION }}.tar.gz       
           mv PrismLauncher-*.AppImage/PrismLauncher-*.AppImage PrismLauncher-Linux-x86_64.AppImage
           mv PrismLauncher-*.AppImage.zsync/PrismLauncher-*.AppImage.zsync PrismLauncher-Linux-x86_64.AppImage.zsync
           mv PrismLauncher-macOS-Legacy*/PrismLauncher.zip PrismLauncher-macOS-Legacy-${{ env.VERSION }}.zip
@@ -92,11 +90,9 @@ jobs:
           draft: true
           prerelease: false
           files: |
-            PrismLauncher-Linux-Qt5-${{ env.VERSION }}.tar.gz
             PrismLauncher-Linux-Qt5-Portable-${{ env.VERSION }}.tar.gz
             PrismLauncher-Linux-x86_64.AppImage
             PrismLauncher-Linux-x86_64.AppImage.zsync
-            PrismLauncher-Linux-Qt6-${{ env.VERSION }}.tar.gz
             PrismLauncher-Linux-Qt6-Portable-${{ env.VERSION }}.tar.gz
             PrismLauncher-Windows-MinGW-w64-${{ env.VERSION }}.zip
             PrismLauncher-Windows-MinGW-w64-Portable-${{ env.VERSION }}.zip

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -417,7 +417,11 @@ elseif(UNIX)
     install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${Launcher_mrpack_MIMEInfo} DESTINATION ${KDE_INSTALL_MIMEDIR})
 
     install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/launcher/qtlogging.ini" DESTINATION "share/${Launcher_Name}")
-    
+
+    if (INSTALL_BUNDLE STREQUAL full)
+        set(PLUGIN_DEST_DIR "./plugins/")
+    endif()
+
     if(Launcher_ManPage)
         install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${Launcher_ManPage} DESTINATION "${KDE_INSTALL_MANDIR}/man6")
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -419,7 +419,15 @@ elseif(UNIX)
     install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/launcher/qtlogging.ini" DESTINATION "share/${Launcher_Name}")
 
     if (INSTALL_BUNDLE STREQUAL full)
-        set(PLUGIN_DEST_DIR "./plugins/")
+        set(PLUGIN_DEST_DIR "plugins")
+        set(BUNDLE_DEST_DIR ".")
+        set(RESOURCES_DEST_DIR ".")
+    
+        # Apps to bundle
+        set(APPS "\${CMAKE_INSTALL_PREFIX}/bin/${Launcher_APP_BINARY_NAME}")
+    
+        # directories to look for dependencies
+        set(DIRS ${QT_LIBS_DIR} ${QT_LIBEXECS_DIR} ${CMAKE_LIBRARY_OUTPUT_DIRECTORY} ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
     endif()
 
     if(Launcher_ManPage)

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -1492,7 +1492,6 @@ if(INSTALL_BUNDLE STREQUAL "full")
             CONFIGURATIONS Debug RelWithDebInfo ""
             DESTINATION ${PLUGIN_DEST_DIR}
             COMPONENT Runtime
-            PATTERN "*qopensslbackend*" EXCLUDE
             PATTERN "*qcertonlybackend*" EXCLUDE
         )
         install(
@@ -1503,14 +1502,16 @@ if(INSTALL_BUNDLE STREQUAL "full")
             REGEX "dd\\." EXCLUDE
             REGEX "_debug\\." EXCLUDE
             REGEX "\\.dSYM" EXCLUDE
-            PATTERN "*qopensslbackend*" EXCLUDE
             PATTERN "*qcertonlybackend*" EXCLUDE
         )
     endif()
-    configure_file(
-        "${CMAKE_CURRENT_SOURCE_DIR}/install_prereqs.cmake.in"
-        "${CMAKE_CURRENT_BINARY_DIR}/install_prereqs.cmake"
-        @ONLY
-    )
-    install(SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/install_prereqs.cmake" COMPONENT Runtime)
+    # ignore fixup_bundle on Linux
+    if (NOT (UNIX AND NOT APPLE))
+        configure_file(
+            "${CMAKE_CURRENT_SOURCE_DIR}/install_prereqs.cmake.in"
+            "${CMAKE_CURRENT_BINARY_DIR}/install_prereqs.cmake"
+            @ONLY
+            )
+        install(SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/install_prereqs.cmake" COMPONENT Runtime)
+    endif()
 endif()

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -1505,13 +1505,79 @@ if(INSTALL_BUNDLE STREQUAL "full")
             PATTERN "*qcertonlybackend*" EXCLUDE
         )
     endif()
-    # ignore fixup_bundle on Linux
-    if (NOT (UNIX AND NOT APPLE))
-        configure_file(
-            "${CMAKE_CURRENT_SOURCE_DIR}/install_prereqs.cmake.in"
-            "${CMAKE_CURRENT_BINARY_DIR}/install_prereqs.cmake"
-            @ONLY
-            )
-        install(SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/install_prereqs.cmake" COMPONENT Runtime)
+    # Wayland support
+    if(EXISTS "${QT_PLUGINS_DIR}/wayland-graphics-integration-client")
+        install(
+            DIRECTORY "${QT_PLUGINS_DIR}/wayland-graphics-integration-client"
+            CONFIGURATIONS Debug RelWithDebInfo ""
+            DESTINATION ${PLUGIN_DEST_DIR}
+            COMPONENT Runtime
+        )
+        install(
+            DIRECTORY "${QT_PLUGINS_DIR}/wayland-graphics-integration-client"
+            CONFIGURATIONS Release MinSizeRel
+            DESTINATION ${PLUGIN_DEST_DIR}
+            COMPONENT Runtime
+            REGEX "dd\\." EXCLUDE
+            REGEX "_debug\\." EXCLUDE
+            REGEX "\\.dSYM" EXCLUDE
+        )
     endif()
+    if(EXISTS "${QT_PLUGINS_DIR}/wayland-graphics-integration-server")
+        install(
+            DIRECTORY "${QT_PLUGINS_DIR}/wayland-graphics-integration-server"
+            CONFIGURATIONS Debug RelWithDebInfo ""
+            DESTINATION ${PLUGIN_DEST_DIR}
+            COMPONENT Runtime
+        )
+        install(
+            DIRECTORY "${QT_PLUGINS_DIR}/wayland-graphics-integration-server"
+            CONFIGURATIONS Release MinSizeRel
+            DESTINATION ${PLUGIN_DEST_DIR}
+            COMPONENT Runtime
+            REGEX "dd\\." EXCLUDE
+            REGEX "_debug\\." EXCLUDE
+            REGEX "\\.dSYM" EXCLUDE
+        )
+    endif()
+    if(EXISTS "${QT_PLUGINS_DIR}/wayland-decoration-client")
+        install(
+            DIRECTORY "${QT_PLUGINS_DIR}/wayland-decoration-client"
+            CONFIGURATIONS Debug RelWithDebInfo ""
+            DESTINATION ${PLUGIN_DEST_DIR}
+            COMPONENT Runtime
+        )
+        install(
+            DIRECTORY "${QT_PLUGINS_DIR}/wayland-decoration-client"
+            CONFIGURATIONS Release MinSizeRel
+            DESTINATION ${PLUGIN_DEST_DIR}
+            COMPONENT Runtime
+            REGEX "dd\\." EXCLUDE
+            REGEX "_debug\\." EXCLUDE
+            REGEX "\\.dSYM" EXCLUDE
+        )
+    endif()
+    if(EXISTS "${QT_PLUGINS_DIR}/wayland-shell-integration")
+        install(
+            DIRECTORY "${QT_PLUGINS_DIR}/wayland-shell-integration"
+            CONFIGURATIONS Debug RelWithDebInfo ""
+            DESTINATION ${PLUGIN_DEST_DIR}
+            COMPONENT Runtime
+        )
+        install(
+            DIRECTORY "${QT_PLUGINS_DIR}/wayland-shell-integration"
+            CONFIGURATIONS Release MinSizeRel
+            DESTINATION ${PLUGIN_DEST_DIR}
+            COMPONENT Runtime
+            REGEX "dd\\." EXCLUDE
+            REGEX "_debug\\." EXCLUDE
+            REGEX "\\.dSYM" EXCLUDE
+        )
+    endif()
+    configure_file(
+        "${CMAKE_CURRENT_SOURCE_DIR}/install_prereqs.cmake.in"
+        "${CMAKE_CURRENT_BINARY_DIR}/install_prereqs.cmake"
+        @ONLY
+    )
+    install(SCRIPT "${CMAKE_CURRENT_BINARY_DIR}/install_prereqs.cmake" COMPONENT Runtime)
 endif()

--- a/launcher/install_prereqs.cmake.in
+++ b/launcher/install_prereqs.cmake.in
@@ -1,5 +1,4 @@
 set(CMAKE_MODULE_PATH "@CMAKE_MODULE_PATH@")
-
 file(GLOB_RECURSE    QTPLUGINS "${CMAKE_INSTALL_PREFIX}/@PLUGIN_DEST_DIR@/*@CMAKE_SHARED_LIBRARY_SUFFIX@")
 function(gp_resolved_file_type_override resolved_file type_var)
     if(resolved_file MATCHES "^/(usr/)?lib/libQt")


### PR DESCRIPTION
closes #991 as with this pr there'll be no more prebuilt tarball

Because of MultiMC heritage, we always made prebullt binaries that rely on system libraries (and Qt) on Linux, which isn't really reliable.

At first it didn't create problems to us, then when Arch decided to use a patch to fix a problem with LTO the problems started to come in. Especially as that patch is recommended by many Qt developers to distros. Even [Qt Developers](https://bugreports.qt.io/browse/QTBUG-112332?focusedId=786408&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-786408) think that prebuilt binaries that rely on system libraries is a bad idea and that we should either bundle Qt or build on the distro.

This removes the tarball and bundles Qt with our portable builds (and unlike AppImage, it supports native Wayland).