### PR TITLE
[WIP]Workaround curseforge third-party mods

### DIFF
--- a/launcher/modplatform/flame/FlameModIndex.cpp
+++ b/launcher/modplatform/flame/FlameModIndex.cpp
@@ -136,8 +136,12 @@ auto FlameMod::loadIndexedPackVersion(QJsonObject& obj, bool load_changelog) -> 
     file.fileId = Json::requireInteger(obj, "id");
     file.date = Json::requireString(obj, "fileDate");
     file.version = Json::requireString(obj, "displayName");
-    file.downloadUrl = Json::ensureString(obj, "downloadUrl");
     file.fileName = Json::requireString(obj, "fileName");
+    file.downloadUrl = Json::ensureString(obj, "downloadUrl");
+    if (file.downloadUrl.isEmpty() && !file.fileName.isEmpty()) {
+        auto fileId = file.fileId.toString();
+        file.downloadUrl = QString("https://edge.forgecdn.net/files/%1/%2/%3").arg(fileId.left(4), fileId.mid(4), file.fileName);
+    }
 
     ModPlatform::IndexedVersionType::VersionType ver_type;
     switch (Json::requireInteger(obj, "releaseType")) {

--- a/launcher/modplatform/flame/FlamePackIndex.cpp
+++ b/launcher/modplatform/flame/FlamePackIndex.cpp
@@ -108,6 +108,11 @@ void Flame::loadIndexedPackVersions(Flame::IndexedPack& pack, QJsonArray& arr)
         }
         file.version_type = ModPlatform::IndexedVersionType(ver_type);
         file.downloadUrl = Json::ensureString(version, "downloadUrl");
+        auto fileName = Json::requireString(version, "fileName");
+        if (file.downloadUrl.isEmpty() && !fileName.isEmpty()) {
+            auto fileId = QString::number(file.fileId);
+            file.downloadUrl = QString("https://edge.forgecdn.net/files/%1/%2/%3").arg(fileId.left(4), fileId.mid(4), fileName);
+        }
 
         // only add if we have a download URL (third party distribution is enabled)
         if (!file.downloadUrl.isEmpty()) {

--- a/launcher/modplatform/flame/PackManifest.cpp
+++ b/launcher/modplatform/flame/PackManifest.cpp
@@ -92,6 +92,10 @@ bool Flame::File::parseFromObject(const QJsonObject& obj, bool throw_on_blocked)
 
     // may throw, if the project is blocked
     QString rawUrl = Json::ensureString(obj, "downloadUrl");
+    if (rawUrl.isEmpty() && !fileName.isEmpty()) {
+        auto fileId_ = QString::number(fileId);
+        rawUrl = QString("https://edge.forgecdn.net/files/%1/%2/%3").arg(fileId_.left(4), fileId_.mid(4), fileName);
+    }
     url = QUrl(rawUrl, QUrl::TolerantMode);
     if (!url.isValid() && throw_on_blocked) {
         throw JSONValidationError(QString("Invalid URL: %1").arg(rawUrl));


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
closes #2372
The approach works but I need to find a way to report to the user the failure of the download task is due to curseforge third-party block if it happens on a guessed URL.