### PR TITLE
[macOS] Add sdkman to java search paths 

### DIFF
--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -362,6 +362,12 @@ QList<QString> JavaUtils::FindJavaPaths()
         javas.append(systemLibraryJVMDir.absolutePath() + "/" + java + "/Contents/Home/bin/java");
         javas.append(systemLibraryJVMDir.absolutePath() + "/" + java + "/Contents/Commands/java");
     }
+
+    auto home = qEnvironmentVariable("HOME");
+
+    // javas downloaded by sdkman
+    scanJavaDirs(FS::PathCombine(home, ".sdkman/candidates/java"));
+
     javas.append(getMinecraftJavaBundle());
     javas = addJavasFromEnv(javas);
     javas.removeDuplicates();

--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -366,7 +366,7 @@ QList<QString> JavaUtils::FindJavaPaths()
     auto home = qEnvironmentVariable("HOME");
 
     // javas downloaded by sdkman
-    scanJavaDirs(FS::PathCombine(home, ".sdkman/candidates/java"));
+    javas.append(FS::PathCombine(home, ".sdkman/candidates/java"));
 
     javas.append(getMinecraftJavaBundle());
     javas = addJavasFromEnv(javas);


### PR DESCRIPTION
We're just adding support for sdkman to the MacOs version of the Prism Launcher here.

According to the [install page](https://sdkman.io/install) on the sdkman website, sdkman does support installing Java on MacOs. As such, I think it's a good idea to add support to the Prism Launcher to find sdkman Java installations for those who use sdkman on MacOs to install Java.

This pull request solves this issue: https://github.com/PrismLauncher/PrismLauncher/issues/2336