### PR TITLE
[macOS] Improve blocked mods dialog

### DIFF
--- a/cmake/MacOSXBundleInfo.plist.in
+++ b/cmake/MacOSXBundleInfo.plist.in
@@ -6,6 +6,8 @@
     <string>A Minecraft mod wants to access your camera.</string>
     <key>NSMicrophoneUsageDescription</key>
     <string>A Minecraft mod wants to access your microphone.</string>
+    <key>NSDownloadsFolderUsageDescription</key>
+    <string>Prism uses access to your Downloads folder to help you more quickly add mods that can't be automatically downloaded to your instance. You can change where Prism scans for downloaded mods in Settings or the prompt that appears.</string>
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>
     <key>NSHighResolutionCapable</key>

--- a/launcher/ui/dialogs/BlockedModsDialog.cpp
+++ b/launcher/ui/dialogs/BlockedModsDialog.cpp
@@ -40,6 +40,7 @@
 #include <QMimeData>
 #include <QPushButton>
 #include <QStandardPaths>
+#include <QTimer>
 
 BlockedModsDialog::BlockedModsDialog(QWidget* parent, const QString& title, const QString& text, QList<BlockedMod>& mods, QString hash_type)
     : QDialog(parent), ui(new Ui::BlockedModsDialog), m_mods(mods), m_hash_type(hash_type)
@@ -60,8 +61,13 @@ BlockedModsDialog::BlockedModsDialog(QWidget* parent, const QString& title, cons
 
     qDebug() << "[Blocked Mods Dialog] Mods List: " << mods;
 
-    setupWatch();
-    scanPaths();
+    // defer setup of file system watchers until after the dialog is shown
+    // this allows OS (namely macOS) permission prompts to show after the relevant dialog appears
+    QTimer::singleShot(0, this, [this] {
+        setupWatch();
+        scanPaths();
+        update();
+    });
 
     this->setWindowTitle(title);
     ui->labelDescription->setText(text);
@@ -194,6 +200,10 @@ void BlockedModsDialog::setupWatch()
 void BlockedModsDialog::watchPath(QString path, bool watch_recursive)
 {
     auto to_watch = QFileInfo(path);
+    if (!to_watch.isReadable()) {
+        qWarning() << "[Blocked Mods Dialog] Failed to add Watch Path (unable to read):" << path;
+        return;
+    }
     auto to_watch_path = to_watch.canonicalFilePath();
     if (m_watcher.directories().contains(to_watch_path))
         return;  // don't watch the same path twice (no loops!)

--- a/launcher/ui/dialogs/BlockedModsDialog.cpp
+++ b/launcher/ui/dialogs/BlockedModsDialog.cpp
@@ -164,7 +164,8 @@ void BlockedModsDialog::update()
 
     QString watching;
     for (auto& dir : m_watcher.directories()) {
-        watching += QString("<a href=\"%1\">%1</a><br/>").arg(dir);
+        QUrl fileURL = QUrl::fromLocalFile(dir);
+        watching += QString("<a href=\"%1\">%2</a><br/>").arg(fileURL.toString(), dir);
     }
 
     ui->textBrowserWatched->setText(watching);


### PR DESCRIPTION
The first time a macOS user has to download a blocked mod, this is the initial screen they get:

<img width="481" alt="Screenshot 2024-05-07 at 6 18 09 PM" src="https://github.com/PrismLauncher/PrismLauncher/assets/79120643/ebe5e018-7d10-4b88-a2ad-797ac96dfdab">

There is no context, and this raises a lot of questions: _Why does Prism want Downloads folder access? Is this necessary? How is this relevant to what I just did? What should I choose?_

Only after choosing one of these options does the blocked mods prompt appear.

Additionally, clicking one of the watched directories fails to open it with an error on macOS due to an invalid URL.

This PR improves this experience in these ways:

- Prism's blocked mods dialog appears before trying to access the file system (which will trigger the prompt), adding context
- A usage description for the Downloads folder was added to additionally explain the need for this
- If the user declines (or the folder is otherwise unreadable for some reason), it will not appear in the watched folders list
- Use the proper URL to make the watched directory links clickable

<img width="806" alt="Screenshot 2024-05-07 at 6 08 52 PM" src="https://github.com/PrismLauncher/PrismLauncher/assets/79120643/a47d398b-e551-415e-bac4-fa7e4ec82eb7">

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
