### PR TITLE
Add NeoForge support for Technic packs and ATLauncher packs

### DIFF
--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
@@ -1031,6 +1031,12 @@ void PackInstallTask::install()
             return;
 
         components->setComponentVersion("net.minecraftforge", version);
+    } else if (m_version.loader.type == QString("neoforge")) {
+        auto version = getVersionForLoader("net.neoforged");
+        if (version == Q_NULLPTR)
+            return;
+
+        components->setComponentVersion("net.neoforged", version);
     } else if (m_version.loader.type == QString("fabric")) {
         auto version = getVersionForLoader("net.fabricmc.fabric-loader");
         if (version == Q_NULLPTR)

--- a/launcher/modplatform/technic/TechnicPackProcessor.cpp
+++ b/launcher/modplatform/technic/TechnicPackProcessor.cpp
@@ -155,8 +155,26 @@ void Technic::TechnicPackProcessor::run(SettingsObjectPtr globalSettings,
             auto libraryObject = Json::ensureObject(library, {}, "");
             auto libraryName = Json::ensureString(libraryObject, "name", "", "");
 
-            if ((libraryName.startsWith("net.minecraftforge:forge:") || libraryName.startsWith("net.minecraftforge:fmlloader:")) &&
-                libraryName.contains('-')) {
+            if (libraryName.startsWith("net.neoforged.fancymodloader:")) {  // it is neoforge
+                // no easy way to get the version from the libs so use the arguments
+                auto arguments = Json::ensureObject(root, "arguments", {});
+                bool isVersionArg = false;
+                QString neoforgeVersion;
+                for (auto arg : Json::ensureArray(arguments, "game", {})) {
+                    auto argument = Json::ensureString(arg, "");
+                    if (isVersionArg) {
+                        neoforgeVersion = argument;
+                        break;
+                    } else {
+                        isVersionArg = "--fml.neoForgeVersion" == argument || "--fml.forgeVersion" == argument;
+                    }
+                }
+                if (!neoforgeVersion.isEmpty()) {
+                    components->setComponentVersion("net.neoforged", neoforgeVersion);
+                }
+                break;
+            } else if ((libraryName.startsWith("net.minecraftforge:forge:") || libraryName.startsWith("net.minecraftforge:fmlloader:")) &&
+                       libraryName.contains('-')) {
                 QString libraryVersion = libraryName.section(':', 2);
                 if (!libraryVersion.startsWith("1.7.10-")) {
                     components->setComponentVersion("net.minecraftforge", libraryName.section('-', 1));
@@ -164,6 +182,7 @@ void Technic::TechnicPackProcessor::run(SettingsObjectPtr globalSettings,
                     // 1.7.10 versions sometimes look like 1.7.10-10.13.4.1614-1.7.10, this filters out the 10.13.4.1614 part
                     components->setComponentVersion("net.minecraftforge", libraryName.section('-', 1, 1));
                 }
+                break;
             } else {
                 // <Technic library name prefix> -> <our component name>
                 static QMap<QString, QString> loaderMap{ { "net.minecraftforge:minecraftforge:", "net.minecraftforge" },


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
fixes #2380
Added neoforge support for both technic and atlauncher.
Because there may not be any atlauncher modpack that has yet neoforge that part can't be tested, it should be ok to have the check there for now.
Regarding the technic pack I'm waiting for to get a pack from the user that opened the mentioned issue.
But it should work based on how technic packs are made: https://support.technicpack.net/hc/en-us/articles/17049267195021-How-to-Create-a-Client-Modpack#Installing-a-mod-loader
