### PR TITLE
Delete instaces tmp diectory on startup

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -1209,6 +1209,12 @@ void Application::performMainStartupAction()
         qDebug() << "<> Updater started.";
     }
 
+    {  // delete instances tmp dirctory
+        auto instDir = m_settings->get("InstanceDir").toString();
+        const QString tempRoot = FS::PathCombine(instDir, ".tmp");
+        FS::deletePath(tempRoot);
+    }
+
     if (!m_urlsToImport.isEmpty()) {
         qDebug() << "<> Importing from url:" << m_urlsToImport;
         m_mainWindow->processURLs(m_urlsToImport);


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
The .tmp folder that is inside the instance folder should not exist or be empty. 
This ensures that the mentioned folder will be deleted on launch