### PR TITLE
Fix portable if manifest is missing

### DIFF
--- a/launcher/updater/prismupdater/PrismUpdater.cpp
+++ b/launcher/updater/prismupdater/PrismUpdater.cpp
@@ -475,7 +475,7 @@ PrismUpdaterApp::PrismUpdaterApp(int& argc, char** argv) : QApplication(argc, ar
         }
 
         QMetaObject::invokeMethod(
-           this, [this, target_dir]() { moveAndFinishUpdate(target_dir); }, Qt::QueuedConnection);Qt::QueuedConnection);
+            this, [this, target_dir]() { moveAndFinishUpdate(target_dir); }, Qt::QueuedConnection);
 
     } else {
         QMetaObject::invokeMethod(this, &PrismUpdaterApp::loadReleaseList, Qt::QueuedConnection);

--- a/launcher/updater/prismupdater/PrismUpdater.cpp
+++ b/launcher/updater/prismupdater/PrismUpdater.cpp
@@ -474,8 +474,7 @@ PrismUpdaterApp::PrismUpdaterApp(int& argc, char** argv) : QApplication(argc, ar
             target_dir = QDir(m_rootPath).absoluteFilePath("..");
         }
 
-        QMetaObject::invokeMethod(
-            this, [this, target_dir]() { moveAndFinishUpdate(target_dir); }, Qt::QueuedConnection);
+        QMetaObject::invokeMethod(this, [this, target_dir]() { moveAndFinishUpdate(target_dir); }, Qt::QueuedConnection);
 
     } else {
         QMetaObject::invokeMethod(this, &PrismUpdaterApp::loadReleaseList, Qt::QueuedConnection);
@@ -1118,7 +1117,6 @@ void PrismUpdaterApp::backupAppDir()
                 "Qt*.dll",
             });
         }
-        file_list.append("portable.txt");
         logUpdate("manifest.txt empty or missing. making best guess at files to back up.");
     }
     logUpdate(tr("Backing up:\n  %1").arg(file_list.join(",\n  ")));

--- a/launcher/updater/prismupdater/PrismUpdater.cpp
+++ b/launcher/updater/prismupdater/PrismUpdater.cpp
@@ -474,7 +474,8 @@ PrismUpdaterApp::PrismUpdaterApp(int& argc, char** argv) : QApplication(argc, ar
             target_dir = QDir(m_rootPath).absoluteFilePath("..");
         }
 
-        QMetaObject::invokeMethod(this, [this, target_dir]() { moveAndFinishUpdate(target_dir); }, Qt::QueuedConnection);
+        QMetaObject::invokeMethod(
+           this, [this, target_dir]() { moveAndFinishUpdate(target_dir); }, Qt::QueuedConnection);Qt::QueuedConnection);
 
     } else {
         QMetaObject::invokeMethod(this, &PrismUpdaterApp::loadReleaseList, Qt::QueuedConnection);


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
fixes #2191
Basically, we should not touch the `portable.txt` file on the update