### PR TITLE
nix: replace mesa-demos with glxinfo

### DIFF
--- a/nix/pkg/wrapper.nix
+++ b/nix/pkg/wrapper.nix
@@ -18,7 +18,7 @@
   jdk21,
   gamemode,
   flite,
-  mesa-demos,
+  glxinfo,
   udev,
   libusb1,
   msaClientID ? null,
@@ -81,7 +81,7 @@ in
       runtimePrograms =
         [
           xorg.xrandr
-          mesa-demos # need glxinfo
+          glxinfo
         ]
         ++ additionalPrograms;
     in


### PR DESCRIPTION
Title.

Judging by the flatpak setup, it seems the only thing required from `mesa-demos` is `glxinfo`.
https://github.com/PrismLauncher/PrismLauncher/blob/529dc7c6b71cac4416786bef81399a1aeb23ad7e/flatpak/org.prismlauncher.PrismLauncher.yml#L123-L133

Since there is a `glxinfo` nix pkg that is much smaller than `mesa-demos`, I replaced it.

I have manually verified that the code where glxinfo is used still works as intended.
https://github.com/PrismLauncher/PrismLauncher/blob/529dc7c6b71cac4416786bef81399a1aeb23ad7e/launcher/minecraft/launch/PrintInstanceInfo.cpp#L96-L111 

Fixes #2420 

Nixpkgs PR: https://github.com/NixOS/nixpkgs/pull/313131