### PR TITLE
add detection for IBM Semeru Java runtime and fix x86 detection on 64 bit Windows

### DIFF
--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -424,6 +424,7 @@ QList<QString> JavaUtils::FindJavaPaths()
     // manually installed JDKs in /opt
     scanJavaDirs("/opt/jdk");
     scanJavaDirs("/opt/jdks");
+    scanJavaDirs("/opt/ibm"); // IBM Semeru Certified Edition
     // flatpak
     scanJavaDirs("/app/jdk");
 

--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -284,14 +284,10 @@ QList<QString> JavaUtils::FindJavaPaths()
         this->FindJavaFromRegistryKey(KEY_WOW64_64KEY, "SOFTWARE\\Eclipse Adoptium\\JDK", "Path", "\\hotspot\\MSI");
 
     // IBM Semeru
-    QList<JavaInstallPtr> SEMERUJRE32s =
-        this->FindJavaFromRegistryKey(KEY_WOW64_32KEY, "SOFTWARE\\Semeru\\JRE", "Path", "\\openj9\\MSI");
-    QList<JavaInstallPtr> SEMERUJRE64s =
-        this->FindJavaFromRegistryKey(KEY_WOW64_64KEY, "SOFTWARE\\Semeru\\JRE", "Path", "\\openj9\\MSI");
-    QList<JavaInstallPtr> SEMERUJDK32s =
-        this->FindJavaFromRegistryKey(KEY_WOW64_32KEY, "SOFTWARE\\Semeru\\JDK", "Path", "\\openj9\\MSI");
-    QList<JavaInstallPtr> SEMERUJDK64s =
-        this->FindJavaFromRegistryKey(KEY_WOW64_64KEY, "SOFTWARE\\Semeru\\JDK", "Path", "\\openj9\\MSI");
+    QList<JavaInstallPtr> SEMERUJRE32s = this->FindJavaFromRegistryKey(KEY_WOW64_32KEY, "SOFTWARE\\Semeru\\JRE", "Path", "\\openj9\\MSI");
+    QList<JavaInstallPtr> SEMERUJRE64s = this->FindJavaFromRegistryKey(KEY_WOW64_64KEY, "SOFTWARE\\Semeru\\JRE", "Path", "\\openj9\\MSI");
+    QList<JavaInstallPtr> SEMERUJDK32s = this->FindJavaFromRegistryKey(KEY_WOW64_32KEY, "SOFTWARE\\Semeru\\JDK", "Path", "\\openj9\\MSI");
+    QList<JavaInstallPtr> SEMERUJDK64s = this->FindJavaFromRegistryKey(KEY_WOW64_64KEY, "SOFTWARE\\Semeru\\JDK", "Path", "\\openj9\\MSI");
 
     // Microsoft
     QList<JavaInstallPtr> MICROSOFTJDK64s =
@@ -424,7 +420,7 @@ QList<QString> JavaUtils::FindJavaPaths()
     // manually installed JDKs in /opt
     scanJavaDirs("/opt/jdk");
     scanJavaDirs("/opt/jdks");
-    scanJavaDirs("/opt/ibm"); // IBM Semeru Certified Edition
+    scanJavaDirs("/opt/ibm");  // IBM Semeru Certified Edition
     // flatpak
     scanJavaDirs("/app/jdk");
 

--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -283,6 +283,16 @@ QList<QString> JavaUtils::FindJavaPaths()
     QList<JavaInstallPtr> ADOPTIUMJDK64s =
         this->FindJavaFromRegistryKey(KEY_WOW64_64KEY, "SOFTWARE\\Eclipse Adoptium\\JDK", "Path", "\\hotspot\\MSI");
 
+    // IBM Semeru
+    QList<JavaInstallPtr> SEMERUJRE32s =
+        this->FindJavaFromRegistryKey(KEY_WOW64_32KEY, "SOFTWARE\\Semeru\\JRE", "Path", "\\openj9\\MSI");
+    QList<JavaInstallPtr> SEMERUJRE64s =
+        this->FindJavaFromRegistryKey(KEY_WOW64_64KEY, "SOFTWARE\\Semeru\\JRE", "Path", "\\openj9\\MSI");
+    QList<JavaInstallPtr> SEMERUJDK32s =
+        this->FindJavaFromRegistryKey(KEY_WOW64_32KEY, "SOFTWARE\\Semeru\\JDK", "Path", "\\openj9\\MSI");
+    QList<JavaInstallPtr> SEMERUJDK64s =
+        this->FindJavaFromRegistryKey(KEY_WOW64_64KEY, "SOFTWARE\\Semeru\\JDK", "Path", "\\openj9\\MSI");
+
     // Microsoft
     QList<JavaInstallPtr> MICROSOFTJDK64s =
         this->FindJavaFromRegistryKey(KEY_WOW64_64KEY, "SOFTWARE\\Microsoft\\JDK", "Path", "\\hotspot\\MSI");
@@ -300,6 +310,7 @@ QList<QString> JavaUtils::FindJavaPaths()
     java_candidates.append(NEWJRE64s);
     java_candidates.append(ADOPTOPENJRE64s);
     java_candidates.append(ADOPTIUMJRE64s);
+    java_candidates.append(SEMERUJRE64s);
     java_candidates.append(MakeJavaPtr("C:/Program Files/Java/jre8/bin/javaw.exe"));
     java_candidates.append(MakeJavaPtr("C:/Program Files/Java/jre7/bin/javaw.exe"));
     java_candidates.append(MakeJavaPtr("C:/Program Files/Java/jre6/bin/javaw.exe"));
@@ -308,6 +319,7 @@ QList<QString> JavaUtils::FindJavaPaths()
     java_candidates.append(ADOPTOPENJDK64s);
     java_candidates.append(FOUNDATIONJDK64s);
     java_candidates.append(ADOPTIUMJDK64s);
+    java_candidates.append(SEMERUJDK64s);
     java_candidates.append(MICROSOFTJDK64s);
     java_candidates.append(ZULU64s);
     java_candidates.append(LIBERICA64s);
@@ -316,6 +328,7 @@ QList<QString> JavaUtils::FindJavaPaths()
     java_candidates.append(NEWJRE32s);
     java_candidates.append(ADOPTOPENJRE32s);
     java_candidates.append(ADOPTIUMJRE32s);
+    java_candidates.append(SEMERUJRE32s);
     java_candidates.append(MakeJavaPtr("C:/Program Files (x86)/Java/jre8/bin/javaw.exe"));
     java_candidates.append(MakeJavaPtr("C:/Program Files (x86)/Java/jre7/bin/javaw.exe"));
     java_candidates.append(MakeJavaPtr("C:/Program Files (x86)/Java/jre6/bin/javaw.exe"));
@@ -324,6 +337,7 @@ QList<QString> JavaUtils::FindJavaPaths()
     java_candidates.append(ADOPTOPENJDK32s);
     java_candidates.append(FOUNDATIONJDK32s);
     java_candidates.append(ADOPTIUMJDK32s);
+    java_candidates.append(SEMERUJDK32s);
     java_candidates.append(ZULU32s);
     java_candidates.append(LIBERICA32s);
 

--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -207,7 +207,7 @@ QList<JavaInstallPtr> JavaUtils::FindJavaFromRegistryKey(DWORD keyType, QString 
                     QString newKeyName = keyName + "\\" + newSubkeyName + subkeySuffix;
 
                     HKEY newKey;
-                    if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, newKeyName.toStdWString().c_str(), 0, KEY_READ | KEY_WOW64_64KEY, &newKey) ==
+                    if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, newKeyName.toStdWString().c_str(), 0, KEY_READ | keyType, &newKey) ==
                         ERROR_SUCCESS) {
                         // Read the JavaHome value to find where Java is installed.
                         DWORD valueSz = 0;


### PR DESCRIPTION
[IBM Semeru](https://developer.ibm.com/languages/java/semeru-runtimes/downloads/) uses [OpenJ9](https://en.wikipedia.org/wiki/OpenJ9), which is known to be quite memory efficient, making it potentially interesting for large modpacks.

The detection code is a straight forward copy of the Eclipse Adoptium detection, substituting
`Eclipse Adoptium` -> `Semeru`, `ADOPTIUM` -> `SEMERU`, `hotspot` -> `openj9`

Tested working with 8.0.402.0 x64 JDK and 17.0.10.0 x64 JRE. (I assume x86 should just work.)

P.S.
[MSYS2's build instructions](https://prismlauncher.org/wiki/development/build-instructions/#preparing-msys2) are missing `qt6-networkauth:p` in the pacboy step if someone reading wants to fix it.