### PR TITLE
[Linux] Auto-detect Gentoo installed JDKs

### DIFF
--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -405,6 +405,10 @@ QList<QString> JavaUtils::FindJavaPaths()
     scanJavaDirs("/usr/lib/jvm");
     scanJavaDirs("/usr/lib64/jvm");
     scanJavaDirs("/usr/lib32/jvm");
+    // Gentoo's locations for openjdk and openjdk-bin respectively
+    scanJavaDir("/usr/lib64");
+    scanJavaDir("/usr/lib");
+    scanJavaDir("/opt");
     // javas stored in Prism Launcher's folder
     scanJavaDirs("java");
     // manually installed JDKs in /opt


### PR DESCRIPTION
Here is where Gentoo installs its JDKs

openjdk:
```
/usr/lib64/openjdk-11
/usr/lib64/openjdk-17
/usr/lib64/openjdk-21
/usr/lib64/openjdk-8
```

openjdk-bin and openjdk-jre-bin:
```
/opt/openj9-openjdk-bin-17 // unofficial package
/opt/openj9-openjdk-bin-17.0.9_p9 // unofficial package
/opt/openj9-openjdk-bin-21 // unofficial package
/opt/openj9-openjdk-bin-21.0.1 // unofficial package
/opt/openjdk-bin-11
/opt/openjdk-bin-11.0.18_p10
/opt/openjdk-bin-17
/opt/openjdk-bin-17.0.6_p10
/opt/openjdk-bin-20
/opt/openjdk-bin-20_beta20221125
/opt/openjdk-bin-21
/opt/openjdk-bin-21.0.1_p12
/opt/openjdk-bin-8
/opt/openjdk-bin-8.362_p09
/opt/openjdk-jre-bin-21
```
`/opt/openjdk-bin-8` is symlinked to `/opt/openjdk-bin-8.362_p09` and so on, so it's only important to get `openjdk-{bin-,jre-bin-}` followed by the short version, (ie, 17 instead of 17.0.6_p10), but this doesn't really matter too much as preeeesm does **not** follow symlinks.

Is this fine, or should I limit it only to paths containing `jdk` or `openjdk`?