### PR TITLE
[Linux] Add support for bcachefs for Copy-on-Write instance copies

### DIFF
--- a/launcher/FileSystem.h
+++ b/launcher/FileSystem.h
@@ -460,7 +460,7 @@ QString nearestExistentAncestor(const QString& path);
 FilesystemInfo statFS(const QString& path);
 
 static const QList<FilesystemType> s_clone_filesystems = { FilesystemType::BTRFS, FilesystemType::APFS, FilesystemType::ZFS,
-                                                           FilesystemType::XFS, FilesystemType::REFS, FilesystemType::BCACHEFS };
+                                                           FilesystemType::XFS,   FilesystemType::REFS, FilesystemType::BCACHEFS };
 
 /**
  * @brief if the Filesystem is reflink/clone capable

--- a/launcher/FileSystem.h
+++ b/launcher/FileSystem.h
@@ -378,6 +378,7 @@ enum class FilesystemType {
     HFSX,
     FUSEBLK,
     F2FS,
+    BCACHEFS,
     UNKNOWN
 };
 
@@ -406,6 +407,7 @@ static const QMap<FilesystemType, QStringList> s_filesystem_type_names = { { Fil
                                                                            { FilesystemType::HFSX, { "HFSX" } },
                                                                            { FilesystemType::FUSEBLK, { "FUSEBLK" } },
                                                                            { FilesystemType::F2FS, { "F2FS" } },
+                                                                           { FilesystemType::BCACHEFS, { "BCACHEFS" } },
                                                                            { FilesystemType::UNKNOWN, { "UNKNOWN" } } };
 
 /**
@@ -458,7 +460,7 @@ QString nearestExistentAncestor(const QString& path);
 FilesystemInfo statFS(const QString& path);
 
 static const QList<FilesystemType> s_clone_filesystems = { FilesystemType::BTRFS, FilesystemType::APFS, FilesystemType::ZFS,
-                                                           FilesystemType::XFS, FilesystemType::REFS };
+                                                           FilesystemType::XFS, FilesystemType::REFS, FilesystemType::BCACHEFS };
 
 /**
  * @brief if the Filesystem is reflink/clone capable


### PR DESCRIPTION
This Pull Request introduces file system support for [bcachefs](https://bcachefs.org/) to Prism Launcher. Bcachefs is known for its advanced features, and includes support for reflinks, which is also enabled through this change. Bcachefs is now [merged in Linux 6.7](https://lkml.org/lkml/2023/10/30/1098) so supporting it in Prism Launcher could provide great benefits to Linux users.