### PR TITLE
Fix resizing too small causing an index out of range crash

### DIFF
--- a/launcher/ui/instanceview/VisualGroup.cpp
+++ b/launcher/ui/instanceview/VisualGroup.cpp
@@ -66,6 +66,9 @@ void VisualGroup::update()
             rows[currentRow].height = maxRowHeight;
             rows[currentRow].top = offsetFromTop;
             currentRow++;
+            if(currentRow >= rows.size()) {
+                currentRow = rows.size() - 1;
+            }
             offsetFromTop += maxRowHeight + 5;
             positionInRow = 0;
             maxRowHeight = 0;

--- a/launcher/ui/instanceview/VisualGroup.cpp
+++ b/launcher/ui/instanceview/VisualGroup.cpp
@@ -66,7 +66,7 @@ void VisualGroup::update()
             rows[currentRow].height = maxRowHeight;
             rows[currentRow].top = offsetFromTop;
             currentRow++;
-            if(currentRow >= rows.size()) {
+            if (currentRow >= rows.size()) {
                 currentRow = rows.size() - 1;
             }
             offsetFromTop += maxRowHeight + 5;


### PR DESCRIPTION
I haven't verified the change too much, but it seems to work well.