### PR TITLE
Fix typo in NetJob.cpp

### DIFF
--- a/launcher/net/NetJob.cpp
+++ b/launcher/net/NetJob.cpp
@@ -149,7 +149,7 @@ void NetJob::emitFailed(QString reason)
                                                  "Failed urls\n" +
                                                      getFailedFiles().join("\n\t") +
                                                      "\n"
-                                                     "If this continues to happen please check the logs of the application"
+                                                     "If this continues to happen please check the logs of the application. "
                                                      "Do you want to retry?",
                                                  QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No, QMessageBox::No)
                         ->exec();


### PR DESCRIPTION
Text was reading as

> ...please check the logs of the applicationDo you want to retry?

I believe the intention was for it to read

> ...please check the logs of the application. Do you want to retry?

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->

![image](https://github.com/PrismLauncher/PrismLauncher/assets/58576759/2847a9b2-2641-4f38-9622-1c9b74adae09)

