### PR TITLE
ignore failed dependency checks

### DIFF
--- a/launcher/minecraft/mod/tasks/GetModDependenciesTask.cpp
+++ b/launcher/minecraft/mod/tasks/GetModDependenciesTask.cpp
@@ -156,6 +156,10 @@ Task::Ptr GetModDependenciesTask::getProjectInfoTask(std::shared_ptr<PackDepende
             qWarning() << "Error while reading mod info:" << e.cause();
         }
     });
+    QObject::connect(info.get(), &NetJob::failed, [this, info, pDep] {
+        removePack(pDep->pack->addonId);
+        m_failed.remove(info.get());
+    });
     return info;
 }
 
@@ -230,6 +234,10 @@ Task::Ptr GetModDependenciesTask::prepareDependencyTask(const ModPlatform::Depen
     };
 
     auto version = getAPI(provider)->getDependencyVersion(std::move(args), std::move(callbacks));
+    QObject::connect(version.get(), &NetJob::failed, [this, version, pDep] {
+        removePack(pDep->pack->addonId);
+        m_failed.remove(version.get());
+    });
     tasks->addTask(version);
     return tasks;
 }


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
Parent PR:https://github.com/PrismLauncher/PrismLauncher/pull/1843
in case we fail to get a dep ignore the fail and remove the dependency.
Some relevant discussions
- https://discord.com/channels/1031648380885147709/1252273162574630993
- https://github.com/Scubakay/litematica-enderchest-materials/issues/9

This was introduced when I fixed the concurrent task (now it failed previously it would always succeed)

The mods mentioned were fixed upstream, so until I can find another mod we can test this this can remain as a draft