### PR TITLE
perf: print api servers asynchronously on instance launch

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -163,6 +163,8 @@ set(LAUNCH_SOURCES
     launch/steps/Update.h
     launch/steps/QuitAfterGameStop.cpp
     launch/steps/QuitAfterGameStop.h
+    launch/steps/PrintServers.cpp
+    launch/steps/PrintServers.h
     launch/LaunchStep.cpp
     launch/LaunchStep.h
     launch/LaunchTask.cpp

--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -36,6 +36,7 @@
 
 #include "LaunchController.h"
 #include "Application.h"
+#include "launch/steps/PrintServers.h"
 #include "minecraft/auth/AccountData.h"
 #include "minecraft/auth/AccountList.h"
 
@@ -345,25 +346,8 @@ void LaunchController::launchInstance()
 
         // Prepend Server Status
         QStringList servers = { "login.microsoftonline.com", "session.minecraft.net", "textures.minecraft.net", "api.mojang.com" };
-        QString resolved_servers = "";
-        QHostInfo host_info;
 
-        for (QString server : servers) {
-            host_info = QHostInfo::fromName(server);
-            resolved_servers = resolved_servers + server + " resolves to:\n    [";
-            if (!host_info.addresses().isEmpty()) {
-                for (QHostAddress address : host_info.addresses()) {
-                    resolved_servers = resolved_servers + address.toString();
-                    if (!host_info.addresses().endsWith(address)) {
-                        resolved_servers = resolved_servers + ", ";
-                    }
-                }
-            } else {
-                resolved_servers = resolved_servers + "N/A";
-            }
-            resolved_servers = resolved_servers + "]\n\n";
-        }
-        m_launcher->prependStep(makeShared<TextPrint>(m_launcher.get(), resolved_servers, MessageLevel::Launcher));
+        m_launcher->prependStep(makeShared<PrintServers>(m_launcher.get(), servers));
     } else {
         online_mode = m_demo ? "demo" : "offline";
     }

--- a/launcher/launch/steps/PrintServers.cpp
+++ b/launcher/launch/steps/PrintServers.cpp
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (c) 2024 Leia uwu <leia@tutamail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "PrintServers.h"
+#include "QHostInfo"
+
+PrintServers::PrintServers(LaunchTask* parent, const QStringList& servers) : LaunchStep(parent)
+{
+    m_servers = servers;
+}
+
+void PrintServers::executeTask()
+{
+    for (QString server : m_servers) {
+        QHostInfo::lookupHost(server, this, &PrintServers::resolveServer);
+    }
+}
+
+void PrintServers::resolveServer(const QHostInfo& host_info)
+{
+    QString server = host_info.hostName();
+    QString addresses = server + " resolves to:\n    [";
+
+    if (!host_info.addresses().isEmpty()) {
+        for (QHostAddress address : host_info.addresses()) {
+            addresses += address.toString();
+            if (!host_info.addresses().endsWith(address)) {
+                addresses += ", ";
+            }
+        }
+    } else {
+        addresses += "N/A";
+    }
+    addresses += "]\n\n";
+
+    m_server_to_address.insert(server, addresses);
+
+    // print server info in order once all servers are resolved
+    if (m_server_to_address.size() >= m_servers.size()) {
+        for (QString serv : m_servers) {
+            emit logLine(m_server_to_address.value(serv), MessageLevel::Launcher);
+        }
+        emitSucceeded();
+    }
+}
+
+bool PrintServers::canAbort() const
+{
+    return true;
+}

--- a/launcher/launch/steps/PrintServers.h
+++ b/launcher/launch/steps/PrintServers.h
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (c) 2024 Leia uwu <leia@tutamail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <LoggedProcess.h>
+#include <java/JavaChecker.h>
+#include <launch/LaunchStep.h>
+#include <QHostInfo>
+
+class PrintServers : public LaunchStep {
+    Q_OBJECT
+   public:
+    PrintServers(LaunchTask* parent, const QStringList& servers);
+
+    virtual void executeTask();
+    virtual bool canAbort() const;
+
+   private:
+    void resolveServer(const QHostInfo& host_info);
+    QMap<QString, QString> m_server_to_address;
+    QStringList m_servers;
+};


### PR DESCRIPTION
Doing this on the main thread can cause the launcher to freeze for up to 5 seconds when launching an instance on my system
so i moved it to a launch step where it gets all the servers info asynchronously to print