### PR TITLE
Add functionality to allow overriding ciphers blocked in Java

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -641,6 +641,9 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         m_settings->registerSetting("UseNativeGLFW", false);
         m_settings->registerSetting("CustomGLFWPath", "");
 
+        // Java signature validation workarounds
+        m_settings->registerSetting("AllowOldJarCiphers", false);
+
         // Performance related options
         m_settings->registerSetting("EnableFeralGamemode", false);
         m_settings->registerSetting("EnableMangoHud", false);

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -483,7 +483,7 @@ QStringList MinecraftInstance::javaArguments()
     // custom args go first. we want to override them if we have our own here.
     args.append(extraArguments());
     // Create required java.security file in instance folder.
-    if (settings()->get("AllowOldJarCiphers").toBool()){
+    if (settings()->get("AllowOldJarCiphers").toBool()) {
         QFile jarSecPolicyFile(instanceRoot() + "/java.security");
         jarSecPolicyFile.open(QIODevice::ReadWrite | QIODevice::Text);
         jarSecPolicyFile.resize(0);

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -484,14 +484,14 @@ QStringList MinecraftInstance::javaArguments()
     args.append(extraArguments());
     // Create required java.security file in instance folder.
     if (settings()->get("AllowOldJarCiphers").toBool()) {
-        QFile jarSecPolicyFile(instanceRoot() + "/java.security");
-        jarSecPolicyFile.open(QIODevice::ReadWrite | QIODevice::Text);
-        jarSecPolicyFile.resize(0);
-        jarSecPolicyFile.write("jdk.jar.disabledAlgorithms=MD2, MD5, RSA keySize < 1024");
-        jarSecPolicyFile.flush();
-        jarSecPolicyFile.close();
-        QString oldJarCiphersArgument = "-Djava.security.properties=" + jarSecPolicyFile.fileName();
-        args.append(oldJarCiphersArgument);
+        try {
+            auto fileName=FS::PathCombine(instanceRoot(), "java.security");
+            FS::write(fileName, "jdk.jar.disabledAlgorithms=MD2, MD5, RSA keySize < 1024");
+            QString oldJarCiphersArgument = "-Djava.security.properties="+fileName;
+            args.append(oldJarCiphersArgument);
+        } catch (...) {
+            qWarning() << "Failed to write loosened JAR signature requirement profile";
+        }
     }
     // OSX dock icon and name
 #ifdef Q_OS_MAC

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -485,9 +485,9 @@ QStringList MinecraftInstance::javaArguments()
     // Create required java.security file in instance folder.
     if (settings()->get("AllowOldJarCiphers").toBool()) {
         try {
-            auto fileName=FS::PathCombine(instanceRoot(), "java.security");
+            auto fileName = FS::PathCombine(instanceRoot(), "java.security");
             FS::write(fileName, "jdk.jar.disabledAlgorithms=MD2, MD5, RSA keySize < 1024");
-            QString oldJarCiphersArgument = "-Djava.security.properties="+fileName;
+            QString oldJarCiphersArgument = "-Djava.security.properties=" + fileName;
             args.append(oldJarCiphersArgument);
         } catch (...) {
             qWarning() << "Failed to write loosened JAR signature requirement profile";

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -482,7 +482,17 @@ QStringList MinecraftInstance::javaArguments()
 
     // custom args go first. we want to override them if we have our own here.
     args.append(extraArguments());
-
+    // Create required java.security file in instance folder.
+    if (settings()->get("AllowOldJarCiphers").toBool()){
+        QFile jarSecPolicyFile(instanceRoot() + "/java.security");
+        jarSecPolicyFile.open(QIODevice::ReadWrite | QIODevice::Text);
+        jarSecPolicyFile.resize(0);
+        jarSecPolicyFile.write("jdk.jar.disabledAlgorithms=MD2, MD5, RSA keySize < 1024");
+        jarSecPolicyFile.flush();
+        jarSecPolicyFile.close();
+        QString oldJarCiphersArgument = "-Djava.security.properties=" + jarSecPolicyFile.fileName();
+        args.append(oldJarCiphersArgument);
+    }
     // OSX dock icon and name
 #ifdef Q_OS_MAC
     args << "-Xdock:icon=icon.png";

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -173,6 +173,10 @@ void MinecraftInstance::loadSpecificSettings()
         m_settings->registerOverride(global_settings->getSetting("UseNativeGLFW"), nativeLibraryWorkaroundsOverride);
         m_settings->registerOverride(global_settings->getSetting("CustomGLFWPath"), nativeLibraryWorkaroundsOverride);
 
+        // Java signature validation workarounds
+        auto signatureValidationWorkaroundsOverride = m_settings->registerSetting("OverrideSignatureWorkarounds", false);
+        m_settings->registerOverride(global_settings->getSetting("AllowOldJarCiphers"), signatureValidationWorkaroundsOverride);
+
         // Performance related options
         auto performanceOverride = m_settings->registerSetting("OverridePerformance", false);
         m_settings->registerOverride(global_settings->getSetting("EnableFeralGamemode"), performanceOverride);

--- a/launcher/ui/pages/global/JavaPage.cpp
+++ b/launcher/ui/pages/global/JavaPage.cpp
@@ -95,6 +95,9 @@ void JavaPage::applySettings()
     s->set("IgnoreJavaCompatibility", ui->skipCompatibilityCheckbox->isChecked());
     s->set("IgnoreJavaWizard", ui->skipJavaWizardCheckbox->isChecked());
     JavaCommon::checkJVMArgs(s->get("JvmArgs").toString(), this->parentWidget());
+
+    // Security Settings
+    s->set("AllowOldJarCiphers", ui->reenableOldCiphersForJarCheck->isChecked());
 }
 void JavaPage::loadSettings()
 {
@@ -116,6 +119,9 @@ void JavaPage::loadSettings()
     ui->jvmArgsTextBox->setPlainText(s->get("JvmArgs").toString());
     ui->skipCompatibilityCheckbox->setChecked(s->get("IgnoreJavaCompatibility").toBool());
     ui->skipJavaWizardCheckbox->setChecked(s->get("IgnoreJavaWizard").toBool());
+
+    // Security Settings
+    ui->reenableOldCiphersForJarCheck->setChecked(s->get("AllowOldJarCiphers").toBool());
 }
 
 void JavaPage::on_javaDetectBtn_clicked()

--- a/launcher/ui/pages/global/JavaPage.ui
+++ b/launcher/ui/pages/global/JavaPage.ui
@@ -291,6 +291,22 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="securityGroupBox">
+         <property name="title">
+          <string>Security</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout">
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="reenableOldCiphersForJarCheck">
+            <property name="text">
+             <string>Re-enable old ciphers for JAR validation</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>

--- a/launcher/ui/pages/instance/InstanceSettingsPage.cpp
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.cpp
@@ -211,9 +211,9 @@ void InstanceSettingsPage::applySettings()
         m_settings->reset("Env");
 
     // Workarounds
-    bool workarounds = ui->nativeWorkaroundsGroupBox->isChecked();
-    m_settings->set("OverrideNativeWorkarounds", workarounds);
-    if (workarounds) {
+    bool nativeWorkarounds = ui->nativeWorkaroundsGroupBox->isChecked();
+    m_settings->set("OverrideNativeWorkarounds", nativeWorkarounds);
+    if (nativeWorkarounds) {
         m_settings->set("UseNativeGLFW", ui->useNativeGLFWCheck->isChecked());
         m_settings->set("CustomGLFWPath", ui->lineEditGLFWPath->text());
         m_settings->set("UseNativeOpenAL", ui->useNativeOpenALCheck->isChecked());
@@ -224,6 +224,14 @@ void InstanceSettingsPage::applySettings()
         m_settings->reset("UseNativeOpenAL");
         m_settings->reset("CustomOpenALPath");
     }
+    bool signatureWorkarounds = ui->signatureWorkaroundsGroupBox->isChecked();
+    m_settings->set("OverrideSignatureWorkarounds", signatureWorkarounds);
+    if (signatureWorkarounds) {
+        m_settings->set("AllowOldJarCiphers", ui->reenableOldCiphersForJarCheck->isChecked());
+    } else {
+        m_settings->reset("AllowOldJarCiphers");
+    }
+
 
     // Performance
     bool performance = ui->perfomanceGroupBox->isChecked();
@@ -351,6 +359,8 @@ void InstanceSettingsPage::loadSettings()
 #else
     ui->lineEditOpenALPath->setPlaceholderText(tr("Path to %1 library file").arg(BuildConfig.OPENAL_LIBRARY_NAME));
 #endif
+    ui->signatureWorkaroundsGroupBox->setChecked(m_settings->get("OverrideSignatureWorkarounds").toBool());
+    ui->reenableOldCiphersForJarCheck->setChecked(m_settings->get("AllowOldJarCiphers").toBool());
 
     // Performance
     ui->perfomanceGroupBox->setChecked(m_settings->get("OverridePerformance").toBool());

--- a/launcher/ui/pages/instance/InstanceSettingsPage.cpp
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.cpp
@@ -232,7 +232,6 @@ void InstanceSettingsPage::applySettings()
         m_settings->reset("AllowOldJarCiphers");
     }
 
-
     // Performance
     bool performance = ui->perfomanceGroupBox->isChecked();
     m_settings->set("OverridePerformance", performance);

--- a/launcher/ui/pages/instance/InstanceSettingsPage.ui
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.ui
@@ -36,7 +36,7 @@
    <item>
     <widget class="QTabWidget" name="settingsTabs">
      <property name="currentIndex">
-      <number>0</number>
+      <number>4</number>
      </property>
      <widget class="QWidget" name="minecraftPage">
       <attribute name="title">
@@ -496,6 +496,28 @@
            <widget class="QLineEdit" name="lineEditOpenALPath">
             <property name="enabled">
              <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="signatureWorkaroundsGroupBox">
+         <property name="title">
+          <string>Signature validation</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_4">
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="reenableOldCiphersForJarCheck">
+            <property name="text">
+             <string>Re-enable old ciphers for JAR validation. (Warning! Only do this to make older mods work.)</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
This series of commits adds functionality that allows for the automatic creation and loading of a Java security property file which allows more antiquated ciphers to be used to verify Jar files, intended to allow easy running of old modpacks that use ciphers not accepted by current Java.

I have only been able to test this on the Linux Flatpak build, and while everything I've added should be OS-agnostic, I can't guarantee it is.

An example of a modpack that fails without the fix implemented by this pull request, and the reason I did the troubleshooting that led me to creating the fix, is the original Agrarian Skies. I would suggest using that pack to test.