### PR TITLE
Fix missing curseforge logo

### DIFF
--- a/launcher/modplatform/flame/FlameModIndex.cpp
+++ b/launcher/modplatform/flame/FlameModIndex.cpp
@@ -20,6 +20,9 @@ void FlameMod::loadIndexedPack(ModPlatform::IndexedPack& pack, QJsonObject& obj)
     QJsonObject logo = Json::ensureObject(obj, "logo");
     pack.logoName = Json::ensureString(logo, "title");
     pack.logoUrl = Json::ensureString(logo, "thumbnailUrl");
+    if (pack.logoUrl.isEmpty()) {
+        pack.logoUrl = Json::ensureString(logo, "url");
+    }
 
     auto authors = Json::ensureArray(obj, "authors");
     for (auto authorIter : authors) {


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
fixes https://discord.com/channels/1031648380885147709/1031823065937629267/1254853868169461833
basically in case the `thumbnailUrl` is empty use the `url` for the logo