### PR TITLE
Do not display message that no update is available if the check was …

### DIFF
--- a/launcher/updater/PrismExternalUpdater.cpp
+++ b/launcher/updater/PrismExternalUpdater.cpp
@@ -86,6 +86,11 @@ PrismExternalUpdater::~PrismExternalUpdater()
 
 void PrismExternalUpdater::checkForUpdates()
 {
+    checkForUpdates(true);
+}
+
+void PrismExternalUpdater::checkForUpdates(bool triggeredByUser)
+{
     QProgressDialog progress(tr("Checking for updates..."), "", 0, 0, priv->parent);
     progress.setCancelButton(nullptr);
     progress.adjustSize();
@@ -160,7 +165,7 @@ void PrismExternalUpdater::checkForUpdates()
     switch (exit_code) {
         case 0:
             // no update available
-            {
+            if (triggeredByUser) {
                 qDebug() << "No update available";
                 auto msgBox = QMessageBox(QMessageBox::Information, tr("No Update Available"), tr("You are running the latest version."),
                                           QMessageBox::Ok, priv->parent);
@@ -288,7 +293,7 @@ void PrismExternalUpdater::disconnectTimer()
 void PrismExternalUpdater::autoCheckTimerFired()
 {
     qDebug() << "Auto update Timer fired";
-    checkForUpdates();
+    checkForUpdates(false);
 }
 
 void PrismExternalUpdater::offerUpdate(const QString& version_name, const QString& version_tag, const QString& release_notes)

--- a/launcher/updater/PrismExternalUpdater.h
+++ b/launcher/updater/PrismExternalUpdater.h
@@ -41,6 +41,7 @@ class PrismExternalUpdater : public ExternalUpdater {
      * Check for updates manually, showing the user a progress bar and an alert if no updates are found.
      */
     void checkForUpdates() override;
+    void checkForUpdates(bool triggeredByUser);
 
     /*!
      * Indicates whether or not to check for updates automatically.


### PR DESCRIPTION
…done in the background

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
fixes #2579