### PR TITLE
Fix linux non portable update

### DIFF
--- a/launcher/updater/prismupdater/PrismUpdater.cpp
+++ b/launcher/updater/prismupdater/PrismUpdater.cpp
@@ -787,6 +787,10 @@ QList<GitHubReleaseAsset> PrismUpdaterApp::validReleaseArtifacts(const GitHubRel
     if (BuildConfig.BUILD_ARTIFACT.isEmpty())
         qWarning() << "Build platform is not set!";
     for (auto asset : release.assets) {
+        if (asset.name.endsWith("zsync")) {
+            qDebug() << "Rejecting zsync file" << asset.name;
+            continue;
+        }
         if (!m_isAppimage && asset.name.toLower().endsWith("appimage")) {
             qDebug() << "Rejecting" << asset.name << "because it is an AppImage";
             continue;

--- a/launcher/updater/prismupdater/PrismUpdater.cpp
+++ b/launcher/updater/prismupdater/PrismUpdater.cpp
@@ -1020,7 +1020,7 @@ void PrismUpdaterApp::performInstall(QFileInfo file)
     FS::write(changelog_path, m_install_release.body.toUtf8());
 
     logUpdate(tr("Updating from %1 to %2").arg(m_prismVersion).arg(m_install_release.tag_name));
-    if (m_isPortable || file.suffix().toLower() == "zip") {
+    if (m_isPortable || file.fileName().endsWith(".zip") || file.fileName().endsWith(".tar.gz")) {
         write_lock_file(update_lock_path, QDateTime::currentDateTime(), m_prismVersion, m_install_release.tag_name, m_rootPath, m_dataPath);
         logUpdate(tr("Updating portable install at %1").arg(m_rootPath));
         unpackAndInstall(file);

--- a/launcher/updater/prismupdater/PrismUpdater.cpp
+++ b/launcher/updater/prismupdater/PrismUpdater.cpp
@@ -244,8 +244,9 @@ PrismUpdaterApp::PrismUpdaterApp(int& argc, char** argv) : QApplication(argc, ar
 
     auto updater_executable = QCoreApplication::applicationFilePath();
 
-    if (BuildConfig.BUILD_ARTIFACT.toLower() == "macos")
-        showFatalErrorMessage(tr("MacOS Not Supported"), tr("The updater does not support installations on MacOS"));
+#ifdef Q_OS_MACOS
+    showFatalErrorMessage(tr("MacOS Not Supported"), tr("The updater does not support installations on MacOS"));
+#endif
 
     if (updater_executable.startsWith("/tmp/.mount_")) {
         m_isAppimage = true;
@@ -578,12 +579,6 @@ void PrismUpdaterApp::run()
         if (need_update)
             result = callAppImageUpdate();
         return exit(result ? 0 : 1);
-    }
-
-    if (BuildConfig.BUILD_ARTIFACT.toLower() == "linux" && !m_isPortable) {
-        showFatalErrorMessage(tr("Updating Not Supported"),
-                              tr("Updating non-portable linux installations is not supported. Please use your system package manager"));
-        return;
     }
 
     if (need_update || m_forceUpdate || !m_userSelectedVersion.isEmpty()) {
@@ -1098,7 +1093,7 @@ void PrismUpdaterApp::backupAppDir()
 
     if (file_list.isEmpty()) {
         // best guess
-        if (BuildConfig.BUILD_ARTIFACT.toLower() == "linux") {
+        if (BuildConfig.BUILD_ARTIFACT.toLower().contains("linux")) {
             file_list.append({ "PrismLauncher", "bin", "share", "lib" });
         } else {  // windows by process of elimination
             file_list.append({

--- a/launcher/updater/prismupdater/PrismUpdater.cpp
+++ b/launcher/updater/prismupdater/PrismUpdater.cpp
@@ -787,7 +787,7 @@ QList<GitHubReleaseAsset> PrismUpdaterApp::validReleaseArtifacts(const GitHubRel
     if (BuildConfig.BUILD_ARTIFACT.isEmpty())
         qWarning() << "Build platform is not set!";
     for (auto asset : release.assets) {
-        if (asset.name.endsWith("zsync")) {
+        if (asset.name.endsWith(".zsync")) {
             qDebug() << "Rejecting zsync file" << asset.name;
             continue;
         }


### PR DESCRIPTION
Fix #2586
non portable linux updates technically works via a `.tar.gz` just like the portable version would even if not generally a good idea.


We probably want some sort of way to flag that the updater should be disabled if some packager is reusing our binary builds, that can be another PR though.
