### PR TITLE
control Prism data directory via env variable

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -292,12 +292,17 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
     QString adjustedBy;
     QString dataPath;
     // change folder
+    QString dataDirEnv;
     QString dirParam = parser.value("dir");
     if (!dirParam.isEmpty()) {
         // the dir param. it makes multimc data path point to whatever the user specified
         // on command line
         adjustedBy = "Command line";
         dataPath = dirParam;
+    } else if (dataDirEnv = QProcessEnvironment::systemEnvironment().value(QString("%1_DATA_DIR").arg(BuildConfig.LAUNCHER_NAME.toUpper()));
+               !dataDirEnv.isEmpty()) {
+        adjustedBy = "System environment";
+        dataPath = dataDirEnv;
     } else {
         QDir foo;
         if (DesktopServices::isSnap()) {
@@ -443,7 +448,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
 
         // search the dataPath()
         // seach app data standard path
-        if (!foundLoggingRules && !isPortable() && dirParam.isEmpty()) {
+        if (!foundLoggingRules && !isPortable() && dirParam.isEmpty() && dataDirEnv.isEmpty()) {
             logRulesPath = QStandardPaths::locate(QStandardPaths::AppDataLocation, FS::PathCombine("..", logRulesFile));
             if (!logRulesPath.isEmpty()) {
                 qDebug() << "Found" << logRulesPath << "...";

--- a/launcher/updater/prismupdater/PrismUpdater.cpp
+++ b/launcher/updater/prismupdater/PrismUpdater.cpp
@@ -332,6 +332,16 @@ PrismUpdaterApp::PrismUpdaterApp(int& argc, char** argv) : QApplication(argc, ar
             m_isPortable = true;
         }
 #endif
+    } else if (auto dataDirEnv =
+                   QProcessEnvironment::systemEnvironment().value(QString("%1_DATA_DIR").arg(BuildConfig.LAUNCHER_NAME.toUpper()));
+               !dataDirEnv.isEmpty()) {
+        adjustedBy = "System environment";
+        m_dataPath = dataDirEnv;
+#ifndef Q_OS_MACOS
+        if (QFile::exists(FS::PathCombine(m_rootPath, "portable.txt"))) {
+            m_isPortable = true;
+        }
+#endif
     } else {
         QDir foo(FS::PathCombine(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation), ".."));
         m_dataPath = foo.absolutePath();


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
fixes #2577 by adding an env variable that controls the data directory(`PRISMLAUNCHER_DATA_DIR`)
see https://github.com/PrismLauncher/PrismLauncher/issues/2577#issuecomment-2198208483