### PR TITLE
Add SkipModpackUpdatePrompt setting

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -662,7 +662,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         // Minecraft mods
         m_settings->registerSetting("ModMetadataDisabled", false);
         m_settings->registerSetting("ModDependenciesDisabled", false);
-        m_settings->registerSetting("ModpackUpdatePromptDisabled", false);
+        m_settings->registerSetting("SkipModpackUpdatePrompt", false);
 
         // Minecraft offline player name
         m_settings->registerSetting("LastOfflinePlayerName", "");

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -662,6 +662,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         // Minecraft mods
         m_settings->registerSetting("ModMetadataDisabled", false);
         m_settings->registerSetting("ModDependenciesDisabled", false);
+        m_settings->registerSetting("ModpackUpdatePromptDisabled", false);
 
         // Minecraft offline player name
         m_settings->registerSetting("LastOfflinePlayerName", "");

--- a/launcher/InstanceTask.cpp
+++ b/launcher/InstanceTask.cpp
@@ -24,7 +24,7 @@ InstanceNameChange askForChangingInstanceName(QWidget* parent, const QString& ol
 
 ShouldUpdate askIfShouldUpdate(QWidget* parent, QString original_version_name)
 {
-    if (APPLICATION->settings()->get("ModpackUpdatePromptDisabled").toBool())
+    if (APPLICATION->settings()->get("SkipModpackUpdatePrompt").toBool())
         return ShouldUpdate::SkipUpdating;
 
     auto info = CustomMessageBox::selectable(

--- a/launcher/InstanceTask.cpp
+++ b/launcher/InstanceTask.cpp
@@ -1,5 +1,7 @@
 #include "InstanceTask.h"
 
+#include "Application.h"
+#include "settings/SettingsObject.h"
 #include "ui/dialogs/CustomMessageBox.h"
 
 #include <QPushButton>
@@ -22,6 +24,9 @@ InstanceNameChange askForChangingInstanceName(QWidget* parent, const QString& ol
 
 ShouldUpdate askIfShouldUpdate(QWidget* parent, QString original_version_name)
 {
+    if (APPLICATION->settings()->get("ModpackUpdatePromptDisabled").toBool())
+        return ShouldUpdate::SkipUpdating;
+
     auto info = CustomMessageBox::selectable(
         parent, QObject::tr("Similar modpack was found!"),
         QObject::tr(

--- a/launcher/ui/pages/global/LauncherPage.cpp
+++ b/launcher/ui/pages/global/LauncherPage.cpp
@@ -241,7 +241,7 @@ void LauncherPage::applySettings()
     // Mods
     s->set("ModMetadataDisabled", ui->metadataDisableBtn->isChecked());
     s->set("ModDependenciesDisabled", ui->dependenciesDisableBtn->isChecked());
-    s->set("ModpackUpdatePromptDisabled", ui->modpackUpdatePromptDisableBtn->isChecked());
+    s->set("SkipModpackUpdatePrompt", ui->skipModpackUpdatePromptBtn->isChecked());
 }
 void LauncherPage::loadSettings()
 {
@@ -304,7 +304,7 @@ void LauncherPage::loadSettings()
     ui->metadataDisableBtn->setChecked(s->get("ModMetadataDisabled").toBool());
     ui->metadataWarningLabel->setHidden(!ui->metadataDisableBtn->isChecked());
     ui->dependenciesDisableBtn->setChecked(s->get("ModDependenciesDisabled").toBool());
-    ui->modpackUpdatePromptDisableBtn->setChecked(s->get("ModpackUpdatePromptDisabled").toBool());
+    ui->skipModpackUpdatePromptBtn->setChecked(s->get("SkipModpackUpdatePrompt").toBool());
 }
 
 void LauncherPage::refreshFontPreview()

--- a/launcher/ui/pages/global/LauncherPage.cpp
+++ b/launcher/ui/pages/global/LauncherPage.cpp
@@ -241,6 +241,7 @@ void LauncherPage::applySettings()
     // Mods
     s->set("ModMetadataDisabled", ui->metadataDisableBtn->isChecked());
     s->set("ModDependenciesDisabled", ui->dependenciesDisableBtn->isChecked());
+    s->set("ModpackUpdatePromptDisabled", ui->modpackUpdatePromptDisableBtn->isChecked());
 }
 void LauncherPage::loadSettings()
 {
@@ -303,6 +304,7 @@ void LauncherPage::loadSettings()
     ui->metadataDisableBtn->setChecked(s->get("ModMetadataDisabled").toBool());
     ui->metadataWarningLabel->setHidden(!ui->metadataDisableBtn->isChecked());
     ui->dependenciesDisableBtn->setChecked(s->get("ModDependenciesDisabled").toBool());
+    ui->modpackUpdatePromptDisableBtn->setChecked(s->get("ModpackUpdatePromptDisabled").toBool());
 }
 
 void LauncherPage::refreshFontPreview()

--- a/launcher/ui/pages/global/LauncherPage.ui
+++ b/launcher/ui/pages/global/LauncherPage.ui
@@ -244,12 +244,12 @@
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="modpackUpdatePromptDisableBtn">
+           <widget class="QCheckBox" name="skipModpackUpdatePromptBtn">
             <property name="toolTip">
-             <string>When creating a new modpack instance, do not suggest updating existing instances.</string>
+             <string>When creating a new modpack instance, do not suggest updating existing instances instead.</string>
             </property>
             <property name="text">
-             <string>Always create new modpack instance</string>
+             <string>Skip modpack update prompt</string>
             </property>
            </widget>
           </item>

--- a/launcher/ui/pages/global/LauncherPage.ui
+++ b/launcher/ui/pages/global/LauncherPage.ui
@@ -243,6 +243,16 @@
             </property>
            </widget>
           </item>
+          <item>
+           <widget class="QCheckBox" name="modpackUpdatePromptDisableBtn">
+            <property name="toolTip">
+             <string>When creating a new modpack instance, do not suggest updating existing instances.</string>
+            </property>
+            <property name="text">
+             <string>Always create new modpack instance</string>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>


### PR DESCRIPTION
Fixes #2556

When creating an instance of a modpack that's already associated with another instance, the user gets asked if they want to update that instance instead. As somebody with a lot of instances of the same optimisation modpacks, this behaviour is inconvenient. This PR adds the ~~`ModpackUpdatePromptDisabled`~~ (renamed to `SkipModpackUpdatePrompt`) setting, which skips the prompt and immediately creates the instance when enabled.

**Note:** Not confident about the name of the setting, feel free to suggest alternatives.