### PR TITLE
feat: propagate Sink error handling

### DIFF
--- a/launcher/net/ByteArraySink.h
+++ b/launcher/net/ByteArraySink.h
@@ -58,6 +58,7 @@ class ByteArraySink : public Sink {
             qWarning() << "ByteArraySink did not initialize the buffer because it's not addressable";
         if (initAllValidators(request))
             return Task::State::Running;
+        m_fail_reason = "Failed to initialize validators";
         return Task::State::Failed;
     };
 
@@ -69,12 +70,14 @@ class ByteArraySink : public Sink {
             qWarning() << "ByteArraySink did not write the buffer because it's not addressable";
         if (writeAllValidators(data))
             return Task::State::Running;
+        m_fail_reason = "Failed to write validators";
         return Task::State::Failed;
     }
 
     auto abort() -> Task::State override
     {
         failAllValidators();
+        m_fail_reason = "Aborted";
         return Task::State::Failed;
     }
 
@@ -82,12 +85,13 @@ class ByteArraySink : public Sink {
     {
         if (finalizeAllValidators(reply))
             return Task::State::Succeeded;
+        m_fail_reason = "Failed to finalize validators";
         return Task::State::Failed;
     }
 
     auto hasLocalData() -> bool override { return false; }
 
-   private:
+   protected:
     std::shared_ptr<QByteArray> m_output;
 };
 }  // namespace Net

--- a/launcher/net/FileSink.cpp
+++ b/launcher/net/FileSink.cpp
@@ -51,6 +51,7 @@ Task::State FileSink::init(QNetworkRequest& request)
     // create a new save file and open it for writing
     if (!FS::ensureFilePathExists(m_filename)) {
         qCCritical(taskNetLogC) << "Could not create folder for " + m_filename;
+        m_fail_reason = "Could not create folder";
         return Task::State::Failed;
     }
 
@@ -58,11 +59,13 @@ Task::State FileSink::init(QNetworkRequest& request)
     m_output_file.reset(new PSaveFile(m_filename));
     if (!m_output_file->open(QIODevice::WriteOnly)) {
         qCCritical(taskNetLogC) << "Could not open " + m_filename + " for writing";
+        m_fail_reason = "Could not open file";
         return Task::State::Failed;
     }
 
     if (initAllValidators(request))
         return Task::State::Running;
+    m_fail_reason = "Failed to initialize validators";
     return Task::State::Failed;
 }
 
@@ -73,6 +76,7 @@ Task::State FileSink::write(QByteArray& data)
         m_output_file->cancelWriting();
         m_output_file.reset();
         m_wroteAnyData = false;
+        m_fail_reason = "Failed to write validators";
         return Task::State::Failed;
     }
 
@@ -105,13 +109,16 @@ Task::State FileSink::finalize(QNetworkReply& reply)
     if (gotFile || m_wroteAnyData) {
         // ask validators for data consistency
         // we only do this for actual downloads, not 'your data is still the same' cache hits
-        if (!finalizeAllValidators(reply))
+        if (!finalizeAllValidators(reply)) {
+            m_fail_reason = "Failed to finalize validators";
             return Task::State::Failed;
+        }
 
         // nothing went wrong...
         if (!m_output_file->commit()) {
             qCCritical(taskNetLogC) << "Failed to commit changes to " << m_filename;
             m_output_file->cancelWriting();
+            m_fail_reason = "Failed to commit changes";
             return Task::State::Failed;
         }
     }

--- a/launcher/net/Sink.h
+++ b/launcher/net/Sink.h
@@ -52,6 +52,8 @@ class Sink {
 
     virtual auto hasLocalData() -> bool = 0;
 
+    QString failReason() const { return m_fail_reason; }
+
     void addValidator(Validator* validator)
     {
         if (validator) {
@@ -95,5 +97,6 @@ class Sink {
 
    protected:
     std::vector<std::shared_ptr<Validator>> validators;
+    QString m_fail_reason;
 };
 }  // namespace Net

--- a/launcher/screenshots/ImgurAlbumCreation.cpp
+++ b/launcher/screenshots/ImgurAlbumCreation.cpp
@@ -86,6 +86,7 @@ auto ImgurAlbumCreation::Sink::write(QByteArray& data) -> Task::State
 auto ImgurAlbumCreation::Sink::abort() -> Task::State
 {
     m_output.clear();
+    m_fail_reason = "Aborted";
     return Task::State::Failed;
 }
 
@@ -95,11 +96,13 @@ auto ImgurAlbumCreation::Sink::finalize(QNetworkReply&) -> Task::State
     QJsonDocument doc = QJsonDocument::fromJson(m_output, &jsonError);
     if (jsonError.error != QJsonParseError::NoError) {
         qDebug() << jsonError.errorString();
+        m_fail_reason = "Invalid json reply";
         return Task::State::Failed;
     }
     auto object = doc.object();
     if (!object.value("success").toBool()) {
         qDebug() << doc.toJson();
+        m_fail_reason = "Failed to create album";
         return Task::State::Failed;
     }
     m_result->deleteHash = object.value("data").toObject().value("deletehash").toString();

--- a/launcher/screenshots/ImgurUpload.cpp
+++ b/launcher/screenshots/ImgurUpload.cpp
@@ -90,6 +90,7 @@ auto ImgurUpload::Sink::write(QByteArray& data) -> Task::State
 auto ImgurUpload::Sink::abort() -> Task::State
 {
     m_output.clear();
+    m_fail_reason = "Aborted";
     return Task::State::Failed;
 }
 
@@ -99,11 +100,13 @@ auto ImgurUpload::Sink::finalize(QNetworkReply&) -> Task::State
     QJsonDocument doc = QJsonDocument::fromJson(m_output, &jsonError);
     if (jsonError.error != QJsonParseError::NoError) {
         qDebug() << "imgur server did not reply with JSON" << jsonError.errorString();
+        m_fail_reason = "Invalid json reply";
         return Task::State::Failed;
     }
     auto object = doc.object();
     if (!object.value("success").toBool()) {
         qDebug() << "Screenshot upload not successful:" << doc.toJson();
+        m_fail_reason = "Screenshot was not uploaded successfully";
         return Task::State::Failed;
     }
     m_shot->m_imgurId = object.value("data").toObject().value("id").toString();

--- a/launcher/tasks/ConcurrentTask.cpp
+++ b/launcher/tasks/ConcurrentTask.cpp
@@ -118,10 +118,14 @@ void ConcurrentTask::executeNextSubTask()
     }
     if (m_queue.isEmpty()) {
         if (m_doing.isEmpty()) {
-            if (m_failed.isEmpty())
+            if (m_failed.isEmpty()) {
                 emitSucceeded();
-            else
+            } else if (m_failed.count() == 1) {
+                auto task = m_failed.keys().first();
+                emitFailed(task->failReason());
+            } else {
                 emitFailed(tr("One or more subtasks failed"));
+            }
         }
         return;
     }

--- a/launcher/tasks/ConcurrentTask.cpp
+++ b/launcher/tasks/ConcurrentTask.cpp
@@ -122,9 +122,24 @@ void ConcurrentTask::executeNextSubTask()
                 emitSucceeded();
             } else if (m_failed.count() == 1) {
                 auto task = m_failed.keys().first();
-                emitFailed(task->failReason());
+                auto reason = task->failReason();
+                if (reason.isEmpty()) {  // clearly a bug somewhere
+                    reason = tr("Task failed");
+                }
+                emitFailed(reason);
             } else {
-                emitFailed(tr("One or more subtasks failed"));
+                QStringList failReason;
+                for (auto t : m_failed) {
+                    auto reason = t->failReason();
+                    if (!reason.isEmpty()) {
+                        failReason << reason;
+                    }
+                }
+                if (failReason.isEmpty()) {
+                    emitFailed(tr("Multiple subtasks failed"));
+                } else {
+                    emitFailed(tr("Multiple subtasks failed\n%1").arg(failReason.join("\n")));
+                }
             }
         }
         return;


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
~~blocked by #2617~~
blocked by #1872
This Pr aims to refactor paste upload to use netrequest class. 
Also adds a way for sinks to report the fail reason.
fixes #3093