### PR TITLE
Fix JavaUtils to properly autodetect JVM paths on BSDs

### DIFF
--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -394,7 +394,7 @@ QList<QString> JavaUtils::FindJavaPaths()
     return javas;
 }
 
-#elif defined(Q_OS_LINUX)
+#elif defined(Q_OS_LINUX) || defined(Q_OS_OPENBSD) || defined(Q_OS_FREEBSD)
 QList<QString> JavaUtils::FindJavaPaths()
 {
     QList<QString> javas;
@@ -419,6 +419,7 @@ QList<QString> JavaUtils::FindJavaPaths()
             scanJavaDir(snap + dirPath);
         }
     };
+#if defined(Q_OS_LINUX)
     // oracle RPMs
     scanJavaDirs("/usr/java");
     // general locations used by distro packaging
@@ -437,7 +438,10 @@ QList<QString> JavaUtils::FindJavaPaths()
     scanJavaDirs("/opt/ibm");  // IBM Semeru Certified Edition
     // flatpak
     scanJavaDirs("/app/jdk");
-
+#elif defined(Q_OS_OPENBSD) || defined(Q_OS_FREEBSD)
+    // ports install to /usr/local on OpenBSD & FreeBSD
+    scanJavaDirs("/usr/local");
+#endif
     auto home = qEnvironmentVariable("HOME");
 
     // javas downloaded by IntelliJ


### PR DESCRIPTION
Self Explanatory.

I use the existing Linux JVM PATH autodetect and add `defined()` preprocessor conditionals to check FreeBSD and OpenBSD target paths as well.

The Java binaries are installed as subdirectories in `/usr/local`.

I have only tested on OpenBSD.