### PR TITLE
Fix a few typos

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -817,7 +817,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         m_icons.reset(new IconList(instFolders, setting->get().toString()));
         connect(setting.get(), &Setting::SettingChanged,
                 [&](const Setting&, QVariant value) { m_icons->directoryChanged(value.toString()); });
-        qDebug() << "<> Instance icons intialized.";
+        qDebug() << "<> Instance icons initialized.";
     }
 
     // Themes

--- a/launcher/minecraft/PackProfile.cpp
+++ b/launcher/minecraft/PackProfile.cpp
@@ -181,7 +181,7 @@ static bool loadPackProfile(PackProfile* parent,
     }
     if (!componentsFile.open(QFile::ReadOnly)) {
         qCritical() << "Couldn't open" << componentsFile.fileName() << " for reading:" << componentsFile.errorString();
-        qWarning() << "Ignoring overriden order";
+        qWarning() << "Ignoring overridden order";
         return false;
     }
 
@@ -190,7 +190,7 @@ static bool loadPackProfile(PackProfile* parent,
     QJsonDocument doc = QJsonDocument::fromJson(componentsFile.readAll(), &error);
     if (error.error != QJsonParseError::NoError) {
         qCritical() << "Couldn't parse" << componentsFile.fileName() << ":" << error.errorString();
-        qWarning() << "Ignoring overriden order";
+        qWarning() << "Ignoring overridden order";
         return false;
     }
 

--- a/launcher/minecraft/ProfileUtils.cpp
+++ b/launcher/minecraft/ProfileUtils.cpp
@@ -57,7 +57,7 @@ bool readOverrideOrders(QString path, PatchOrder& order)
     }
     if (!orderFile.open(QFile::ReadOnly)) {
         qCritical() << "Couldn't open" << orderFile.fileName() << " for reading:" << orderFile.errorString();
-        qWarning() << "Ignoring overriden order";
+        qWarning() << "Ignoring overridden order";
         return false;
     }
 
@@ -66,7 +66,7 @@ bool readOverrideOrders(QString path, PatchOrder& order)
     QJsonDocument doc = QJsonDocument::fromJson(orderFile.readAll(), &error);
     if (error.error != QJsonParseError::NoError) {
         qCritical() << "Couldn't parse" << orderFile.fileName() << ":" << error.errorString();
-        qWarning() << "Ignoring overriden order";
+        qWarning() << "Ignoring overridden order";
         return false;
     }
 
@@ -84,7 +84,7 @@ bool readOverrideOrders(QString path, PatchOrder& order)
         }
     } catch ([[maybe_unused]] const JSONValidationError& err) {
         qCritical() << "Couldn't parse" << orderFile.fileName() << ": bad file format";
-        qWarning() << "Ignoring overriden order";
+        qWarning() << "Ignoring overridden order";
         order.clear();
         return false;
     }

--- a/launcher/net/NetRequest.cpp
+++ b/launcher/net/NetRequest.cpp
@@ -86,7 +86,7 @@ void NetRequest::executeTask()
             break;
         case State::Inactive:
         case State::Failed:
-            emit failed("Failed to initilize sink");
+            emit failed("Failed to initialize sink");
             emit finished();
             return;
         case State::AbortedByUser:

--- a/launcher/settings/OverrideSetting.h
+++ b/launcher/settings/OverrideSetting.h
@@ -29,7 +29,7 @@
 class OverrideSetting : public Setting {
     Q_OBJECT
    public:
-    explicit OverrideSetting(std::shared_ptr<Setting> overriden, std::shared_ptr<Setting> gate);
+    explicit OverrideSetting(std::shared_ptr<Setting> overridden, std::shared_ptr<Setting> gate);
 
     virtual QVariant defValue() const;
     virtual QVariant get() const;

--- a/launcher/settings/PassthroughSetting.h
+++ b/launcher/settings/PassthroughSetting.h
@@ -28,7 +28,7 @@
 class PassthroughSetting : public Setting {
     Q_OBJECT
    public:
-    explicit PassthroughSetting(std::shared_ptr<Setting> overriden, std::shared_ptr<Setting> gate);
+    explicit PassthroughSetting(std::shared_ptr<Setting> overridden, std::shared_ptr<Setting> gate);
 
     virtual QVariant defValue() const;
     virtual QVariant get() const;

--- a/launcher/ui/pages/modplatform/flame/FlameModel.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameModel.cpp
@@ -172,7 +172,7 @@ void ListModel::performPaginatedSearch()
             callbacks.on_succeed = [this](auto& doc, auto& pack) { searchRequestForOneSucceeded(doc); };
             callbacks.on_abort = [this] {
                 qCritical() << "Search task aborted by an unknown reason!";
-                searchRequestFailed("Abborted");
+                searchRequestFailed("Aborted");
             };
             static const FlameAPI api;
             if (auto job = api.getProjectInfo({ projectId }, std::move(callbacks)); job) {


### PR DESCRIPTION
As part of packaging Prism Launcher for Debian, I have run a package linter called lintian which found a few spelling errors throughout the source.

I am not a fan of contributions that only fix cosmetics like spelling errors, but Debian encourages forwarding this stuff upstream instead of letting it get fixed naturally over time.

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
