### PR TITLE
ui: swap timeoutSecondsLabel and numberOfManualRetriesLabel order

### DIFF
--- a/launcher/ui/pages/global/LauncherPage.ui
+++ b/launcher/ui/pages/global/LauncherPage.ui
@@ -291,6 +291,20 @@
            </widget>
           </item>
           <item row="2" column="0">
+           <widget class="QLabel" name="numberOfManualRetriesLabel">
+            <property name="text">
+             <string>Number of manual retries</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QSpinBox" name="numberOfManualRetriesSpinBox">
+            <property name="minimum">
+             <number>0</number>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
            <widget class="QLabel" name="timeoutSecondsLabel">
             <property name="toolTip">
              <string>Seconds to wait until the requests are terminated</string>
@@ -300,24 +314,10 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
+          <item row="3" column="1">
            <widget class="QSpinBox" name="timeoutSecondsSpinBox">
             <property name="suffix">
              <string>s</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="numberOfManualRetriesLabel">
-            <property name="text">
-             <string>Number of manual retries</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1">
-           <widget class="QSpinBox" name="numberOfManualRetriesSpinBox">
-            <property name="minimum">
-             <number>0</number>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Parent PR: #2415
Parent PR: #2440
fixes: 7a200a337f08cfa1e32102594958f10cb7f000c6
conflicted with 6078a771c18fd749f38d7c1a2f80ed3c7ec7ad28


![image](https://github.com/user-attachments/assets/4a3fe688-2e73-46e9-9aa0-40094de3871f)
