### PR TITLE
nix: sync changes from nixpkgs

### DIFF
--- a/nix/distribution.nix
+++ b/nix/distribution.nix
@@ -24,9 +24,8 @@
     overlays.default = final: prev: let
       version = builtins.substring 0 8 self.lastModifiedDate or "dirty";
     in {
-      prismlauncher-unwrapped = prev.qt6Packages.callPackage ./pkg {
+      prismlauncher-unwrapped = prev.callPackage ./pkg {
         inherit (inputs) libnbtplusplus;
-        inherit ((final.darwin or prev.darwin).apple_sdk.frameworks) Cocoa;
         inherit version;
       };
 

--- a/nix/pkg/wrapper.nix
+++ b/nix/pkg/wrapper.nix
@@ -3,94 +3,143 @@
   stdenv,
   symlinkJoin,
   prismlauncher-unwrapped,
-  wrapQtAppsHook,
   addOpenGLRunpath,
-  qtbase, # needed for wrapQtAppsHook
-  qtsvg,
-  qtwayland,
-  xorg,
-  libpulseaudio,
-  libGL,
+  flite,
+  gamemode,
   glfw,
-  openal,
+  glfw-wayland-minecraft,
+  glxinfo,
   jdk8,
   jdk17,
   jdk21,
-  gamemode,
-  flite,
-  glxinfo,
-  udev,
+  kdePackages,
+  libGL,
+  libpulseaudio,
   libusb1,
-  msaClientID ? null,
-  gamemodeSupport ? stdenv.isLinux,
-  textToSpeechSupport ? stdenv.isLinux,
-  controllerSupport ? stdenv.isLinux,
-  jdks ? [jdk21 jdk17 jdk8],
+  makeWrapper,
+  openal,
+  pciutils,
+  udev,
+  vulkan-loader,
+  xorg,
   additionalLibs ? [],
   additionalPrograms ? [],
-}: let
-  prismlauncherFinal = prismlauncher-unwrapped.override {
-    inherit msaClientID gamemodeSupport;
-  };
+  controllerSupport ? stdenv.isLinux,
+  gamemodeSupport ? stdenv.isLinux,
+  jdks ? [
+    jdk21
+    jdk17
+    jdk8
+  ],
+  msaClientID ? null,
+  textToSpeechSupport ? stdenv.isLinux,
+  # Adds `glfw-wayland-minecraft` to `LD_LIBRARY_PATH`
+  # when launched on wayland, allowing for the game to be run natively.
+  # Make sure to enable "Use system installation of GLFW" in instance settings
+  # for this to take effect
+  #
+  # Warning: This build of glfw may be unstable, and the launcher
+  # itself can take slightly longer to start
+  withWaylandGLFW ? false,
+}:
+assert lib.assertMsg (
+  controllerSupport -> stdenv.isLinux
+) "controllerSupport only has an effect on Linux.";
+assert lib.assertMsg (
+  textToSpeechSupport -> stdenv.isLinux
+) "textToSpeechSupport only has an effect on Linux.";
+assert lib.assertMsg (
+  withWaylandGLFW -> stdenv.isLinux
+) "withWaylandGLFW is only available on Linux."; let
+  prismlauncher' = prismlauncher-unwrapped.override {inherit msaClientID gamemodeSupport;};
 in
   symlinkJoin {
-    name = "prismlauncher-${prismlauncherFinal.version}";
+    name = "prismlauncher-${prismlauncher'.version}";
 
-    paths = [prismlauncherFinal];
+    paths = [prismlauncher'];
 
-    nativeBuildInputs = [
-      wrapQtAppsHook
-    ];
+    nativeBuildInputs =
+      [kdePackages.wrapQtAppsHook]
+      # purposefully using a shell wrapper here for variable expansion
+      # see https://github.com/NixOS/nixpkgs/issues/172583
+      ++ lib.optional withWaylandGLFW makeWrapper;
 
     buildInputs =
       [
-        qtbase
-        qtsvg
+        kdePackages.qtbase
+        kdePackages.qtsvg
       ]
-      ++ lib.optional (lib.versionAtLeast qtbase.version "6" && stdenv.isLinux) qtwayland;
+      ++ lib.optional (
+        lib.versionAtLeast kdePackages.qtbase.version "6" && stdenv.isLinux
+      )
+      kdePackages.qtwayland;
 
-    postBuild = ''
-      wrapQtAppsHook
-    '';
+    env = {
+      waylandPreExec = lib.optionalString withWaylandGLFW ''
+        if [ -n "$WAYLAND_DISPLAY" ]; then
+          export LD_LIBRARY_PATH=${lib.getLib glfw-wayland-minecraft}/lib:"$LD_LIBRARY_PATH"
+        fi
+      '';
+    };
+
+    postBuild =
+      lib.optionalString withWaylandGLFW ''
+        qtWrapperArgs+=(--run "$waylandPreExec")
+      ''
+      + ''
+        wrapQtAppsHook
+      '';
 
     qtWrapperArgs = let
       runtimeLibs =
-        (with xorg; [
-          libX11
-          libXext
-          libXcursor
-          libXrandr
-          libXxf86vm
-        ])
-        ++ [
+        [
           # lwjgl
+          glfw
           libpulseaudio
           libGL
-          glfw
           openal
           stdenv.cc.cc.lib
 
-          # oshi
-          udev
+          vulkan-loader # VulkanMod's lwjgl
+
+          udev # oshi
+
+          xorg.libX11
+          xorg.libXext
+          xorg.libXcursor
+          xorg.libXrandr
+          xorg.libXxf86vm
         ]
-        ++ lib.optional gamemodeSupport gamemode.lib
         ++ lib.optional textToSpeechSupport flite
+        ++ lib.optional gamemodeSupport gamemode.lib
         ++ lib.optional controllerSupport libusb1
         ++ additionalLibs;
 
       runtimePrograms =
         [
-          xorg.xrandr
           glxinfo
+          pciutils # need lspci
+          xorg.xrandr # needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
         ]
         ++ additionalPrograms;
     in
       ["--prefix PRISMLAUNCHER_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks}"]
       ++ lib.optionals stdenv.isLinux [
         "--set LD_LIBRARY_PATH ${addOpenGLRunpath.driverLink}/lib:${lib.makeLibraryPath runtimeLibs}"
-        # xorg.xrandr needed for LWJGL [2.9.2, 3) https://github.com/LWJGL/lwjgl/issues/128
         "--prefix PATH : ${lib.makeBinPath runtimePrograms}"
       ];
 
-    inherit (prismlauncherFinal) meta;
+    meta = {
+      inherit
+        (prismlauncher'.meta)
+        description
+        longDescription
+        homepage
+        changelog
+        license
+        maintainers
+        mainProgram
+        platforms
+        ;
+    };
   }


### PR DESCRIPTION
Brings in changes from the Prism Launcher derivation(s) in nixpkgs, notably from https://github.com/NixOS/nixpkgs/pull/321851 and https://github.com/NixOS/nixpkgs/pull/303880.

The packages here in upstream and in nixpkgs are essentially the same now. Tested on x86-64 Linux and x86-64 Darwin.

cc @getchoo @Scrumplex @Minion3665

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
