### PR TITLE
Restore connect line for device authorization in MSADeviceCodeStep

### DIFF
--- a/launcher/minecraft/auth/steps/MSADeviceCodeStep.cpp
+++ b/launcher/minecraft/auth/steps/MSADeviceCodeStep.cpp
@@ -74,6 +74,8 @@ void MSADeviceCodeStep::perform()
     m_task->setAskRetry(false);
     m_task->addNetAction(m_request);
 
+    connect(m_task.get(), &Task::finished, this, &MSADeviceCodeStep::deviceAutorizationFinished);
+
     m_task->start();
 }
 


### PR DESCRIPTION
Parent PR: #2617

fixes https://github.com/PrismLauncher/PrismLauncher/issues/2705

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
