### PR TITLE
mangohud support: MangoHud::getLibraryString should return absolute path

### DIFF
--- a/launcher/MangoHud.cpp
+++ b/launcher/MangoHud.cpp
@@ -40,8 +40,8 @@ namespace MangoHud {
 
 QString getLibraryString()
 {
-    /*
-     * Check for vulkan layers in this order:
+    /**
+     * Guess MangoHud install location by searching for vulkan layers in this order:
      *
      * $VK_LAYER_PATH
      * $XDG_DATA_DIRS (/usr/local/share/:/usr/share/)
@@ -49,8 +49,9 @@ QString getLibraryString()
      * /etc
      * $XDG_CONFIG_DIRS (/etc/xdg)
      * $XDG_CONFIG_HOME (~/.config)
+     *
+     * @returns Absolute path of libMangoHud.so if found and empty QString otherwise.
      */
-
     QStringList vkLayerList;
     {
         QString home = QDir::homePath();
@@ -85,7 +86,7 @@ QString getLibraryString()
         vkLayerList << FS::PathCombine(xdgConfigHome, "vulkan", "implicit_layer.d");
     }
 
-    for (QString vkLayer : vkLayerList) {
+    for (const QString& vkLayer : vkLayerList) {
         // prefer to use architecture specific vulkan layers
         QString currentArch = QSysInfo::currentCpuArchitecture();
 
@@ -95,8 +96,8 @@ QString getLibraryString()
 
         QStringList manifestNames = { QString("MangoHud.%1.json").arg(currentArch), "MangoHud.json" };
 
-        QString filePath = "";
-        for (QString manifestName : manifestNames) {
+        QString filePath{};
+        for (const QString& manifestName : manifestNames) {
             QString tryPath = FS::PathCombine(vkLayer, manifestName);
             if (QFile::exists(tryPath)) {
                 filePath = tryPath;
@@ -111,10 +112,23 @@ QString getLibraryString()
         auto conf = Json::requireDocument(filePath, vkLayer);
         auto confObject = Json::requireObject(conf, vkLayer);
         auto layer = Json::ensureObject(confObject, "layer");
-        return Json::ensureString(layer, "library_path");
+        QString libraryName = Json::ensureString(layer, "library_path");
+
+#ifdef __GLIBC__
+        // Check whether mangohud is usable on a glibc based system
+        if (!libraryName.isEmpty()) {
+            QString libraryPath = findLibrary(libraryName);
+            if (!libraryPath.isEmpty()) {
+                return libraryPath;
+            }
+        }
+#else
+        // Without glibc return recorded shared library as-is.
+        return libraryName;
+#endif
     }
 
-    return QString();
+    return {};
 }
 
 QString findLibrary(QString libName)

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -608,7 +608,7 @@ QProcessEnvironment MinecraftInstance::createLaunchEnvironment()
             // dlsym variant is only needed for OpenGL and not included in the vulkan layer
             appendLib("libMangoHud_dlsym.so");
             appendLib("libMangoHud_opengl.so");
-            appendLib(mangoHudLib.fileName());
+            preloadList << mangoHudLibString;
         }
 
         env.insert("LD_PRELOAD", preloadList.join(QLatin1String(":")));


### PR DESCRIPTION
Some distros ship MangoHub vulkan layer json with bare shared object name instead of an absolute path. This breaks environment config as `MinecraftInstance::createLaunchEnvironment()` seems to require absolute path of `libMangoHud.so`.

Since we already have `MangoHud::findLibrary()` lying around, use that to figure out where `libMangoHud.so` really is.

Also made a few related variables into const-reference along the way.