### PR TITLE
Truncate logs for mclo.gs to fit 25k line limit

### DIFF
--- a/launcher/net/PasteUpload.cpp
+++ b/launcher/net/PasteUpload.cpp
@@ -49,6 +49,27 @@
 
 #include "net/Logging.h"
 
+constexpr int MaxMclogsLines = 25000;
+constexpr int InitialMclogsLines = 10000;
+constexpr int FinalMclogsLines = 14900;
+
+QString truncateLogForMclogs(const QString &logContent) {
+    QStringList lines = logContent.split("\n");
+    if (lines.size() > MaxMclogsLines) {
+        QString truncatedLog = lines.mid(0, InitialMclogsLines).join("\n");
+        truncatedLog += "\n\n\n\n\n\n\n\n\n\n"
+                        "------------------------------------------------------------\n"
+                        "--------------------- Log truncated by ---------------------\n"
+                        "---------------------- Prism Launcher ----------------------\n"
+                        "----- Middle portion omitted to fit mclo.gs size limits ----\n"
+                        "------------------------------------------------------------\n"
+                        "\n\n\n\n\n\n\n\n\n\n";
+        truncatedLog += lines.mid(lines.size() - FinalMclogsLines, FinalMclogsLines).join("\n");
+        return truncatedLog;
+    }
+    return logContent;
+}
+
 std::array<PasteUpload::PasteTypeInfo, 4> PasteUpload::PasteTypes = { { { "0x0.st", "https://0x0.st", "" },
                                                                         { "hastebin", "https://hst.sh", "/documents" },
                                                                         { "paste.gg", "https://paste.gg", "/api/v1/pastes" },
@@ -98,6 +119,7 @@ void PasteUpload::executeTask()
         }
         case Mclogs: {
             QUrlQuery postData;
+            m_text = truncateLogForMclogs(m_text).toUtf8();
             postData.addQueryItem("content", m_text);
             request.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
             rep = APPLICATION->network()->post(request, postData.toString().toUtf8());

--- a/launcher/net/PasteUpload.cpp
+++ b/launcher/net/PasteUpload.cpp
@@ -49,29 +49,6 @@
 
 #include "net/Logging.h"
 
-constexpr int MaxMclogsLines = 25000;
-constexpr int InitialMclogsLines = 10000;
-constexpr int FinalMclogsLines = 14900;
-
-QString truncateLogForMclogs(const QString& logContent)
-{
-    QStringList lines = logContent.split("\n");
-    if (lines.size() > MaxMclogsLines) {
-        QString truncatedLog = lines.mid(0, InitialMclogsLines).join("\n");
-        truncatedLog +=
-            "\n\n\n\n\n\n\n\n\n\n"
-            "------------------------------------------------------------\n"
-            "--------------------- Log truncated by ---------------------\n"
-            "---------------------- Prism Launcher ----------------------\n"
-            "----- Middle portion omitted to fit mclo.gs size limits ----\n"
-            "------------------------------------------------------------\n"
-            "\n\n\n\n\n\n\n\n\n\n";
-        truncatedLog += lines.mid(lines.size() - FinalMclogsLines, FinalMclogsLines).join("\n");
-        return truncatedLog;
-    }
-    return logContent;
-}
-
 std::array<PasteUpload::PasteTypeInfo, 4> PasteUpload::PasteTypes = { { { "0x0.st", "https://0x0.st", "" },
                                                                         { "hastebin", "https://hst.sh", "/documents" },
                                                                         { "paste.gg", "https://paste.gg", "/api/v1/pastes" },
@@ -121,7 +98,6 @@ void PasteUpload::executeTask()
         }
         case Mclogs: {
             QUrlQuery postData;
-            m_text = truncateLogForMclogs(m_text).toUtf8();
             postData.addQueryItem("content", m_text);
             request.setHeader(QNetworkRequest::ContentTypeHeader, "application/x-www-form-urlencoded");
             rep = APPLICATION->network()->post(request, postData.toString().toUtf8());

--- a/launcher/net/PasteUpload.cpp
+++ b/launcher/net/PasteUpload.cpp
@@ -53,17 +53,19 @@ constexpr int MaxMclogsLines = 25000;
 constexpr int InitialMclogsLines = 10000;
 constexpr int FinalMclogsLines = 14900;
 
-QString truncateLogForMclogs(const QString &logContent) {
+QString truncateLogForMclogs(const QString &logContent)
+{
     QStringList lines = logContent.split("\n");
     if (lines.size() > MaxMclogsLines) {
         QString truncatedLog = lines.mid(0, InitialMclogsLines).join("\n");
-        truncatedLog += "\n\n\n\n\n\n\n\n\n\n"
-                        "------------------------------------------------------------\n"
-                        "--------------------- Log truncated by ---------------------\n"
-                        "---------------------- Prism Launcher ----------------------\n"
-                        "----- Middle portion omitted to fit mclo.gs size limits ----\n"
-                        "------------------------------------------------------------\n"
-                        "\n\n\n\n\n\n\n\n\n\n";
+        truncatedLog +=
+            "\n\n\n\n\n\n\n\n\n\n"
+            "------------------------------------------------------------\n"
+            "--------------------- Log truncated by ---------------------\n"
+            "---------------------- Prism Launcher ----------------------\n"
+            "----- Middle portion omitted to fit mclo.gs size limits ----\n"
+            "------------------------------------------------------------\n"
+            "\n\n\n\n\n\n\n\n\n\n";
         truncatedLog += lines.mid(lines.size() - FinalMclogsLines, FinalMclogsLines).join("\n");
         return truncatedLog;
     }

--- a/launcher/net/PasteUpload.cpp
+++ b/launcher/net/PasteUpload.cpp
@@ -53,7 +53,7 @@ constexpr int MaxMclogsLines = 25000;
 constexpr int InitialMclogsLines = 10000;
 constexpr int FinalMclogsLines = 14900;
 
-QString truncateLogForMclogs(const QString &logContent)
+QString truncateLogForMclogs(const QString& logContent)
 {
     QStringList lines = logContent.split("\n");
     if (lines.size() > MaxMclogsLines) {

--- a/launcher/ui/GuiUtil.cpp
+++ b/launcher/ui/GuiUtil.cpp
@@ -63,8 +63,8 @@ QString truncateLogForMclogs(const QString& logContent)
         truncatedLog +=
             "\n\n\n\n\n\n\n\n\n\n"
             "------------------------------------------------------------\n"
-            "--------------------- Log truncated by ---------------------\n"
-            "---------------------- Prism Launcher ----------------------\n"
+            "----------------------- Log truncated ----------------------\n"
+            "------------------------------------------------------------\n"
             "----- Middle portion omitted to fit mclo.gs size limits ----\n"
             "------------------------------------------------------------\n"
             "\n\n\n\n\n\n\n\n\n\n";

--- a/launcher/ui/GuiUtil.cpp
+++ b/launcher/ui/GuiUtil.cpp
@@ -115,17 +115,15 @@ std::optional<QString> GuiUtil::uploadPaste(const QString& name, const QString& 
                                                  QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No, QMessageBox::No)
                         ->exec();
 
-                if (truncateResponse == QMessageBox::Yes)
-                    shouldTruncate = true;
+                shouldTruncate = truncateResponse == QMessageBox::Yes;
             }
         }
     }
 
-    QString textToUpload;
-    if (shouldTruncate)
+    QString textToUpload = text;
+    if (shouldTruncate) {
         textToUpload = truncateLogForMclogs(text);
-    else
-        textToUpload = text;
+    }
 
     std::unique_ptr<PasteUpload> paste(new PasteUpload(parentWidget, textToUpload, pasteCustomAPIBaseSetting, pasteTypeSetting));
 

--- a/launcher/ui/GuiUtil.cpp
+++ b/launcher/ui/GuiUtil.cpp
@@ -112,9 +112,10 @@ std::optional<QString> GuiUtil::uploadPaste(const QString& name, const QString& 
                                                      .arg(MaxMclogsLines)
                                                      .arg(InitialMclogsLines)
                                                      .arg(FinalMclogsLines),
-                                                 QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No, QMessageBox::No)
+                                                 QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel, QMessageBox::No)
                         ->exec();
 
+                if (truncateResponse == QMessageBox::Cancel) { return {} ; }
                 shouldTruncate = truncateResponse == QMessageBox::Yes;
             }
         }

--- a/launcher/ui/GuiUtil.cpp
+++ b/launcher/ui/GuiUtil.cpp
@@ -103,11 +103,11 @@ std::optional<QString> GuiUtil::uploadPaste(const QString& name, const QString& 
             if (baseUrl.toString() == "https://api.mclo.gs" && text.count("\n") > MaxMclogsLines) {
                 auto truncateResponse = CustomMessageBox::selectable(
                                             parentWidget, QObject::tr("Confirm Truncate"),
-                                            QObject::tr("The log exceeds mclo.gs' limit: %1 lines (max %2).\n"
-                                                        "Prism can keep the first %3 and last %4 lines, trimming the middle.\n\n"
+                                            QObject::tr("The log has %1 lines, exceeding mclo.gs' limit of %2.\n"
+                                                        "The launcher can keep the first %3 and last %4 lines, trimming the middle.\n\n"
                                                         "If you choose 'No', mclo.gs will only keep the first %2 lines, cutting off "
                                                         "potentially useful info like crashes at the end.\n\n"
-                                                        "Proceed with Prism's truncation?")
+                                                        "Proceed with truncation?")
                                                 .arg(text.count("\n"))
                                                 .arg(MaxMclogsLines)
                                                 .arg(InitialMclogsLines)

--- a/launcher/ui/GuiUtil.cpp
+++ b/launcher/ui/GuiUtil.cpp
@@ -68,7 +68,7 @@ QString truncateLogForMclogs(const QString& logContent)
             "----- Middle portion omitted to fit mclo.gs size limits ----\n"
             "------------------------------------------------------------\n"
             "\n\n\n\n\n\n\n\n\n\n";
-        truncatedLog += lines.mid(lines.size() - FinalMclogsLines, FinalMclogsLines).join("\n");
+        truncatedLog += lines.mid(lines.size() - FinalMclogsLines - 1).join("\n");
         return truncatedLog;
     }
     return logContent;

--- a/launcher/ui/GuiUtil.cpp
+++ b/launcher/ui/GuiUtil.cpp
@@ -102,7 +102,7 @@ std::optional<QString> GuiUtil::uploadPaste(const QString& name, const QString& 
 
             if (baseUrl.toString() == "https://api.mclo.gs" && text.count("\n") > MaxMclogsLines) {
                 auto truncateResponse = CustomMessageBox::selectable(
-                                            parentWidget, QObject::tr("Confirm Truncate"),
+                                            parentWidget, QObject::tr("Confirm Truncation"),
                                             QObject::tr("The log has %1 lines, exceeding mclo.gs' limit of %2.\n"
                                                         "The launcher can keep the first %3 and last %4 lines, trimming the middle.\n\n"
                                                         "If you choose 'No', mclo.gs will only keep the first %2 lines, cutting off "

--- a/launcher/ui/GuiUtil.cpp
+++ b/launcher/ui/GuiUtil.cpp
@@ -101,21 +101,23 @@ std::optional<QString> GuiUtil::uploadPaste(const QString& name, const QString& 
                 return {};
 
             if (baseUrl.toString() == "https://api.mclo.gs" && text.count("\n") > MaxMclogsLines) {
-                auto truncateResponse =
-                    CustomMessageBox::selectable(parentWidget, QObject::tr("Confirm Truncate"),
-                                                 QObject::tr("The log exceeds mclo.gs' limit: %1 lines (max %2).\n"
-                                                             "Prism can keep the first %3 and last %4 lines, trimming the middle.\n\n"
-                                                             "If you choose 'No', mclo.gs will only keep the first %2 lines, cutting off "
-                                                             "potentially useful info like crashes at the end.\n\n"
-                                                             "Proceed with Prism's truncation?")
-                                                     .arg(text.count("\n"))
-                                                     .arg(MaxMclogsLines)
-                                                     .arg(InitialMclogsLines)
-                                                     .arg(FinalMclogsLines),
-                                                 QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel, QMessageBox::No)
-                        ->exec();
+                auto truncateResponse = CustomMessageBox::selectable(
+                                            parentWidget, QObject::tr("Confirm Truncate"),
+                                            QObject::tr("The log exceeds mclo.gs' limit: %1 lines (max %2).\n"
+                                                        "Prism can keep the first %3 and last %4 lines, trimming the middle.\n\n"
+                                                        "If you choose 'No', mclo.gs will only keep the first %2 lines, cutting off "
+                                                        "potentially useful info like crashes at the end.\n\n"
+                                                        "Proceed with Prism's truncation?")
+                                                .arg(text.count("\n"))
+                                                .arg(MaxMclogsLines)
+                                                .arg(InitialMclogsLines)
+                                                .arg(FinalMclogsLines),
+                                            QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel, QMessageBox::No)
+                                            ->exec();
 
-                if (truncateResponse == QMessageBox::Cancel) { return {} ; }
+                if (truncateResponse == QMessageBox::Cancel) {
+                    return {};
+                }
                 shouldTruncate = truncateResponse == QMessageBox::Yes;
             }
         }


### PR DESCRIPTION
This PR truncates Minecraft logs for `mclo.gs` uploads to fit their 25,000 line limit. Logs now include the first 10k lines, last 14.9k lines, and a marker indicating the middle portion is omitted.

Currently, Prism submits the entire log, leading to `mclo.gs` truncating only the first 25,000 lines of it. This can cause important info, such as crashes, to get cut off. Some examples from Discord: https://discord.com/channels/1031648380885147709/1118165588200657006/1253040769162412052, https://discord.com/channels/1031648380885147709/1118165588200657006/1262515643362836480, and more

I only changed how uploading logs works for mclo.gs and not other file upload services, since:
1) by far the majority of people use mclo.gs,
2) I was too lazy to deal with filesize-based limits (i.e. 256 MB),

but if you all think that it's silly to only include it as a feature for `mclo.gs`, I can look into adding support for something similar for other services