### PR TITLE
Stop accepting malformed hashes object

### DIFF
--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
@@ -346,23 +346,8 @@ bool ModrinthCreationTask::parseManifest(const QString& index_path,
                 }
 
                 QJsonObject hashes = Json::requireObject(modInfo, "hashes");
-                QString hash;
-                QCryptographicHash::Algorithm hashAlgorithm;
-                hash = Json::ensureString(hashes, "sha512");
-                hashAlgorithm = QCryptographicHash::Sha512;
-                if (hash.isEmpty()) {
-                    hash = Json::ensureString(hashes, "sha256");
-                    hashAlgorithm = QCryptographicHash::Sha256;
-                    if (hash.isEmpty()) {
-                        hash = Json::ensureString(hashes, "sha1");
-                        hashAlgorithm = QCryptographicHash::Sha1;
-                        if (hash.isEmpty()) {
-                            throw JSONValidationError("No hash found for: " + file.path);
-                        }
-                    }
-                }
-                file.hash = QByteArray::fromHex(hash.toLatin1());
-                file.hashAlgorithm = hashAlgorithm;
+                file.hash = QByteArray::fromHex(Json::requireString(hashes, "sha512").toLatin1());
+                file.hashAlgorithm = QCryptographicHash::Sha512;
 
                 // Do not use requireUrl, which uses StrictMode, instead use QUrl's default TolerantMode
                 // (as Modrinth seems to incorrectly handle spaces)


### PR DESCRIPTION
https://support.modrinth.com/en/articles/8802351-modrinth-modpack-format-mrpack:
> The hashes of the file specified. This MUST contain the SHA1 hash and the SHA512 hash. Other hashes are optional, but will usually be ignored.

Therefore there is no point having a fallback.