### PR TITLE
Add webp to validIconExtensions

### DIFF
--- a/launcher/icons/IconUtils.cpp
+++ b/launcher/icons/IconUtils.cpp
@@ -39,7 +39,7 @@
 #include "FileSystem.h"
 
 namespace {
-static const QStringList validIconExtensions = { { "svg", "png", "ico", "gif", "jpg", "jpeg" } };
+static const QStringList validIconExtensions = { { "svg", "png", "ico", "gif", "jpg", "jpeg", "webp" } };
 }
 
 namespace IconUtils {


### PR DESCRIPTION
Add webp to list of valid file extensions for Icons

This allows webp icons to be selected in the icon selector file browser.

Fixes/adds #2712 