### PR TITLE
Sort screenshots chronologically in descending order

### DIFF
--- a/launcher/ui/pages/instance/ScreenshotsPage.cpp
+++ b/launcher/ui/pages/instance/ScreenshotsPage.cpp
@@ -246,6 +246,7 @@ ScreenshotsPage::ScreenshotsPage(QString path, QWidget* parent) : QMainWindow(pa
     // considering screenshots aren't modified after creation.
     constexpr int file_modified_column_index = 3;
     m_model->sort(file_modified_column_index, Qt::DescendingOrder);
+
     m_folder = path;
     m_valid = FS::ensureFolderPathExists(m_folder);
 

--- a/launcher/ui/pages/instance/ScreenshotsPage.cpp
+++ b/launcher/ui/pages/instance/ScreenshotsPage.cpp
@@ -242,6 +242,10 @@ ScreenshotsPage::ScreenshotsPage(QString path, QWidget* parent) : QMainWindow(pa
     m_model->setReadOnly(false);
     m_model->setNameFilters({ "*.png" });
     m_model->setNameFilterDisables(false);
+    // Sorts by modified date instead of creation date because that column is not available and would require subclassing, this should work
+    // considering screenshots aren't modified after creation.
+    constexpr int file_modified_column_index = 3;
+    m_model->sort(file_modified_column_index, Qt::DescendingOrder);
     m_folder = path;
     m_valid = FS::ensureFolderPathExists(m_folder);
 


### PR DESCRIPTION
Feature request as mentioned in #2763.

# Test

Screenshots used for test and their modification times
```
Mar 20 21:25 'Mox Landing Cropped.png'
Mar 22 17:07 "97b's platform.png"
Dec  3  2023  2023-12-03_21.37.22.png
Jun 23  2023  2023-06-23_15.29.04.png
Jun  6  2023  2023-06-06_22.05.34.png
```

Before:
![before_image](https://github.com/user-attachments/assets/66489539-e514-47ff-98df-457b813682db)


After:
![after_image](https://github.com/user-attachments/assets/e97646c5-0106-4ce4-a88a-672029b7056e)
