### PR TITLE
Add search and support for subdirectories to icon picker

### DIFF
--- a/launcher/icons/IconList.cpp
+++ b/launcher/icons/IconList.cpp
@@ -147,13 +147,13 @@ QStringList IconList::getIconFilePaths() const
     return iconFiles;
 }
 
-QString formatName(const QDir& icons_dir, const QFileInfo& file)
+QString formatName(const QDir& iconsDir, const QFileInfo& file)
 {
-    if (file.dir() == icons_dir)
+    if (file.dir() == iconsDir)
         return file.baseName();
 
     constexpr auto delimiter = " » ";
-    QString relativePathWithoutExtension = icons_dir.relativeFilePath(file.dir().path()) + QDir::separator() + file.baseName();
+    QString relativePathWithoutExtension = iconsDir.relativeFilePath(file.dir().path()) + QDir::separator() + file.baseName();
     return relativePathWithoutExtension.replace(QDir::separator(), delimiter);
 }
 
@@ -171,9 +171,9 @@ void IconList::directoryChanged(const QString& path)
         if (!FS::ensureFolderPathExists(m_dir.absolutePath()))
             return;
     m_dir.refresh();
-    QStringList new_file_names_list = getIconFilePaths();
+    QStringList newFileNamesList = getIconFilePaths();
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
-    QSet<QString> new_set(new_file_names_list.begin(), new_file_names_list.end());
+    QSet<QString> new_set(newFileNamesList.begin(), newFileNamesList.end());
 #else
     auto new_set = new_file_names_list.toSet();
 #endif
@@ -192,13 +192,13 @@ void IconList::directoryChanged(const QString& path)
     QSet<QString> to_remove = current_set;
     to_remove -= new_set;
 
-    QSet<QString> to_add = new_set;
-    to_add -= current_set;
+    QSet<QString> toAdd = new_set;
+    toAdd -= current_set;
 
     for (const auto& remove : to_remove) {
         qDebug() << "Removing " << remove;
-        QFileInfo removed_file(remove);
-        QString key = m_dir.relativeFilePath(removed_file.absoluteFilePath());
+        QFileInfo removedFile(remove);
+        QString key = m_dir.relativeFilePath(removedFile.absoluteFilePath());
 
         int idx = getIconIndex(key);
         if (idx == -1)
@@ -216,7 +216,7 @@ void IconList::directoryChanged(const QString& path)
         emit iconUpdated(key);
     }
 
-    for (const auto& add : to_add) {
+    for (const auto& add : toAdd) {
         qDebug() << "Adding " << add;
 
         QFileInfo addfile(add);
@@ -464,16 +464,16 @@ void IconList::reindex()
 
 QIcon IconList::getIcon(const QString& key) const
 {
-    int icon_index = getIconIndex(key);
+    int iconIndex = getIconIndex(key);
 
-    if (icon_index != -1)
-        return icons[icon_index].icon();
+    if (iconIndex != -1)
+        return icons[iconIndex].icon();
 
     // Fallback for icons that don't exist.
-    icon_index = getIconIndex("grass");
+    iconIndex = getIconIndex("grass");
 
-    if (icon_index != -1)
-        return icons[icon_index].icon();
+    if (iconIndex != -1)
+        return icons[iconIndex].icon();
     return {};
 }
 
@@ -494,9 +494,9 @@ QString IconList::getDirectory() const
 /// Returns the directory of the icon with the given key or the default directory if it's a builtin icon.
 QString IconList::iconDirectory(const QString& key) const
 {
-    for (const auto& mmc_icon : icons) {
-        if (mmc_icon.m_key == key && mmc_icon.has(IconType::FileBased)) {
-            QFileInfo icon_file(mmc_icon.getFilePath());
+    for (const auto& mmcIcon : icons) {
+        if (mmcIcon.m_key == key && mmcIcon.has(IconType::FileBased)) {
+            QFileInfo icon_file(mmcIcon.getFilePath());
             return icon_file.dir().path();
         }
     }

--- a/launcher/icons/IconList.cpp
+++ b/launcher/icons/IconList.cpp
@@ -35,7 +35,6 @@
  */
 
 #include "IconList.h"
-#include <filesystem>
 #include <FileSystem.h>
 #include <QDebug>
 #include <QEventLoop>
@@ -154,13 +153,13 @@ QStringList IconList::getIconFilePaths() const
 
 QString formatName(const QDir& icons_dir, const QFileInfo& file)
 {
-    if (file.dir() == icons_dir) {
+    if (file.dir() == icons_dir)
         return file.baseName();
-    } else {
-        const QString delimiter = " » ";
-        return (icons_dir.relativeFilePath(file.dir().path()) + std::filesystem::path::preferred_separator + file.baseName())
-            .replace(std::filesystem::path::preferred_separator, delimiter);
-    }
+
+    constexpr auto delimiter = " » ";
+    constexpr auto fs_separator = std::filesystem::path::preferred_separator;
+    QString relative_path_without_extension = icons_dir.relativeFilePath(file.dir().path()) + fs_separator + file.baseName();
+    return relative_path_without_extension.replace(fs_separator, delimiter);
 }
 
 void IconList::directoryChanged(const QString& path)
@@ -311,7 +310,7 @@ bool IconList::dropMimeData(const QMimeData* data,
     if (data->hasUrls()) {
         auto urls = data->urls();
         QStringList iconFiles;
-        for (auto url : urls) {
+        for (const auto& url : urls) {
             // only local files may be dropped...
             if (!url.isLocalFile())
                 continue;

--- a/launcher/icons/IconList.cpp
+++ b/launcher/icons/IconList.cpp
@@ -35,6 +35,7 @@
  */
 
 #include "IconList.h"
+#include <filesystem>
 #include <FileSystem.h>
 #include <QDebug>
 #include <QEventLoop>

--- a/launcher/icons/IconList.cpp
+++ b/launcher/icons/IconList.cpp
@@ -35,6 +35,7 @@
  */
 
 #include "IconList.h"
+#include <filesystem>
 #include <FileSystem.h>
 #include <QDebug>
 #include <QEventLoop>
@@ -180,7 +181,7 @@ void IconList::directoryChanged(const QString& path)
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
     QSet<QString> new_set(new_file_names_list.begin(), new_file_names_list.end());
 #else
-    auto new_set = new_list.toSet();
+    auto new_set = new_file_names_list.toSet();
 #endif
     QList<QString> current_list;
     for (auto& it : icons) {

--- a/launcher/icons/IconList.cpp
+++ b/launcher/icons/IconList.cpp
@@ -95,10 +95,8 @@ bool IconList::addPathRecursively(const QString& path)
     if (!dir.exists())
         return false;
 
-    bool watching = false;
-
     // Add the directory itself
-    watching = m_watcher->addPath(path);
+    bool watching = m_watcher->addPath(path);
 
     // Add all subdirectories
     QFileInfoList entries = dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
@@ -134,21 +132,19 @@ void IconList::removePathRecursively(const QString& path)
 
 QStringList IconList::getIconFilePaths() const
 {
-    QStringList icon_files{};
+    QStringList iconFiles{};
     QStringList directories{ m_dir.absolutePath() };
     while (!directories.isEmpty()) {
         QString first = directories.takeFirst();
         QDir dir(first);
-        for (QString& file_name : dir.entryList(QDir::AllDirs | QDir::Files | QDir::NoDotAndDotDot, QDir::Name)) {
-            QString full_path = dir.filePath(file_name);  // Convert to full path
-            QFileInfo file_info(full_path);
-            if (file_info.isDir())
-                directories.push_back(full_path);
+        for (QFileInfo& fileInfo : dir.entryInfoList(QDir::AllDirs | QDir::Files | QDir::NoDotAndDotDot, QDir::Name)) {
+            if (fileInfo.isDir())
+                directories.push_back(fileInfo.absoluteFilePath());
             else
-                icon_files.push_back(full_path);
+                iconFiles.push_back(fileInfo.absoluteFilePath());
         }
     }
-    return icon_files;
+    return iconFiles;
 }
 
 QString formatName(const QDir& icons_dir, const QFileInfo& file)
@@ -157,8 +153,8 @@ QString formatName(const QDir& icons_dir, const QFileInfo& file)
         return file.baseName();
 
     constexpr auto delimiter = " » ";
-    QString relative_path_without_extension = icons_dir.relativeFilePath(file.dir().path()) + QDir::separator() + file.baseName();
-    return relative_path_without_extension.replace(QDir::separator(), delimiter);
+    QString relativePathWithoutExtension = icons_dir.relativeFilePath(file.dir().path()) + QDir::separator() + file.baseName();
+    return relativePathWithoutExtension.replace(QDir::separator(), delimiter);
 }
 
 void IconList::directoryChanged(const QString& path)

--- a/launcher/icons/IconList.cpp
+++ b/launcher/icons/IconList.cpp
@@ -169,8 +169,8 @@ QSet<QString> toStringSet(const QList<QString>& list) // Split into a separate f
 
 void IconList::directoryChanged(const QString& path)
 {
-    QDir new_dir(path);
-    if (m_dir.absolutePath() != new_dir.absolutePath()) {
+    QDir newDir(path);
+    if (m_dir.absolutePath() != newDir.absolutePath()) {
         m_dir.setPath(path);
         m_dir.refresh();
         if (is_watching)
@@ -183,19 +183,14 @@ void IconList::directoryChanged(const QString& path)
     m_dir.refresh();
     const QStringList newFileNamesList = getIconFilePaths();
     const QSet<QString> newSet = toStringSet(newFileNamesList);
-    QList<QString> current_list;
-    for (auto& it : icons) {
+    QSet<QString> currentSet;
+    for (const MMCIcon& it : icons) {
         if (!it.has(IconType::FileBased))
             continue;
-        current_list.push_back(it.m_images[IconType::FileBased].filename);
+        currentSet.insert(it.m_images[IconType::FileBased].filename);
     }
-    const QSet<QString> currentSet = toStringSet(current_list);
-
-    QSet<QString> toRemove = currentSet;
-    toRemove -= newSet;
-
-    QSet<QString> toAdd = newSet;
-    toAdd -= currentSet;
+    QSet<QString> toRemove = currentSet - newSet;
+    QSet<QString> toAdd = newSet - currentSet;
 
     for (const auto& remove : toRemove) {
         qDebug() << "Removing " << remove;
@@ -456,11 +451,9 @@ void IconList::saveIcon(const QString& key, const QString& path, const char* for
 void IconList::reindex()
 {
     name_index.clear();
-    int i = 0;
-    for (auto& iter : icons) {
-        name_index[iter.m_key] = i;
-        i++;
-        emit iconUpdated(iter.m_key);  // prevents incorrect indices with proxy model
+    for (int i = 0; i < icons.size(); i++) {
+        name_index[icons[i].m_key] = i;
+        emit iconUpdated(icons[i].m_key);  // prevents incorrect indices with proxy model
     }
 }
 
@@ -471,7 +464,7 @@ QIcon IconList::getIcon(const QString& key) const
     if (iconIndex != -1)
         return icons[iconIndex].icon();
 
-    // Fallback for icons that don't exist.
+    // Fallback for icons that don't exist.b
     iconIndex = getIconIndex("grass");
 
     if (iconIndex != -1)

--- a/launcher/icons/IconList.cpp
+++ b/launcher/icons/IconList.cpp
@@ -35,7 +35,6 @@
  */
 
 #include "IconList.h"
-#include <filesystem>
 #include <FileSystem.h>
 #include <QDebug>
 #include <QEventLoop>
@@ -79,8 +78,8 @@ void IconList::sortIconList()
 {
     qDebug() << "Sorting icon list...";
     std::sort(icons.begin(), icons.end(), [](const MMCIcon& a, const MMCIcon& b) {
-        bool aIsSubdir = a.m_key.contains(std::filesystem::path::preferred_separator);
-        bool bIsSubdir = b.m_key.contains(std::filesystem::path::preferred_separator);
+        bool aIsSubdir = a.m_key.contains(QDir::separator());
+        bool bIsSubdir = b.m_key.contains(QDir::separator());
         if (aIsSubdir != bIsSubdir) {
             return !aIsSubdir;  // root-level icons come first
         }
@@ -158,9 +157,8 @@ QString formatName(const QDir& icons_dir, const QFileInfo& file)
         return file.baseName();
 
     constexpr auto delimiter = " » ";
-    constexpr auto fs_separator = std::filesystem::path::preferred_separator;
-    QString relative_path_without_extension = icons_dir.relativeFilePath(file.dir().path()) + fs_separator + file.baseName();
-    return relative_path_without_extension.replace(fs_separator, delimiter);
+    QString relative_path_without_extension = icons_dir.relativeFilePath(file.dir().path()) + QDir::separator() + file.baseName();
+    return relative_path_without_extension.replace(QDir::separator(), delimiter);
 }
 
 void IconList::directoryChanged(const QString& path)

--- a/launcher/icons/IconList.cpp
+++ b/launcher/icons/IconList.cpp
@@ -64,7 +64,7 @@ IconList::IconList(const QStringList& builtinPaths, const QString& path, QObject
     }
 
     m_watcher.reset(new QFileSystemWatcher());
-    m_is_watching = false;
+    m_isWatching = false;
     connect(m_watcher.get(), &QFileSystemWatcher::directoryChanged, this, &IconList::directoryChanged);
     connect(m_watcher.get(), &QFileSystemWatcher::fileChanged, this, &IconList::fileChanged);
 
@@ -153,7 +153,7 @@ void IconList::directoryChanged(const QString& path)
         if (!path.startsWith(m_dir.absolutePath()))
             m_dir.setPath(path);
         m_dir.refresh();
-        if (m_is_watching)
+        if (m_isWatching)
             stopWatching();
         startWatching();
     }
@@ -239,8 +239,8 @@ void IconList::startWatching()
 {
     auto abs_path = m_dir.absolutePath();
     FS::ensureFolderPathExists(abs_path);
-    m_is_watching = addPathRecursively(abs_path);
-    if (m_is_watching) {
+    m_isWatching = addPathRecursively(abs_path);
+    if (m_isWatching) {
         qDebug() << "Started watching " << abs_path;
     } else {
         qDebug() << "Failed to start watching " << abs_path;
@@ -251,7 +251,7 @@ void IconList::stopWatching()
 {
     m_watcher->removePaths(m_watcher->files());
     m_watcher->removePaths(m_watcher->directories());
-    m_is_watching = false;
+    m_isWatching = false;
 }
 
 QStringList IconList::mimeTypes() const
@@ -372,8 +372,8 @@ bool IconList::trashIcon(const QString& key)
 
 bool IconList::addThemeIcon(const QString& key)
 {
-    auto iter = m_name_index.find(key);
-    if (iter != m_name_index.end()) {
+    auto iter = m_nameIndex.find(key);
+    if (iter != m_nameIndex.end()) {
         auto& oldOne = m_icons[*iter];
         oldOne.replace(Builtin, key);
         dataChanged(index(*iter), index(*iter));
@@ -387,7 +387,7 @@ bool IconList::addThemeIcon(const QString& key)
         mmc_icon.m_key = key;
         mmc_icon.replace(Builtin, key);
         m_icons.push_back(mmc_icon);
-        m_name_index[key] = m_icons.size() - 1;
+        m_nameIndex[key] = m_icons.size() - 1;
     }
     endInsertRows();
     return true;
@@ -399,8 +399,8 @@ bool IconList::addIcon(const QString& key, const QString& name, const QString& p
     QIcon icon(path);
     if (icon.isNull())
         return false;
-    auto iter = m_name_index.find(key);
-    if (iter != m_name_index.end()) {
+    auto iter = m_nameIndex.find(key);
+    if (iter != m_nameIndex.end()) {
         auto& oldOne = m_icons[*iter];
         oldOne.replace(type, icon, path);
         dataChanged(index(*iter), index(*iter));
@@ -414,7 +414,7 @@ bool IconList::addIcon(const QString& key, const QString& name, const QString& p
         mmc_icon.m_key = key;
         mmc_icon.replace(type, icon, path);
         m_icons.push_back(mmc_icon);
-        m_name_index[key] = m_icons.size() - 1;
+        m_nameIndex[key] = m_icons.size() - 1;
     }
     endInsertRows();
     return true;
@@ -429,9 +429,9 @@ void IconList::saveIcon(const QString& key, const QString& path, const char* for
 
 void IconList::reindex()
 {
-    m_name_index.clear();
+    m_nameIndex.clear();
     for (int i = 0; i < m_icons.size(); i++) {
-        m_name_index[m_icons[i].m_key] = i;
+        m_nameIndex[m_icons[i].m_key] = i;
         emit iconUpdated(m_icons[i].m_key);  // prevents incorrect indices with proxy model
     }
 }
@@ -453,8 +453,8 @@ QIcon IconList::getIcon(const QString& key) const
 
 int IconList::getIconIndex(const QString& key) const
 {
-    auto iter = m_name_index.find(key == "default" ? "grass" : key);
-    if (iter != m_name_index.end())
+    auto iter = m_nameIndex.find(key == "default" ? "grass" : key);
+    if (iter != m_nameIndex.end())
         return *iter;
 
     return -1;
@@ -470,8 +470,8 @@ QString IconList::iconDirectory(const QString& key) const
 {
     for (const auto& mmcIcon : m_icons) {
         if (mmcIcon.m_key == key && mmcIcon.has(IconType::FileBased)) {
-            QFileInfo icon_file(mmcIcon.getFilePath());
-            return icon_file.dir().path();
+            QFileInfo iconFile(mmcIcon.getFilePath());
+            return iconFile.dir().path();
         }
     }
     return getDirectory();

--- a/launcher/icons/IconList.cpp
+++ b/launcher/icons/IconList.cpp
@@ -108,28 +108,6 @@ bool IconList::addPathRecursively(const QString& path)
     return watching;
 }
 
-void IconList::removePathRecursively(const QString& path)
-{
-    QFileInfo file_info(path);
-    if (file_info.isFile()) {
-        // Remove the icon belonging to the file
-        QString key = m_dir.relativeFilePath(file_info.absoluteFilePath());
-        int idx = getIconIndex(key);
-        if (idx == -1)
-            return;
-
-    } else if (file_info.isDir()) {
-        // Remove the directory itself
-        m_watcher->removePath(path);
-
-        const QDir dir(path);
-        // Remove all files within the directory
-        for (const QFileInfo& file : dir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot)) {
-            removePathRecursively(file.absoluteFilePath());
-        }
-    }
-}
-
 QStringList IconList::getIconFilePaths() const
 {
     QStringList iconFiles{};
@@ -179,9 +157,8 @@ void IconList::directoryChanged(const QString& path)
             stopWatching();
         startWatching();
     }
-    if (!m_dir.exists())
-        if (!FS::ensureFolderPathExists(m_dir.absolutePath()))
-            return;
+    if (!m_dir.exists() && !FS::ensureFolderPathExists(m_dir.absolutePath()))
+        return;
     m_dir.refresh();
     const QStringList newFileNamesList = getIconFilePaths();
     const QSet<QString> newSet = toStringSet(newFileNamesList);

--- a/launcher/icons/IconList.h
+++ b/launcher/icons/IconList.h
@@ -51,7 +51,7 @@ class QFileSystemWatcher;
 class IconList : public QAbstractListModel {
     Q_OBJECT
    public:
-    explicit IconList(const QStringList& builtinPaths, QString path, QObject* parent = 0);
+    explicit IconList(const QStringList& builtinPaths, const QString& path, QObject* parent = 0);
     virtual ~IconList() {};
 
     QIcon getIcon(const QString& key) const;
@@ -101,7 +101,7 @@ class IconList : public QAbstractListModel {
 
    protected slots:
     void fileChanged(const QString& path);
-    void SettingChanged(const Setting& setting, QVariant value);
+    void SettingChanged(const Setting& setting, const QVariant& value);
 
    private:
     shared_qobject_ptr<QFileSystemWatcher> m_watcher;

--- a/launcher/icons/IconList.h
+++ b/launcher/icons/IconList.h
@@ -72,6 +72,7 @@ class IconList : public QAbstractListModel {
     bool deleteIcon(const QString& key);
     bool trashIcon(const QString& key);
     bool iconFileExists(const QString& key) const;
+    QString iconDirectory(const QString& key) const;
 
     void installIcons(const QStringList& iconFiles);
     void installIcon(const QString& file, const QString& name);
@@ -91,6 +92,9 @@ class IconList : public QAbstractListModel {
     IconList& operator=(const IconList&) = delete;
     void reindex();
     void sortIconList();
+    bool addPathRecursively(const QString& path);
+    void removePathRecursively(const QString& path);
+    QStringList getIconFilePaths() const;
 
    public slots:
     void directoryChanged(const QString& path);

--- a/launcher/icons/IconList.h
+++ b/launcher/icons/IconList.h
@@ -105,8 +105,8 @@ class IconList : public QAbstractListModel {
 
    private:
     shared_qobject_ptr<QFileSystemWatcher> m_watcher;
-    bool is_watching;
-    QMap<QString, int> name_index;
-    QVector<MMCIcon> icons;
+    bool m_is_watching;
+    QMap<QString, int> m_name_index;
+    QVector<MMCIcon> m_icons;
     QDir m_dir;
 };

--- a/launcher/icons/IconList.h
+++ b/launcher/icons/IconList.h
@@ -93,7 +93,6 @@ class IconList : public QAbstractListModel {
     void reindex();
     void sortIconList();
     bool addPathRecursively(const QString& path);
-    void removePathRecursively(const QString& path);
     QStringList getIconFilePaths() const;
 
    public slots:

--- a/launcher/icons/IconList.h
+++ b/launcher/icons/IconList.h
@@ -104,8 +104,8 @@ class IconList : public QAbstractListModel {
 
    private:
     shared_qobject_ptr<QFileSystemWatcher> m_watcher;
-    bool m_is_watching;
-    QMap<QString, int> m_name_index;
+    bool m_isWatching;
+    QMap<QString, int> m_nameIndex;
     QVector<MMCIcon> m_icons;
     QDir m_dir;
 };

--- a/launcher/ui/dialogs/IconPickerDialog.cpp
+++ b/launcher/ui/dialogs/IconPickerDialog.cpp
@@ -15,9 +15,9 @@
 
 #include <QFileDialog>
 #include <QKeyEvent>
+#include <QLineEdit>
 #include <QPushButton>
 #include <QSortFilterProxyModel>
-#include <QLineEdit>
 
 #include "Application.h"
 

--- a/launcher/ui/dialogs/IconPickerDialog.h
+++ b/launcher/ui/dialogs/IconPickerDialog.h
@@ -16,6 +16,8 @@
 #pragma once
 #include <QDialog>
 #include <QItemSelection>
+#include <QLineEdit>
+#include <QSortFilterProxyModel>
 
 namespace Ui {
 class IconPickerDialog;
@@ -36,6 +38,8 @@ class IconPickerDialog : public QDialog {
    private:
     Ui::IconPickerDialog* ui;
     QPushButton* buttonRemove;
+    QLineEdit* searchBar;
+    QSortFilterProxyModel* proxyModel;
 
    private slots:
     void selectionChanged(QItemSelection, QItemSelection);
@@ -44,4 +48,5 @@ class IconPickerDialog : public QDialog {
     void addNewIcon();
     void removeSelectedIcon();
     void openFolder();
+    void filterIcons(const QString& text);
 };


### PR DESCRIPTION
Adds subdirectory functionality for use case #2476 and search functionality

# Main changes
## Searching / filtering
- text ui element (`launcher/ui/dialogs/IconPickerDialog.cpp:38`)
- proxy model for filtering (`launcher/ui/dialogs/IconPickerDialog.cpp:40`)
- emit event to prevent incorrect indices of proxy model (`launcher/icons/IconList.cpp:470`)

## Support for subdirectories
- new `addPathRecursively` & `removePathRecursively` methods
- sort change to put all icons subdirectories last
- icon key uses relative path to icons directory instead of basename
- open folder button follows directory of selected icon (`IconList::iconDirectory`)

# Showcase
## Searching / filtering
![image](https://github.com/user-attachments/assets/6ab92e95-d4d7-4abd-973c-2080ddaa6de1)

## Support for subdirectories
Folder structure of test
![image](https://github.com/user-attachments/assets/1d45fb02-1c68-43c7-b1cb-15f9353d9cac)

It currently shows the name of the subdirectory separated by » to avoid confusion when an icon is present in two directories.
![image](https://github.com/user-attachments/assets/2c51d681-ee9c-4c0b-8371-cbe8e0024fd1)
![image](https://github.com/user-attachments/assets/df463440-5853-4048-9cc4-ee4d824be7de)
