### PR TITLE
Add extra step to macos java install

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -439,6 +439,8 @@ set(JAVA_SOURCES
     java/download/ArchiveDownloadTask.h
     java/download/ManifestDownloadTask.cpp
     java/download/ManifestDownloadTask.h
+    java/download/SymlinkTask.cpp
+    java/download/SymlinkTask.h
 
     ui/java/InstallJavaDialog.h
     ui/java/InstallJavaDialog.cpp

--- a/launcher/java/download/SymlinkTask.cpp
+++ b/launcher/java/download/SymlinkTask.cpp
@@ -43,7 +43,7 @@ QString findBinPath(QString root, QString pattern)
 
 void SymlinkTask::executeTask()
 {
-    setStatus(tr("Check Java bin"));
+    setStatus(tr("Checking for Java binary path"));
     const auto binPath = FS::PathCombine("bin", "java");
     const auto wantedPath = FS::PathCombine(m_path, binPath);
     if (QFileInfo::exists(wantedPath)) {
@@ -51,16 +51,16 @@ void SymlinkTask::executeTask()
         return;
     }
 
-    setStatus(tr("Search for Java bin"));
+    setStatus(tr("Searching for Java binary path"));
     const auto contentsPartialPath = FS::PathCombine("Contents", "Home", binPath);
     const auto relativePathToBin = findBinPath(m_path, contentsPartialPath);
     if (relativePathToBin.isEmpty()) {
-        emitFailed(tr("Failed to find bin java"));
+        emitFailed(tr("Failed to find Java binary path"));
         return;
     }
     const auto folderToLink = relativePathToBin.chopped(binPath.length());
 
-    setStatus(tr("Collect folders to symlink"));
+    setStatus(tr("Collecting folders to symlink"));
     auto entries = QDir(folderToLink).entryInfoList(QDir::NoDotAndDotDot | QDir::AllEntries);
     QList<FS::LinkPair> files;
     setProgress(0, entries.length());
@@ -68,7 +68,7 @@ void SymlinkTask::executeTask()
         files.append({ entry.absoluteFilePath(), FS::PathCombine(m_path, entry.fileName()) });
     }
 
-    setStatus(tr("Symlink Java"));
+    setStatus(tr("Symlinking Java binary path"));
     FS::create_link folderLink(files);
     connect(&folderLink, &FS::create_link::fileLinked, [this](QString src, QString dst) { setProgress(m_progress + 1, m_progressTotal); });
     if (!folderLink()) {

--- a/launcher/java/download/SymlinkTask.cpp
+++ b/launcher/java/download/SymlinkTask.cpp
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (c) 2023-2024 Trial97 <alexandru.tripon97@gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+#include "java/download/SymlinkTask.h"
+#include <QFileInfo>
+
+#include "FileSystem.h"
+
+namespace Java {
+SymlinkTask::SymlinkTask(QString final_path) : m_path(final_path) {}
+
+QString findBinPath(QString root, QString pattern)
+{
+    auto path = FS::PathCombine(root, pattern);
+    if (QFileInfo::exists(path)) {
+        return path;
+    }
+
+    auto entries = QDir(root).entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
+    for (auto& entry : entries) {
+        path = FS::PathCombine(entry.absoluteFilePath(), pattern);
+        if (QFileInfo::exists(path)) {
+            return path;
+        }
+    }
+
+    return {};
+}
+
+void SymlinkTask::executeTask()
+{
+    setStatus(tr("Check Java bin"));
+    const auto binPath = FS::PathCombine("bin", "java");
+    const auto wantedPath = FS::PathCombine(m_path, binPath);
+    if (QFileInfo::exists(wantedPath)) {
+        emitSucceeded();
+        return;
+    }
+
+    setStatus(tr("Search for Java bin"));
+    const auto contentsPartialPath = FS::PathCombine("Contents", "Home", binPath);
+    const auto relativePathToBin = findBinPath(m_path, contentsPartialPath);
+    if (relativePathToBin.isEmpty()) {
+        emitFailed(tr("Failed to find bin java"));
+        return;
+    }
+    const auto folderToLink = relativePathToBin.chopped(binPath.length());
+
+    setStatus(tr("Collect folders to symlink"));
+    auto entries = QDir(folderToLink).entryInfoList(QDir::NoDotAndDotDot | QDir::AllEntries);
+    QList<FS::LinkPair> files;
+    setProgress(0, entries.length());
+    for (auto& entry : entries) {
+        files.append({ entry.absoluteFilePath(), FS::PathCombine(m_path, entry.fileName()) });
+    }
+
+    setStatus(tr("Symlink Java"));
+    FS::create_link folderLink(files);
+    connect(&folderLink, &FS::create_link::fileLinked, [this](QString src, QString dst) { setProgress(m_progress + 1, m_progressTotal); });
+    if (!folderLink()) {
+        emitFailed(folderLink.getOSError().message().c_str());
+    } else {
+        emitSucceeded();
+    }
+}
+
+}  // namespace Java

--- a/launcher/java/download/SymlinkTask.h
+++ b/launcher/java/download/SymlinkTask.h
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (c) 2023-2024 Trial97 <alexandru.tripon97@gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "tasks/Task.h"
+namespace Java {
+
+class SymlinkTask : public Task {
+    Q_OBJECT
+   public:
+    SymlinkTask(QString final_path);
+    virtual ~SymlinkTask() = default;
+
+    void executeTask() override;
+
+   protected:
+    QString m_path;
+    Task::Ptr m_task;
+};
+}  // namespace Java


### PR DESCRIPTION
Parent PR: #2069
fixes #2814

so basically the java downloads on mac add another layer to java
this ensures that there is a link to the bin directory on the root java folder 