### PR TITLE
Show login dialog again if account login fails

### DIFF
--- a/launcher/ui/setupwizard/LoginWizardPage.cpp
+++ b/launcher/ui/setupwizard/LoginWizardPage.cpp
@@ -35,11 +35,10 @@ void LoginWizardPage::on_pushButton_clicked()
     if (account) {
         APPLICATION->accounts()->addAccount(account);
         APPLICATION->accounts()->setDefaultAccount(account);
-    }
-
-    if (wizard()->currentId() == wizard()->pageIds().last()) {
-        wizard()->accept();
-    } else {
-        wizard()->next();
+        if (wizard()->currentId() == wizard()->pageIds().last()) {
+            wizard()->accept();
+        } else {
+            wizard()->next();
+        }
     }
 }


### PR DESCRIPTION
Parent PR: #2803
@ZekeZDev  this makes the wizard reappear if the account login fails or you click cancel