### PR TITLE
Shorten error descriptions

### DIFF
--- a/launcher/modplatform/flame/FlameCheckUpdate.cpp
+++ b/launcher/modplatform/flame/FlameCheckUpdate.cpp
@@ -147,7 +147,7 @@ void FlameCheckUpdate::executeTask()
         if (latest_ver->downloadUrl.isEmpty() && latest_ver->fileId != mod->metadata()->file_id) {
             auto pack = getProjectInfo(latest_ver.value());
             auto recover_url = QString("%1/download/%2").arg(pack.websiteUrl, latest_ver->fileId.toString());
-            emit checkFailed(mod, tr("Mod update is not downloadable using Prism."), recover_url);
+            emit checkFailed(mod, tr("Cannot download update due to author restrictions."), recover_url);
 
             continue;
         }

--- a/launcher/modplatform/flame/FlameCheckUpdate.cpp
+++ b/launcher/modplatform/flame/FlameCheckUpdate.cpp
@@ -140,7 +140,7 @@ void FlameCheckUpdate::executeTask()
         setStatus(tr("Parsing the API response from CurseForge for '%1'...").arg(mod->name()));
 
         if (!latest_ver.has_value() || !latest_ver->addonId.isValid()) {
-            emit checkFailed(mod, tr("No valid version found for this mod."));
+            emit checkFailed(mod, tr("Mod and/or mod data could not be found in Curseforge."));
             continue;
         }
 

--- a/launcher/modplatform/flame/FlameCheckUpdate.cpp
+++ b/launcher/modplatform/flame/FlameCheckUpdate.cpp
@@ -147,7 +147,7 @@ void FlameCheckUpdate::executeTask()
         if (latest_ver->downloadUrl.isEmpty() && latest_ver->fileId != mod->metadata()->file_id) {
             auto pack = getProjectInfo(latest_ver.value());
             auto recover_url = QString("%1/download/%2").arg(pack.websiteUrl, latest_ver->fileId.toString());
-            emit checkFailed(mod, tr("Cannot download update due to author restrictions."), recover_url);
+            emit checkFailed(mod, tr("Unable to update mod due to author restrictions."), recover_url);
 
             continue;
         }

--- a/launcher/modplatform/flame/FlameCheckUpdate.cpp
+++ b/launcher/modplatform/flame/FlameCheckUpdate.cpp
@@ -140,15 +140,14 @@ void FlameCheckUpdate::executeTask()
         setStatus(tr("Parsing the API response from CurseForge for '%1'...").arg(mod->name()));
 
         if (!latest_ver.has_value() || !latest_ver->addonId.isValid()) {
-            emit checkFailed(mod, tr("No valid version found for this mod. It's probably unavailable for the current game "
-                                     "version / mod loader."));
+            emit checkFailed(mod, tr("No valid version found for this mod."));
             continue;
         }
 
         if (latest_ver->downloadUrl.isEmpty() && latest_ver->fileId != mod->metadata()->file_id) {
             auto pack = getProjectInfo(latest_ver.value());
             auto recover_url = QString("%1/download/%2").arg(pack.websiteUrl, latest_ver->fileId.toString());
-            emit checkFailed(mod, tr("Mod has a new update available, but is not downloadable using CurseForge."), recover_url);
+            emit checkFailed(mod, tr("Mod update is not downloadable using Prism."), recover_url);
 
             continue;
         }

--- a/launcher/modplatform/flame/FlameCheckUpdate.cpp
+++ b/launcher/modplatform/flame/FlameCheckUpdate.cpp
@@ -140,7 +140,7 @@ void FlameCheckUpdate::executeTask()
         setStatus(tr("Parsing the API response from CurseForge for '%1'...").arg(mod->name()));
 
         if (!latest_ver.has_value() || !latest_ver->addonId.isValid()) {
-            emit checkFailed(mod, tr("Mod and/or mod data could not be found in Curseforge."));
+            emit checkFailed(mod, tr("No version found! It is likely unavailable for this mc version/ mod loader."));
             continue;
         }
 

--- a/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
+++ b/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
@@ -213,8 +213,7 @@ void ModrinthCheckUpdate::checkNextLoader()
         }
     }
     for (auto m : m_mappings) {
-        emit checkFailed(m,
-                         tr("No valid version found for this mod."));
+        emit checkFailed(m, tr("Mod and/or mod data could not be found in Modrinth."));
     }
     emitSucceeded();
     return;

--- a/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
+++ b/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
@@ -213,7 +213,7 @@ void ModrinthCheckUpdate::checkNextLoader()
         }
     }
     for (auto m : m_mappings) {
-        emit checkFailed(m, tr("Mod and/or mod data could not be found in Modrinth."));
+        emit checkFailed(m, tr("No version found! It is likely unavailable for this mc version/ mod loader."));
     }
     emitSucceeded();
     return;

--- a/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
+++ b/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
@@ -214,7 +214,7 @@ void ModrinthCheckUpdate::checkNextLoader()
     }
     for (auto m : m_mappings) {
         emit checkFailed(m,
-                         tr("No valid version found for this mod. It's probably unavailable for the current game version / mod loader."));
+                         tr("No valid version found for this mod."));
     }
     emitSucceeded();
     return;


### PR DESCRIPTION
This will reduce the verbal clutter when an update has several mods which throw error(s). Keeping the errors to one line will allow room for more errors within the precious default textbox size.