### PR TITLE
Fix case for Java strings

### DIFF
--- a/launcher/VersionProxyModel.cpp
+++ b/launcher/VersionProxyModel.cpp
@@ -140,9 +140,9 @@ QVariant VersionProxyModel::headerData(int section, Qt::Orientation orientation,
             case Path:
                 return tr("Filesystem path to this version");
             case JavaName:
-                return tr("The alternative name of the java version");
+                return tr("The alternative name of the Java version");
             case JavaMajor:
-                return tr("The java major version");
+                return tr("The Java major version");
             case Time:
                 return tr("Release date of this version");
         }

--- a/launcher/java/download/ArchiveDownloadTask.cpp
+++ b/launcher/java/download/ArchiveDownloadTask.cpp
@@ -65,7 +65,7 @@ void ArchiveDownloadTask::executeTask()
 
 void ArchiveDownloadTask::extractJava(QString input)
 {
-    setStatus(tr("Extracting java"));
+    setStatus(tr("Extracting Java"));
     if (input.endsWith("tar")) {
         setStatus(tr("Extracting Java (Progress is not reported for tar archives)"));
         QFile in(input);

--- a/launcher/ui/MainWindow.ui
+++ b/launcher/ui/MainWindow.ui
@@ -798,7 +798,7 @@
     <string>Java</string>
    </property>
    <property name="toolTip">
-    <string>Open the java folder in a file browser. Only available if the built-in Java downloader is used.</string>
+    <string>Open the Java folder in a file browser. Only available if the built-in Java downloader is used.</string>
    </property>
   </action>
  </widget>

--- a/launcher/ui/java/InstallJavaDialog.cpp
+++ b/launcher/ui/java/InstallJavaDialog.cpp
@@ -57,13 +57,13 @@ class InstallJavaPage : public QWidget, public BasePage {
 
         majorVersionSelect = new VersionSelectWidget(this);
         majorVersionSelect->selectCurrent();
-        majorVersionSelect->setEmptyString(tr("No java versions are currently available in the meta."));
-        majorVersionSelect->setEmptyErrorString(tr("Couldn't load or download the java version lists!"));
+        majorVersionSelect->setEmptyString(tr("No Java versions are currently available in the meta."));
+        majorVersionSelect->setEmptyErrorString(tr("Couldn't load or download the Java version lists!"));
         horizontalLayout->addWidget(majorVersionSelect, 1);
 
         javaVersionSelect = new VersionSelectWidget(this);
-        javaVersionSelect->setEmptyString(tr("No java versions are currently available for your OS."));
-        javaVersionSelect->setEmptyErrorString(tr("Couldn't load or download the java version lists!"));
+        javaVersionSelect->setEmptyString(tr("No Java versions are currently available for your OS."));
+        javaVersionSelect->setEmptyErrorString(tr("Couldn't load or download the Java version lists!"));
         horizontalLayout->addWidget(javaVersionSelect, 4);
         connect(majorVersionSelect, &VersionSelectWidget::selectedVersionChanged, this, &InstallJavaPage::setSelectedVersion);
         connect(majorVersionSelect, &VersionSelectWidget::selectedVersionChanged, this, &InstallJavaPage::selectionChanged);

--- a/launcher/ui/pages/global/JavaPage.cpp
+++ b/launcher/ui/pages/global/JavaPage.cpp
@@ -67,8 +67,8 @@ JavaPage::JavaPage(QWidget* parent) : QWidget(parent), ui(new Ui::JavaPage)
         ui->managedJavaList->initialize(new JavaInstallList(this, true));
         ui->managedJavaList->setResizeOn(2);
         ui->managedJavaList->selectCurrent();
-        ui->managedJavaList->setEmptyString(tr("No managed java versions are installed"));
-        ui->managedJavaList->setEmptyErrorString(tr("Couldn't load the managed java list!"));
+        ui->managedJavaList->setEmptyString(tr("No managed Java versions are installed"));
+        ui->managedJavaList->setEmptyErrorString(tr("Couldn't load the managed Java list!"));
         connect(ui->autodetectJavaCheckBox, &QCheckBox::stateChanged, this, [this] {
             ui->autodownloadCheckBox->setEnabled(ui->autodetectJavaCheckBox->isChecked());
             if (!ui->autodetectJavaCheckBox->isChecked())

--- a/launcher/ui/setupwizard/AutoJavaWizardPage.ui
+++ b/launcher/ui/setupwizard/AutoJavaWizardPage.ui
@@ -30,7 +30,7 @@
    <item>
     <widget class="QLabel" name="label_2">
      <property name="text">
-      <string>We've added a feature to automatically download the correct Java version for each version of Minecraft(this can be changed in the Java Settings). Would you like to enable or disable this feature?</string>
+      <string>We've added a feature to automatically download the correct Java version for each version of Minecraft (this can be changed in the Java Settings). Would you like to enable or disable this feature?</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/launcher/ui/setupwizard/JavaWizardPage.cpp
+++ b/launcher/ui/setupwizard/JavaWizardPage.cpp
@@ -83,6 +83,6 @@ void JavaWizardPage::retranslate()
 {
     setTitle(tr("Java"));
     setSubTitle(
-        tr("Please select how much memory to allocate to instances and if Prism Launcher should manage java automatically or manually."));
+        tr("Please select how much memory to allocate to instances and if Prism Launcher should manage Java automatically or manually."));
     m_java_widget->retranslate();
 }


### PR DESCRIPTION
While translating for English/CA I found multiple strings of "Java" to be "java" instead. I thought there was enough to make a Pull Request as there was more than 3. Some files had 2 strings that were incorrect.

Also for launcher/ui/setupwizard/AutoJavaWizardPage.ui, a bracket wasn't spaced which still is proper, but looks better in my eyes with a space.