### PR TITLE
Add vc_redist as a NSIS install section

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,8 @@ jobs:
             qt_arch: ""
             qt_version: "6.7.2"
             qt_modules: "qt5compat qtimageformats qtnetworkauth"
+            nscurl_tag: "v24.9.26.122"
+            nscurl_sha256: "AEE6C4BE3CB6455858E9C1EE4B3AFE0DB9960FA03FE99CCDEDC28390D57CCBB0"
 
           - os: windows-2022
             name: "Windows-MSVC-arm64"
@@ -92,6 +94,8 @@ jobs:
             qt_arch: "win64_msvc2019_arm64"
             qt_version: "6.7.2"
             qt_modules: "qt5compat qtimageformats qtnetworkauth"
+            nscurl_tag: "v24.9.26.122"
+            nscurl_sha256: "AEE6C4BE3CB6455858E9C1EE4B3AFE0DB9960FA03FE99CCDEDC28390D57CCBB0"
 
           - os: macos-14
             name: macOS
@@ -472,8 +476,13 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           New-Item -Name NSISPlugins -ItemType Directory
-          Invoke-Webrequest https://github.com/negrutiu/nsis-nscurl/releases/latest/download/NScurl.zip -OutFile NSISPlugins\NScurl.zip
-          Expand-Archive -Path NSISPlugins\NScurl.zip -DestinationPath NSISPlugins\NSIScurl
+          Invoke-Webrequest https://github.com/negrutiu/nsis-nscurl/releases/download/${{ matrix.nscurl_tag }}/NScurl.zip -OutFile NSISPlugins\NScurl.zip
+          $nscurl_hash = Get-FileHash NSISPlugins\NScurl.zip -Algorithm Sha256 | Select-Object -ExpandProperty Hash
+          if ( $nscurl_hash -ne "${{ matrix.nscurl_sha256 }}") {
+            echo "::error:: NSCurl.zib sha256 mismatch"
+            exit 1
+          }
+          Expand-Archive -Path NSISPlugins\NScurl.zip -DestinationPath NSISPlugins\NScurl
           cd ${{ env.INSTALL_DIR }}
           makensis -NOCD "${{ github.workspace }}/${{ env.BUILD_DIR }}/program_info/win_install.nsi"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -471,6 +471,9 @@ jobs:
       - name: Package (Windows, installer)
         if: runner.os == 'Windows'
         run: |
+          New-Item -Name NSISPlugins -ItemType Directory
+          Invoke-Webrequest https://github.com/negrutiu/nsis-nscurl/releases/latest/download/NScurl.zip -OutFile NSISPlugins\NScurl.zip
+          Expand-Archive -Path NSISPlugins\NScurl.zip -DestinationPath NSISPlugins\NSIScurl
           cd ${{ env.INSTALL_DIR }}
           makensis -NOCD "${{ github.workspace }}/${{ env.BUILD_DIR }}/program_info/win_install.nsi"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -480,7 +480,7 @@ jobs:
             Invoke-Webrequest https://github.com/negrutiu/nsis-nscurl/releases/download/${{ matrix.nscurl_tag }}/NScurl.zip -OutFile NSISPlugins\NScurl.zip
             $nscurl_hash = Get-FileHash NSISPlugins\NScurl.zip -Algorithm Sha256 | Select-Object -ExpandProperty Hash
             if ( $nscurl_hash -ne "${{ matrix.nscurl_sha256 }}") {
-              echo "::error:: NSCurl.zib sha256 mismatch"
+              echo "::error:: NSCurl.zip sha256 mismatch"
               exit 1
             }
             Expand-Archive -Path NSISPlugins\NScurl.zip -DestinationPath NSISPlugins\NScurl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -475,14 +475,16 @@ jobs:
       - name: Package (Windows, installer)
         if: runner.os == 'Windows'
         run: |
-          New-Item -Name NSISPlugins -ItemType Directory
-          Invoke-Webrequest https://github.com/negrutiu/nsis-nscurl/releases/download/${{ matrix.nscurl_tag }}/NScurl.zip -OutFile NSISPlugins\NScurl.zip
-          $nscurl_hash = Get-FileHash NSISPlugins\NScurl.zip -Algorithm Sha256 | Select-Object -ExpandProperty Hash
-          if ( $nscurl_hash -ne "${{ matrix.nscurl_sha256 }}") {
-            echo "::error:: NSCurl.zib sha256 mismatch"
-            exit 1
+          if ('${{ matrix.nscurl_tag }}') {
+            New-Item -Name NSISPlugins -ItemType Directory
+            Invoke-Webrequest https://github.com/negrutiu/nsis-nscurl/releases/download/${{ matrix.nscurl_tag }}/NScurl.zip -OutFile NSISPlugins\NScurl.zip
+            $nscurl_hash = Get-FileHash NSISPlugins\NScurl.zip -Algorithm Sha256 | Select-Object -ExpandProperty Hash
+            if ( $nscurl_hash -ne "${{ matrix.nscurl_sha256 }}") {
+              echo "::error:: NSCurl.zib sha256 mismatch"
+              exit 1
+            }
+            Expand-Archive -Path NSISPlugins\NScurl.zip -DestinationPath NSISPlugins\NScurl
           }
-          Expand-Archive -Path NSISPlugins\NScurl.zip -DestinationPath NSISPlugins\NScurl
           cd ${{ env.INSTALL_DIR }}
           makensis -NOCD "${{ github.workspace }}/${{ env.BUILD_DIR }}/program_info/win_install.nsi"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,6 +372,11 @@ endif()
 if(NOT (UNIX AND APPLE))
     # Install "portable.txt" if selected component is "portable"
     install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/${Launcher_Portable_File}" DESTINATION "." COMPONENT portable EXCLUDE_FROM_ALL)
+    if (MSVC)
+        set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP true)
+        include(InstallRequiredSystemLibraries)
+        install(FILES "${MSVC_REDIST_DIR}/vc_redist.x64.exe" DESTINATION "vc_redist/." COMPONENT portable EXCLUDE_FROM_ALL )
+    endif()
 endif()
 
 if(UNIX AND APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,10 +358,6 @@ include(ECMQtDeclareLoggingCategory)
 ####################################### Program Info #######################################
 
 set(Launcher_APP_BINARY_NAME "prismlauncher" CACHE STRING "Name of the Launcher binary")
-if(MSVC)
-    set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP true)
-    include(InstallRequiredSystemLibraries)
-endif()
 add_subdirectory(program_info)
 
 ####################################### Install layout #######################################
@@ -376,9 +372,6 @@ endif()
 if(NOT (UNIX AND APPLE))
     # Install "portable.txt" if selected component is "portable"
     install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/${Launcher_Portable_File}" DESTINATION "." COMPONENT portable EXCLUDE_FROM_ALL)
-    if (MSVC)
-        install(FILES "${MSVC_REDIST_DIR}/vc_redist.x64.exe" DESTINATION "vc_redist/." COMPONENT portable EXCLUDE_FROM_ALL )
-    endif()
 endif()
 
 if(UNIX AND APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,6 +358,10 @@ include(ECMQtDeclareLoggingCategory)
 ####################################### Program Info #######################################
 
 set(Launcher_APP_BINARY_NAME "prismlauncher" CACHE STRING "Name of the Launcher binary")
+if(MSVC)
+    set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP true)
+    include(InstallRequiredSystemLibraries)
+endif()
 add_subdirectory(program_info)
 
 ####################################### Install layout #######################################
@@ -373,8 +377,6 @@ if(NOT (UNIX AND APPLE))
     # Install "portable.txt" if selected component is "portable"
     install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/${Launcher_Portable_File}" DESTINATION "." COMPONENT portable EXCLUDE_FROM_ALL)
     if (MSVC)
-        set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP true)
-        include(InstallRequiredSystemLibraries)
         install(FILES "${MSVC_REDIST_DIR}/vc_redist.x64.exe" DESTINATION "vc_redist/." COMPONENT portable EXCLUDE_FROM_ALL )
     endif()
 endif()

--- a/program_info/CMakeLists.txt
+++ b/program_info/CMakeLists.txt
@@ -50,7 +50,7 @@ if(MSVC)
 Section \"Visual Studio Runtime\"
   SetOutPath \"$INSTDIR\\vc_redist\"
   File \"${Native_MSVC_REDIST_DIR}\\vc_redist.x64.exe\"
-  ExecWait \"$INSTDIR\\vc_redist\\vc_redist.x64.exe /install /passive\"
+  ExecWait \"$INSTDIR\\vc_redist\\vc_redist.x64.exe /install /passive /norestart\"
   ; Delete \"$INSTDIR\\vc_redist\\vc_redist.x64.exe\"
 SectionEnd\
 ")

--- a/program_info/CMakeLists.txt
+++ b/program_info/CMakeLists.txt
@@ -43,16 +43,21 @@ configure_file(prismlauncher.manifest.in prismlauncher.manifest @ONLY)
 configure_file(prismlauncher.ico prismlauncher.ico COPYONLY)
 
 if(MSVC)
-    include(InstallRequiredSystemLibraries)
-    file(TO_NATIVE_PATH ${MSVC_REDIST_DIR} Native_MSVC_REDIST_DIR)
-    set(Launcher_MSVC_Redist_NSIS_Section "\
-Section \"Visual Studio Runtime\"
-  SetOutPath \"$INSTDIR\\vc_redist\"
-  File \"${Native_MSVC_REDIST_DIR}\\vc_redist.x64.exe\"
-  ExecWait \"$INSTDIR\\vc_redist\\vc_redist.x64.exe /install /passive /norestart\"
-  ; Delete \"$INSTDIR\\vc_redist\\vc_redist.x64.exe\"
-SectionEnd\
-")
+    set(Launcher_MSVC_Redist_NSIS_Section [=[
+!ifdef haveNSIScurl
+Section "Visual Studio Runtime"
+    DetailPrint 'Downloading Microsoft Visual C++ Redistributable...'
+    NScurl::http GET "https://aka.ms/vs/17/release/vc_redist.x64.exe" "$INSTDIR\vc_redist\vc_redist.x64.exe" /INSIST /CANCEL /Zone.Identifier /END
+    Pop $0
+    ${If} $0 == "OK"
+        DetailPrint "Download successful"
+        ExecWait "$INSTDIR\vc_redist\vc_redist.x64.exe /install /passive /norestart\"
+    ${Else}
+        DetailPrint "Download failed with error $0"
+    ${EndIf}
+SectionEnd
+!endif
+]=])
 endif()
 
 configure_file(win_install.nsi.in win_install.nsi @ONLY)

--- a/program_info/CMakeLists.txt
+++ b/program_info/CMakeLists.txt
@@ -44,14 +44,20 @@ configure_file(prismlauncher.ico prismlauncher.ico COPYONLY)
 
 if(MSVC)
     set(Launcher_MSVC_Redist_NSIS_Section [=[
-!ifdef haveNSIScurl
+!ifdef haveNScurl
 Section "Visual Studio Runtime"
+    Var /GLOBAL vc_redist_exe
+    ${If} ${IsNativeARM64}
+        StrCpy $vc_redist_exe "vc_redist.arm64.exe"
+    ${Else}
+        StrCpy $vc_redist_exe "vc_redist.x64.exe"
+    ${EndIf}
     DetailPrint 'Downloading Microsoft Visual C++ Redistributable...'
-    NScurl::http GET "https://aka.ms/vs/17/release/vc_redist.x64.exe" "$INSTDIR\vc_redist\vc_redist.x64.exe" /INSIST /CANCEL /Zone.Identifier /END
+    NScurl::http GET "https://aka.ms/vs/17/release/${vc_redist_exe}" "$INSTDIR\vc_redist\${vc_redist_exe}" /INSIST /CANCEL /Zone.Identifier /END
     Pop $0
     ${If} $0 == "OK"
         DetailPrint "Download successful"
-        ExecWait "$INSTDIR\vc_redist\vc_redist.x64.exe /install /passive /norestart\"
+        ExecWait "$INSTDIR\vc_redist\${vc_redist_exe} /install /passive /norestart\"
     ${Else}
         DetailPrint "Download failed with error $0"
     ${EndIf}

--- a/program_info/CMakeLists.txt
+++ b/program_info/CMakeLists.txt
@@ -43,7 +43,6 @@ configure_file(prismlauncher.manifest.in prismlauncher.manifest @ONLY)
 configure_file(prismlauncher.ico prismlauncher.ico COPYONLY)
 
 if(MSVC)
-    set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP true)
     include(InstallRequiredSystemLibraries)
     file(TO_NATIVE_PATH ${MSVC_REDIST_DIR} Native_MSVC_REDIST_DIR)
     set(Launcher_MSVC_Redist_NSIS_Section "\

--- a/program_info/CMakeLists.txt
+++ b/program_info/CMakeLists.txt
@@ -41,6 +41,21 @@ configure_file(org.prismlauncher.PrismLauncher.metainfo.xml.in org.prismlauncher
 configure_file(prismlauncher.rc.in prismlauncher.rc @ONLY)
 configure_file(prismlauncher.manifest.in prismlauncher.manifest @ONLY)
 configure_file(prismlauncher.ico prismlauncher.ico COPYONLY)
+
+if(MSVC)
+    set(CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION vc_redist)
+    include(InstallRequiredSystemLibraries)
+    file(TO_NATIVE_PATH ${MSVC_REDIST_DIR} Native_MSVC_REDIST_DIR)
+    set(Launcher_MSVC_Redist_NSIS_Section "\
+Section \"Visual Studio Runtime\"
+  SetOutPath \"$INSTDIR\\vc_redist\"
+  File \"${Native_MSVC_REDIST_DIR}\\vc_redist.x64.exe\"
+  ExecWait \"$INSTDIR\\vc_redist\\vc_redist.x64.exe /install /passive\"
+  ; Delete \"$INSTDIR\\vc_redist\\vc_redist.x64.exe\"
+SectionEnd\
+")
+endif()
+
 configure_file(win_install.nsi.in win_install.nsi @ONLY)
 
 if(SCDOC_FOUND)

--- a/program_info/CMakeLists.txt
+++ b/program_info/CMakeLists.txt
@@ -43,7 +43,7 @@ configure_file(prismlauncher.manifest.in prismlauncher.manifest @ONLY)
 configure_file(prismlauncher.ico prismlauncher.ico COPYONLY)
 
 if(MSVC)
-    set(CMAKE_INSTALL_SYSTEM_RUNTIME_DESTINATION vc_redist)
+    set(CMAKE_INSTALL_SYSTEM_RUNTIME_LIBS_SKIP true)
     include(InstallRequiredSystemLibraries)
     file(TO_NATIVE_PATH ${MSVC_REDIST_DIR} Native_MSVC_REDIST_DIR)
     set(Launcher_MSVC_Redist_NSIS_Section "\

--- a/program_info/CMakeLists.txt
+++ b/program_info/CMakeLists.txt
@@ -53,11 +53,11 @@ Section "Visual Studio Runtime"
         StrCpy $vc_redist_exe "vc_redist.x64.exe"
     ${EndIf}
     DetailPrint 'Downloading Microsoft Visual C++ Redistributable...'
-    NScurl::http GET "https://aka.ms/vs/17/release/${vc_redist_exe}" "$INSTDIR\vc_redist\${vc_redist_exe}" /INSIST /CANCEL /Zone.Identifier /END
+    NScurl::http GET "https://aka.ms/vs/17/release/$vc_redist_exe" "$INSTDIR\vc_redist\$vc_redist_exe" /INSIST /CANCEL /Zone.Identifier /END
     Pop $0
     ${If} $0 == "OK"
         DetailPrint "Download successful"
-        ExecWait "$INSTDIR\vc_redist\${vc_redist_exe} /install /passive /norestart\"
+        ExecWait "$INSTDIR\vc_redist\$vc_redist_exe /install /passive /norestart\"
     ${Else}
         DetailPrint "Download failed with error $0"
     ${EndIf}

--- a/program_info/win_install.nsi.in
+++ b/program_info/win_install.nsi.in
@@ -396,6 +396,8 @@ Section "@Launcher_DisplayName@"
 
 SectionEnd
 
+@Launcher_MSVC_Redist_NSIS_Section@
+
 Section "Start Menu Shortcut" SM_SHORTCUTS
 
   CreateShortcut "$SMPROGRAMS\@Launcher_DisplayName@.lnk" "$INSTDIR\@Launcher_APP_BINARY_NAME@.exe" "" "$INSTDIR\@Launcher_APP_BINARY_NAME@.exe" 0

--- a/program_info/win_install.nsi.in
+++ b/program_info/win_install.nsi.in
@@ -349,15 +349,15 @@ SectionEnd
 ;------------------------------------
 ; include nice plugins
 
-; NSIScurl - curl in NSIS
+; NScurl - curl in NSIS
 ; used for MSVS redist download
-; extract to ../NSISPlugins/NSIScurl
+; extract to ../NSISPlugins/NScurl
 ; https://github.com/negrutiu/nsis-nscurl/releases/latest/download/NScurl.zip
-!insertmacro CompileTimeIfFileExist "../NSISPlugins/NSIScurl/Plugins/" haveNSIScurl
-!ifdef haveNSIScurl
-!AddPluginDir /x86-unicode     "../NSISPlugins/NSIScurl/Plugins/x86-unicode"
-!AddPluginDir /x86-ansi        "../NSISPlugins/NSIScurl/Plugins/x86-ansi"
-!AddPluginDir /amd64-unicode   "../NSISPlugins/NSIScurl/Plugins/amd64-unicode"
+!insertmacro CompileTimeIfFileExist "../NSISPlugins/NScurl/Plugins/" haveNScurl
+!ifdef haveNScurl
+!AddPluginDir /x86-unicode     "../NSISPlugins/NScurl/Plugins/x86-unicode"
+!AddPluginDir /x86-ansi        "../NSISPlugins/NScurl/Plugins/x86-ansi"
+!AddPluginDir /amd64-unicode   "../NSISPlugins/NScurl/Plugins/amd64-unicode"
 !endif
 
 ;------------------------------------

--- a/program_info/win_install.nsi.in
+++ b/program_info/win_install.nsi.in
@@ -2,6 +2,8 @@
 !include "LogicLib.nsh"
 !include "MUI2.nsh"
 
+!include "x64.nsh"
+
 Unicode true
 
 Name "@Launcher_DisplayName@"
@@ -185,7 +187,7 @@ VIAddVersionKey /LANG=${LANG_ENGLISH} "ProductVersion" "@Launcher_VERSION_NAME4@
 
 !macroend
 
-!macro APP_UNASSOCIATE EXT APP_ID
+!macro APP_UNASSOCIATE EXT APP_ID APP_EXE
 
   # Unregister file type
   ClearErrors
@@ -489,8 +491,8 @@ Section -un.ShellAssoc
   
   !insertmacro APP_TEARDOWN_DEFAULT `${APPID}` `${APPNAME}` `${APPEXE}`
 
-  !insertmacro APP_UNASSOCIATE ".zip" `${APPID}`
-  !insertmacro APP_UNASSOCIATE ".mrpack" `${APPID}`
+  !insertmacro APP_UNASSOCIATE ".zip" `${APPID}` `${APPEXE}`
+  !insertmacro APP_UNASSOCIATE ".mrpack" `${APPID}` `${APPEXE}`
 
   !insertmacro NotifyShell_AssocChanged
 SectionEnd

--- a/program_info/win_install.nsi.in
+++ b/program_info/win_install.nsi.in
@@ -112,6 +112,16 @@ VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalCopyright" "@Launcher_Copyright@"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "FileVersion" "@Launcher_VERSION_NAME4@"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "ProductVersion" "@Launcher_VERSION_NAME4@"
 
+;--------------------------------
+; Conditional comp with file exist
+
+!macro CompileTimeIfFileExist path define
+!tempfile tmpinc
+!system 'IF EXIST "${path}" echo !define ${define} > "${tmpinc}"'
+!include "${tmpinc}"
+!delfile "${tmpinc}"
+!undef tmpinc
+!macroend
 
 ;--------------------------------
 ; Shell Associate Macros
@@ -336,6 +346,19 @@ Section "" UninstallPrevious
 
 SectionEnd
 
+;------------------------------------
+; include nice plugins
+
+; NSIScurl - curl in NSIS
+; used for MSVS redist download
+; extract to ../NSISPlugins/NSIScurl
+; https://github.com/negrutiu/nsis-nscurl/releases/latest/download/NScurl.zip
+!insertmacro CompileTimeIfFileExist "../NSISPlugins/NSIScurl/Plugins/" haveNSIScurl
+!ifdef haveNSIScurl
+!AddPluginDir /x86-unicode     "../NSISPlugins/NSIScurl/Plugins/x86-unicode"
+!AddPluginDir /x86-ansi        "../NSISPlugins/NSIScurl/Plugins/x86-ansi"
+!AddPluginDir /amd64-unicode   "../NSISPlugins/NSIScurl/Plugins/amd64-unicode"
+!endif
 
 ;------------------------------------
 


### PR DESCRIPTION
~~So, after a bunch of faffing about it turns out that Cmake exports the redist location if you ask it nicely~~
Which would break the GPL so we can't do that
NSIScurl exists though and it's the only remaining options
built in NSISdl can't do https and other NSIS net enabling plugins arn't mantained
please let us drop this installer soon

anyway, we can make cmake add the install section to our NSIS template when compiling with MSVC.
This *should* hold us over until such a time as we start using a better installer framework