### PR TITLE
Fix: don't annoy when java tmpdir jvmarg is set & /tmp is noexec

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -1025,7 +1025,8 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
     }
 
     // notify user if /tmp is mounted with `noexec` (#1693)
-    {
+    QString jvmArgs = m_settings->get("JvmArgs").toString();
+    if(jvmArgs.indexOf("java.io.tmpdir") == -1) { /* java.io.tmpdir is a valid workaround, so don't annoy */
         bool is_tmp_noexec = false;
 
 #if defined(Q_OS_LINUX)
@@ -1045,7 +1046,11 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         if (is_tmp_noexec) {
             auto infoMsg =
                 tr("Your /tmp directory is currently mounted with the 'noexec' flag enabled.\n"
-                   "Some versions of Minecraft may not launch.\n");
+                   "Some versions of Minecraft may not launch.\n"
+                   "\n"
+                   "You may solve this issue by remounting /tmp as 'exec' or setting "
+                   "the java.io.tmpdir JVM argument to a writeable directory in a "
+                   "filesystem where the 'exec' flag is set (e.g., /home/user/.local/tmp)\n");
             auto msgBox = new QMessageBox(QMessageBox::Information, tr("Incompatible system configuration"), infoMsg, QMessageBox::Ok);
             msgBox->setDefaultButton(QMessageBox::Ok);
             msgBox->setAttribute(Qt::WA_DeleteOnClose);


### PR DESCRIPTION
Got annoyed, didn't want to see it anymore.

Sorry for using goto but I didn't see a way to skip the syscalls without adding for(;0;), do {}, or any other weird symantics when goto seemed much simpler.

Also: changed the java tmpdir noexec warning to include information about remedying the problem, including remounting /tmp as 'exec' and setting the java.io.tmpdir jvm arg which solves the issue.

First contribution, please let me know if I didn't follow some code style or weird Qt/CPP coding recommendations (I'm a C programmer by trade)