### PR TITLE
chore: update Qt to 6.7.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
             qt_ver: 6
             qt_host: windows
             qt_arch: ""
-            qt_version: "6.7.2"
+            qt_version: "6.7.3"
             qt_modules: "qt5compat qtimageformats qtnetworkauth"
 
           - os: windows-2022
@@ -90,7 +90,7 @@ jobs:
             qt_ver: 6
             qt_host: windows
             qt_arch: "win64_msvc2019_arm64"
-            qt_version: "6.7.2"
+            qt_version: "6.7.3"
             qt_modules: "qt5compat qtimageformats qtnetworkauth"
 
           - os: macos-14
@@ -99,7 +99,7 @@ jobs:
             qt_ver: 6
             qt_host: mac
             qt_arch: ""
-            qt_version: "6.7.2"
+            qt_version: "6.7.3"
             qt_modules: "qt5compat qtimageformats qtnetworkauth"
 
           - os: macos-14


### PR DESCRIPTION
Only bug fixes from ( qt 6.8 squashed ) no breaking changes
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
