### PR TITLE
Keep libGLU in Flatpak

### DIFF
--- a/flatpak/org.prismlauncher.PrismLauncher.yml
+++ b/flatpak/org.prismlauncher.PrismLauncher.yml
@@ -22,9 +22,6 @@ finish-args:
     # FTBApp import
   - --filesystem=~/.ftba:ro
 
-cleanup:
-  - /lib/libGLU*
-
 modules:
   # Might be needed by some Controller mods (see https://github.com/isXander/Controlify/issues/31)
   - shared-modules/libusb/libusb.json


### PR DESCRIPTION
The mod AAA Particles (found in the modpack Prominence II RPG) fails to start due to a missing `libGLU.so.1` file. Removing this cleanup command fixes the issue and makes the modpack run without issue.

I reproduced the issue at the head of the develop branch, with and without the change. No other issue was detected by adding the library, and I could not find the initial justification for removing it.