### PR TITLE
Disable retry for private pack fetch

### DIFF
--- a/launcher/modplatform/legacy_ftb/PackFetchTask.cpp
+++ b/launcher/modplatform/legacy_ftb/PackFetchTask.cpp
@@ -74,6 +74,7 @@ void PackFetchTask::fetchPrivate(const QStringList& toFetch)
         auto data = std::make_shared<QByteArray>();
         NetJob* job = new NetJob("Fetching private pack", m_network);
         job->addNetAction(Net::ApiDownload::makeByteArray(privatePackBaseUrl.arg(packCode), data));
+        job->setAskRetry(false);
 
         QObject::connect(job, &NetJob::succeeded, this, [this, job, data, packCode] {
             ModpackList packs;


### PR DESCRIPTION
Errors are already handled with a dialog asking whether you want it to be removed. Maybe we should make it so that the retry dialog only shows for non 404 errors? Why wasn't that how it was implemented to begin with?

![image](https://github.com/user-attachments/assets/0f2fc57a-7250-448d-aca4-560af89f646c)

(no idea where I got the idea to use this code from but it has been there for at least a year!)