### PR TITLE
Fix crash when no resorce version is available

### DIFF
--- a/launcher/ui/pages/modplatform/ResourcePage.cpp
+++ b/launcher/ui/pages/modplatform/ResourcePage.cpp
@@ -254,7 +254,10 @@ void ResourcePage::updateSelectionButton()
 
     m_ui->resourceSelectionButton->setEnabled(true);
     if (auto current_pack = getCurrentPack(); current_pack) {
-        if (!current_pack->isVersionSelected(m_selected_version_index))
+        if (current_pack->versionsLoaded && current_pack->versions.empty()) {
+            m_ui->resourceSelectionButton->setEnabled(false);
+            qWarning() << tr("No version available for the selected pack");
+        } else if (!current_pack->isVersionSelected(m_selected_version_index))
             m_ui->resourceSelectionButton->setText(tr("Select %1 for download").arg(resourceString()));
         else
             m_ui->resourceSelectionButton->setText(tr("Deselect %1 for download").arg(resourceString()));


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
video to demonstrate crash: https://discord.com/channels/1031648380885147709/1031648381514289175/1293283113673166921