### PR TITLE
Use UTF-8 to decode logs on Java 18 or newer 

### DIFF
--- a/launcher/LoggedProcess.cpp
+++ b/launcher/LoggedProcess.cpp
@@ -39,7 +39,8 @@
 #include <QTextDecoder>
 #include "MessageLevel.h"
 
-LoggedProcess::LoggedProcess(QObject* parent) : QProcess(parent)
+LoggedProcess::LoggedProcess(const QTextCodec* output_codec, QObject* parent)
+    : QProcess(parent), m_err_decoder(output_codec), m_out_decoder(output_codec)
 {
     // QProcess has a strange interface... let's map a lot of those into a few.
     connect(this, &QProcess::readyReadStandardOutput, this, &LoggedProcess::on_stdOut);

--- a/launcher/LoggedProcess.h
+++ b/launcher/LoggedProcess.h
@@ -49,7 +49,7 @@ class LoggedProcess : public QProcess {
     enum State { NotRunning, Starting, FailedToStart, Running, Finished, Crashed, Aborted };
 
    public:
-    explicit LoggedProcess(QObject* parent = 0);
+    explicit LoggedProcess(const QTextCodec* output_codec = QTextCodec::codecForLocale(), QObject* parent = 0);
     virtual ~LoggedProcess();
 
     State state() const;
@@ -80,8 +80,8 @@ class LoggedProcess : public QProcess {
     QStringList reprocess(const QByteArray& data, QTextDecoder& decoder);
 
    private:
-    QTextDecoder m_err_decoder = QTextDecoder(QTextCodec::codecForLocale());
-    QTextDecoder m_out_decoder = QTextDecoder(QTextCodec::codecForLocale());
+    QTextDecoder m_err_decoder;
+    QTextDecoder m_out_decoder;
     QString m_leftover_line;
     bool m_killed = false;
     State m_state = NotRunning;

--- a/launcher/java/JavaVersion.cpp
+++ b/launcher/java/JavaVersion.cpp
@@ -48,6 +48,12 @@ bool JavaVersion::requiresPermGen() const
     return !m_parseable || m_major < 8;
 }
 
+bool JavaVersion::defaultsToUtf8() const
+{
+    // starting from Java 18, UTF-8 is the default charset: https://openjdk.org/jeps/400
+    return m_parseable && m_major >= 18;
+}
+
 bool JavaVersion::isModular() const
 {
     return m_parseable && m_major >= 9;

--- a/launcher/java/JavaVersion.h
+++ b/launcher/java/JavaVersion.h
@@ -25,7 +25,7 @@ class JavaVersion {
     bool operator>(const JavaVersion& rhs);
 
     bool requiresPermGen() const;
-
+    bool defaultsToUtf8() const;
     bool isModular() const;
 
     QString toString() const;

--- a/launcher/launch/LaunchTask.cpp
+++ b/launcher/launch/LaunchTask.cpp
@@ -51,14 +51,14 @@ void LaunchTask::init()
     m_instance->setRunning(true);
 }
 
-shared_qobject_ptr<LaunchTask> LaunchTask::create(InstancePtr inst)
+shared_qobject_ptr<LaunchTask> LaunchTask::create(MinecraftInstancePtr inst)
 {
     shared_qobject_ptr<LaunchTask> proc(new LaunchTask(inst));
     proc->init();
     return proc;
 }
 
-LaunchTask::LaunchTask(InstancePtr instance) : m_instance(instance) {}
+LaunchTask::LaunchTask(MinecraftInstancePtr instance) : m_instance(instance) {}
 
 void LaunchTask::appendStep(shared_qobject_ptr<LaunchStep> step)
 {

--- a/launcher/launch/LaunchTask.h
+++ b/launcher/launch/LaunchTask.h
@@ -37,6 +37,7 @@
 
 #pragma once
 #include <QObjectPtr.h>
+#include <minecraft/MinecraftInstance.h>
 #include <QProcess>
 #include "BaseInstance.h"
 #include "LaunchStep.h"
@@ -46,21 +47,21 @@
 class LaunchTask : public Task {
     Q_OBJECT
    protected:
-    explicit LaunchTask(InstancePtr instance);
+    explicit LaunchTask(MinecraftInstancePtr instance);
     void init();
 
    public:
     enum State { NotStarted, Running, Waiting, Failed, Aborted, Finished };
 
    public: /* methods */
-    static shared_qobject_ptr<LaunchTask> create(InstancePtr inst);
+    static shared_qobject_ptr<LaunchTask> create(MinecraftInstancePtr inst);
     virtual ~LaunchTask() = default;
 
     void appendStep(shared_qobject_ptr<LaunchStep> step);
     void prependStep(shared_qobject_ptr<LaunchStep> step);
     void setCensorFilter(QMap<QString, QString> filter);
 
-    InstancePtr instance() { return m_instance; }
+    MinecraftInstancePtr instance() { return m_instance; }
 
     void setPid(qint64 pid) { m_pid = pid; }
 
@@ -115,7 +116,7 @@ class LaunchTask : public Task {
     void finalizeSteps(bool successful, const QString& error);
 
    protected: /* data */
-    InstancePtr m_instance;
+    MinecraftInstancePtr m_instance;
     shared_qobject_ptr<LogModel> m_logModel;
     QList<shared_qobject_ptr<LaunchStep>> m_steps;
     QMap<QString, QString> m_censorFilter;

--- a/launcher/minecraft/launch/AutoInstallJava.cpp
+++ b/launcher/minecraft/launch/AutoInstallJava.cpp
@@ -58,7 +58,7 @@
 
 AutoInstallJava::AutoInstallJava(LaunchTask* parent)
     : LaunchStep(parent)
-    , m_instance(std::dynamic_pointer_cast<MinecraftInstance>(m_parent->instance()))
+    , m_instance(m_parent->instance())
     , m_supported_arch(SysInfo::getSupportedJavaArchitecture()) {};
 
 void AutoInstallJava::executeTask()

--- a/launcher/minecraft/launch/CreateGameFolders.cpp
+++ b/launcher/minecraft/launch/CreateGameFolders.cpp
@@ -8,16 +8,15 @@ CreateGameFolders::CreateGameFolders(LaunchTask* parent) : LaunchStep(parent) {}
 void CreateGameFolders::executeTask()
 {
     auto instance = m_parent->instance();
-    std::shared_ptr<MinecraftInstance> minecraftInstance = std::dynamic_pointer_cast<MinecraftInstance>(instance);
 
-    if (!FS::ensureFolderPathExists(minecraftInstance->gameRoot())) {
+    if (!FS::ensureFolderPathExists(instance->gameRoot())) {
         emit logLine("Couldn't create the main game folder", MessageLevel::Error);
         emitFailed(tr("Couldn't create the main game folder"));
         return;
     }
 
     // HACK: this is a workaround for MCL-3732 - 'server-resource-packs' folder is created.
-    if (!FS::ensureFolderPathExists(FS::PathCombine(minecraftInstance->gameRoot(), "server-resource-packs"))) {
+    if (!FS::ensureFolderPathExists(FS::PathCombine(instance->gameRoot(), "server-resource-packs"))) {
         emit logLine("Couldn't create the 'server-resource-packs' folder", MessageLevel::Error);
     }
     emitSucceeded();

--- a/launcher/minecraft/launch/ExtractNatives.cpp
+++ b/launcher/minecraft/launch/ExtractNatives.cpp
@@ -70,17 +70,16 @@ static bool unzipNatives(QString source, QString targetFolder, bool applyJnilibH
 void ExtractNatives::executeTask()
 {
     auto instance = m_parent->instance();
-    std::shared_ptr<MinecraftInstance> minecraftInstance = std::dynamic_pointer_cast<MinecraftInstance>(instance);
-    auto toExtract = minecraftInstance->getNativeJars();
+    auto toExtract = instance->getNativeJars();
     if (toExtract.isEmpty()) {
         emitSucceeded();
         return;
     }
-    auto settings = minecraftInstance->settings();
+    auto settings = instance->settings();
 
-    auto outputPath = minecraftInstance->getNativePath();
+    auto outputPath = instance->getNativePath();
     FS::ensureFolderPathExists(outputPath);
-    auto javaVersion = minecraftInstance->getJavaVersion();
+    auto javaVersion = instance->getJavaVersion();
     bool jniHackEnabled = javaVersion.major() >= 8;
     for (const auto& source : toExtract) {
         if (!unzipNatives(source, outputPath, jniHackEnabled)) {

--- a/launcher/minecraft/launch/LauncherPartLaunch.cpp
+++ b/launcher/minecraft/launch/LauncherPartLaunch.cpp
@@ -48,7 +48,9 @@
 #include "gamemode_client.h"
 #endif
 
-LauncherPartLaunch::LauncherPartLaunch(LaunchTask* parent) : LaunchStep(parent)
+LauncherPartLaunch::LauncherPartLaunch(LaunchTask* parent)
+    : LaunchStep(parent)
+    , m_process(parent->instance()->getJavaVersion().defaultsToUtf8() ? QTextCodec::codecForName("UTF-8") : QTextCodec::codecForLocale())
 {
     if (parent->instance()->settings()->get("CloseAfterLaunch").toBool()) {
         std::shared_ptr<QMetaObject::Connection> connection{ new QMetaObject::Connection };

--- a/launcher/minecraft/launch/ModMinecraftJar.cpp
+++ b/launcher/minecraft/launch/ModMinecraftJar.cpp
@@ -42,7 +42,7 @@
 
 void ModMinecraftJar::executeTask()
 {
-    auto m_inst = std::dynamic_pointer_cast<MinecraftInstance>(m_parent->instance());
+    auto m_inst = m_parent->instance();
 
     if (!m_inst->getJarMods().size()) {
         emitSucceeded();
@@ -82,7 +82,7 @@ void ModMinecraftJar::finalize()
 
 bool ModMinecraftJar::removeJar()
 {
-    auto m_inst = std::dynamic_pointer_cast<MinecraftInstance>(m_parent->instance());
+    auto m_inst = m_parent->instance();
     auto finalJarPath = QDir(m_inst->binRoot()).absoluteFilePath("minecraft.jar");
     QFile finalJar(finalJarPath);
     if (finalJar.exists()) {

--- a/launcher/minecraft/launch/ReconstructAssets.cpp
+++ b/launcher/minecraft/launch/ReconstructAssets.cpp
@@ -22,12 +22,11 @@
 void ReconstructAssets::executeTask()
 {
     auto instance = m_parent->instance();
-    std::shared_ptr<MinecraftInstance> minecraftInstance = std::dynamic_pointer_cast<MinecraftInstance>(instance);
-    auto components = minecraftInstance->getPackProfile();
+    auto components = instance->getPackProfile();
     auto profile = components->getProfile();
     auto assets = profile->getMinecraftAssets();
 
-    if (!AssetsUtils::reconstructAssets(assets->id, minecraftInstance->resourcesDir())) {
+    if (!AssetsUtils::reconstructAssets(assets->id, instance->resourcesDir())) {
         emit logLine("Failed to reconstruct Minecraft assets.", MessageLevel::Error);
     }
 

--- a/launcher/minecraft/launch/ScanModFolders.cpp
+++ b/launcher/minecraft/launch/ScanModFolders.cpp
@@ -42,7 +42,7 @@
 
 void ScanModFolders::executeTask()
 {
-    auto m_inst = std::dynamic_pointer_cast<MinecraftInstance>(m_parent->instance());
+    auto m_inst = m_parent->instance();
 
     auto loaders = m_inst->loaderModList();
     connect(loaders.get(), &ModFolderModel::updateFinished, this, &ScanModFolders::modsDone);

--- a/launcher/minecraft/launch/VerifyJavaInstall.cpp
+++ b/launcher/minecraft/launch/VerifyJavaInstall.cpp
@@ -46,7 +46,7 @@
 
 void VerifyJavaInstall::executeTask()
 {
-    auto instance = std::dynamic_pointer_cast<MinecraftInstance>(m_parent->instance());
+    auto instance = m_parent->instance();
     auto packProfile = instance->getPackProfile();
     auto settings = instance->settings();
     auto storedVersion = settings->get("JavaVersion").toString();


### PR DESCRIPTION
I feel this is the most compatible and least risky way to implement a fix for #2419 (fixes #2419)

If the user manually specifies `-Dfile.encoding=something` the log window will not know to use this specified encoding but we didn't have this functionality before. Starting from Java 18 it seems that UTF-8 will *always* be the default unless overriden, so this seems the most logical change to simply make logs work as intended with Java 18.

The reason for refactoring LaunchTask to use MinecraftInstance is:
- MinecraftInstance is the only instance type passed in
- I needed to initialise the LoggedProcess in the initialiser list as copy and move construction or assignment are both impossible - this means the line would become very long as the dynamic cast can't be put in a local variable