### PR TITLE
Prevent directories from being removed on instance update

### DIFF
--- a/launcher/InstanceCreationTask.cpp
+++ b/launcher/InstanceCreationTask.cpp
@@ -42,11 +42,11 @@ void InstanceCreationTask::executeTask()
         setStatus(tr("Removing old conflicting files..."));
         qDebug() << "Removing old files";
 
-        for (auto path : m_files_to_remove) {
+        for (const QString& path : m_files_to_remove) {
             if (!QFile::exists(path))
                 continue;
             qDebug() << "Removing" << path;
-            if (!FS::deletePath(path)) {
+            if (!QFile::remove(path)) {
                 qCritical() << "Couldn't remove the old conflicting files.";
                 emitFailed(tr("Failed to remove old conflicting files."));
                 return;
@@ -55,5 +55,4 @@ void InstanceCreationTask::executeTask()
     }
 
     emitSucceeded();
-    return;
 }

--- a/launcher/InstanceCreationTask.cpp
+++ b/launcher/InstanceCreationTask.cpp
@@ -38,6 +38,8 @@ void InstanceCreationTask::executeTask()
     // files scheduled to, and we'd better not let the user abort in the middle of it, since it'd
     // put the instance in an invalid state.
     if (shouldOverride()) {
+        bool deleteFailed = false;
+
         setAbortable(false);
         setStatus(tr("Removing old conflicting files..."));
         qDebug() << "Removing old files";
@@ -45,12 +47,18 @@ void InstanceCreationTask::executeTask()
         for (const QString& path : m_files_to_remove) {
             if (!QFile::exists(path))
                 continue;
+
             qDebug() << "Removing" << path;
+
             if (!QFile::remove(path)) {
-                qCritical() << "Couldn't remove the old conflicting files.";
-                emitFailed(tr("Failed to remove old conflicting files."));
-                return;
+                qCritical() << "Could not remove" << path;
+                deleteFailed = true;
             }
+        }
+
+        if (deleteFailed) {
+            emitFailed(tr("Failed to remove old conflicting files."));
+            return;
         }
     }
 


### PR DESCRIPTION
I have no idea how #2904 happened, but this should ensure that we do not remove any directories if there is some very unfortunate issue with how the paths are determined. Even if it is not caused by this (pretty sure it is the only place where files are deleted on update), it should prevent any regressions from being too destructive