### PR TITLE
remove client overrides instead of double deleting the normal ones

### DIFF
--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
@@ -136,7 +136,7 @@ bool ModrinthCreationTask::updateInstance()
         }
 
         auto old_client_overrides = Override::readOverrides("client-overrides", old_index_folder);
-        for (const auto& entry : old_overrides) {
+        for (const auto& entry : old_client_overrides) {
             if (entry.isEmpty())
                 continue;
             qDebug() << "Scheduling" << entry << "for removal";


### PR DESCRIPTION
found bug when testing https://github.com/PrismLauncher/PrismLauncher/pull/2906
We previously added twice the old_overrides instead of old_client_overrides
