### PR TITLE
Fix tab order on custom command inputs

### DIFF
--- a/launcher/ui/widgets/CustomCommands.ui
+++ b/launcher/ui/widgets/CustomCommands.ui
@@ -38,19 +38,6 @@
       <bool>false</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
-      <item row="2" column="0">
-       <widget class="QLabel" name="labelPostExitCmd">
-        <property name="text">
-         <string>P&amp;ost-exit command:</string>
-        </property>
-        <property name="buddy">
-         <cstring>postExitCmdTextBox</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLineEdit" name="preLaunchCmdTextBox"/>
-      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="labelPreLaunchCmd">
         <property name="text">
@@ -61,8 +48,8 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
-       <widget class="QLineEdit" name="postExitCmdTextBox"/>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="preLaunchCmdTextBox"/>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="labelWrapperCmd">
@@ -76,6 +63,19 @@
       </item>
       <item row="1" column="1">
        <widget class="QLineEdit" name="wrapperCmdTextBox"/>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="labelPostExitCmd">
+        <property name="text">
+         <string>P&amp;ost-exit command:</string>
+        </property>
+        <property name="buddy">
+         <cstring>postExitCmdTextBox</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLineEdit" name="postExitCmdTextBox"/>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
The tab order on the custom command UI in the instance settings is off, it goes 0 -> 2 -> 1, This re-orders the ui file to fix the order the inputs are in.