### PR TITLE
Don't bundle JREs in Flatpak

### DIFF
--- a/flatpak/org.prismlauncher.PrismLauncher.yml
+++ b/flatpak/org.prismlauncher.PrismLauncher.yml
@@ -3,9 +3,7 @@ runtime: org.kde.Platform
 runtime-version: 6.7
 sdk: org.kde.Sdk
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.openjdk21
   - org.freedesktop.Sdk.Extension.openjdk17
-  - org.freedesktop.Sdk.Extension.openjdk8
 
 command: prismlauncher
 finish-args:
@@ -42,19 +40,6 @@ modules:
     sources:
       - type: dir
         path: ../
-
-  - name: openjdk
-    buildsystem: simple
-    build-commands:
-      - mkdir -p /app/jdk/
-      - /usr/lib/sdk/openjdk21/install.sh
-      - mv /app/jre /app/jdk/21
-      - /usr/lib/sdk/openjdk17/install.sh
-      - mv /app/jre /app/jdk/17
-      - /usr/lib/sdk/openjdk8/install.sh
-      - mv /app/jre /app/jdk/8
-    cleanup:
-      - /jre
 
   - name: glfw
     buildsystem: cmake-ninja

--- a/flatpak/org.prismlauncher.PrismLauncher.yml
+++ b/flatpak/org.prismlauncher.PrismLauncher.yml
@@ -37,6 +37,7 @@ modules:
       env:
         JAVA_HOME: /usr/lib/sdk/openjdk17/jvm/openjdk-17
         JAVA_COMPILER: /usr/lib/sdk/openjdk17/jvm/openjdk-17/bin/javac
+    run-tests: true
     sources:
       - type: dir
         path: ../


### PR DESCRIPTION
After https://github.com/PrismLauncher/PrismLauncher/pull/2069, JREs can be managed at runtime. This is great for the Flatpak, as previously *all* JREs had to be installed and could not be updated independently of the launcher's Flatpak. It also makes using unsupported Java versions easier as the launcher can download any version in the sandbox

We don't need to include these anymore

Checks are also enabled to help fix https://github.com/PrismLauncher/PrismLauncher/issues/2926

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
