### PR TITLE
Fix Windows installer restarting device

### DIFF
--- a/program_info/CMakeLists.txt
+++ b/program_info/CMakeLists.txt
@@ -57,7 +57,7 @@ Section "Visual Studio Runtime"
     Pop $0
     ${If} $0 == "OK"
         DetailPrint "Download successful"
-        ExecWait "$INSTDIR\vc_redist\$vc_redist_exe /install /passive /norestart\"
+        ExecWait "$INSTDIR\vc_redist\$vc_redist_exe /install /passive /norestart"
     ${Else}
         DetailPrint "Download failed with error $0"
     ${EndIf}


### PR DESCRIPTION
People are reporting the installer restarts their PC, and this is my best guess why
![image](https://github.com/user-attachments/assets/8861e946-943e-44fe-88d5-7a8ec91781da)
