### PR TITLE
javautils: add a filter for detecting Java paths on AOSC OS

### DIFF
--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -440,9 +440,15 @@ QList<QString> JavaUtils::FindJavaPaths()
         QString fileName = info.fileName();
         return fileName.startsWith("openjdk-") || fileName.startsWith("openj9-");
     };
+    // AOSC OS's locations for openjdk
+    auto aoscFilter = [](const QFileInfo& info) {
+        QString fileName = info.fileName();
+        return fileName == "java" || fileName.startsWith("java-");
+    };
     scanJavaDir("/usr/lib64", gentooFilter);
     scanJavaDir("/usr/lib", gentooFilter);
     scanJavaDir("/opt", gentooFilter);
+    scanJavaDir("/usr/lib", aoscFilter);
     // javas stored in Prism Launcher's folder
     scanJavaDirs("java");
     // manually installed JDKs in /opt


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
Hi, I was inspired by https://github.com/PrismLauncher/PrismLauncher/pull/2429 and want to upstream our patch using similar methods to support detecting installed JDKs on AOSC OS.

AOSC OS JDK paths:
```
/usr/lib/java -> /etc/alternatives/java-home
/usr/lib/java-11
/usr/lib/java-17
/usr/lib/java-21
/usr/lib/java-22
/usr/lib/java-23
/usr/lib/java-8
```

Patched example:
![圖片](https://github.com/user-attachments/assets/f71ec461-bbec-4395-a78e-b7097a75253c)

