### PR TITLE
Fix launching Minecraft in portable Linux

### DIFF
--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -102,6 +102,8 @@ QProcessEnvironment CleanEnviroment()
             QString newValue = stripVariableEntries(key, value, rawenv.value("LAUNCHER_" + key));
 
             qDebug() << "Env: stripped" << key << value << "to" << newValue;
+
+            value = newValue;
         }
 #if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD) || defined(Q_OS_OPENBSD)
         // Strip IBus


### PR DESCRIPTION
We should find a better solution but this just fixes the biggest issue