### PR TITLE
Add extra protection against empty download link

### DIFF
--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -99,7 +99,7 @@ void ModPage::triggerSearch()
     updateSelectionButton();
 
     static_cast<ModModel*>(m_model)->searchWithTerm(getSearchTerm(), m_ui->sortByBox->currentData().toUInt(), changed);
-    m_fetch_progress.watch(m_model->activeSearchJob().get());
+    m_fetchProgress.watch(m_model->activeSearchJob().get());
 }
 
 QMap<QString, QString> ModPage::urlHandlers() const

--- a/launcher/ui/pages/modplatform/ResourcePackPage.cpp
+++ b/launcher/ui/pages/modplatform/ResourcePackPage.cpp
@@ -30,7 +30,7 @@ void ResourcePackResourcePage::triggerSearch()
     updateSelectionButton();
 
     static_cast<ResourcePackResourceModel*>(m_model)->searchWithTerm(getSearchTerm(), m_ui->sortByBox->currentData().toUInt());
-    m_fetch_progress.watch(m_model->activeSearchJob().get());
+    m_fetchProgress.watch(m_model->activeSearchJob().get());
 }
 
 QMap<QString, QString> ResourcePackResourcePage::urlHandlers() const

--- a/launcher/ui/pages/modplatform/ResourcePage.cpp
+++ b/launcher/ui/pages/modplatform/ResourcePage.cpp
@@ -364,11 +364,7 @@ void ResourcePage::onResourceSelected()
 
     auto& version = current_pack->versions[m_selectedVersionIndex];
     if (version.downloadUrl.isNull()) {
-        CustomMessageBox::selectable(
-            this, tr("Download Link Missing"),
-            tr("It looks like the resource you selected doesn't have a download link, so Prism won't attempt to download it."),
-            QMessageBox::Warning)
-            ->show();
+        qCritical() << tr("It looks like the resource you selected doesn't have a download link, so Prism won't attempt to download it.");
         return;
     }
     if (version.is_currently_selected)

--- a/launcher/ui/pages/modplatform/ResourcePage.cpp
+++ b/launcher/ui/pages/modplatform/ResourcePage.cpp
@@ -363,10 +363,7 @@ void ResourcePage::onResourceSelected()
         return;
 
     auto& version = current_pack->versions[m_selectedVersionIndex];
-    if (version.downloadUrl.isNull()) {
-        qCritical() << tr("It looks like the resource you selected doesn't have a download link, so Prism won't attempt to download it.");
-        return;
-    }
+    Q_ASSERT(!version.downloadUrl.isNull());
     if (version.is_currently_selected)
         removeResourceFromDialog(current_pack->name);
     else

--- a/launcher/ui/pages/modplatform/ResourcePage.cpp
+++ b/launcher/ui/pages/modplatform/ResourcePage.cpp
@@ -483,11 +483,13 @@ void ResourcePage::openProject(QVariant projectID)
     connect(cancelBtn, &QPushButton::clicked, m_parentDialog, &ResourceDownloadDialog::reject);
     m_ui->gridLayout_4->addWidget(buttonBox, 1, 2);
 
-    auto jump = [this, okBtn] {
+    connect(m_ui->versionSelectionBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
+            [this, okBtn] { okBtn->setEnabled(m_ui->versionSelectionBox->currentData().toInt() >= 0); });
+
+    auto jump = [this] {
         for (int row = 0; row < m_model->rowCount({}); row++) {
             const QModelIndex index = m_model->index(row);
             m_ui->packView->setCurrentIndex(index);
-            okBtn->setEnabled(true);
             return;
         }
         m_ui->packDescription->setText(tr("The resource was not found"));

--- a/launcher/ui/pages/modplatform/ResourcePage.cpp
+++ b/launcher/ui/pages/modplatform/ResourcePage.cpp
@@ -55,7 +55,7 @@
 namespace ResourceDownload {
 
 ResourcePage::ResourcePage(ResourceDownloadDialog* parent, BaseInstance& base_instance)
-    : QWidget(parent), m_base_instance(base_instance), m_ui(new Ui::ResourcePage), m_parent_dialog(parent), m_fetch_progress(this, false)
+    : QWidget(parent), m_baseInstance(base_instance), m_ui(new Ui::ResourcePage), m_parentDialog(parent), m_fetchProgress(this, false)
 {
     m_ui->setupUi(this);
 
@@ -64,18 +64,18 @@ ResourcePage::ResourcePage(ResourceDownloadDialog* parent, BaseInstance& base_in
     m_ui->versionSelectionBox->view()->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     m_ui->versionSelectionBox->view()->parentWidget()->setMaximumHeight(300);
 
-    m_search_timer.setTimerType(Qt::TimerType::CoarseTimer);
-    m_search_timer.setSingleShot(true);
+    m_searchTimer.setTimerType(Qt::TimerType::CoarseTimer);
+    m_searchTimer.setSingleShot(true);
 
-    connect(&m_search_timer, &QTimer::timeout, this, &ResourcePage::triggerSearch);
+    connect(&m_searchTimer, &QTimer::timeout, this, &ResourcePage::triggerSearch);
 
     // hide progress bar to prevent weird artifact
-    m_fetch_progress.hide();
-    m_fetch_progress.hideIfInactive(true);
-    m_fetch_progress.setFixedHeight(24);
-    m_fetch_progress.progressFormat("");
+    m_fetchProgress.hide();
+    m_fetchProgress.hideIfInactive(true);
+    m_fetchProgress.setFixedHeight(24);
+    m_fetchProgress.progressFormat("");
 
-    m_ui->verticalLayout->insertWidget(1, &m_fetch_progress);
+    m_ui->verticalLayout->insertWidget(1, &m_fetchProgress);
 
     m_ui->packView->setItemDelegate(new ProjectItemDelegate(this));
     m_ui->packView->installEventFilter(this);
@@ -121,10 +121,10 @@ auto ResourcePage::eventFilter(QObject* watched, QEvent* event) -> bool
                 keyEvent->accept();
                 return true;
             } else {
-                if (m_search_timer.isActive())
-                    m_search_timer.stop();
+                if (m_searchTimer.isActive())
+                    m_searchTimer.stop();
 
-                m_search_timer.start(350);
+                m_searchTimer.start(350);
             }
         } else if (watched == m_ui->packView) {
             if (keyEvent->key() == Qt::Key_Return) {
@@ -248,7 +248,7 @@ void ResourcePage::updateUi()
 
 void ResourcePage::updateSelectionButton()
 {
-    if (!isOpened || m_selected_version_index < 0) {
+    if (!isOpened || m_selectedVersionIndex < 0) {
         m_ui->resourceSelectionButton->setEnabled(false);
         return;
     }
@@ -258,7 +258,7 @@ void ResourcePage::updateSelectionButton()
         if (current_pack->versionsLoaded && current_pack->versions.empty()) {
             m_ui->resourceSelectionButton->setEnabled(false);
             qWarning() << tr("No version available for the selected pack");
-        } else if (!current_pack->isVersionSelected(m_selected_version_index))
+        } else if (!current_pack->isVersionSelected(m_selectedVersionIndex))
             m_ui->resourceSelectionButton->setText(tr("Select %1 for download").arg(resourceString()));
         else
             m_ui->resourceSelectionButton->setText(tr("Deselect %1 for download").arg(resourceString()));
@@ -327,18 +327,18 @@ void ResourcePage::onSelectionChanged(QModelIndex curr, [[maybe_unused]] QModelI
 
 void ResourcePage::onVersionSelectionChanged(int)
 {
-    m_selected_version_index = m_ui->versionSelectionBox->currentData().toInt();
+    m_selectedVersionIndex = m_ui->versionSelectionBox->currentData().toInt();
     updateSelectionButton();
 }
 
 void ResourcePage::addResourceToDialog(ModPlatform::IndexedPack::Ptr pack, ModPlatform::IndexedVersion& version)
 {
-    m_parent_dialog->addResource(pack, version);
+    m_parentDialog->addResource(pack, version);
 }
 
 void ResourcePage::removeResourceFromDialog(const QString& pack_name)
 {
-    m_parent_dialog->removeResource(pack_name);
+    m_parentDialog->removeResource(pack_name);
 }
 
 void ResourcePage::addResourceToPage(ModPlatform::IndexedPack::Ptr pack,
@@ -355,14 +355,14 @@ void ResourcePage::removeResourceFromPage(const QString& name)
 
 void ResourcePage::onResourceSelected()
 {
-    if (m_selected_version_index < 0)
+    if (m_selectedVersionIndex < 0)
         return;
 
     auto current_pack = getCurrentPack();
-    if (!current_pack || !current_pack->versionsLoaded || current_pack->versions.size() < m_selected_version_index)
+    if (!current_pack || !current_pack->versionsLoaded || current_pack->versions.size() < m_selectedVersionIndex)
         return;
 
-    auto& version = current_pack->versions[m_selected_version_index];
+    auto& version = current_pack->versions[m_selectedVersionIndex];
     if (version.downloadUrl.isNull()) {
         CustomMessageBox::selectable(this, tr("How?"),
                                      "You managed to select a resource that doesn't have a download link. Because of this missing "
@@ -409,14 +409,14 @@ void ResourcePage::openUrl(const QUrl& url)
         }
     }
 
-    if (!page.isNull() && !m_do_not_jump_to_mod) {
+    if (!page.isNull() && !m_doNotJumpToMod) {
         const QString slug = match.captured(1);
 
         // ensure the user isn't opening the same mod
         if (auto current_pack = getCurrentPack(); current_pack && slug != current_pack->slug) {
-            m_parent_dialog->selectPage(page);
+            m_parentDialog->selectPage(page);
 
-            auto newPage = m_parent_dialog->selectedPage();
+            auto newPage = m_parentDialog->selectedPage();
 
             QLineEdit* searchEdit = newPage->m_ui->searchEdit;
             auto model = newPage->m_model;
@@ -460,7 +460,7 @@ void ResourcePage::openProject(QVariant projectID)
     m_ui->resourceFilterButton->hide();
     m_ui->packView->hide();
     m_ui->resourceSelectionButton->hide();
-    m_do_not_jump_to_mod = true;
+    m_doNotJumpToMod = true;
 
     auto buttonBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
 
@@ -477,10 +477,10 @@ void ResourcePage::openProject(QVariant projectID)
 
     connect(okBtn, &QPushButton::clicked, this, [this] {
         onResourceSelected();
-        m_parent_dialog->accept();
+        m_parentDialog->accept();
     });
 
-    connect(cancelBtn, &QPushButton::clicked, m_parent_dialog, &ResourceDownloadDialog::reject);
+    connect(cancelBtn, &QPushButton::clicked, m_parentDialog, &ResourceDownloadDialog::reject);
     m_ui->gridLayout_4->addWidget(buttonBox, 1, 2);
 
     auto jump = [this, okBtn] {

--- a/launcher/ui/pages/modplatform/ResourcePage.cpp
+++ b/launcher/ui/pages/modplatform/ResourcePage.cpp
@@ -325,9 +325,9 @@ void ResourcePage::onSelectionChanged(QModelIndex curr, [[maybe_unused]] QModelI
     updateUi();
 }
 
-void ResourcePage::onVersionSelectionChanged(int)
+void ResourcePage::onVersionSelectionChanged(int index)
 {
-    m_selectedVersionIndex = m_ui->versionSelectionBox->currentData().toInt();
+    m_selectedVersionIndex = m_ui->versionSelectionBox->itemData(index).toInt();
     updateSelectionButton();
 }
 
@@ -364,10 +364,10 @@ void ResourcePage::onResourceSelected()
 
     auto& version = current_pack->versions[m_selectedVersionIndex];
     if (version.downloadUrl.isNull()) {
-        CustomMessageBox::selectable(this, tr("How?"),
-                                     "You managed to select a resource that doesn't have a download link. Because of this missing "
-                                     "information prism will not try to download it.",
-                                     QMessageBox::Warning)
+        CustomMessageBox::selectable(
+            this, tr("Download Link Missing"),
+            tr("It looks like the resource you selected doesn't have a download link, so Prism won't attempt to download it."),
+            QMessageBox::Warning)
             ->show();
         return;
     }
@@ -484,7 +484,7 @@ void ResourcePage::openProject(QVariant projectID)
     m_ui->gridLayout_4->addWidget(buttonBox, 1, 2);
 
     connect(m_ui->versionSelectionBox, QOverload<int>::of(&QComboBox::currentIndexChanged), this,
-            [this, okBtn] { okBtn->setEnabled(m_ui->versionSelectionBox->currentData().toInt() >= 0); });
+            [this, okBtn](int index) { okBtn->setEnabled(m_ui->versionSelectionBox->itemData(index).toInt() >= 0); });
 
     auto jump = [this] {
         for (int row = 0; row < m_model->rowCount({}); row++) {

--- a/launcher/ui/pages/modplatform/ResourcePage.h
+++ b/launcher/ui/pages/modplatform/ResourcePage.h
@@ -62,7 +62,7 @@ class ResourcePage : public QWidget, public BasePage {
 
     [[nodiscard]] bool setCurrentPack(ModPlatform::IndexedPack::Ptr);
     [[nodiscard]] auto getCurrentPack() const -> ModPlatform::IndexedPack::Ptr;
-    [[nodiscard]] auto getDialog() const -> const ResourceDownloadDialog* { return m_parent_dialog; }
+    [[nodiscard]] auto getDialog() const -> const ResourceDownloadDialog* { return m_parentDialog; }
     [[nodiscard]] auto getModel() const -> ResourceModel* { return m_model; }
 
    protected:
@@ -99,22 +99,22 @@ class ResourcePage : public QWidget, public BasePage {
     virtual void openUrl(const QUrl&);
 
    public:
-    BaseInstance& m_base_instance;
+    BaseInstance& m_baseInstance;
 
    protected:
     Ui::ResourcePage* m_ui;
 
-    ResourceDownloadDialog* m_parent_dialog = nullptr;
+    ResourceDownloadDialog* m_parentDialog = nullptr;
     ResourceModel* m_model = nullptr;
 
-    int m_selected_version_index = -1;
+    int m_selectedVersionIndex = -1;
 
-    ProgressWidget m_fetch_progress;
+    ProgressWidget m_fetchProgress;
 
     // Used to do instant searching with a delay to cache quick changes
-    QTimer m_search_timer;
+    QTimer m_searchTimer;
 
-    bool m_do_not_jump_to_mod = false;
+    bool m_doNotJumpToMod = false;
 };
 
 }  // namespace ResourceDownload

--- a/launcher/ui/pages/modplatform/ShaderPackPage.cpp
+++ b/launcher/ui/pages/modplatform/ShaderPackPage.cpp
@@ -31,7 +31,7 @@ void ShaderPackResourcePage::triggerSearch()
     updateSelectionButton();
 
     static_cast<ShaderPackResourceModel*>(m_model)->searchWithTerm(getSearchTerm(), m_ui->sortByBox->currentData().toUInt());
-    m_fetch_progress.watch(m_model->activeSearchJob().get());
+    m_fetchProgress.watch(m_model->activeSearchJob().get());
 }
 
 QMap<QString, QString> ShaderPackResourcePage::urlHandlers() const

--- a/launcher/ui/pages/modplatform/flame/FlamePage.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.cpp
@@ -273,7 +273,7 @@ void FlamePage::suggestCurrent()
 void FlamePage::onVersionSelectionChanged(int index)
 {
     bool is_blocked = false;
-    ui->versionSelectionBox->currentData().toInt(&is_blocked);
+    ui->versionSelectionBox->itemData(index).toInt(&is_blocked);
 
     if (index == -1 || is_blocked) {
         m_selected_version_index = -1;

--- a/launcher/ui/pages/modplatform/flame/FlameResourcePages.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameResourcePages.cpp
@@ -209,7 +209,7 @@ auto FlameShaderPackPage::shouldDisplay() const -> bool
 
 unique_qobject_ptr<ModFilterWidget> FlameModPage::createFilterWidget()
 {
-    return ModFilterWidget::create(&static_cast<MinecraftInstance&>(m_base_instance), false, this);
+    return ModFilterWidget::create(&static_cast<MinecraftInstance&>(m_baseInstance), false, this);
 }
 
 void FlameModPage::prepareProviderCategories()

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
@@ -375,7 +375,7 @@ void ModrinthPage::onVersionSelectionChanged(int index)
         selectedVersion = "";
         return;
     }
-    selectedVersion = ui->versionSelectionBox->currentData().toString();
+    selectedVersion = ui->versionSelectionBox->itemData(index).toString();
     suggestCurrent();
 }
 

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.cpp
@@ -144,7 +144,7 @@ auto ModrinthShaderPackPage::shouldDisplay() const -> bool
 
 unique_qobject_ptr<ModFilterWidget> ModrinthModPage::createFilterWidget()
 {
-    return ModFilterWidget::create(&static_cast<MinecraftInstance&>(m_base_instance), true, this);
+    return ModFilterWidget::create(&static_cast<MinecraftInstance&>(m_baseInstance), true, this);
 }
 
 void ModrinthModPage::prepareProviderCategories()

--- a/launcher/ui/widgets/ThemeCustomizationWidget.cpp
+++ b/launcher/ui/widgets/ThemeCustomizationWidget.cpp
@@ -87,7 +87,7 @@ void ThemeCustomizationWidget::applyIconTheme(int index)
 {
     auto settings = APPLICATION->settings();
     auto originalIconTheme = settings->get("IconTheme").toString();
-    auto newIconTheme = ui->iconsComboBox->currentData().toString();
+    auto newIconTheme = ui->iconsComboBox->itemData(index).toString();
     if (originalIconTheme != newIconTheme) {
         settings->set("IconTheme", newIconTheme);
         APPLICATION->themeManager()->applyCurrentlySelectedTheme();
@@ -100,7 +100,7 @@ void ThemeCustomizationWidget::applyWidgetTheme(int index)
 {
     auto settings = APPLICATION->settings();
     auto originalAppTheme = settings->get("ApplicationTheme").toString();
-    auto newAppTheme = ui->widgetStyleComboBox->currentData().toString();
+    auto newAppTheme = ui->widgetStyleComboBox->itemData(index).toString();
     if (originalAppTheme != newAppTheme) {
         settings->set("ApplicationTheme", newAppTheme);
         APPLICATION->themeManager()->applyCurrentlySelectedTheme();
@@ -113,7 +113,7 @@ void ThemeCustomizationWidget::applyCatTheme(int index)
 {
     auto settings = APPLICATION->settings();
     auto originalCat = settings->get("BackgroundCat").toString();
-    auto newCat = ui->backgroundCatComboBox->currentData().toString();
+    auto newCat = ui->backgroundCatComboBox->itemData(index).toString();
     if (originalCat != newCat) {
         settings->set("BackgroundCat", newCat);
     }


### PR DESCRIPTION
Based on the report found here: https://github.com/PrismLauncher/PrismLauncher/issues/2985 (this doesn't fix the  issue)

First line change is the fact that we should not rely on the combobox index but use instead the use the userdata(the real index). It is unlikely but there may be cases for curseforge where only one version is blocked(did not see one in the wild).

The second is just an extra size check(not likely to happen but still)

And the third is another protection against the curseforge behavior if for any reason we do end up trying to select a resource that doesn't have a download URL then refuse and display a message to the user.
