### PR TITLE
add release_type filer for mod/modpacks

### DIFF
--- a/launcher/ui/widgets/ModFilterWidget.cpp
+++ b/launcher/ui/widgets/ModFilterWidget.cpp
@@ -162,6 +162,11 @@ ModFilterWidget::ModFilterWidget(MinecraftInstance* instance, bool extended, QWi
     connect(ui->hideInstalled, &QCheckBox::stateChanged, this, &ModFilterWidget::onHideInstalledFilterChanged);
     connect(ui->openSource, &QCheckBox::stateChanged, this, &ModFilterWidget::onOpenSourceFilterChanged);
 
+    connect(ui->releaseCb, &QCheckBox::stateChanged, this, &ModFilterWidget::onReleaseFilterChanged);
+    connect(ui->betaCb, &QCheckBox::stateChanged, this, &ModFilterWidget::onReleaseFilterChanged);
+    connect(ui->alphaCb, &QCheckBox::stateChanged, this, &ModFilterWidget::onReleaseFilterChanged);
+    connect(ui->unknownCb, &QCheckBox::stateChanged, this, &ModFilterWidget::onReleaseFilterChanged);
+
     setHidden(true);
     loadVersionList();
     prepareBasicFilter();
@@ -345,6 +350,23 @@ void ModFilterWidget::onOpenSourceFilterChanged()
     auto open = ui->openSource->isChecked();
     m_filter_changed = open != m_filter->openSource;
     m_filter->openSource = open;
+    if (m_filter_changed)
+        emit filterChanged();
+}
+
+void ModFilterWidget::onReleaseFilterChanged()
+{
+    std::list<ModPlatform::IndexedVersionType> releases;
+    if (ui->releaseCb->isChecked())
+        releases.push_back(ModPlatform::IndexedVersionType(ModPlatform::IndexedVersionType::VersionType::Release));
+    if (ui->betaCb->isChecked())
+        releases.push_back(ModPlatform::IndexedVersionType(ModPlatform::IndexedVersionType::VersionType::Beta));
+    if (ui->alphaCb->isChecked())
+        releases.push_back(ModPlatform::IndexedVersionType(ModPlatform::IndexedVersionType::VersionType::Alpha));
+    if (ui->unknownCb->isChecked())
+        releases.push_back(ModPlatform::IndexedVersionType(ModPlatform::IndexedVersionType::VersionType::Unknown));
+    m_filter_changed = releases != m_filter->releases;
+    m_filter->releases = releases;
     if (m_filter_changed)
         emit filterChanged();
 }

--- a/launcher/ui/widgets/ModFilterWidget.h
+++ b/launcher/ui/widgets/ModFilterWidget.h
@@ -109,6 +109,7 @@ class ModFilterWidget : public QTabWidget {
     void onHideInstalledFilterChanged();
     void onShowAllVersionsChanged();
     void onOpenSourceFilterChanged();
+    void onReleaseFilterChanged();
 
    private:
     Ui::ModFilterWidget* ui;

--- a/launcher/ui/widgets/ModFilterWidget.ui
+++ b/launcher/ui/widgets/ModFilterWidget.ui
@@ -63,8 +63,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>308</width>
-        <height>598</height>
+        <width>294</width>
+        <height>781</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -193,6 +193,43 @@
          <property name="text">
           <string>Open source only</string>
          </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="releaseGroup">
+         <property name="title">
+          <string>Release type</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_6">
+          <item>
+           <widget class="QCheckBox" name="releaseCb">
+            <property name="text">
+             <string>Release</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="betaCb">
+            <property name="text">
+             <string>Beta</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="alphaCb">
+            <property name="text">
+             <string>Alpha</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="unknownCb">
+            <property name="text">
+             <string>Unknown</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
        <item>


### PR DESCRIPTION
adds back the release type filter( do not know why it was removed but only from the ui and not the code)