### PR TITLE
Fix some typos and shorten metainfo.xml app summary

### DIFF
--- a/launcher/minecraft/auth/steps/MSADeviceCodeStep.cpp
+++ b/launcher/minecraft/auth/steps/MSADeviceCodeStep.cpp
@@ -74,12 +74,12 @@ void MSADeviceCodeStep::perform()
     m_task->setAskRetry(false);
     m_task->addNetAction(m_request);
 
-    connect(m_task.get(), &Task::finished, this, &MSADeviceCodeStep::deviceAutorizationFinished);
+    connect(m_task.get(), &Task::finished, this, &MSADeviceCodeStep::deviceAuthorizationFinished);
 
     m_task->start();
 }
 
-struct DeviceAutorizationResponse {
+struct DeviceAuthorizationResponse {
     QString device_code;
     QString user_code;
     QString verification_uri;
@@ -90,17 +90,17 @@ struct DeviceAutorizationResponse {
     QString error_description;
 };
 
-DeviceAutorizationResponse parseDeviceAutorizationResponse(const QByteArray& data)
+DeviceAuthorizationResponse parseDeviceAuthorizationResponse(const QByteArray& data)
 {
     QJsonParseError err;
     QJsonDocument doc = QJsonDocument::fromJson(data, &err);
     if (err.error != QJsonParseError::NoError) {
-        qWarning() << "Failed to parse device autorization response due to err:" << err.errorString();
+        qWarning() << "Failed to parse device authorization response due to err:" << err.errorString();
         return {};
     }
 
     if (!doc.isObject()) {
-        qWarning() << "Device autorization response is not an object";
+        qWarning() << "Device authorization response is not an object";
         return {};
     }
     auto obj = doc.object();
@@ -111,9 +111,9 @@ DeviceAutorizationResponse parseDeviceAutorizationResponse(const QByteArray& dat
     };
 }
 
-void MSADeviceCodeStep::deviceAutorizationFinished()
+void MSADeviceCodeStep::deviceAuthorizationFinished()
 {
-    auto rsp = parseDeviceAutorizationResponse(*m_response);
+    auto rsp = parseDeviceAuthorizationResponse(*m_response);
     if (!rsp.error.isEmpty() || !rsp.error_description.isEmpty()) {
         qWarning() << "Device authorization failed:" << rsp.error;
         emit finished(AccountTaskState::STATE_FAILED_HARD,
@@ -208,12 +208,12 @@ AuthenticationResponse parseAuthenticationResponse(const QByteArray& data)
     QJsonParseError err;
     QJsonDocument doc = QJsonDocument::fromJson(data, &err);
     if (err.error != QJsonParseError::NoError) {
-        qWarning() << "Failed to parse device autorization response due to err:" << err.errorString();
+        qWarning() << "Failed to parse device authorization response due to err:" << err.errorString();
         return {};
     }
 
     if (!doc.isObject()) {
-        qWarning() << "Device autorization response is not an object";
+        qWarning() << "Device authorization response is not an object";
         return {};
     }
     auto obj = doc.object();

--- a/launcher/minecraft/auth/steps/MSADeviceCodeStep.h
+++ b/launcher/minecraft/auth/steps/MSADeviceCodeStep.h
@@ -58,7 +58,7 @@ class MSADeviceCodeStep : public AuthStep {
     void authorizeWithBrowser(QString url, QString code, int expiresIn);
 
    private slots:
-    void deviceAutorizationFinished();
+    void deviceAuthorizationFinished();
     void startPoolTimer();
     void authenticateUser();
     void authenticationFinished();

--- a/launcher/ui/java/InstallJavaDialog.cpp
+++ b/launcher/ui/java/InstallJavaDialog.cpp
@@ -132,9 +132,9 @@ class InstallJavaPage : public QWidget, public BasePage {
         m_recommended_majors = majors;
         recommendedFilterChanged();
     }
-    void setRecomend(bool recomend)
+    void setRecommend(bool recommend)
     {
-        m_recommend = recomend;
+        m_recommend = recommend;
         recommendedFilterChanged();
     }
     void recommendedFilterChanged()
@@ -202,7 +202,7 @@ InstallDialog::InstallDialog(const QString& uid, BaseInstance* instance, QWidget
     recommendedCheckBox->setCheckState(Qt::CheckState::Checked);
     connect(recommendedCheckBox, &QCheckBox::stateChanged, this, [this](int state) {
         for (BasePage* page : container->getPages()) {
-            pageCast(page)->setRecomend(state == Qt::Checked);
+            pageCast(page)->setRecommend(state == Qt::Checked);
         }
     });
 
@@ -261,7 +261,7 @@ InstallDialog::InstallDialog(const QString& uid, BaseInstance* instance, QWidget
             container->selectPage(page->id());
 
         auto cast = pageCast(page);
-        cast->setRecomend(true);
+        cast->setRecommend(true);
         connect(cast, &InstallJavaPage::selectionChanged, this, [this, cast] { validate(cast); });
         if (!recommendedJavas.isEmpty()) {
             cast->setRecommendedMajors(recommendedJavas);

--- a/program_info/org.prismlauncher.PrismLauncher.metainfo.xml.in
+++ b/program_info/org.prismlauncher.PrismLauncher.metainfo.xml.in
@@ -4,7 +4,7 @@
   <launchable type="desktop-id">org.prismlauncher.PrismLauncher.desktop</launchable>
   <name>Prism Launcher</name>
   <developer_name>Prism Launcher Contributors</developer_name>
-  <summary>A custom launcher for Minecraft that allows you to easily manage multiple installations of Minecraft at once</summary>
+  <summary>Custom Minecraft Launcher to easily manage multiple Minecraft installations at once</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-3.0-only</project_license>
   <url type="homepage">https://prismlauncher.org/</url>


### PR DESCRIPTION
When I packaged version 9 of PrismLauncher for Debian, the linter found a couple spelling errors in the source, which I have fixed.
I also trimmed down the app summary in metainfo.xml a little, because the appstream linter says it is too long.

Like I said last time, I am not generally a fan of contributions that only fix cosmetics like spelling errors, but Debian encourages forwarding this stuff upstream instead of letting it get fixed naturally over time.