### PR TITLE
use isPortable to determine if the MSAStep should check for url handler

### DIFF
--- a/launcher/minecraft/auth/steps/MSAStep.cpp
+++ b/launcher/minecraft/auth/steps/MSAStep.cpp
@@ -85,8 +85,7 @@ class CustomOAuthOobReplyHandler : public QOAuthOobReplyHandler {
 MSAStep::MSAStep(AccountData* data, bool silent) : AuthStep(data), m_silent(silent)
 {
     m_clientId = APPLICATION->getMSAClientID();
-    if (QCoreApplication::applicationFilePath().startsWith("/tmp/.mount_") ||
-        QFile::exists(FS::PathCombine(APPLICATION->root(), "portable.txt")) || !isSchemeHandlerRegistered())
+    if (QCoreApplication::applicationFilePath().startsWith("/tmp/.mount_") || APPLICATION->isPortable() || !isSchemeHandlerRegistered())
 
     {
         auto replyHandler = new QOAuthHttpServerReplyHandler(this);


### PR DESCRIPTION
Between the auth flow refactoring and the previous release, another condition to determine whether the launcher is portable was added(UserData directory).
This change uses the boolean value stored on the APPLICATION, eliminating the need to check for a specific file. 