### PR TITLE
Fix the update mods for old curseforge mods with no loader information

### DIFF
--- a/launcher/minecraft/mod/Mod.cpp
+++ b/launcher/minecraft/mod/Mod.cpp
@@ -48,6 +48,7 @@
 #include "Version.h"
 #include "minecraft/mod/ModDetails.h"
 #include "minecraft/mod/tasks/LocalModParseTask.h"
+#include "modplatform/ModIndex.h"
 
 Mod::Mod(const QFileInfo& file) : Resource(file), m_local_details()
 {
@@ -157,11 +158,8 @@ auto Mod::loaders() const -> QString
     if (metadata()) {
         QStringList loaders;
         auto modLoaders = metadata()->loaders;
-        for (auto loader : { ModPlatform::NeoForge, ModPlatform::Forge, ModPlatform::Cauldron, ModPlatform::LiteLoader, ModPlatform::Fabric,
-                             ModPlatform::Quilt }) {
-            if (modLoaders & loader) {
-                loaders << getModLoaderAsString(loader);
-            }
+        for (auto loader : ModPlatform::modLoaderTypesToList(modLoaders)) {
+            loaders << getModLoaderAsString(loader);
         }
         return loaders.join(", ");
     }

--- a/launcher/modplatform/ModIndex.cpp
+++ b/launcher/modplatform/ModIndex.cpp
@@ -31,6 +31,19 @@ static const QMap<QString, IndexedVersionType::VersionType> s_indexed_version_ty
     { "alpha", IndexedVersionType::VersionType::Alpha }
 };
 
+static const QList<ModLoaderType> loaderList = { NeoForge, Forge, Cauldron, LiteLoader, Quilt, Fabric };
+
+QList<ModLoaderType> modLoaderTypesToList(ModLoaderTypes flags)
+{
+    QList<ModLoaderType> flagList;
+    for (auto flag : loaderList) {
+        if (flags.testFlag(flag)) {
+            flagList.append(flag);
+        }
+    }
+    return flagList;
+}
+
 IndexedVersionType::IndexedVersionType(const QString& type) : IndexedVersionType(enumFromString(type)) {}
 
 IndexedVersionType::IndexedVersionType(const IndexedVersionType::VersionType& type)

--- a/launcher/modplatform/ModIndex.h
+++ b/launcher/modplatform/ModIndex.h
@@ -32,6 +32,7 @@ namespace ModPlatform {
 
 enum ModLoaderType { NeoForge = 1 << 0, Forge = 1 << 1, Cauldron = 1 << 2, LiteLoader = 1 << 3, Fabric = 1 << 4, Quilt = 1 << 5 };
 Q_DECLARE_FLAGS(ModLoaderTypes, ModLoaderType)
+QList<ModLoaderType> modLoaderTypesToList(ModLoaderTypes flags);
 
 enum class ResourceProvider { MODRINTH, FLAME };
 

--- a/launcher/modplatform/flame/FlameAPI.cpp
+++ b/launcher/modplatform/flame/FlameAPI.cpp
@@ -270,21 +270,35 @@ std::optional<ModPlatform::IndexedVersion> FlameAPI::getLatestVersion(QList<ModP
                                                                       QList<ModPlatform::ModLoaderType> instanceLoaders,
                                                                       ModPlatform::ModLoaderTypes modLoaders)
 {
-    // edge case: mod has installed for forge but the instance is fabric => fabric version will be prioritizated on update
-    auto bestVersion = [&versions](ModPlatform::ModLoaderTypes loader) {
-        std::optional<ModPlatform::IndexedVersion> ver;
-        for (auto file_tmp : versions) {
-            if (file_tmp.loaders & loader && (!ver.has_value() || file_tmp.date > ver->date)) {
-                ver = file_tmp;
+    QHash<ModPlatform::ModLoaderType, ModPlatform::IndexedVersion> bestMatch;
+    auto checkVersion = [&bestMatch](const ModPlatform::IndexedVersion& version, const ModPlatform::ModLoaderType& loader) {
+        if (bestMatch.contains(loader)) {
+            auto best = bestMatch.value(loader);
+            if (version.date > best.date) {
+                bestMatch[loader] = version;
+            }
+        } else {
+            bestMatch[loader] = version;
+        }
+    };
+    for (auto file_tmp : versions) {
+        auto loaders = ModPlatform::modLoaderTypesToList(file_tmp.loaders);
+        if (loaders.isEmpty()) {
+            checkVersion(file_tmp, ModPlatform::ModLoaderType(0));
+        } else {
+            for (auto loader : loaders) {
+                checkVersion(file_tmp, loader);
             }
         }
-        return ver;
-    };
-    for (auto l : instanceLoaders) {
-        auto ver = bestVersion(l);
-        if (ver.has_value()) {
-            return ver;
+    }
+    // edge case: mod has installed for forge but the instance is fabric => fabric version will be prioritizated on update
+    auto currentLoaders = instanceLoaders + ModPlatform::modLoaderTypesToList(modLoaders);
+    currentLoaders.append(ModPlatform::ModLoaderType(0));  // add a fallback in case the versions do not define a loader
+
+    for (auto loader : currentLoaders) {
+        if (bestMatch.contains(loader)) {
+            return bestMatch.value(loader);
         }
     }
-    return bestVersion(modLoaders);
+    return {};
 }

--- a/launcher/modplatform/flame/FlameCheckUpdate.h
+++ b/launcher/modplatform/flame/FlameCheckUpdate.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "Application.h"
 #include "modplatform/CheckUpdateTask.h"
 #include "net/NetJob.h"
 

--- a/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
+++ b/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
@@ -8,6 +8,7 @@
 #include "QObjectPtr.h"
 #include "ResourceDownloadTask.h"
 
+#include "modplatform/ModIndex.h"
 #include "modplatform/helpers/HashUtils.h"
 
 #include "tasks/ConcurrentTask.h"
@@ -99,8 +100,7 @@ void ModrinthCheckUpdate::checkVersionsResponse(std::shared_ptr<QByteArray> resp
             // If the returned project is empty, but we have Modrinth metadata,
             // it means this specific version is not available
             if (project_obj.isEmpty()) {
-                qDebug() << "Mod " << m_mappings.find(hash).value()->name() << " got an empty response."
-                         << "Hash: " << hash;
+                qDebug() << "Mod " << m_mappings.find(hash).value()->name() << " got an empty response." << "Hash: " << hash;
                 ++iter;
                 continue;
             }
@@ -108,10 +108,8 @@ void ModrinthCheckUpdate::checkVersionsResponse(std::shared_ptr<QByteArray> resp
             // Sometimes a version may have multiple files, one with "forge" and one with "fabric",
             // so we may want to filter it
             QString loader_filter;
-            static auto flags = { ModPlatform::ModLoaderType::NeoForge, ModPlatform::ModLoaderType::Forge,
-                                  ModPlatform::ModLoaderType::Quilt, ModPlatform::ModLoaderType::Fabric };
-            for (auto flag : flags) {
-                if (loader.has_value() && loader->testFlag(flag)) {
+            if (loader.has_value()) {
+                for (auto flag : ModPlatform::modLoaderTypesToList(*loader)) {
                     loader_filter = ModPlatform::getModLoaderAsString(flag);
                     break;
                 }
@@ -173,7 +171,7 @@ void ModrinthCheckUpdate::checkNextLoader()
         m_loader_idx++;
         return;
     }
-    
+
     if (m_loader_idx < m_loaders_list.size()) {
         getUpdateModsForLoader(m_loaders_list.at(m_loader_idx));
         m_loader_idx++;

--- a/launcher/modplatform/packwiz/Packwiz.cpp
+++ b/launcher/modplatform/packwiz/Packwiz.cpp
@@ -190,11 +190,8 @@ void V1::updateModIndex(const QDir& index_dir, Mod& mod)
     }
 
     toml::array loaders;
-    for (auto loader : { ModPlatform::NeoForge, ModPlatform::Forge, ModPlatform::Cauldron, ModPlatform::LiteLoader, ModPlatform::Fabric,
-                         ModPlatform::Quilt }) {
-        if (mod.loaders & loader) {
-            loaders.push_back(getModLoaderAsString(loader).toStdString());
-        }
+    for (auto loader : ModPlatform::modLoaderTypesToList(mod.loaders)) {
+        loaders.push_back(getModLoaderAsString(loader).toStdString());
     }
     toml::array mcVersions;
     for (auto version : mod.mcVersions) {

--- a/launcher/ui/dialogs/ResourceUpdateDialog.cpp
+++ b/launcher/ui/dialogs/ResourceUpdateDialog.cpp
@@ -1,4 +1,5 @@
 #include "ResourceUpdateDialog.h"
+#include "Application.h"
 #include "ChooseProviderDialog.h"
 #include "CustomMessageBox.h"
 #include "ProgressDialog.h"


### PR DESCRIPTION
fixes #3040

Looks like curseforge did not update the db for all versions to have loader information

Also made the list of loaders a constant and defined a function to split the flag