### PR TITLE
refactor FlameCheckUpdate to remove qEventLoop

### DIFF
--- a/launcher/minecraft/auth/AuthFlow.cpp
+++ b/launcher/minecraft/auth/AuthFlow.cpp
@@ -1,5 +1,4 @@
 #include <QDebug>
-#include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QNetworkRequest>
 

--- a/launcher/minecraft/auth/AuthSession.h
+++ b/launcher/minecraft/auth/AuthSession.h
@@ -1,12 +1,9 @@
 #pragma once
 
-#include <QMultiMap>
 #include <QString>
 #include <memory>
-#include "QObjectPtr.h"
 
 class MinecraftAccount;
-class QNetworkAccessManager;
 
 struct AuthSession {
     bool MakeOffline(QString offline_playername);

--- a/launcher/modplatform/flame/FileResolvingTask.cpp
+++ b/launcher/modplatform/flame/FileResolvingTask.cpp
@@ -20,7 +20,6 @@
 #include <algorithm>
 
 #include "Json.h"
-#include "QObjectPtr.h"
 #include "modplatform/ModIndex.h"
 #include "modplatform/flame/FlameAPI.h"
 #include "modplatform/flame/FlameModIndex.h"
@@ -33,9 +32,7 @@
 static const FlameAPI flameAPI;
 static ModrinthAPI modrinthAPI;
 
-Flame::FileResolvingTask::FileResolvingTask(const shared_qobject_ptr<QNetworkAccessManager>& network, Flame::Manifest& toProcess)
-    : m_network(network), m_manifest(toProcess)
-{}
+Flame::FileResolvingTask::FileResolvingTask(Flame::Manifest& toProcess) : m_manifest(toProcess) {}
 
 bool Flame::FileResolvingTask::abort()
 {

--- a/launcher/modplatform/flame/FileResolvingTask.h
+++ b/launcher/modplatform/flame/FileResolvingTask.h
@@ -17,8 +17,6 @@
  */
 #pragma once
 
-#include <QNetworkAccessManager>
-
 #include "PackManifest.h"
 #include "tasks/Task.h"
 
@@ -26,7 +24,7 @@ namespace Flame {
 class FileResolvingTask : public Task {
     Q_OBJECT
    public:
-    explicit FileResolvingTask(const shared_qobject_ptr<QNetworkAccessManager>& network, Flame::Manifest& toProcess);
+    explicit FileResolvingTask(Flame::Manifest& toProcess);
     virtual ~FileResolvingTask() = default;
 
     bool canAbort() const override { return true; }
@@ -44,7 +42,6 @@ class FileResolvingTask : public Task {
     void getFlameProjects();
 
    private: /* data */
-    shared_qobject_ptr<QNetworkAccessManager> m_network;
     Flame::Manifest m_manifest;
     std::shared_ptr<QByteArray> m_result;
     Task::Ptr m_task;

--- a/launcher/modplatform/flame/FlameAPI.cpp
+++ b/launcher/modplatform/flame/FlameAPI.cpp
@@ -215,7 +215,7 @@ QList<ModPlatform::Category> FlameAPI::loadModCategories(std::shared_ptr<QByteAr
     return categories;
 };
 
-std::optional<ModPlatform::IndexedVersion> FlameAPI::getLatestVersion(QList<ModPlatform::IndexedVersion> versions,
+std::optional<ModPlatform::IndexedVersion> FlameAPI::getLatestVersion(QVector<ModPlatform::IndexedVersion> versions,
                                                                       QList<ModPlatform::ModLoaderType> instanceLoaders,
                                                                       ModPlatform::ModLoaderTypes modLoaders)
 {

--- a/launcher/modplatform/flame/FlameAPI.h
+++ b/launcher/modplatform/flame/FlameAPI.h
@@ -15,7 +15,7 @@ class FlameAPI : public NetworkResourceAPI {
     QString getModFileChangelog(int modId, int fileId);
     QString getModDescription(int modId);
 
-    std::optional<ModPlatform::IndexedVersion> getLatestVersion(QList<ModPlatform::IndexedVersion> versions,
+    std::optional<ModPlatform::IndexedVersion> getLatestVersion(QVector<ModPlatform::IndexedVersion> versions,
                                                                 QList<ModPlatform::ModLoaderType> instanceLoaders,
                                                                 ModPlatform::ModLoaderTypes fallback);
 

--- a/launcher/modplatform/flame/FlameAPI.h
+++ b/launcher/modplatform/flame/FlameAPI.h
@@ -15,7 +15,6 @@ class FlameAPI : public NetworkResourceAPI {
     QString getModFileChangelog(int modId, int fileId);
     QString getModDescription(int modId);
 
-    QList<ModPlatform::IndexedVersion> getLatestVersions(VersionSearchArgs&& args);
     std::optional<ModPlatform::IndexedVersion> getLatestVersion(QList<ModPlatform::IndexedVersion> versions,
                                                                 QList<ModPlatform::ModLoaderType> instanceLoaders,
                                                                 ModPlatform::ModLoaderTypes fallback);
@@ -108,12 +107,6 @@ class FlameAPI : public NetworkResourceAPI {
         return "https://api.curseforge.com/v1/mods/search?gameId=432&" + get_arguments.join('&');
     }
 
-   private:
-    [[nodiscard]] std::optional<QString> getInfoURL(QString const& id) const override
-    {
-        return QString("https://api.curseforge.com/v1/mods/%1").arg(id);
-    }
-
     [[nodiscard]] std::optional<QString> getVersionsURL(VersionSearchArgs const& args) const override
     {
         auto addonId = args.pack.addonId.toString();
@@ -129,6 +122,11 @@ class FlameAPI : public NetworkResourceAPI {
         return url;
     }
 
+   private:
+    [[nodiscard]] std::optional<QString> getInfoURL(QString const& id) const override
+    {
+        return QString("https://api.curseforge.com/v1/mods/%1").arg(id);
+    }
     [[nodiscard]] std::optional<QString> getDependencyURL(DependencySearchArgs const& args) const override
     {
         auto addonId = args.dependency.addonId.toString();

--- a/launcher/modplatform/flame/FlameCheckUpdate.h
+++ b/launcher/modplatform/flame/FlameCheckUpdate.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "modplatform/CheckUpdateTask.h"
-#include "net/NetJob.h"
 
 class FlameCheckUpdate : public CheckUpdateTask {
     Q_OBJECT
@@ -19,12 +18,12 @@ class FlameCheckUpdate : public CheckUpdateTask {
 
    protected slots:
     void executeTask() override;
+   private slots:
+    void getLatestVersionCallback(Resource* resource, std::shared_ptr<QByteArray> response);
+    void collectBlockedMods();
 
    private:
-    ModPlatform::IndexedPack getProjectInfo(ModPlatform::IndexedVersion& ver_info);
-    ModPlatform::IndexedVersion getFileInfo(int addonId, int fileId);
+    Task::Ptr m_task = nullptr;
 
-    NetJob* m_net_job = nullptr;
-
-    bool m_was_aborted = false;
+    QHash<Resource*, QString> m_blocked;
 };

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -437,7 +437,7 @@ bool FlameCreationTask::createInstance()
 
     instance.setName(name());
 
-    m_modIdResolver.reset(new Flame::FileResolvingTask(APPLICATION->network(), m_pack));
+    m_modIdResolver.reset(new Flame::FileResolvingTask(m_pack));
     connect(m_modIdResolver.get(), &Flame::FileResolvingTask::succeeded, this, [this, &loop] { idResolverSucceeded(loop); });
     connect(m_modIdResolver.get(), &Flame::FileResolvingTask::failed, [this, &loop](QString reason) {
         m_modIdResolver.reset();

--- a/launcher/modplatform/flame/FlameModIndex.cpp
+++ b/launcher/modplatform/flame/FlameModIndex.cpp
@@ -76,10 +76,7 @@ static QString enumToString(int hash_algorithm)
     }
 }
 
-void FlameMod::loadIndexedPackVersions(ModPlatform::IndexedPack& pack,
-                                       QJsonArray& arr,
-                                       [[maybe_unused]] const shared_qobject_ptr<QNetworkAccessManager>& network,
-                                       const BaseInstance* inst)
+void FlameMod::loadIndexedPackVersions(ModPlatform::IndexedPack& pack, QJsonArray& arr, const BaseInstance* inst)
 {
     QVector<ModPlatform::IndexedVersion> unsortedVersions;
     for (auto versionIter : arr) {

--- a/launcher/modplatform/flame/FlameModIndex.cpp
+++ b/launcher/modplatform/flame/FlameModIndex.cpp
@@ -76,7 +76,7 @@ static QString enumToString(int hash_algorithm)
     }
 }
 
-void FlameMod::loadIndexedPackVersions(ModPlatform::IndexedPack& pack, QJsonArray& arr, const BaseInstance* inst)
+void FlameMod::loadIndexedPackVersions(ModPlatform::IndexedPack& pack, QJsonArray& arr)
 {
     QVector<ModPlatform::IndexedVersion> unsortedVersions;
     for (auto versionIter : arr) {

--- a/launcher/modplatform/flame/FlameModIndex.h
+++ b/launcher/modplatform/flame/FlameModIndex.h
@@ -13,7 +13,7 @@ namespace FlameMod {
 void loadIndexedPack(ModPlatform::IndexedPack& m, QJsonObject& obj);
 void loadURLs(ModPlatform::IndexedPack& m, QJsonObject& obj);
 void loadBody(ModPlatform::IndexedPack& m, QJsonObject& obj);
-void loadIndexedPackVersions(ModPlatform::IndexedPack& pack, QJsonArray& arr, const BaseInstance* inst);
-auto loadIndexedPackVersion(QJsonObject& obj, bool load_changelog = false) -> ModPlatform::IndexedVersion;
-auto loadDependencyVersions(const ModPlatform::Dependency& m, QJsonArray& arr, const BaseInstance* inst) -> ModPlatform::IndexedVersion;
+void loadIndexedPackVersions(ModPlatform::IndexedPack& pack, QJsonArray& arr);
+ModPlatform::IndexedVersion loadIndexedPackVersion(QJsonObject& obj, bool load_changelog = false);
+ModPlatform::IndexedVersion loadDependencyVersions(const ModPlatform::Dependency& m, QJsonArray& arr, const BaseInstance* inst);
 }  // namespace FlameMod

--- a/launcher/modplatform/flame/FlameModIndex.h
+++ b/launcher/modplatform/flame/FlameModIndex.h
@@ -6,7 +6,6 @@
 
 #include "modplatform/ModIndex.h"
 
-#include <QNetworkAccessManager>
 #include "BaseInstance.h"
 
 namespace FlameMod {
@@ -14,10 +13,7 @@ namespace FlameMod {
 void loadIndexedPack(ModPlatform::IndexedPack& m, QJsonObject& obj);
 void loadURLs(ModPlatform::IndexedPack& m, QJsonObject& obj);
 void loadBody(ModPlatform::IndexedPack& m, QJsonObject& obj);
-void loadIndexedPackVersions(ModPlatform::IndexedPack& pack,
-                             QJsonArray& arr,
-                             const shared_qobject_ptr<QNetworkAccessManager>& network,
-                             const BaseInstance* inst);
+void loadIndexedPackVersions(ModPlatform::IndexedPack& pack, QJsonArray& arr, const BaseInstance* inst);
 auto loadIndexedPackVersion(QJsonObject& obj, bool load_changelog = false) -> ModPlatform::IndexedVersion;
 auto loadDependencyVersions(const ModPlatform::Dependency& m, QJsonArray& arr, const BaseInstance* inst) -> ModPlatform::IndexedVersion;
 }  // namespace FlameMod

--- a/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
@@ -112,7 +112,7 @@ void Modrinth::loadExtraPackData(ModPlatform::IndexedPack& pack, QJsonObject& ob
     pack.extraDataLoaded = true;
 }
 
-void Modrinth::loadIndexedPackVersions(ModPlatform::IndexedPack& pack, QJsonArray& arr, const BaseInstance* inst)
+void Modrinth::loadIndexedPackVersions(ModPlatform::IndexedPack& pack, QJsonArray& arr)
 {
     QVector<ModPlatform::IndexedVersion> unsortedVersions;
     for (auto versionIter : arr) {

--- a/launcher/modplatform/modrinth/ModrinthPackIndex.h
+++ b/launcher/modplatform/modrinth/ModrinthPackIndex.h
@@ -19,7 +19,6 @@
 
 #include "modplatform/ModIndex.h"
 
-#include <QNetworkAccessManager>
 #include "BaseInstance.h"
 
 namespace Modrinth {

--- a/launcher/modplatform/modrinth/ModrinthPackIndex.h
+++ b/launcher/modplatform/modrinth/ModrinthPackIndex.h
@@ -25,7 +25,7 @@ namespace Modrinth {
 
 void loadIndexedPack(ModPlatform::IndexedPack& m, QJsonObject& obj);
 void loadExtraPackData(ModPlatform::IndexedPack& m, QJsonObject& obj);
-void loadIndexedPackVersions(ModPlatform::IndexedPack& pack, QJsonArray& arr, const BaseInstance* inst);
+void loadIndexedPackVersions(ModPlatform::IndexedPack& pack, QJsonArray& arr);
 auto loadIndexedPackVersion(QJsonObject& obj, QString hash_type = "sha512", QString filename_prefer = "") -> ModPlatform::IndexedVersion;
 auto loadDependencyVersions(const ModPlatform::Dependency& m, QJsonArray& arr, const BaseInstance* inst) -> ModPlatform::IndexedVersion;
 

--- a/launcher/ui/pages/modplatform/flame/FlameResourceModels.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameResourceModels.cpp
@@ -32,7 +32,7 @@ void FlameModModel::loadExtraPackInfo(ModPlatform::IndexedPack& m, QJsonObject& 
 
 void FlameModModel::loadIndexedPackVersions(ModPlatform::IndexedPack& m, QJsonArray& arr)
 {
-    FlameMod::loadIndexedPackVersions(m, arr, &m_base_instance);
+    FlameMod::loadIndexedPackVersions(m, arr);
 }
 
 auto FlameModModel::loadDependencyVersions(const ModPlatform::Dependency& m, QJsonArray& arr) -> ModPlatform::IndexedVersion
@@ -65,7 +65,7 @@ void FlameResourcePackModel::loadExtraPackInfo(ModPlatform::IndexedPack& m, QJso
 
 void FlameResourcePackModel::loadIndexedPackVersions(ModPlatform::IndexedPack& m, QJsonArray& arr)
 {
-    FlameMod::loadIndexedPackVersions(m, arr, &m_base_instance);
+    FlameMod::loadIndexedPackVersions(m, arr);
 }
 
 bool FlameResourcePackModel::optedOut(const ModPlatform::IndexedVersion& ver) const
@@ -93,7 +93,7 @@ void FlameTexturePackModel::loadExtraPackInfo(ModPlatform::IndexedPack& m, QJson
 
 void FlameTexturePackModel::loadIndexedPackVersions(ModPlatform::IndexedPack& m, QJsonArray& arr)
 {
-    FlameMod::loadIndexedPackVersions(m, arr, &m_base_instance);
+    FlameMod::loadIndexedPackVersions(m, arr);
 
     QVector<ModPlatform::IndexedVersion> filtered_versions(m.versions.size());
 
@@ -157,7 +157,7 @@ void FlameShaderPackModel::loadExtraPackInfo(ModPlatform::IndexedPack& m, QJsonO
 
 void FlameShaderPackModel::loadIndexedPackVersions(ModPlatform::IndexedPack& m, QJsonArray& arr)
 {
-    FlameMod::loadIndexedPackVersions(m, arr, &m_base_instance);
+    FlameMod::loadIndexedPackVersions(m, arr);
 }
 
 bool FlameShaderPackModel::optedOut(const ModPlatform::IndexedVersion& ver) const

--- a/launcher/ui/pages/modplatform/flame/FlameResourceModels.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameResourceModels.cpp
@@ -32,7 +32,7 @@ void FlameModModel::loadExtraPackInfo(ModPlatform::IndexedPack& m, QJsonObject& 
 
 void FlameModModel::loadIndexedPackVersions(ModPlatform::IndexedPack& m, QJsonArray& arr)
 {
-    FlameMod::loadIndexedPackVersions(m, arr, APPLICATION->network(), &m_base_instance);
+    FlameMod::loadIndexedPackVersions(m, arr, &m_base_instance);
 }
 
 auto FlameModModel::loadDependencyVersions(const ModPlatform::Dependency& m, QJsonArray& arr) -> ModPlatform::IndexedVersion
@@ -65,7 +65,7 @@ void FlameResourcePackModel::loadExtraPackInfo(ModPlatform::IndexedPack& m, QJso
 
 void FlameResourcePackModel::loadIndexedPackVersions(ModPlatform::IndexedPack& m, QJsonArray& arr)
 {
-    FlameMod::loadIndexedPackVersions(m, arr, APPLICATION->network(), &m_base_instance);
+    FlameMod::loadIndexedPackVersions(m, arr, &m_base_instance);
 }
 
 bool FlameResourcePackModel::optedOut(const ModPlatform::IndexedVersion& ver) const
@@ -93,7 +93,7 @@ void FlameTexturePackModel::loadExtraPackInfo(ModPlatform::IndexedPack& m, QJson
 
 void FlameTexturePackModel::loadIndexedPackVersions(ModPlatform::IndexedPack& m, QJsonArray& arr)
 {
-    FlameMod::loadIndexedPackVersions(m, arr, APPLICATION->network(), &m_base_instance);
+    FlameMod::loadIndexedPackVersions(m, arr, &m_base_instance);
 
     QVector<ModPlatform::IndexedVersion> filtered_versions(m.versions.size());
 
@@ -157,7 +157,7 @@ void FlameShaderPackModel::loadExtraPackInfo(ModPlatform::IndexedPack& m, QJsonO
 
 void FlameShaderPackModel::loadIndexedPackVersions(ModPlatform::IndexedPack& m, QJsonArray& arr)
 {
-    FlameMod::loadIndexedPackVersions(m, arr, APPLICATION->network(), &m_base_instance);
+    FlameMod::loadIndexedPackVersions(m, arr, &m_base_instance);
 }
 
 bool FlameShaderPackModel::optedOut(const ModPlatform::IndexedVersion& ver) const

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthResourceModels.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthResourceModels.cpp
@@ -39,7 +39,7 @@ void ModrinthModModel::loadExtraPackInfo(ModPlatform::IndexedPack& m, QJsonObjec
 
 void ModrinthModModel::loadIndexedPackVersions(ModPlatform::IndexedPack& m, QJsonArray& arr)
 {
-    ::Modrinth::loadIndexedPackVersions(m, arr, &m_base_instance);
+    ::Modrinth::loadIndexedPackVersions(m, arr);
 }
 
 auto ModrinthModModel::loadDependencyVersions(const ModPlatform::Dependency& m, QJsonArray& arr) -> ModPlatform::IndexedVersion
@@ -66,7 +66,7 @@ void ModrinthResourcePackModel::loadExtraPackInfo(ModPlatform::IndexedPack& m, Q
 
 void ModrinthResourcePackModel::loadIndexedPackVersions(ModPlatform::IndexedPack& m, QJsonArray& arr)
 {
-    ::Modrinth::loadIndexedPackVersions(m, arr, &m_base_instance);
+    ::Modrinth::loadIndexedPackVersions(m, arr);
 }
 
 auto ModrinthResourcePackModel::documentToArray(QJsonDocument& obj) const -> QJsonArray
@@ -88,7 +88,7 @@ void ModrinthTexturePackModel::loadExtraPackInfo(ModPlatform::IndexedPack& m, QJ
 
 void ModrinthTexturePackModel::loadIndexedPackVersions(ModPlatform::IndexedPack& m, QJsonArray& arr)
 {
-    ::Modrinth::loadIndexedPackVersions(m, arr, &m_base_instance);
+    ::Modrinth::loadIndexedPackVersions(m, arr);
 }
 
 auto ModrinthTexturePackModel::documentToArray(QJsonDocument& obj) const -> QJsonArray
@@ -110,7 +110,7 @@ void ModrinthShaderPackModel::loadExtraPackInfo(ModPlatform::IndexedPack& m, QJs
 
 void ModrinthShaderPackModel::loadIndexedPackVersions(ModPlatform::IndexedPack& m, QJsonArray& arr)
 {
-    ::Modrinth::loadIndexedPackVersions(m, arr, &m_base_instance);
+    ::Modrinth::loadIndexedPackVersions(m, arr);
 }
 
 auto ModrinthShaderPackModel::documentToArray(QJsonDocument& obj) const -> QJsonArray


### PR DESCRIPTION
~~blocked by https://github.com/PrismLauncher/PrismLauncher/pull/3044 and https://github.com/PrismLauncher/PrismLauncher/pull/3043~~
This removes the QEventLoops from the FlameCheckUpdate