### PR TITLE
change CMAKE_JAVA_COMPILE_FLAGS from Java 7 to Java 8

### DIFF
--- a/libraries/javacheck/CMakeLists.txt
+++ b/libraries/javacheck/CMakeLists.txt
@@ -4,7 +4,7 @@ find_package(Java 1.7 REQUIRED COMPONENTS Development)
 
 include(UseJava)
 set(CMAKE_JAVA_JAR_ENTRY_POINT JavaCheck)
-set(CMAKE_JAVA_COMPILE_FLAGS -target 7 -source 7 -Xlint:deprecation -Xlint:unchecked)
+set(CMAKE_JAVA_COMPILE_FLAGS -target 8 -source 8 -Xlint:deprecation -Xlint:unchecked)
 
 set(SRC
     JavaCheck.java

--- a/libraries/launcher/CMakeLists.txt
+++ b/libraries/launcher/CMakeLists.txt
@@ -4,7 +4,7 @@ find_package(Java 1.7 REQUIRED COMPONENTS Development)
 
 include(UseJava)
 set(CMAKE_JAVA_JAR_ENTRY_POINT org.prismlauncher.EntryPoint)
-set(CMAKE_JAVA_COMPILE_FLAGS -target 7 -source 7)
+set(CMAKE_JAVA_COMPILE_FLAGS -target 8 -source 8)
 
 set(SRC
     org/prismlauncher/EntryPoint.java


### PR DESCRIPTION
I am not sure I am doing the thing right or wrong,
but this patch fixes my issue.

Please let me tell my situation:
- Using M1 Macbook Air (aarch64) with Asahi linux (Ubuntu / GNOME)
- Cannot use pre-built Flatpak since Flatpak cannot use GPU which makes Minecraft runs at ~10fps ([related reddit](https://www.reddit.com/r/AsahiLinux/comments/105mbgo/comment/j3br7ju/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button)) 
- Try to compile PrismLauncher by myself
- The error below occurs

```
$ cmake --build build
[13/622] Building Java objects for NewLaunch.jar
FAILED: libraries/launcher/CMakeFiles/NewLaunch.dir/java_compiled_NewLaunch /home/plus/workbench/minecraft/PrismLauncher/build/libraries/launcher/CMakeFiles/NewLaunch.dir/java_compiled_NewLaunch 
cd /home/plus/workbench/minecraft/PrismLauncher/libraries/launcher && /usr/bin/cmake -DCMAKE_JAVA_CLASS_OUTPUT_PATH=/home/plus/workbench/minecraft/PrismLauncher/build/libraries/launcher/CMakeFiles/NewLaunch.dir -DCMAKE_JAR_CLASSES_PREFIX= -P /usr/share/cmake-3.27/Modules/UseJava/ClearClassFiles.cmake && /home/plus/.sdkman/candidates/java/current/bin/javac -target 7 -source 7 -classpath :/home/plus/workbench/minecraft/PrismLauncher/libraries/launcher:/home/plus/workbench/minecraft/PrismLauncher/build/jars -d /home/plus/workbench/minecraft/PrismLauncher/build/libraries/launcher/CMakeFiles/NewLaunch.dir @/home/plus/workbench/minecraft/PrismLauncher/build/libraries/launcher/CMakeFiles/NewLaunch.dir/java_sources && /usr/bin/cmake -E touch /home/plus/workbench/minecraft/PrismLauncher/build/libraries/launcher/CMakeFiles/NewLaunch.dir/java_compiled_NewLaunch
warning: [options] bootstrap class path not set in conjunction with -source 7
error: Source option 7 is no longer supported. Use 8 or later.
error: Target option 7 is no longer supported. Use 8 or later.
[14/622] Building Java objects for JavaCheck.jar
FAILED: libraries/javacheck/CMakeFiles/JavaCheck.dir/java_compiled_JavaCheck /home/plus/workbench/minecraft/PrismLauncher/build/libraries/javacheck/CMakeFiles/JavaCheck.dir/java_compiled_JavaCheck 
cd /home/plus/workbench/minecraft/PrismLauncher/libraries/javacheck && /usr/bin/cmake -DCMAKE_JAVA_CLASS_OUTPUT_PATH=/home/plus/workbench/minecraft/PrismLauncher/build/libraries/javacheck/CMakeFiles/JavaCheck.dir -DCMAKE_JAR_CLASSES_PREFIX= -P /usr/share/cmake-3.27/Modules/UseJava/ClearClassFiles.cmake && /home/plus/.sdkman/candidates/java/current/bin/javac -target 7 -source 7 -Xlint:deprecation -Xlint:unchecked -classpath :/home/plus/workbench/minecraft/PrismLauncher/libraries/javacheck:/home/plus/workbench/minecraft/PrismLauncher/build/jars -d /home/plus/workbench/minecraft/PrismLauncher/build/libraries/javacheck/CMakeFiles/JavaCheck.dir @/home/plus/workbench/minecraft/PrismLauncher/build/libraries/javacheck/CMakeFiles/JavaCheck.dir/java_sources && /usr/bin/cmake -E touch /home/plus/workbench/minecraft/PrismLauncher/build/libraries/javacheck/CMakeFiles/JavaCheck.dir/java_compiled_JavaCheck
warning: [options] bootstrap class path not set in conjunction with -source 7
error: Source option 7 is no longer supported. Use 8 or later.
error: Target option 7 is no longer supported. Use 8 or later.
[22/622] Building CXX object libraries/libnbtplusplus/CMakeFiles/nbt++.dir/src/tag_list.cpp.o
ninja: build stopped: subcommand failed.
```

It simply says `7 is no longer supported` so I brain-deadly change it from 7 to 8,
then I successfully compile the PrismLauncher and play minecraft without issues. 

Hope this PR could help someone who play in aarch64 / arm64 machines.