### PR TITLE
ci: bump linux qt version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,14 +59,14 @@ jobs:
             qt_ver: 5
             qt_host: linux
             qt_arch: ""
-            qt_version: "5.12.8"
+            qt_version: "5.15.2"
             qt_modules: "qtnetworkauth"
 
           - os: ubuntu-20.04
             qt_ver: 6
             qt_host: linux
             qt_arch: ""
-            qt_version: "6.2.4"
+            qt_version: "6.5.3"
             qt_modules: "qt5compat qtimageformats qtnetworkauth"
 
           - os: windows-2022

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,7 +206,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get -y update
-          sudo apt-get -y install ninja-build extra-cmake-modules scdoc appstream
+          sudo apt-get -y install ninja-build extra-cmake-modules scdoc appstream libxcb-cursor-dev
 
       - name: Install Dependencies (macOS)
         if: runner.os == 'macOS'


### PR DESCRIPTION
6.2.4 is very EOL

EDIT: apparently this is sufficient to fix #2998 and #2978
