### PR TITLE
Close the window using the invokeMethod to not block

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -1507,7 +1507,7 @@ void Application::controllerSucceeded()
     // on success, do...
     if (controller->instance()->settings()->get("AutoCloseConsole").toBool()) {
         if (extras.window) {
-            extras.window->close();
+            QMetaObject::invokeMethod(extras.window, &QWidget::close, Qt::QueuedConnection);
         }
     }
     extras.controller.reset();


### PR DESCRIPTION
fixes #3071
@TheKodeToad please check if this is ok( also let me know if there are other cases for this to reproduce).
Spoiler there may be a small delay between Minecraft closing and the console window closing
