### PR TITLE
Fix file remaining open after program closure

### DIFF
--- a/launcher/InstanceCreationTask.cpp
+++ b/launcher/InstanceCreationTask.cpp
@@ -61,6 +61,6 @@ void InstanceCreationTask::executeTask()
             return;
         }
     }
-
-    emitSucceeded();
+    if (!m_abort)
+        emitSucceeded();
 }

--- a/launcher/InstanceImportTask.h
+++ b/launcher/InstanceImportTask.h
@@ -40,16 +40,13 @@
 #include <QUrl>
 #include "InstanceTask.h"
 
-#include <memory>
-#include <optional>
-
 class QuaZip;
 
 class InstanceImportTask : public InstanceTask {
     Q_OBJECT
    public:
     explicit InstanceImportTask(const QUrl& sourceUrl, QWidget* parent = nullptr, QMap<QString, QString>&& extra_info = {});
-
+    virtual ~InstanceImportTask() = default;
     bool abort() override;
 
    protected:
@@ -70,7 +67,7 @@ class InstanceImportTask : public InstanceTask {
    private: /* data */
     QUrl m_sourceUrl;
     QString m_archivePath;
-    Task::Ptr task;
+    Task::Ptr m_task;
     enum class ModpackType {
         Unknown,
         MultiMC,

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -444,6 +444,7 @@ bool FlameCreationTask::createInstance()
         setError(tr("Unable to resolve mod IDs:\n") + reason);
         loop.quit();
     });
+    connect(m_mod_id_resolver.get(), &Flame::FileResolvingTask::aborted, &loop, &QEventLoop::quit);
     connect(m_mod_id_resolver.get(), &Flame::FileResolvingTask::progress, this, &FlameCreationTask::setProgress);
     connect(m_mod_id_resolver.get(), &Flame::FileResolvingTask::status, this, &FlameCreationTask::setStatus);
     connect(m_mod_id_resolver.get(), &Flame::FileResolvingTask::stepProgress, this, &FlameCreationTask::propagateStepProgress);


### PR DESCRIPTION
fixes #2915 

Changed made in this PR: 
- ensure that the eventloop on flameInstance creation is handled on abort
- made some parts of import instance not abortable (prism format and techic)
- in import instance ensured that the pointers created for flame and modrinth are kept on the same class to avoid them not being deleted
- made sure no emitSuccess is called if the instanceCreation was aborted(already fired the abort signal)