### PR TITLE
Fix crash caused by invalid resource pointer

### DIFF
--- a/launcher/minecraft/mod/ResourceFolderModel.h
+++ b/launcher/minecraft/mod/ResourceFolderModel.h
@@ -76,7 +76,7 @@ class ResourceFolderModel : public QAbstractListModel {
     virtual bool update();
 
     /** Creates a new parse task, if needed, for 'res' and start it.*/
-    virtual void resolveResource(Resource* res);
+    virtual void resolveResource(Resource::Ptr res);
 
     [[nodiscard]] qsizetype size() const { return m_resources.size(); }
     [[nodiscard]] bool empty() const { return size() == 0; }
@@ -285,7 +285,7 @@ void ResourceFolderModel::applyUpdates(QSet<QString>& current_set, QSet<QString>
             }
 
             m_resources[row].reset(new_resource);
-            resolveResource(m_resources.at(row).get());
+            resolveResource(m_resources.at(row));
             emit dataChanged(index(row, 0), index(row, columnCount(QModelIndex()) - 1));
         }
     }
@@ -333,7 +333,7 @@ void ResourceFolderModel::applyUpdates(QSet<QString>& current_set, QSet<QString>
             for (auto& added : added_set) {
                 auto res = new_resources[added];
                 m_resources.append(res);
-                resolveResource(m_resources.last().get());
+                resolveResource(m_resources.last());
             }
 
             endInsertRows();


### PR DESCRIPTION
this is a backport of https://github.com/PrismLauncher/PrismLauncher/pull/3094
(the original one changed a little too much for it to be included in 9.2) 
but this should fix the crash mentioned here: https://discord.com/channels/1031648380885147709/1118165588200657006/1306324806450544651