### PR TITLE
Fix resource update with loaders

### DIFF
--- a/launcher/modplatform/CheckUpdateTask.h
+++ b/launcher/modplatform/CheckUpdateTask.h
@@ -1,9 +1,7 @@
 #pragma once
 
-#include "minecraft/mod/Mod.h"
 #include "minecraft/mod/tasks/GetModDependenciesTask.h"
 #include "modplatform/ModIndex.h"
-#include "modplatform/ResourceAPI.h"
 #include "tasks/Task.h"
 
 class ResourceDownloadTask;
@@ -19,9 +17,9 @@ class CheckUpdateTask : public Task {
                     std::shared_ptr<ResourceFolderModel> resourceModel)
         : Task()
         , m_resources(resources)
-        , m_game_versions(mcVersions)
-        , m_loaders_list(std::move(loadersList))
-        , m_resource_model(std::move(resourceModel))
+        , m_gameVersions(mcVersions)
+        , m_loadersList(std::move(loadersList))
+        , m_resourceModel(std::move(resourceModel))
     {}
 
     struct Update {
@@ -71,9 +69,9 @@ class CheckUpdateTask : public Task {
 
    protected:
     QList<Resource*>& m_resources;
-    std::list<Version>& m_game_versions;
-    QList<ModPlatform::ModLoaderType> m_loaders_list;
-    std::shared_ptr<ResourceFolderModel> m_resource_model;
+    std::list<Version>& m_gameVersions;
+    QList<ModPlatform::ModLoaderType> m_loadersList;
+    std::shared_ptr<ResourceFolderModel> m_resourceModel;
 
     std::vector<Update> m_updates;
     QList<std::shared_ptr<GetModDependenciesTask::PackDependency>> m_deps;

--- a/launcher/modplatform/flame/FlameAPI.cpp
+++ b/launcher/modplatform/flame/FlameAPI.cpp
@@ -218,9 +218,19 @@ QList<ModPlatform::Category> FlameAPI::loadModCategories(std::shared_ptr<QByteAr
 
 std::optional<ModPlatform::IndexedVersion> FlameAPI::getLatestVersion(QList<ModPlatform::IndexedVersion> versions,
                                                                       QList<ModPlatform::ModLoaderType> instanceLoaders,
-                                                                      ModPlatform::ModLoaderTypes modLoaders)
+                                                                      ModPlatform::ModLoaderTypes modLoaders,
+                                                                      bool checkLoaders)
 {
     static const auto noLoader = ModPlatform::ModLoaderType(0);
+    if (!checkLoaders) {
+        std::optional<ModPlatform::IndexedVersion> ver;
+        for (auto file_tmp : versions) {
+            if (!ver.has_value() || file_tmp.date > ver->date) {
+                ver = file_tmp;
+            }
+        }
+        return ver;
+    }
     QHash<ModPlatform::ModLoaderType, ModPlatform::IndexedVersion> bestMatch;
     auto checkVersion = [&bestMatch](const ModPlatform::IndexedVersion& version, const ModPlatform::ModLoaderType& loader) {
         if (bestMatch.contains(loader)) {

--- a/launcher/modplatform/flame/FlameAPI.h
+++ b/launcher/modplatform/flame/FlameAPI.h
@@ -18,7 +18,8 @@ class FlameAPI : public NetworkResourceAPI {
 
     std::optional<ModPlatform::IndexedVersion> getLatestVersion(QList<ModPlatform::IndexedVersion> versions,
                                                                 QList<ModPlatform::ModLoaderType> instanceLoaders,
-                                                                ModPlatform::ModLoaderTypes fallback);
+                                                                ModPlatform::ModLoaderTypes fallback,
+                                                                bool checkLoaders);
 
     Task::Ptr getProjects(QStringList addonIds, std::shared_ptr<QByteArray> response) const override;
     Task::Ptr matchFingerprints(const QList<uint>& fingerprints, std::shared_ptr<QByteArray> response);

--- a/launcher/modplatform/flame/FlameCheckUpdate.cpp
+++ b/launcher/modplatform/flame/FlameCheckUpdate.cpp
@@ -87,7 +87,7 @@ void FlameCheckUpdate::getLatestVersionCallback(Resource* resource, std::shared_
         qCritical() << e.what();
         qDebug() << doc;
     }
-    auto latest_ver = api.getLatestVersion(pack->versions, m_loadersList, resource->metadata()->loaders);
+    auto latest_ver = api.getLatestVersion(pack->versions, m_loadersList, resource->metadata()->loaders, !m_loadersList.isEmpty());
 
     setStatus(tr("Parsing the API response from CurseForge for '%1'...").arg(resource->name()));
 

--- a/launcher/modplatform/flame/FlameCheckUpdate.cpp
+++ b/launcher/modplatform/flame/FlameCheckUpdate.cpp
@@ -46,12 +46,12 @@ void FlameCheckUpdate::executeTask()
     connect(netJob, &Task::stepProgress, this, &FlameCheckUpdate::propagateStepProgress);
     connect(netJob, &Task::details, this, &FlameCheckUpdate::setDetails);
     for (auto* resource : m_resources) {
-        auto versions_url_optional = api.getVersionsURL({ { resource->metadata()->project_id.toString() }, m_game_versions });
-        if (!versions_url_optional.has_value())
+        auto versionsUrlOptional = api.getVersionsURL({ { resource->metadata()->project_id.toString() }, m_gameVersions });
+        if (!versionsUrlOptional.has_value())
             continue;
 
         auto response = std::make_shared<QByteArray>();
-        auto task = Net::ApiDownload::makeByteArray(versions_url_optional.value(), response);
+        auto task = Net::ApiDownload::makeByteArray(versionsUrlOptional.value(), response);
 
         connect(task.get(), &Task::succeeded, this, [this, resource, response] { getLatestVersionCallback(resource, response); });
         netJob->addNetAction(task);
@@ -87,7 +87,7 @@ void FlameCheckUpdate::getLatestVersionCallback(Resource* resource, std::shared_
         qCritical() << e.what();
         qDebug() << doc;
     }
-    auto latest_ver = api.getLatestVersion(pack->versions, m_loaders_list, resource->metadata()->loaders);
+    auto latest_ver = api.getLatestVersion(pack->versions, m_loadersList, resource->metadata()->loaders);
 
     setStatus(tr("Parsing the API response from CurseForge for '%1'...").arg(resource->name()));
 
@@ -119,7 +119,7 @@ void FlameCheckUpdate::getLatestVersionCallback(Resource* resource, std::shared_
                 old_version = tr("Unknown");
         }
 
-        auto download_task = makeShared<ResourceDownloadTask>(pack, latest_ver.value(), m_resource_model);
+        auto download_task = makeShared<ResourceDownloadTask>(pack, latest_ver.value(), m_resourceModel);
         m_updates.emplace_back(pack->name, resource->metadata()->hash, old_version, latest_ver->version, latest_ver->version_type,
                                api.getModFileChangelog(latest_ver->addonId.toInt(), latest_ver->fileId.toInt()),
                                ModPlatform::ResourceProvider::FLAME, download_task, resource->enabled());

--- a/launcher/modplatform/modrinth/ModrinthCheckUpdate.h
+++ b/launcher/modplatform/modrinth/ModrinthCheckUpdate.h
@@ -11,7 +11,7 @@ class ModrinthCheckUpdate : public CheckUpdateTask {
                         QList<ModPlatform::ModLoaderType> loadersList,
                         std::shared_ptr<ResourceFolderModel> resourceModel)
         : CheckUpdateTask(resources, mcVersions, std::move(loadersList), std::move(resourceModel))
-        , m_hash_type(ModPlatform::ProviderCapabilities::hashType(ModPlatform::ResourceProvider::MODRINTH).first())
+        , m_hashType(ModPlatform::ProviderCapabilities::hashType(ModPlatform::ResourceProvider::MODRINTH).first())
     {}
 
    public slots:
@@ -26,6 +26,6 @@ class ModrinthCheckUpdate : public CheckUpdateTask {
    private:
     Task::Ptr m_job = nullptr;
     QHash<QString, Resource*> m_mappings;
-    QString m_hash_type;
-    int m_loader_idx = 0;
+    QString m_hashType;
+    int m_loaderIdx = 0;
 };

--- a/launcher/modplatform/modrinth/ModrinthCheckUpdate.h
+++ b/launcher/modplatform/modrinth/ModrinthCheckUpdate.h
@@ -9,17 +9,14 @@ class ModrinthCheckUpdate : public CheckUpdateTask {
     ModrinthCheckUpdate(QList<Resource*>& resources,
                         std::list<Version>& mcVersions,
                         QList<ModPlatform::ModLoaderType> loadersList,
-                        std::shared_ptr<ResourceFolderModel> resourceModel)
-        : CheckUpdateTask(resources, mcVersions, std::move(loadersList), std::move(resourceModel))
-        , m_hashType(ModPlatform::ProviderCapabilities::hashType(ModPlatform::ResourceProvider::MODRINTH).first())
-    {}
+                        std::shared_ptr<ResourceFolderModel> resourceModel);
 
    public slots:
     bool abort() override;
 
    protected slots:
     void executeTask() override;
-    void getUpdateModsForLoader(std::optional<ModPlatform::ModLoaderTypes> loader);
+    void getUpdateModsForLoader(std::optional<ModPlatform::ModLoaderTypes> loader = {}, bool forceModLoaderCheck = false);
     void checkVersionsResponse(std::shared_ptr<QByteArray> response, std::optional<ModPlatform::ModLoaderTypes> loader);
     void checkNextLoader();
 
@@ -28,4 +25,5 @@ class ModrinthCheckUpdate : public CheckUpdateTask {
     QHash<QString, Resource*> m_mappings;
     QString m_hashType;
     int m_loaderIdx = 0;
+    int m_initialSize = 0;
 };

--- a/launcher/ui/dialogs/ResourceUpdateDialog.h
+++ b/launcher/ui/dialogs/ResourceUpdateDialog.h
@@ -18,9 +18,9 @@ class ResourceUpdateDialog final : public ReviewMessageBox {
    public:
     explicit ResourceUpdateDialog(QWidget* parent,
                                   BaseInstance* instance,
-                                  std::shared_ptr<ResourceFolderModel> resource_model,
-                                  QList<Resource*>& search_for,
-                                  bool include_deps,
+                                  std::shared_ptr<ResourceFolderModel> resourceModel,
+                                  QList<Resource*>& searchFor,
+                                  bool includeDeps,
                                   QList<ModPlatform::ModLoaderType> loadersList = {});
 
     void checkCandidates();
@@ -28,9 +28,9 @@ class ResourceUpdateDialog final : public ReviewMessageBox {
     void appendResource(const CheckUpdateTask::Update& info, QStringList requiredBy = {});
 
     const QList<ResourceDownloadTask::Ptr> getTasks();
-    auto indexDir() const -> QDir { return m_resource_model->indexDir(); }
+    auto indexDir() const -> QDir { return m_resourceModel->indexDir(); }
 
-    auto noUpdates() const -> bool { return m_no_updates; };
+    auto noUpdates() const -> bool { return m_noUpdates; };
     auto aborted() const -> bool { return m_aborted; };
 
    private:
@@ -40,29 +40,29 @@ class ResourceUpdateDialog final : public ReviewMessageBox {
     void onMetadataEnsured(Resource* resource);
     void onMetadataFailed(Resource* resource,
                           bool try_others = false,
-                          ModPlatform::ResourceProvider first_choice = ModPlatform::ResourceProvider::MODRINTH);
+                          ModPlatform::ResourceProvider firstChoice = ModPlatform::ResourceProvider::MODRINTH);
 
    private:
     QWidget* m_parent;
 
-    shared_qobject_ptr<ModrinthCheckUpdate> m_modrinth_check_task;
-    shared_qobject_ptr<FlameCheckUpdate> m_flame_check_task;
+    shared_qobject_ptr<ModrinthCheckUpdate> m_modrinthCheckTask;
+    shared_qobject_ptr<FlameCheckUpdate> m_flameCheckTask;
 
-    const std::shared_ptr<ResourceFolderModel> m_resource_model;
+    const std::shared_ptr<ResourceFolderModel> m_resourceModel;
 
     QList<Resource*>& m_candidates;
-    QList<Resource*> m_modrinth_to_update;
-    QList<Resource*> m_flame_to_update;
+    QList<Resource*> m_modrinthToUpdate;
+    QList<Resource*> m_flameToUpdate;
 
-    ConcurrentTask::Ptr m_second_try_metadata;
-    QList<std::tuple<Resource*, QString>> m_failed_metadata;
-    QList<std::tuple<Resource*, QString, QUrl>> m_failed_check_update;
+    ConcurrentTask::Ptr m_secondTryMetadata;
+    QList<std::tuple<Resource*, QString>> m_failedMetadata;
+    QList<std::tuple<Resource*, QString, QUrl>> m_failedCheckUpdate;
 
     QHash<QString, ResourceDownloadTask::Ptr> m_tasks;
     BaseInstance* m_instance;
 
-    bool m_no_updates = false;
+    bool m_noUpdates = false;
     bool m_aborted = false;
-    bool m_include_deps = false;
+    bool m_includeDeps = false;
     QList<ModPlatform::ModLoaderType> m_loadersList;
 };


### PR DESCRIPTION
~~blocked by #3046~~
blocked by #3746
refixes https://github.com/PrismLauncher/PrismLauncher/pull/2558 (that was removed in https://github.com/PrismLauncher/PrismLauncher/pull/1588)
fixes #3104

So basically the track PR removed the Modrinth code (and some from flame) that handled multiple loaders for mods
this PR aims to fix that while keeping the other resources update the same.
Right now, I have a few PRs that block this because I did not want to reimplement some stuff from the mentioned PRs, nor did I want to deal with conflicts.
As for added commits the last two (after 83c8d28b0052df176252aaf1d7a858569d5f482f) is all this PR adds:
- a few variables rename(not all but if you find more I may need to split this into another PR with only renames)
- and the actual fix