### PR TITLE
Add command line option to force on/off calendar events

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -245,6 +245,12 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
           { { "a", "profile" }, "Use the account specified by its profile name (only valid in combination with --launch)", "profile" },
           { { "o", "offline" }, "Launch offline, with given player name (only valid in combination with --launch)", "offline" },
           { "alive", "Write a small '" + liveCheckFile + "' file after the launcher starts" },
+          { { "X", "xmas" }, "Force xmas cat" },
+          { "no-xmas", "" },
+          { { "H", "halloween" }, "Force halloween cat" },
+          { "no-halloween", "" },
+          { { "B", "birthday" }, "Force birthday cat" },
+          { "no-birthday", "" },
           { { "I", "import" }, "Import instance or resource from specified local path or URL", "url" },
           { "show", "Opens the window for the specified instance (by instance ID)", "show" } });
     // Has to be positional for some OS to handle that properly
@@ -264,6 +270,23 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         m_offlineName = parser.value("offline");
     }
     m_liveCheck = parser.isSet("alive");
+
+    // Checking cat overrides
+    if (parser.isSet("xmas")) {
+        forceXmas = ForceOn;
+    } else if (parser.isSet("no-xmas")) {
+        forceXmas = ForceOff;
+    }
+    if (parser.isSet("halloween")) {
+        forceHalloween = ForceOn;
+    } else if (parser.isSet("no-halloween")) {
+        forceHalloween = ForceOff;
+    }
+    if (parser.isSet("birthday")) {
+        forceBirthday = ForceOn;
+    } else if (parser.isSet("no-birthday")) {
+        forceBirthday = ForceOff;
+    }
 
     m_instanceIdToShowWindowOf = parser.value("show");
 

--- a/launcher/Application.h
+++ b/launcher/Application.h
@@ -305,6 +305,10 @@ class Application : public QApplication {
     bool m_offline = false;
     QString m_offlineName;
     bool m_liveCheck = false;
+    enum Flag { ForceOff, ForceOn, Detect };
+    Flag forceXmas = Detect;
+    Flag forceHalloween = Detect;
+    Flag forceBirthday = Detect;
     QList<QUrl> m_urlsToImport;
     QString m_instanceIdToShowWindowOf;
     std::unique_ptr<QFile> logFile;

--- a/launcher/ui/themes/CatPack.cpp
+++ b/launcher/ui/themes/CatPack.cpp
@@ -40,6 +40,7 @@
 #include <QFileInfo>
 #include <QImageReader>
 #include <QRandomGenerator>
+#include "Application.h"
 #include "FileSystem.h"
 #include "Json.h"
 
@@ -51,11 +52,25 @@ QString BasicCatPack::path()
     const auto halloween = QDate(now.year(), 10, 31);
 
     QString cat = QString(":/backgrounds/%1").arg(m_id);
-    if (std::abs(now.daysTo(xmas)) <= 4) {
+
+    const auto forceXmas = APPLICATION->forceXmas;
+    const auto forceHalloween = APPLICATION->forceHalloween;
+    const auto forceBirthday = APPLICATION->forceBirthday;
+
+    bool shouldCheck = true;
+    // Don't check if anything is forced on
+    if (forceXmas == APPLICATION->ForceOn || forceHalloween == APPLICATION->ForceOn || forceBirthday == APPLICATION->ForceOn) {
+        shouldCheck = false;
+    }
+
+    // Check if needed, apply if force, don't do anything otherwise
+    if ((shouldCheck && forceXmas == APPLICATION->Detect && std::abs(now.daysTo(xmas)) <= 4) || forceXmas == APPLICATION->ForceOn) {
         cat += "-xmas";
-    } else if (std::abs(now.daysTo(halloween)) <= 4) {
+    } else if ((shouldCheck && forceHalloween == APPLICATION->Detect && std::abs(now.daysTo(halloween)) <= 4) ||
+               forceHalloween == APPLICATION->ForceOn) {
         cat += "-spooky";
-    } else if (std::abs(now.daysTo(birthday)) <= 12) {
+    } else if ((shouldCheck && forceBirthday == APPLICATION->Detect && std::abs(now.daysTo(birthday)) <= 12) ||
+               forceBirthday == APPLICATION->ForceOn) {
         cat += "-bday";
     }
     return cat;

--- a/launcher/ui/themes/CatPack.cpp
+++ b/launcher/ui/themes/CatPack.cpp
@@ -53,9 +53,9 @@ QString BasicCatPack::path()
 
     QString cat = QString(":/backgrounds/%1").arg(m_id);
 
-    const auto forceXmas = APPLICATION->forceXmas;
-    const auto forceHalloween = APPLICATION->forceHalloween;
-    const auto forceBirthday = APPLICATION->forceBirthday;
+    Application::Flag forceXmas = APPLICATION->forceXmas;
+    Application::Flag forceHalloween = APPLICATION->forceHalloween;
+    Application::Flag forceBirthday = APPLICATION->forceBirthday;
 
     bool shouldCheck = true;
     // Don't check if anything is forced on


### PR DESCRIPTION
### This PR adds the following command line options:
 - `--[no-]xmas`: force on/off cat with xmas style
 - `--[no-]halloween`: force on/off cat with halloween style
 - `--[no-]birthday`:  force on/off cat with birthday style

### Examples

Always use cat with xmas style
```shell
prismlauncher --xmas
```

Only change the cat when it's close to birthday. Ignore every other event
```
prismlauncher --no-halloween --no-xmas
```