### PR TITLE
build: update java to 8+

### DIFF
--- a/libraries/javacheck/CMakeLists.txt
+++ b/libraries/javacheck/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.9.4)
 project(launcher Java)
-find_package(Java 1.7 REQUIRED COMPONENTS Development)
+find_package(Java 1.8 REQUIRED COMPONENTS Development)
 
 include(UseJava)
 set(CMAKE_JAVA_JAR_ENTRY_POINT JavaCheck)
-set(CMAKE_JAVA_COMPILE_FLAGS -target 7 -source 7 -Xlint:deprecation -Xlint:unchecked)
+set(CMAKE_JAVA_COMPILE_FLAGS -target 8 -source 8 -Xlint:deprecation -Xlint:unchecked)
 
 set(SRC
     JavaCheck.java

--- a/libraries/launcher/CMakeLists.txt
+++ b/libraries/launcher/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.9.4)
 project(launcher Java)
-find_package(Java 1.7 REQUIRED COMPONENTS Development)
+find_package(Java 1.8 REQUIRED COMPONENTS Development)
 
 include(UseJava)
 set(CMAKE_JAVA_JAR_ENTRY_POINT org.prismlauncher.EntryPoint)
-set(CMAKE_JAVA_COMPILE_FLAGS -target 7 -source 7)
+set(CMAKE_JAVA_COMPILE_FLAGS -target 8 -source 8)
 
 set(SRC
     org/prismlauncher/EntryPoint.java


### PR DESCRIPTION
Building with OpenJDK 23 leads to the following error:
```
warning: [options] bootstrap class path is not set in conjunction with -source 7
  not setting the bootstrap class path may lead to class files that cannot run on JDK 8
    --release 7 is recommended instead of -source 7 -target 7 because it sets the bootstrap class path automatically
error: Source option 7 is no longer supported. Use 8 or later. error: Target option 7 is no longer supported. Use 8 or later.
```
Upgrading to Java 8 fixes the issue since Java 7 is deprecated
