### PR TITLE
Add naming check in `.clang-tidy` file

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,8 +1,8 @@
-Checks: >
-  modernize-use-using
-  readability-avoid-const-params-in-decls
-  misc-unused-parameters,
-  readability-identifier-naming
+Checks:
+  - modernize-use-using
+  - readability-avoid-const-params-in-decls
+  - misc-unused-parameters,
+  - readability-identifier-naming
 
 # ^ Without unused-parameters the readability-identifier-naming check doesn't cause any warnings.
 

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,23 @@
-Checks:
-  - modernize-use-using
-  - readability-avoid-const-params-in-decls
+Checks: >
+  modernize-use-using
+  readability-avoid-const-params-in-decls
+  misc-unused-parameters,
+  readability-identifier-naming
 
-SystemHeaders: false
+# ^ Without unused-parameters the readability-identifier-naming check doesn't cause any warnings.
+
+CheckOptions:
+  - { key: readability-identifier-naming.ClassCase,              value: PascalCase }
+  - { key: readability-identifier-naming.EnumCase,               value: PascalCase }
+  - { key: readability-identifier-naming.FunctionCase,           value: camelCase }
+  - { key: readability-identifier-naming.GlobalVariableCase,     value: camelCase }
+  - { key: readability-identifier-naming.GlobalFunctionCase,     value: camelCase }
+  - { key: readability-identifier-naming.GlobalConstantCase,     value: SCREAMING_SNAKE_CASE }
+  - { key: readability-identifier-naming.MacroDefinitionCase,    value: SCREAMING_SNAKE_CASE }
+  - { key: readability-identifier-naming.ClassMemberCase,        value: camelCase }
+  - { key: readability-identifier-naming.PrivateMemberPrefix,    value: m_ }
+  - { key: readability-identifier-naming.ProtectedMemberPrefix,  value: m_ }
+  - { key: readability-identifier-naming.PrivateStaticMemberPrefix, value: s_ }
+  - { key: readability-identifier-naming.ProtectedStaticMemberPrefix, value: s_ }
+  - { key: readability-identifier-naming.PublicStaticConstantCase, value: SCREAMING_SNAKE_CASE }
+  - { key: readability-identifier-naming.EnumConstantCase,       value: SCREAMING_SNAKE_CASE }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 All files are formatted with `clang-format` using the configuration in `.clang-format`. Ensure it is run on changed files before committing!
 
-We have no tool for enforcing names but please follow the following conventions for C++:
+Please also follow the project's conventions for C++:
 
 - Class and type names should be formatted as `PascalCase`: `MyClass`.
 - Private or protected class data members should be formatted as `camelCase` prefixed with `m_`: `m_myCounter`.
@@ -15,6 +15,8 @@ We have no tool for enforcing names but please follow the following conventions 
 - Global functions and non-`const` global variables should be formatted as `camelCase` without a prefix: `globalData`.
 - `const` global variables, macros, and enum constants should be formatted as `SCREAMING_SNAKE_CASE`: `LIGHT_GRAY`.
 - Avoid inventing acronyms or abbreviations especially for a name of multiple words - like `tp` for `texturePack`.
+
+Most of these rules are included in the `.clang-tidy` file, so you can run `clang-tidy` to check for any violations.
 
 Here is what these conventions with the formatting configuration look like:
 


### PR DESCRIPTION
The [contributing docs](https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#code-formatting) specify these naming guidelines:

> **We have no tool for enforcing names but please follow the following conventions for C++:**
> 
> - Class and type names should be formatted as `PascalCase`: `MyClass`.
> - Private or protected class data members should be formatted as `camelCase` prefixed with `m_`: `m_myCounter`.
> - Private or protected `static` class data members should be formatted as `camelCase` prefixed with `s_`: `s_instance`.
> - Public class data members should be formatted as `camelCase` without the prefix: `dateOfBirth`.
> - Public, private or protected `static const` class data members should be formatted as `SCREAMING_SNAKE_CASE`: `MAX_VALUE`.
> - Class function members should be formatted as `camelCase` without a prefix: `incrementCounter`.
> - Global functions and non-`const` global variables should be formatted as `camelCase` without a prefix: `globalData`.
> - `const` global variables, macros, and enum constants should be formatted as `SCREAMING_SNAKE_CASE`: `LIGHT_GRAY`.
> - Avoid inventing acronyms or abbreviations especially for a name of multiple words - like `tp` for `texturePack`.

This change to the `.clang-tidy` config makes those naming violations show up as warnings in the user's IDE.
![image](https://github.com/user-attachments/assets/05c4e9b1-19dc-4028-86d2-5c38f252db64)