### PR TITLE
Fix MANIFEST.MF parsing

### DIFF
--- a/launcher/minecraft/mod/tasks/LocalModParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalModParseTask.cpp
@@ -8,12 +8,15 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonValue>
+#include <QRegularExpression>
 #include <QString>
 
 #include "FileSystem.h"
 #include "Json.h"
 #include "minecraft/mod/ModDetails.h"
 #include "settings/INIFile.h"
+
+static QRegularExpression newlineRegex("\r\n|\n|\r");
 
 namespace ModUtils {
 
@@ -487,11 +490,11 @@ bool processZIP(Mod& mod, [[maybe_unused]] ProcessingLevel level)
                 }
 
                 // quick and dirty line-by-line parser
-                auto manifestLines = file.readAll().split('\n');
+                auto manifestLines = QString(file.readAll()).split(newlineRegex);
                 QString manifestVersion = "";
                 for (auto& line : manifestLines) {
-                    if (QString(line).startsWith("Implementation-Version: ")) {
-                        manifestVersion = QString(line).remove("Implementation-Version: ");
+                    if (line.startsWith("Implementation-Version: ", Qt::CaseInsensitive)) {
+                        manifestVersion = line.remove("Implementation-Version: ", Qt::CaseInsensitive);
                         break;
                     }
                 }


### PR DESCRIPTION
Related to #3122 (CRLF-encoded manifests cause a trailing CR in the version).

~~Not a great solution, but the simplest I could think of. (others include using QStrings split() with a regex, simply special-casing the carriage return, and normalizing EOLs beforehand)~~

~~This definitely does not comply with the manifest specification, but it's not like the previous implementation did either.~~