### PR TITLE
Remove unnecessary hardened runtime exceptions on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -380,11 +380,13 @@ jobs:
 
           if [ -n '${{ secrets.APPLE_CODESIGN_ID }}' ]; then
             APPLE_CODESIGN_ID='${{ secrets.APPLE_CODESIGN_ID }}'
+            ENTITLEMENTS_FILE='../program_info/App.entitlements'
           else
             APPLE_CODESIGN_ID='-'
+            ENTITLEMENTS_FILE='../program_info/AdhocSignedApp.entitlements'
           fi
 
-          sudo codesign --sign "$APPLE_CODESIGN_ID" --deep --force --entitlements "../program_info/App.entitlements" --options runtime "PrismLauncher.app/Contents/MacOS/prismlauncher"
+          sudo codesign --sign "$APPLE_CODESIGN_ID" --deep --force --entitlements "$ENTITLEMENTS_FILE" --options runtime "PrismLauncher.app/Contents/MacOS/prismlauncher"
           mv "PrismLauncher.app" "Prism Launcher.app"
 
       - name: Notarize (macOS)

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -554,6 +554,13 @@ QMap<QString, QString> MinecraftInstance::getVariables()
     out.insert("INST_JAVA", settings()->get("JavaPath").toString());
     out.insert("INST_JAVA_ARGS", javaArguments().join(' '));
     out.insert("NO_COLOR", "1");
+#ifdef Q_OS_MACOS
+    // get library for Steam overlay support
+    QString steamDyldInsertLibraries = qEnvironmentVariable("STEAM_DYLD_INSERT_LIBRARIES");
+    if (!steamDyldInsertLibraries.isEmpty()) {
+        out.insert("DYLD_INSERT_LIBRARIES", steamDyldInsertLibraries);
+    }
+#endif
     return out;
 }
 

--- a/program_info/AdhocSignedApp.entitlements
+++ b/program_info/AdhocSignedApp.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+    <key>com.apple.security.device.camera</key>
+    <true/>
+</dict>
+</plist>

--- a/program_info/App.entitlements
+++ b/program_info/App.entitlements
@@ -2,10 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <key>com.apple.security.cs.disable-library-validation</key>
-    <true/>
-    <key>com.apple.security.cs.allow-dyld-environment-variables</key>
-    <true/>
     <key>com.apple.security.device.audio-input</key>
     <true/>
     <key>com.apple.security.device.camera</key>


### PR DESCRIPTION
These are cruft from Back in the Day™ when the (not Prism) launcher was ad-hoc signed, and the OS couldn't tell that the Qt libraries and launcher were signed by the same party. Library validation is [considered quite important](https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.security.cs.disable-library-validation), so re-enabling this security feature is probably a good idea for security of the launcher itself. For convenience, CI will still apply the disable library validation entitlement when an ad-hoc signature is used.

Allowing dyld environment variables was done to support Steam overlay. To prevent a regression where Steam overlay doesn't work anymore, I pass the `STEAM_DYLD_INSERT_LIBRARIES` environment variable into the game as `DYLD_INSERT_LIBRARIES` when it is launched (usually, the game would inherit `DYLD_INSERT_LIBRARIES` from the launcher process, but with these restrictions doing so explicitly is necessary). I tested this without both of these entitlements and Steam overlay appears to work when opening Minecraft.