### PR TITLE
Fix system icons on Linux

### DIFF
--- a/launcher/resources/multimc/index.theme
+++ b/launcher/resources/multimc/index.theme
@@ -1,7 +1,6 @@
 [Icon Theme]
 Name=Legacy
 Comment=Default Icons
-Inherits=default
 Directories=8x8,16x16,22x22,24x24,32x32,32x32/instances,48x48,50x50/instances,64x64,128x128/instances,256x256,scalable,scalable/instances
 
 [8x8]

--- a/launcher/ui/themes/ThemeManager.cpp
+++ b/launcher/ui/themes/ThemeManager.cpp
@@ -37,6 +37,7 @@
 ThemeManager::ThemeManager()
 {
     QIcon::setFallbackThemeName(QIcon::themeName());
+    QIcon::setFallbackSearchPaths(QIcon::themeSearchPaths());
     themeDebugLog() << "Determining System Widget Theme...";
     const auto& style = QApplication::style();
     m_defaultStyle = style->objectName();
@@ -94,9 +95,7 @@ void ThemeManager::initializeIcons()
     // set icon theme search path!
     themeDebugLog() << "<> Initializing Icon Themes";
 
-    auto searchPaths = QIcon::themeSearchPaths();
-    searchPaths.append(m_iconThemeFolder.path());
-    QIcon::setThemeSearchPaths(searchPaths);
+    QIcon::setThemeSearchPaths({ m_iconThemeFolder.path(), ":/icons" });
 
     for (const QString& id : builtinIcons) {
         IconTheme theme(id, QString(":/icons/%1").arg(id));

--- a/launcher/ui/themes/ThemeManager.cpp
+++ b/launcher/ui/themes/ThemeManager.cpp
@@ -36,6 +36,7 @@
 
 ThemeManager::ThemeManager()
 {
+    QIcon::setFallbackThemeName(QIcon::themeName());
     themeDebugLog() << "Determining System Widget Theme...";
     const auto& style = QApplication::style();
     m_defaultStyle = style->objectName();


### PR DESCRIPTION
This sets the fallback icon theme to the current(system default) icon theme before
launcher specific themes are applied

And removes `Inherits` line of multimc/legacy icon theme because it can end up making it
inherit a default theme set from /usr/share/icons/default/index.theme
instead of the user configured theme (probably a qt bug?)

fixes #2769