### PR TITLE
Do not fail curseforge import if modrinth file check fails

### DIFF
--- a/launcher/modplatform/flame/FileResolvingTask.cpp
+++ b/launcher/modplatform/flame/FileResolvingTask.cpp
@@ -144,7 +144,7 @@ void Flame::FileResolvingTask::netJobFinished()
                        << " reason: " << parse_error.errorString();
             qWarning() << *m_result;
 
-            failed(parse_error.errorString());
+            getFlameProjects();
             return;
         }
 


### PR DESCRIPTION
modrith is down: this causes prism curseforge modpack import to fail if they contain blocked mods
This change prevents that.
This was reported on discord: https://discord.com/channels/1031648380885147709/1316778017221251093/1316778017221251093
also fixes #3196 ?