### PR TITLE
[macOS] Add local network usage description

### DIFF
--- a/cmake/MacOSXBundleInfo.plist.in
+++ b/cmake/MacOSXBundleInfo.plist.in
@@ -8,6 +8,8 @@
     <string>A Minecraft mod wants to access your microphone.</string>
     <key>NSDownloadsFolderUsageDescription</key>
     <string>Prism uses access to your Downloads folder to help you more quickly add mods that can't be automatically downloaded to your instance. You can change where Prism scans for downloaded mods in Settings or the prompt that appears.</string>
+    <key>NSLocalNetworkUsageDescription</key>
+    <string>Minecraft uses the local network to find and connect to LAN servers.</string>
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>
     <key>NSHighResolutionCapable</key>


### PR DESCRIPTION
Adds [`NSLocalNetworkUsageDescription`](https://developer.apple.com/documentation/bundleresources/information-property-list/nslocalnetworkusagedescription) to support local network privacy in macOS Sequoia 15, which requires user permission to access LAN servers. This message appears when the system prompts the user for permission.

Not currently required, but recommended and it's probably best to add it in case it does ever become required (like it is for microphone).