### PR TITLE
Fix tab order in launcher settings

### DIFF
--- a/launcher/ui/pages/global/LauncherPage.ui
+++ b/launcher/ui/pages/global/LauncherPage.ui
@@ -35,7 +35,7 @@
       <string notr="true"/>
      </property>
      <property name="tabShape">
-      <enum>QTabWidget::Rounded</enum>
+      <enum>QTabWidget::TabShape::Rounded</enum>
      </property>
      <property name="currentIndex">
       <number>0</number>
@@ -48,7 +48,7 @@
        <item>
         <widget class="QScrollArea" name="scrollArea">
          <property name="horizontalScrollBarPolicy">
-          <enum>Qt::ScrollBarAlwaysOff</enum>
+          <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
          </property>
          <property name="widgetResizable">
           <bool>true</bool>
@@ -365,7 +365,7 @@
            <item>
             <spacer name="verticalSpacer_FeaturesTab">
              <property name="orientation">
-              <enum>Qt::Vertical</enum>
+              <enum>Qt::Orientation::Vertical</enum>
              </property>
              <property name="sizeHint" stdset="0">
               <size>
@@ -465,7 +465,7 @@
           <item row="0" column="1">
            <spacer name="horizontalSpacer">
             <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+             <enum>Qt::Orientation::Horizontal</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -506,7 +506,7 @@
        <item>
         <spacer name="verticalSpacer_UserInterfaceTab">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -615,13 +615,13 @@
              </sizepolicy>
             </property>
             <property name="horizontalScrollBarPolicy">
-             <enum>Qt::ScrollBarAlwaysOff</enum>
+             <enum>Qt::ScrollBarPolicy::ScrollBarAlwaysOff</enum>
             </property>
             <property name="undoRedoEnabled">
              <bool>false</bool>
             </property>
             <property name="textInteractionFlags">
-             <set>Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+             <set>Qt::TextInteractionFlag::TextSelectableByKeyboard|Qt::TextInteractionFlag::TextSelectableByMouse</set>
             </property>
            </widget>
           </item>
@@ -667,15 +667,33 @@
  </customwidgets>
  <tabstops>
   <tabstop>tabWidget</tabstop>
+  <tabstop>scrollArea</tabstop>
   <tabstop>autoUpdateCheckBox</tabstop>
+  <tabstop>updateIntervalSpinBox</tabstop>
   <tabstop>instDirTextBox</tabstop>
   <tabstop>instDirBrowseBtn</tabstop>
   <tabstop>modsDirTextBox</tabstop>
   <tabstop>modsDirBrowseBtn</tabstop>
   <tabstop>iconsDirTextBox</tabstop>
   <tabstop>iconsDirBrowseBtn</tabstop>
+  <tabstop>javaDirTextBox</tabstop>
+  <tabstop>javaDirBrowseBtn</tabstop>
+  <tabstop>skinsDirTextBox</tabstop>
+  <tabstop>skinsDirBrowseBtn</tabstop>
+  <tabstop>downloadsDirTextBox</tabstop>
+  <tabstop>downloadsDirBrowseBtn</tabstop>
+  <tabstop>downloadsDirWatchRecursiveCheckBox</tabstop>
+  <tabstop>metadataDisableBtn</tabstop>
+  <tabstop>dependenciesDisableBtn</tabstop>
+  <tabstop>skipModpackUpdatePromptBtn</tabstop>
+  <tabstop>numberOfConcurrentTasksSpinBox</tabstop>
+  <tabstop>numberOfConcurrentDownloadsSpinBox</tabstop>
+  <tabstop>numberOfManualRetriesSpinBox</tabstop>
+  <tabstop>timeoutSecondsSpinBox</tabstop>
   <tabstop>sortLastLaunchedBtn</tabstop>
   <tabstop>sortByNameBtn</tabstop>
+  <tabstop>catOpacitySpinBox</tabstop>
+  <tabstop>preferMenuBarCheckBox</tabstop>
   <tabstop>showConsoleCheck</tabstop>
   <tabstop>autoCloseConsoleCheck</tabstop>
   <tabstop>showConsoleErrorCheck</tabstop>


### PR DESCRIPTION
In launcher settings, the order that elements are selected when you repeatedly press tab doesn't make sense:

https://github.com/user-attachments/assets/fd047c3d-5024-458b-b68c-cbaf38050211

This fixes the order.