### PR TITLE
Correct symbolic link destination on the manifest (Mojang) Java download

### DIFF
--- a/launcher/java/download/ManifestDownloadTask.cpp
+++ b/launcher/java/download/ManifestDownloadTask.cpp
@@ -86,11 +86,10 @@ void ManifestDownloadTask::downloadJava(const QJsonDocument& doc)
         if (type == "directory") {
             FS::ensureFolderPathExists(file);
         } else if (type == "link") {
-            // this is linux only !
+            // this is *nix only !
             auto path = Json::ensureString(meta, "target");
             if (!path.isEmpty()) {
-                auto target = FS::PathCombine(file, "../" + path);
-                QFile(target).link(file);
+                QFile::link(path, file);
             }
         } else if (type == "file") {
             // TODO download compressed version if it exists ?


### PR DESCRIPTION
Symbolic links don't currently point to the correct location when downloading a Mojang Java runtime. Example for 21.0.3 `java-runtime-delta`:

```
$ ls -l ~/Downloads/prism/java/java-runtime-delta/legal/java.compiler/ADDITIONAL_LICENSE_INFO
lrwxrwxrwx 1 kenneth kenneth 63 Dec 16 02:10 /home/kenneth/Downloads/prism/java/java-runtime-delta/legal/java.compiler/ADDITIONAL_LICENSE_INFO -> java/java-runtime-delta/legal/java.base/ADDITIONAL_LICENSE_INFO
$ cat ~/Downloads/prism/java/java-runtime-delta/legal/java.compiler/ADDITIONAL_LICENSE_INFO
cat: /home/kenneth/Downloads/prism/java/java-runtime-delta/legal/java.compiler/ADDITIONAL_LICENSE_INFO: No such file or directory
```

This fixes it to be correct:
```
$ ls -l '/home/kenneth/Downloads/PrismLauncher-Linux-Qt5-Portable-de0e149-Debug/PrismLauncher-portable/java/java-runtime-delta/legal/java.compiler/ADDITIONAL_LICENSE_INFO' 
lrwxrwxrwx 1 kenneth kenneth 36 Dec 16 03:27 /home/kenneth/Downloads/PrismLauncher-Linux-Qt5-Portable-de0e149-Debug/PrismLauncher-portable/java/java-runtime-delta/legal/java.compiler/ADDITIONAL_LICENSE_INFO -> ../java.base/ADDITIONAL_LICENSE_INFO
```

---

btw, the comment that was there lies, symlinks are in the java manifests for both linux and mac ;-)