### PR TITLE
Fix curseforge/modrinth instance icons

### DIFF
--- a/launcher/icons/IconList.cpp
+++ b/launcher/icons/IconList.cpp
@@ -196,7 +196,8 @@ void IconList::directoryChanged(const QString& path)
         qDebug() << "Adding icon " << addedPath;
 
         QFileInfo addfile(addedPath);
-        QString key = m_dir.relativeFilePath(addfile.absoluteFilePath());
+        QString relativePath = m_dir.relativeFilePath(addfile.absoluteFilePath());
+        QString key = QFileInfo(relativePath).completeBaseName();
         QString name = formatName(m_dir, addfile);
 
         if (addIcon(key, name, addfile.filePath(), IconType::FileBased)) {


### PR DESCRIPTION
Right now on develop if you create an instance through prism(curseforge/modrinth/atlauncher,...) the icon is not correctly applied  
Introduce by https://github.com/PrismLauncher/PrismLauncher/pull/2800
Steps:
- Add Instance
- Select any provider(except custom and import)
- Select and download an instance
- Observe the instance icon(on dev is not present with this it should be present)