### PR TITLE
Add a lock update checkbox

### DIFF
--- a/launcher/meta/BaseEntity.cpp
+++ b/launcher/meta/BaseEntity.cpp
@@ -138,7 +138,7 @@ void BaseEntityLoadTask::executeTask()
             }
 
         } catch (const Exception& e) {
-            qDebug() << QString("Unable to parse file %1: %2").arg(fname, e.cause());
+            qCritical() << QString("Unable to parse file %1: %2").arg(fname, e.cause());
             // just make sure it's gone and we never consider it again.
             FS::deletePath(fname);
             m_entity->m_load_status = BaseEntity::LoadStatus::NotLoaded;
@@ -167,10 +167,10 @@ void BaseEntityLoadTask::executeTask()
     m_task->addNetAction(dl);
     m_task->setAskRetry(false);
     connect(m_task.get(), &Task::failed, this, &BaseEntityLoadTask::emitFailed);
-    connect(m_task.get(), &Task::succeeded, this, &BaseEntityLoadTask::emitSucceeded);
     connect(m_task.get(), &Task::succeeded, this, [this]() {
         m_entity->m_load_status = BaseEntity::LoadStatus::Remote;
         m_entity->m_file_sha256 = m_entity->m_sha256;
+        emitSucceeded();
     });
 
     connect(m_task.get(), &Task::progress, this, &Task::setProgress);

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -51,22 +51,24 @@
 
 #include "Application.h"
 
+#include "minecraft/mod/ResourceFolderModel.h"
 #include "minecraft/mod/tasks/LocalModParseTask.h"
 
 ModFolderModel::ModFolderModel(const QDir& dir, BaseInstance* instance, bool is_indexed, bool create_dir, QObject* parent)
     : ResourceFolderModel(QDir(dir), instance, is_indexed, create_dir, parent)
 {
     m_column_names = QStringList({ "Enable", "Image", "Name", "Version", "Last Modified", "Provider", "Size", "Side", "Loaders",
-                                   "Minecraft Versions", "Release Type" });
-    m_column_names_translated = QStringList({ tr("Enable"), tr("Image"), tr("Name"), tr("Version"), tr("Last Modified"), tr("Provider"),
-                                              tr("Size"), tr("Side"), tr("Loaders"), tr("Minecraft Versions"), tr("Release Type") });
-    m_column_sort_keys = { SortType::ENABLED, SortType::NAME,        SortType::NAME,        SortType::VERSION,
-                           SortType::DATE,    SortType::PROVIDER,    SortType::SIZE,        SortType::SIDE,
-                           SortType::LOADERS, SortType::MC_VERSIONS, SortType::RELEASE_TYPE };
+                                   "Minecraft Versions", "Release Type", "Update" });
+    m_column_names_translated =
+        QStringList({ tr("Enable"), tr("Image"), tr("Name"), tr("Version"), tr("Last Modified"), tr("Provider"), tr("Size"), tr("Side"),
+                      tr("Loaders"), tr("Minecraft Versions"), tr("Release Type"), tr("Update") });
+    m_column_sort_keys = { SortType::ENABLED, SortType::NAME,        SortType::NAME,         SortType::VERSION,
+                           SortType::DATE,    SortType::PROVIDER,    SortType::SIZE,         SortType::SIDE,
+                           SortType::LOADERS, SortType::MC_VERSIONS, SortType::RELEASE_TYPE, SortType::LOCK_UPDATE };
     m_column_resize_modes = { QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Stretch,     QHeaderView::Interactive,
                               QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive,
-                              QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive };
-    m_columnsHideable = { false, true, false, true, true, true, true, true, true, true, true };
+                              QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive };
+    m_columnsHideable = { false, true, false, true, true, true, true, true, true, true, true, true };
 }
 
 QVariant ModFolderModel::data(const QModelIndex& index, int role) const
@@ -146,6 +148,8 @@ QVariant ModFolderModel::data(const QModelIndex& index, int role) const
         case Qt::CheckStateRole:
             if (column == ActiveColumn)
                 return at(row).enabled() ? Qt::Checked : Qt::Unchecked;
+            else if (column == LockUpdateCoumn)
+                return !at(row).lockUpdate() ? Qt::Checked : Qt::Unchecked;
             return QVariant();
         default:
             return QVariant();
@@ -168,6 +172,7 @@ QVariant ModFolderModel::headerData(int section, [[maybe_unused]] Qt::Orientatio
                 case McVersionsColumn:
                 case ReleaseTypeColumn:
                 case SizeColumn:
+                case LockUpdateCoumn:
                     return columnNames().at(section);
                 default:
                     return QVariant();
@@ -195,6 +200,8 @@ QVariant ModFolderModel::headerData(int section, [[maybe_unused]] Qt::Orientatio
                     return tr("The release type.");
                 case SizeColumn:
                     return tr("The size of the mod.");
+                case LockUpdateCoumn:
+                    return tr("Should this mod be updated?");
                 default:
                     return QVariant();
             }

--- a/launcher/minecraft/mod/ModFolderModel.h
+++ b/launcher/minecraft/mod/ModFolderModel.h
@@ -69,6 +69,7 @@ class ModFolderModel : public ResourceFolderModel {
         LoadersColumn,
         McVersionsColumn,
         ReleaseTypeColumn,
+        LockUpdateCoumn,
         NUM_COLUMNS
     };
     ModFolderModel(const QDir& dir, BaseInstance* instance, bool is_indexed, bool create_dir, QObject* parent = nullptr);

--- a/launcher/minecraft/mod/Resource.cpp
+++ b/launcher/minecraft/mod/Resource.cpp
@@ -103,6 +103,14 @@ auto Resource::homepage() const -> QString
     return {};
 }
 
+bool Resource::lockUpdate() const
+{
+    if (metadata())
+        return metadata()->lockUpdate;
+
+    return false;
+}
+
 void Resource::setMetadata(std::shared_ptr<Metadata::ModStruct>&& metadata)
 {
     if (status() == ResourceStatus::NO_METADATA)

--- a/launcher/minecraft/mod/Resource.h
+++ b/launcher/minecraft/mod/Resource.h
@@ -58,7 +58,7 @@ enum class ResourceStatus {
     UNKNOWN,        // Default status
 };
 
-enum class SortType { NAME, DATE, VERSION, ENABLED, PACK_FORMAT, PROVIDER, SIZE, SIDE, MC_VERSIONS, LOADERS, RELEASE_TYPE };
+enum class SortType { NAME, DATE, VERSION, ENABLED, PACK_FORMAT, PROVIDER, SIZE, SIDE, MC_VERSIONS, LOADERS, RELEASE_TYPE, LOCK_UPDATE };
 
 enum class EnableAction { ENABLE, DISABLE, TOGGLE };
 

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -510,6 +510,8 @@ QVariant ResourceFolderModel::data(const QModelIndex& index, int role) const
         case Qt::CheckStateRole:
             if (column == ActiveColumn)
                 return m_resources[row]->enabled() ? Qt::Checked : Qt::Unchecked;
+            else if (column == LockUpdateCoumn)
+                return !at(row).lockUpdate() ? Qt::Checked : Qt::Unchecked;
             return {};
         default:
             return {};
@@ -523,6 +525,9 @@ bool ResourceFolderModel::setData(const QModelIndex& index, [[maybe_unused]] con
         return false;
 
     if (role == Qt::CheckStateRole) {
+        if (columnNames(false).at(index.column()) == "Update") {
+            return setModUpdate({ index }, EnableAction::TOGGLE);
+        }
         if (m_instance != nullptr && m_instance->isRunning()) {
             auto response =
                 CustomMessageBox::selectable(nullptr, tr("Confirm toggle"),
@@ -550,6 +555,7 @@ QVariant ResourceFolderModel::headerData(int section, [[maybe_unused]] Qt::Orien
                 case DateColumn:
                 case ProviderColumn:
                 case SizeColumn:
+                case LockUpdateCoumn:
                     return columnNames().at(section);
                 default:
                     return {};
@@ -567,6 +573,8 @@ QVariant ResourceFolderModel::headerData(int section, [[maybe_unused]] Qt::Orien
                     return tr("The source provider of the resource.");
                 case SizeColumn:
                     return tr("The size of the resource.");
+                case LockUpdateCoumn:
+                    return tr("Should this mod be updated?");
                 default:
                     return {};
             }
@@ -891,4 +899,49 @@ QList<Resource*> ResourceFolderModel::selectedResources(const QModelIndexList& i
         result.append(&at(index.row()));
     }
     return result;
+}
+
+bool ResourceFolderModel::setModUpdate(const QModelIndexList& indexes, EnableAction action)
+{
+    if (indexes.isEmpty())
+        return true;
+
+    bool succeeded = true;
+    auto updateColumn = columnNames(false).indexOf("Update");
+    for (auto const& idx : indexes) {
+        if (!validateIndex(idx) || idx.column() != updateColumn)
+            continue;
+
+        int row = idx.row();
+        auto& resource = m_resources[row];
+
+        bool update = true;
+        switch (action) {
+            case EnableAction::ENABLE:
+                update = false;
+                break;
+            case EnableAction::DISABLE:
+                update = true;
+                break;
+            case EnableAction::TOGGLE:
+            default:
+                update = !resource->lockUpdate();
+                break;
+        }
+
+        if (resource->lockUpdate() == update) {
+            succeeded = false;
+            continue;
+        }
+
+        auto meta = resource->metadata();
+        if (meta) {
+            meta->lockUpdate = update;
+            Metadata::update(indexDir(), *meta.get());
+            resource->setMetadata(*meta.get());
+            emit dataChanged(index(row, updateColumn), index(row, columnCount(QModelIndex()) - 1));
+        }
+    }
+
+    return succeeded;
 }

--- a/launcher/minecraft/mod/ResourceFolderModel.h
+++ b/launcher/minecraft/mod/ResourceFolderModel.h
@@ -137,7 +137,7 @@ class ResourceFolderModel : public QAbstractListModel {
     /* Qt behavior */
 
     /* Basic columns */
-    enum Columns { ActiveColumn = 0, NameColumn, DateColumn, ProviderColumn, SizeColumn, NUM_COLUMNS };
+    enum Columns { ActiveColumn = 0, NameColumn, DateColumn, ProviderColumn, SizeColumn, LockUpdateCoumn, NUM_COLUMNS };
 
     QStringList columnNames(bool translated = true) const { return translated ? m_column_names_translated : m_column_names; }
 
@@ -182,6 +182,8 @@ class ResourceFolderModel : public QAbstractListModel {
     };
 
     QString instDirPath() const;
+
+    bool setModUpdate(const QModelIndexList& indexes, EnableAction action);
 
    signals:
     void updateFinished();
@@ -238,11 +240,11 @@ class ResourceFolderModel : public QAbstractListModel {
     // Represents the relationship between a column's index (represented by the list index), and it's sorting key.
     // As such, the order in with they appear is very important!
     QList<SortType> m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::DATE, SortType::PROVIDER, SortType::SIZE };
-    QStringList m_column_names = { "Enable", "Name", "Last Modified", "Provider", "Size" };
-    QStringList m_column_names_translated = { tr("Enable"), tr("Name"), tr("Last Modified"), tr("Provider"), tr("Size") };
-    QList<QHeaderView::ResizeMode> m_column_resize_modes = { QHeaderView::Interactive, QHeaderView::Stretch, QHeaderView::Interactive,
-                                                             QHeaderView::Interactive, QHeaderView::Interactive };
-    QList<bool> m_columnsHideable = { false, false, true, true, true };
+    QStringList m_column_names = { "Enable", "Name", "Last Modified", "Provider", "Size", "Update" };
+    QStringList m_column_names_translated = { tr("Enable"), tr("Name"), tr("Last Modified"), tr("Provider"), tr("Size"), tr("Update") };
+    QList<QHeaderView::ResizeMode> m_column_resize_modes = { QHeaderView::Interactive, QHeaderView::Stretch,     QHeaderView::Interactive,
+                                                             QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive };
+    QList<bool> m_columnsHideable = { false, false, true, true, true, true };
 
     QDir m_dir;
     BaseInstance* m_instance;

--- a/launcher/minecraft/mod/ResourcePackFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourcePackFolderModel.cpp
@@ -44,19 +44,21 @@
 #include "Application.h"
 #include "Version.h"
 
+#include "minecraft/mod/Resource.h"
+#include "minecraft/mod/ResourceFolderModel.h"
 #include "minecraft/mod/tasks/LocalDataPackParseTask.h"
 
 ResourcePackFolderModel::ResourcePackFolderModel(const QDir& dir, BaseInstance* instance, bool is_indexed, bool create_dir, QObject* parent)
     : ResourceFolderModel(dir, instance, is_indexed, create_dir, parent)
 {
-    m_column_names = QStringList({ "Enable", "Image", "Name", "Pack Format", "Last Modified", "Provider", "Size" });
-    m_column_names_translated =
-        QStringList({ tr("Enable"), tr("Image"), tr("Name"), tr("Pack Format"), tr("Last Modified"), tr("Provider"), tr("Size") });
+    m_column_names = QStringList({ "Enable", "Image", "Name", "Pack Format", "Last Modified", "Provider", "Size", "Update" });
+    m_column_names_translated = QStringList(
+        { tr("Enable"), tr("Image"), tr("Name"), tr("Pack Format"), tr("Last Modified"), tr("Provider"), tr("Size"), tr("Update") });
     m_column_sort_keys = { SortType::ENABLED, SortType::NAME,     SortType::NAME, SortType::PACK_FORMAT,
-                           SortType::DATE,    SortType::PROVIDER, SortType::SIZE };
-    m_column_resize_modes = { QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Stretch,    QHeaderView::Interactive,
-                              QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive };
-    m_columnsHideable = { false, true, false, true, true, true, true };
+                           SortType::DATE,    SortType::PROVIDER, SortType::SIZE, SortType::LOCK_UPDATE };
+    m_column_resize_modes = { QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Stretch,     QHeaderView::Interactive,
+                              QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive };
+    m_columnsHideable = { false, true, false, true, true, true, true, true };
 }
 
 QVariant ResourcePackFolderModel::data(const QModelIndex& index, int role) const
@@ -130,6 +132,8 @@ QVariant ResourcePackFolderModel::data(const QModelIndex& index, int role) const
         case Qt::CheckStateRole:
             if (column == ActiveColumn)
                 return at(row).enabled() ? Qt::Checked : Qt::Unchecked;
+            else if (column == LockUpdateCoumn)
+                return !at(row).lockUpdate() ? Qt::Checked : Qt::Unchecked;
             return {};
         default:
             return {};
@@ -148,6 +152,7 @@ QVariant ResourcePackFolderModel::headerData(int section, [[maybe_unused]] Qt::O
                 case ImageColumn:
                 case ProviderColumn:
                 case SizeColumn:
+                case LockUpdateCoumn:
                     return columnNames().at(section);
                 default:
                     return {};
@@ -168,6 +173,8 @@ QVariant ResourcePackFolderModel::headerData(int section, [[maybe_unused]] Qt::O
                     return tr("The source provider of the resource pack.");
                 case SizeColumn:
                     return tr("The size of the resource pack.");
+                case LockUpdateCoumn:
+                    return tr("Should this mod be updated?");
                 default:
                     return {};
             }

--- a/launcher/minecraft/mod/ResourcePackFolderModel.h
+++ b/launcher/minecraft/mod/ResourcePackFolderModel.h
@@ -7,7 +7,17 @@
 class ResourcePackFolderModel : public ResourceFolderModel {
     Q_OBJECT
    public:
-    enum Columns { ActiveColumn = 0, ImageColumn, NameColumn, PackFormatColumn, DateColumn, ProviderColumn, SizeColumn, NUM_COLUMNS };
+    enum Columns {
+        ActiveColumn = 0,
+        ImageColumn,
+        NameColumn,
+        PackFormatColumn,
+        DateColumn,
+        ProviderColumn,
+        SizeColumn,
+        LockUpdateCoumn,
+        NUM_COLUMNS
+    };
 
     explicit ResourcePackFolderModel(const QDir& dir, BaseInstance* instance, bool is_indexed, bool create_dir, QObject* parent = nullptr);
 

--- a/launcher/minecraft/mod/TexturePackFolderModel.cpp
+++ b/launcher/minecraft/mod/TexturePackFolderModel.cpp
@@ -39,18 +39,21 @@
 
 #include "TexturePackFolderModel.h"
 
+#include "minecraft/mod/Resource.h"
 #include "minecraft/mod/tasks/LocalTexturePackParseTask.h"
 #include "minecraft/mod/tasks/ResourceFolderLoadTask.h"
 
 TexturePackFolderModel::TexturePackFolderModel(const QDir& dir, BaseInstance* instance, bool is_indexed, bool create_dir, QObject* parent)
     : ResourceFolderModel(QDir(dir), instance, is_indexed, create_dir, parent)
 {
-    m_column_names = QStringList({ "Enable", "Image", "Name", "Last Modified", "Provider", "Size" });
-    m_column_names_translated = QStringList({ tr("Enable"), tr("Image"), tr("Name"), tr("Last Modified"), tr("Provider"), tr("Size") });
-    m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::NAME, SortType::DATE, SortType::PROVIDER, SortType::SIZE };
-    m_column_resize_modes = { QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Stretch,
+    m_column_names = QStringList({ "Enable", "Image", "Name", "Last Modified", "Provider", "Size", "Update" });
+    m_column_names_translated =
+        QStringList({ tr("Enable"), tr("Image"), tr("Name"), tr("Last Modified"), tr("Provider"), tr("Size"), tr("Update") });
+    m_column_sort_keys = { SortType::ENABLED,  SortType::NAME, SortType::NAME,       SortType::DATE,
+                           SortType::PROVIDER, SortType::SIZE, SortType::LOCK_UPDATE };
+    m_column_resize_modes = { QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Stretch,    QHeaderView::Interactive,
                               QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive };
-    m_columnsHideable = { false, true, false, true, true, true };
+    m_columnsHideable = { false, true, false, true, true, true, true };
 }
 
 Task* TexturePackFolderModel::createParseTask(Resource& resource)
@@ -112,6 +115,8 @@ QVariant TexturePackFolderModel::data(const QModelIndex& index, int role) const
         case Qt::CheckStateRole:
             if (column == ActiveColumn) {
                 return m_resources[row]->enabled() ? Qt::Checked : Qt::Unchecked;
+            } else if (column == LockUpdateCoumn) {
+                return !m_resources[row]->lockUpdate() ? Qt::Checked : Qt::Unchecked;
             }
             return {};
         default:
@@ -130,6 +135,7 @@ QVariant TexturePackFolderModel::headerData(int section, [[maybe_unused]] Qt::Or
                 case ImageColumn:
                 case ProviderColumn:
                 case SizeColumn:
+                case LockUpdateCoumn:
                     return columnNames().at(section);
                 default:
                     return {};
@@ -146,6 +152,8 @@ QVariant TexturePackFolderModel::headerData(int section, [[maybe_unused]] Qt::Or
                     return tr("The source provider of the texture pack.");
                 case SizeColumn:
                     return tr("The size of the texture pack.");
+                case LockUpdateCoumn:
+                    return tr("Should this mod be updated?");
                 default:
                     return {};
             }

--- a/launcher/minecraft/mod/TexturePackFolderModel.h
+++ b/launcher/minecraft/mod/TexturePackFolderModel.h
@@ -44,7 +44,7 @@ class TexturePackFolderModel : public ResourceFolderModel {
     Q_OBJECT
 
    public:
-    enum Columns { ActiveColumn = 0, ImageColumn, NameColumn, DateColumn, ProviderColumn, SizeColumn, NUM_COLUMNS };
+    enum Columns { ActiveColumn = 0, ImageColumn, NameColumn, DateColumn, ProviderColumn, SizeColumn, LockUpdateCoumn, NUM_COLUMNS };
 
     explicit TexturePackFolderModel(const QDir& dir, BaseInstance* instance, bool is_indexed, bool create_dir, QObject* parent = nullptr);
 

--- a/launcher/minecraft/mod/tasks/LocalResourceUpdateTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalResourceUpdateTask.cpp
@@ -26,8 +26,11 @@
 #include <windows.h>
 #endif
 
-LocalResourceUpdateTask::LocalResourceUpdateTask(QDir index_dir, ModPlatform::IndexedPack& project, ModPlatform::IndexedVersion& version)
-    : m_index_dir(index_dir), m_project(project), m_version(version)
+LocalResourceUpdateTask::LocalResourceUpdateTask(QDir index_dir,
+                                                 ModPlatform::IndexedPack& project,
+                                                 ModPlatform::IndexedVersion& version,
+                                                 bool lockUpdate)
+    : m_index_dir(index_dir), m_project(project), m_version(version), m_lockUpdate(lockUpdate)
 {
     // Ensure a '.index' folder exists in the mods folder, and create it if it does not
     if (!FS::ensureFolderPathExists(index_dir.path())) {
@@ -52,6 +55,7 @@ void LocalResourceUpdateTask::executeTask()
 
     auto pw_mod = Metadata::create(m_index_dir, m_project, m_version);
     if (pw_mod.isValid()) {
+        pw_mod.lockUpdate = m_lockUpdate;
         Metadata::update(m_index_dir, pw_mod);
         emitSucceeded();
     } else {

--- a/launcher/minecraft/mod/tasks/LocalResourceUpdateTask.h
+++ b/launcher/minecraft/mod/tasks/LocalResourceUpdateTask.h
@@ -28,7 +28,10 @@ class LocalResourceUpdateTask : public Task {
    public:
     using Ptr = shared_qobject_ptr<LocalResourceUpdateTask>;
 
-    explicit LocalResourceUpdateTask(QDir index_dir, ModPlatform::IndexedPack& project, ModPlatform::IndexedVersion& version);
+    explicit LocalResourceUpdateTask(QDir index_dir,
+                                     ModPlatform::IndexedPack& project,
+                                     ModPlatform::IndexedVersion& version,
+                                     bool lockUpdate = false);
 
     auto canAbort() const -> bool override { return true; }
     auto abort() -> bool override;
@@ -44,4 +47,5 @@ class LocalResourceUpdateTask : public Task {
     QDir m_index_dir;
     ModPlatform::IndexedPack m_project;
     ModPlatform::IndexedVersion m_version;
+    bool m_lockUpdate = false;
 };

--- a/launcher/modplatform/EnsureMetadataTask.cpp
+++ b/launcher/modplatform/EnsureMetadataTask.cpp
@@ -487,7 +487,7 @@ void EnsureMetadataTask::updateMetadata(ModPlatform::IndexedPack& pack, ModPlatf
         if (ver.fileName.endsWith(".disabled"))
             ver.fileName.chop(9);
 
-        auto task = makeShared<LocalResourceUpdateTask>(m_indexDir, pack, ver);
+        auto task = makeShared<LocalResourceUpdateTask>(m_indexDir, pack, ver, m_lockUpdate);
 
         connect(task.get(), &Task::finished, this, [this, &pack, resource] { updateMetadataCallback(pack, resource); });
 

--- a/launcher/modplatform/EnsureMetadataTask.h
+++ b/launcher/modplatform/EnsureMetadataTask.h
@@ -22,6 +22,7 @@ class EnsureMetadataTask : public Task {
     ~EnsureMetadataTask() = default;
 
     Task::Ptr getHashingTask() { return m_hashingTask; }
+    void setLockUpdate(bool lockUpdate) { m_lockUpdate = lockUpdate; }
 
    public slots:
     bool abort() override;
@@ -62,4 +63,5 @@ class EnsureMetadataTask : public Task {
     Task::Ptr m_hashingTask;
     Task::Ptr m_currentTask;
     QHash<QString, Task::Ptr> m_updateMetadataTasks;
+    bool m_lockUpdate = false;
 };

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -724,7 +724,7 @@ void FlameCreationTask::validateOtherResources(QEventLoop& loop)
         if (file.targetFolder != "mods" || (file.version.fileName.endsWith(".zip") && !zipMods.contains(file.version.fileName))) {
             continue;
         }
-        task->addTask(makeShared<LocalResourceUpdateTask>(folder, file.pack, file.version));
+        task->addTask(makeShared<LocalResourceUpdateTask>(folder, file.pack, file.version, true));
     }
     connect(task.get(), &Task::finished, &loop, &QEventLoop::quit);
     m_processUpdateFileInfoJob = task;

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
@@ -319,6 +319,7 @@ bool ModrinthCreationTask::createInstance()
     QEventLoop ensureMetaLoop;
     QDir folder = FS::PathCombine(instance.modsRoot(), ".index");
     auto ensureMetadataTask = makeShared<EnsureMetadataTask>(resources, folder, ModPlatform::ResourceProvider::MODRINTH);
+    ensureMetadataTask->setLockUpdate(true);
     connect(ensureMetadataTask.get(), &Task::succeeded, this, [&ended_well]() { ended_well = true; });
     connect(ensureMetadataTask.get(), &Task::finished, &ensureMetaLoop, &QEventLoop::quit);
     connect(ensureMetadataTask.get(), &Task::progress, [this](qint64 current, qint64 total) {

--- a/launcher/modplatform/packwiz/Packwiz.cpp
+++ b/launcher/modplatform/packwiz/Packwiz.cpp
@@ -200,6 +200,7 @@ void V1::updateModIndex(const QDir& index_dir, Mod& mod)
                                 { "x-prismlauncher-mc-versions", mcVersions },
                                 { "x-prismlauncher-release-type", mod.releaseType.toString().toStdString() },
                                 { "x-prismlauncher-version-number", mod.version_number.toStdString() },
+                                { "x-prismlauncher-lock-update", mod.lockUpdate },
                                 { "download",
                                   toml::table{
                                       { "mode", mod.mode.toStdString() },
@@ -273,6 +274,7 @@ auto V1::getIndexForMod(const QDir& index_dir, QString slug) -> Mod
         mod.filename = stringEntry(table, "filename");
         mod.side = ModPlatform::SideUtils::fromString(stringEntry(table, "side"));
         mod.releaseType = ModPlatform::IndexedVersionType(table["x-prismlauncher-release-type"].value_or(""));
+        mod.lockUpdate = table["x-prismlauncher-lock-update"].value_or(false);
         if (auto loaders = table["x-prismlauncher-loaders"]; loaders && loaders.is_array()) {
             for (auto&& loader : *loaders.as_array()) {
                 if (loader.is_string()) {

--- a/launcher/modplatform/packwiz/Packwiz.h
+++ b/launcher/modplatform/packwiz/Packwiz.h
@@ -55,6 +55,8 @@ class V1 {
         QVariant project_id{};
         QString version_number{};
 
+        bool lockUpdate;
+
        public:
         // This is a totally heuristic, but should work for now.
         auto isValid() const -> bool { return !slug.isEmpty() && !project_id.isNull(); }

--- a/launcher/net/ChecksumValidator.h
+++ b/launcher/net/ChecksumValidator.h
@@ -72,7 +72,7 @@ class ChecksumValidator : public Validator {
     auto validate(QNetworkReply&) -> bool override
     {
         if (m_expected.size() && m_expected != hash()) {
-            qWarning() << "Checksum mismatch, download is bad.";
+            qCritical() << "Checksum mismatch, download is bad.";
             return false;
         }
         return true;

--- a/launcher/ui/dialogs/ResourceUpdateDialog.cpp
+++ b/launcher/ui/dialogs/ResourceUpdateDialog.cpp
@@ -376,7 +376,7 @@ auto ResourceUpdateDialog::ensureMetadata() -> bool
 void ResourceUpdateDialog::onMetadataEnsured(Resource* resource)
 {
     // When the mod is a folder, for instance
-    if (!resource->metadata())
+    if (!resource->metadata() || resource->lockUpdate())
         return;
 
     switch (resource->metadata()->provider) {

--- a/launcher/ui/pages/instance/ExternalResourcesPage.cpp
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.cpp
@@ -81,6 +81,9 @@ ExternalResourcesPage::ExternalResourcesPage(BaseInstance* instance, std::shared
     connect(ui->treeView, &ModListView::customContextMenuRequested, this, &ExternalResourcesPage::ShowContextMenu);
     connect(ui->treeView, &ModListView::activated, this, &ExternalResourcesPage::itemActivated);
 
+    connect(ui->actionEnableUpdates, &QAction::triggered, this, &ExternalResourcesPage::enableUpdates);
+    connect(ui->actionDisableUpdates, &QAction::triggered, this, &ExternalResourcesPage::disableUpdates);
+
     auto selection_model = ui->treeView->selectionModel();
 
     connect(selection_model, &QItemSelectionModel::currentChanged, this, [this](const QModelIndex& current, const QModelIndex& previous) {
@@ -325,6 +328,8 @@ void ExternalResourcesPage::updateActions()
     const bool hasSelection = ui->treeView->selectionModel()->hasSelection();
     const QModelIndexList selection = m_filterModel->mapSelectionToSource(ui->treeView->selectionModel()->selection()).indexes();
     const QList<Resource*> selectedResources = m_model->selectedResources(selection);
+    const bool hasMeta = hasSelection && std::any_of(selectedResources.begin(), selectedResources.end(),
+                                                     [](Resource* resource) { return resource->metadata(); });
 
     ui->actionUpdateItem->setEnabled(!m_model->empty());
     ui->actionResetItemMetadata->setEnabled(hasSelection);
@@ -337,6 +342,9 @@ void ExternalResourcesPage::updateActions()
 
     ui->actionViewHomepage->setEnabled(hasSelection && std::any_of(selectedResources.begin(), selectedResources.end(),
                                                                    [](Resource* resource) { return !resource->homepage().isEmpty(); }));
+
+    ui->actionEnableUpdates->setEnabled(hasMeta);
+    ui->actionDisableUpdates->setEnabled(hasMeta);
     ui->actionExportMetadata->setEnabled(!m_model->empty());
 }
 
@@ -356,4 +364,16 @@ QString ExternalResourcesPage::extraHeaderInfoString()
             return tr(" (%1 installed, %2 selected)").arg(m_model->size()).arg(count);
     }
     return tr(" (%1 installed)").arg(m_model->size());
+}
+
+void ExternalResourcesPage::enableUpdates()
+{
+    auto selection = m_filterModel->mapSelectionToSource(ui->treeView->selectionModel()->selection());
+    m_model->setModUpdate(selection.indexes(), EnableAction::ENABLE);
+}
+
+void ExternalResourcesPage::disableUpdates()
+{
+    auto selection = m_filterModel->mapSelectionToSource(ui->treeView->selectionModel()->selection());
+    m_model->setModUpdate(selection.indexes(), EnableAction::DISABLE);
 }

--- a/launcher/ui/pages/instance/ExternalResourcesPage.h
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.h
@@ -64,6 +64,9 @@ class ExternalResourcesPage : public QMainWindow, public BasePage {
     void ShowContextMenu(const QPoint& pos);
     void ShowHeaderContextMenu(const QPoint& pos);
 
+    void enableUpdates();
+    void disableUpdates();
+
    protected:
     BaseInstance* m_instance = nullptr;
 

--- a/launcher/ui/pages/instance/ExternalResourcesPage.ui
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.ui
@@ -226,6 +226,22 @@
     <string>View the homepages of all selected items.</string>
    </property>
   </action>
+  <action name="actionEnableUpdates">
+   <property name="text">
+    <string>Ena&amp;ble Updates</string>
+   </property>
+   <property name="toolTip">
+    <string>Mark resource to be updated</string>
+   </property>
+  </action>
+  <action name="actionDisableUpdates">
+   <property name="text">
+    <string>Disable U&amp;pdates</string>
+   </property>
+   <property name="toolTip">
+    <string>Mark resource to prevent it from being updated</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>

--- a/launcher/ui/pages/instance/ModFolderPage.cpp
+++ b/launcher/ui/pages/instance/ModFolderPage.cpp
@@ -106,6 +106,9 @@ ModFolderPage::ModFolderPage(BaseInstance* inst, std::shared_ptr<ModFolderModel>
     ui->actionExportMetadata->setToolTip(tr("Export mod's metadata to text."));
     connect(ui->actionExportMetadata, &QAction::triggered, this, &ModFolderPage::exportModMetadata);
     ui->actionsToolbar->insertActionAfter(ui->actionViewHomepage, ui->actionExportMetadata);
+
+    ui->actionsToolbar->insertActionAfter(ui->actionUpdateItem, ui->actionEnableUpdates);
+    ui->actionsToolbar->insertActionAfter(ui->actionEnableUpdates, ui->actionDisableUpdates);
 }
 
 bool ModFolderPage::shouldDisplay() const

--- a/launcher/ui/pages/instance/ResourcePackPage.cpp
+++ b/launcher/ui/pages/instance/ResourcePackPage.cpp
@@ -69,6 +69,9 @@ ResourcePackPage::ResourcePackPage(MinecraftInstance* instance, std::shared_ptr<
     ui->actionChangeVersion->setToolTip(tr("Change a mod's version."));
     connect(ui->actionChangeVersion, &QAction::triggered, this, &ResourcePackPage::changeResourcePackVersion);
     ui->actionsToolbar->insertActionAfter(ui->actionUpdateItem, ui->actionChangeVersion);
+
+    ui->actionsToolbar->insertActionAfter(ui->actionUpdateItem, ui->actionEnableUpdates);
+    ui->actionsToolbar->insertActionAfter(ui->actionEnableUpdates, ui->actionDisableUpdates);
 }
 
 void ResourcePackPage::updateFrame(const QModelIndex& current, [[maybe_unused]] const QModelIndex& previous)

--- a/launcher/ui/pages/instance/ShaderPackPage.cpp
+++ b/launcher/ui/pages/instance/ShaderPackPage.cpp
@@ -74,6 +74,9 @@ ShaderPackPage::ShaderPackPage(MinecraftInstance* instance, std::shared_ptr<Shad
     ui->actionChangeVersion->setToolTip(tr("Change a shader pack's version."));
     connect(ui->actionChangeVersion, &QAction::triggered, this, &ShaderPackPage::changeShaderPackVersion);
     ui->actionsToolbar->insertActionAfter(ui->actionUpdateItem, ui->actionChangeVersion);
+
+    ui->actionsToolbar->insertActionAfter(ui->actionUpdateItem, ui->actionEnableUpdates);
+    ui->actionsToolbar->insertActionAfter(ui->actionEnableUpdates, ui->actionDisableUpdates);
 }
 
 void ShaderPackPage::downloadShaderPack()

--- a/launcher/ui/pages/instance/TexturePackPage.cpp
+++ b/launcher/ui/pages/instance/TexturePackPage.cpp
@@ -75,6 +75,9 @@ TexturePackPage::TexturePackPage(MinecraftInstance* instance, std::shared_ptr<Te
     ui->actionsToolbar->insertActionAfter(ui->actionUpdateItem, ui->actionChangeVersion);
 
     ui->actionViewHomepage->setToolTip(tr("View the homepages of all selected texture packs."));
+
+    ui->actionsToolbar->insertActionAfter(ui->actionUpdateItem, ui->actionEnableUpdates);
+    ui->actionsToolbar->insertActionAfter(ui->actionEnableUpdates, ui->actionDisableUpdates);
 }
 
 void TexturePackPage::updateFrame(const QModelIndex& current, [[maybe_unused]] const QModelIndex& previous)


### PR DESCRIPTION
fixes #83 fixes #440 fixes #1066 closes #764 fixes #1424(by the fact that the lock will be enabled)
regarding #764 I do not feel like it would be useful for the user to lock  Remove, Enable, and Disable options  (but if you consider it is a needed thing then I will leave the issue open)
This only works with managed resources because I do not want to create an additional to maintain alongside the current packwizz. Also, why would you disable updates for mods with no meta?
This should work for all resources.
Based on #1079

