### PR TITLE
add categories for resources

### DIFF
--- a/launcher/meta/BaseEntity.cpp
+++ b/launcher/meta/BaseEntity.cpp
@@ -138,7 +138,7 @@ void BaseEntityLoadTask::executeTask()
             }
 
         } catch (const Exception& e) {
-            qDebug() << QString("Unable to parse file %1: %2").arg(fname, e.cause());
+            qCritical() << QString("Unable to parse file %1: %2").arg(fname, e.cause());
             // just make sure it's gone and we never consider it again.
             FS::deletePath(fname);
             m_entity->m_load_status = BaseEntity::LoadStatus::NotLoaded;
@@ -167,10 +167,10 @@ void BaseEntityLoadTask::executeTask()
     m_task->addNetAction(dl);
     m_task->setAskRetry(false);
     connect(m_task.get(), &Task::failed, this, &BaseEntityLoadTask::emitFailed);
-    connect(m_task.get(), &Task::succeeded, this, &BaseEntityLoadTask::emitSucceeded);
     connect(m_task.get(), &Task::succeeded, this, [this]() {
         m_entity->m_load_status = BaseEntity::LoadStatus::Remote;
         m_entity->m_file_sha256 = m_entity->m_sha256;
+        emitSucceeded();
     });
 
     connect(m_task.get(), &Task::progress, this, &Task::setProgress);

--- a/launcher/minecraft/mod/DataPack.cpp
+++ b/launcher/minecraft/mod/DataPack.cpp
@@ -121,6 +121,11 @@ int DataPack::compare(const Resource& other, SortType type) const
 
 bool DataPack::applyFilter(QRegularExpression filter) const
 {
+    bool earlyExit = false;
+    auto result = checkCategories(filter, earlyExit);
+    if (earlyExit) {
+        return result;
+    }
     if (filter.match(description()).hasMatch())
         return true;
 

--- a/launcher/minecraft/mod/Mod.cpp
+++ b/launcher/minecraft/mod/Mod.cpp
@@ -112,6 +112,11 @@ int Mod::compare(const Resource& other, SortType type) const
 
 bool Mod::applyFilter(QRegularExpression filter) const
 {
+    bool earlyExit = false;
+    auto result = checkCategories(filter, earlyExit);
+    if (earlyExit) {
+        return result;
+    }
     if (filter.match(description()).hasMatch())
         return true;
 

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -51,23 +51,25 @@
 
 #include "Application.h"
 
+#include "minecraft/mod/ResourceFolderModel.h"
 #include "minecraft/mod/tasks/LocalModParseTask.h"
 
 ModFolderModel::ModFolderModel(const QDir& dir, BaseInstance* instance, bool is_indexed, bool create_dir, QObject* parent)
     : ResourceFolderModel(QDir(dir), instance, is_indexed, create_dir, parent)
 {
     m_column_names = QStringList({ "Enable", "Image", "Name", "Version", "Last Modified", "Provider", "Size", "Side", "Loaders",
-                                   "Minecraft Versions", "Release Type" });
-    m_column_names_translated = QStringList({ tr("Enable"), tr("Image"), tr("Name"), tr("Version"), tr("Last Modified"), tr("Provider"),
-                                              tr("Size"), tr("Side"), tr("Loaders"), tr("Minecraft Versions"), tr("Release Type") });
-    m_column_sort_keys = { SortType::ENABLED, SortType::NAME,        SortType::NAME,        SortType::VERSION,
-                           SortType::DATE,    SortType::PROVIDER,    SortType::SIZE,        SortType::SIDE,
-                           SortType::LOADERS, SortType::MC_VERSIONS, SortType::RELEASE_TYPE };
+                                   "Minecraft Versions", "Release Type", "Update" });
+    m_column_names_translated =
+        QStringList({ tr("Enable"), tr("Image"), tr("Name"), tr("Version"), tr("Last Modified"), tr("Provider"), tr("Size"), tr("Side"),
+                      tr("Loaders"), tr("Minecraft Versions"), tr("Release Type"), tr("Update") });
+    m_column_sort_keys = { SortType::ENABLED, SortType::NAME,        SortType::NAME,         SortType::VERSION,
+                           SortType::DATE,    SortType::PROVIDER,    SortType::SIZE,         SortType::SIDE,
+                           SortType::LOADERS, SortType::MC_VERSIONS, SortType::RELEASE_TYPE, SortType::LOCK_UPDATE };
     m_column_resize_modes = { QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Stretch,     QHeaderView::Interactive,
                               QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive,
-                              QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive };
-    m_columnsHideable = { false, true, false, true, true, true, true, true, true, true, true };
-    m_columnsHiddenByDefault = { false, false, false, false, false, false, false, true, true, true, true };
+                              QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive };
+    m_columnsHideable = { false, true, false, true, true, true, true, true, true, true, true, true };
+    m_columnsHiddenByDefault = { false, false, false, false, false, false, false, true, true, true, true, false };
 }
 
 QVariant ModFolderModel::data(const QModelIndex& index, int role) const
@@ -147,6 +149,8 @@ QVariant ModFolderModel::data(const QModelIndex& index, int role) const
         case Qt::CheckStateRole:
             if (column == ActiveColumn)
                 return at(row).enabled() ? Qt::Checked : Qt::Unchecked;
+            else if (column == LockUpdateCoumn)
+                return !at(row).lockUpdate() ? Qt::Checked : Qt::Unchecked;
             return QVariant();
         default:
             return QVariant();
@@ -169,6 +173,7 @@ QVariant ModFolderModel::headerData(int section, [[maybe_unused]] Qt::Orientatio
                 case McVersionsColumn:
                 case ReleaseTypeColumn:
                 case SizeColumn:
+                case LockUpdateCoumn:
                     return columnNames().at(section);
                 default:
                     return QVariant();
@@ -196,6 +201,8 @@ QVariant ModFolderModel::headerData(int section, [[maybe_unused]] Qt::Orientatio
                     return tr("The release type.");
                 case SizeColumn:
                     return tr("The size of the mod.");
+                case LockUpdateCoumn:
+                    return tr("Should this mod be updated?");
                 default:
                     return QVariant();
             }

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -58,18 +58,19 @@ ModFolderModel::ModFolderModel(const QDir& dir, BaseInstance* instance, bool is_
     : ResourceFolderModel(QDir(dir), instance, is_indexed, create_dir, parent)
 {
     m_column_names = QStringList({ "Enable", "Image", "Name", "Version", "Last Modified", "Provider", "Size", "Side", "Loaders",
-                                   "Minecraft Versions", "Release Type", "Update" });
+                                   "Minecraft Versions", "Release Type", "Category", "Update" });
     m_column_names_translated =
         QStringList({ tr("Enable"), tr("Image"), tr("Name"), tr("Version"), tr("Last Modified"), tr("Provider"), tr("Size"), tr("Side"),
-                      tr("Loaders"), tr("Minecraft Versions"), tr("Release Type"), tr("Update") });
-    m_column_sort_keys = { SortType::ENABLED, SortType::NAME,        SortType::NAME,         SortType::VERSION,
-                           SortType::DATE,    SortType::PROVIDER,    SortType::SIZE,         SortType::SIDE,
-                           SortType::LOADERS, SortType::MC_VERSIONS, SortType::RELEASE_TYPE, SortType::LOCK_UPDATE };
+                      tr("Loaders"), tr("Minecraft Versions"), tr("Release Type"), tr("Category"), tr("Update") });
+    m_column_sort_keys = { SortType::ENABLED,      SortType::NAME,     SortType::NAME,       SortType::VERSION, SortType::DATE,
+                           SortType::PROVIDER,     SortType::SIZE,     SortType::SIDE,       SortType::LOADERS, SortType::MC_VERSIONS,
+                           SortType::RELEASE_TYPE, SortType::CATEGORY, SortType::LOCK_UPDATE };
     m_column_resize_modes = { QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Stretch,     QHeaderView::Interactive,
                               QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive,
-                              QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive };
-    m_columnsHideable = { false, true, false, true, true, true, true, true, true, true, true, true };
-    m_columnsHiddenByDefault = { false, false, false, false, false, false, false, true, true, true, true, false };
+                              QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive,
+                              QHeaderView::Interactive };
+    m_columnsHideable = { false, true, false, true, true, true, true, true, true, true, true, true, true };
+    m_columnsHiddenByDefault = { false, false, false, false, false, false, false, true, true, true, true, false, false };
 }
 
 QVariant ModFolderModel::data(const QModelIndex& index, int role) const
@@ -115,6 +116,8 @@ QVariant ModFolderModel::data(const QModelIndex& index, int role) const
                 }
                 case SizeColumn:
                     return at(row).sizeStr();
+                case CategoryColumn:
+                    return at(row).categories();
                 default:
                     return QVariant();
             }
@@ -173,6 +176,7 @@ QVariant ModFolderModel::headerData(int section, [[maybe_unused]] Qt::Orientatio
                 case McVersionsColumn:
                 case ReleaseTypeColumn:
                 case SizeColumn:
+                case CategoryColumn:
                 case LockUpdateCoumn:
                     return columnNames().at(section);
                 default:
@@ -201,6 +205,8 @@ QVariant ModFolderModel::headerData(int section, [[maybe_unused]] Qt::Orientatio
                     return tr("The release type.");
                 case SizeColumn:
                     return tr("The size of the mod.");
+                case CategoryColumn:
+                    return tr("The categories of the mod.");
                 case LockUpdateCoumn:
                     return tr("Should this mod be updated?");
                 default:

--- a/launcher/minecraft/mod/ModFolderModel.h
+++ b/launcher/minecraft/mod/ModFolderModel.h
@@ -69,6 +69,7 @@ class ModFolderModel : public ResourceFolderModel {
         LoadersColumn,
         McVersionsColumn,
         ReleaseTypeColumn,
+        CategoryColumn,
         LockUpdateCoumn,
         NUM_COLUMNS
     };

--- a/launcher/minecraft/mod/ModFolderModel.h
+++ b/launcher/minecraft/mod/ModFolderModel.h
@@ -69,6 +69,7 @@ class ModFolderModel : public ResourceFolderModel {
         LoadersColumn,
         McVersionsColumn,
         ReleaseTypeColumn,
+        LockUpdateCoumn,
         NUM_COLUMNS
     };
     ModFolderModel(const QDir& dir, BaseInstance* instance, bool is_indexed, bool create_dir, QObject* parent = nullptr);

--- a/launcher/minecraft/mod/Resource.cpp
+++ b/launcher/minecraft/mod/Resource.cpp
@@ -103,6 +103,14 @@ auto Resource::homepage() const -> QString
     return {};
 }
 
+bool Resource::lockUpdate() const
+{
+    if (metadata())
+        return metadata()->lockUpdate;
+
+    return false;
+}
+
 void Resource::setMetadata(std::shared_ptr<Metadata::ModStruct>&& metadata)
 {
     if (status() == ResourceStatus::NO_METADATA)

--- a/launcher/minecraft/mod/Resource.cpp
+++ b/launcher/minecraft/mod/Resource.cpp
@@ -103,6 +103,14 @@ auto Resource::homepage() const -> QString
     return {};
 }
 
+QString Resource::categories() const
+{
+    if (metadata())
+        return metadata()->categories.join(", ");
+
+    return {};
+}
+
 bool Resource::lockUpdate() const
 {
     if (metadata())
@@ -172,6 +180,11 @@ int Resource::compare(const Resource& other, SortType type) const
 
 bool Resource::applyFilter(QRegularExpression filter) const
 {
+    bool earlyExit = false;
+    auto result = checkCategories(filter, earlyExit);
+    if (earlyExit) {
+        return result;
+    }
     return filter.match(name()).hasMatch();
 }
 
@@ -268,4 +281,23 @@ auto Resource::getOriginalFileName() const -> QString
     if (!m_enabled)
         fileName.chop(9);
     return fileName;
+}
+
+bool Resource::checkCategories(QRegularExpression filter, bool& match) const
+{
+    auto pat = filter.pattern();
+    match = false;
+    if (pat.startsWith("#")) {
+        match = true;
+        if (!metadata()) {
+            return false;
+        }
+        pat = pat.mid(1);
+        for (auto c : metadata()->categories) {
+            if (c.contains(pat)) {
+                return true;
+            }
+        }
+    }
+    return false;
 }

--- a/launcher/minecraft/mod/Resource.h
+++ b/launcher/minecraft/mod/Resource.h
@@ -58,7 +58,21 @@ enum class ResourceStatus {
     UNKNOWN,        // Default status
 };
 
-enum class SortType { NAME, DATE, VERSION, ENABLED, PACK_FORMAT, PROVIDER, SIZE, SIDE, MC_VERSIONS, LOADERS, RELEASE_TYPE, LOCK_UPDATE };
+enum class SortType {
+    NAME,
+    DATE,
+    VERSION,
+    ENABLED,
+    PACK_FORMAT,
+    PROVIDER,
+    SIZE,
+    SIDE,
+    MC_VERSIONS,
+    LOADERS,
+    RELEASE_TYPE,
+    CATEGORY,
+    LOCK_UPDATE
+};
 
 enum class EnableAction { ENABLE, DISABLE, TOGGLE };
 
@@ -100,6 +114,7 @@ class Resource : public QObject {
     [[nodiscard]] auto metadata() const -> std::shared_ptr<const Metadata::ModStruct> { return m_metadata; }
     [[nodiscard]] auto provider() const -> QString;
     [[nodiscard]] virtual auto homepage() const -> QString;
+    [[nodiscard]] QString categories() const;
     [[nodiscard]] bool lockUpdate() const;
 
     void setStatus(ResourceStatus status) { m_status = status; }
@@ -117,6 +132,7 @@ class Resource : public QObject {
      *  or if such filter includes the Resource (true).
      */
     [[nodiscard]] virtual bool applyFilter(QRegularExpression filter) const;
+    [[nodiscard]] bool checkCategories(QRegularExpression filter, bool& match) const;
 
     /** Changes the enabled property, according to 'action'.
      *

--- a/launcher/minecraft/mod/Resource.h
+++ b/launcher/minecraft/mod/Resource.h
@@ -58,7 +58,7 @@ enum class ResourceStatus {
     UNKNOWN,        // Default status
 };
 
-enum class SortType { NAME, DATE, VERSION, ENABLED, PACK_FORMAT, PROVIDER, SIZE, SIDE, MC_VERSIONS, LOADERS, RELEASE_TYPE };
+enum class SortType { NAME, DATE, VERSION, ENABLED, PACK_FORMAT, PROVIDER, SIZE, SIDE, MC_VERSIONS, LOADERS, RELEASE_TYPE, LOCK_UPDATE };
 
 enum class EnableAction { ENABLE, DISABLE, TOGGLE };
 
@@ -100,6 +100,7 @@ class Resource : public QObject {
     [[nodiscard]] auto metadata() const -> std::shared_ptr<const Metadata::ModStruct> { return m_metadata; }
     [[nodiscard]] auto provider() const -> QString;
     [[nodiscard]] virtual auto homepage() const -> QString;
+    [[nodiscard]] bool lockUpdate() const;
 
     void setStatus(ResourceStatus status) { m_status = status; }
     void setMetadata(std::shared_ptr<Metadata::ModStruct>&& metadata);

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -510,6 +510,8 @@ QVariant ResourceFolderModel::data(const QModelIndex& index, int role) const
         case Qt::CheckStateRole:
             if (column == ActiveColumn)
                 return m_resources[row]->enabled() ? Qt::Checked : Qt::Unchecked;
+            else if (column == LockUpdateCoumn)
+                return !at(row).lockUpdate() ? Qt::Checked : Qt::Unchecked;
             return {};
         default:
             return {};
@@ -523,6 +525,9 @@ bool ResourceFolderModel::setData(const QModelIndex& index, [[maybe_unused]] con
         return false;
 
     if (role == Qt::CheckStateRole) {
+        if (columnNames(false).at(index.column()) == "Update") {
+            return setModUpdate({ index }, EnableAction::TOGGLE);
+        }
         if (m_instance != nullptr && m_instance->isRunning()) {
             auto response =
                 CustomMessageBox::selectable(nullptr, tr("Confirm toggle"),
@@ -550,6 +555,7 @@ QVariant ResourceFolderModel::headerData(int section, [[maybe_unused]] Qt::Orien
                 case DateColumn:
                 case ProviderColumn:
                 case SizeColumn:
+                case LockUpdateCoumn:
                     return columnNames().at(section);
                 default:
                     return {};
@@ -567,6 +573,8 @@ QVariant ResourceFolderModel::headerData(int section, [[maybe_unused]] Qt::Orien
                     return tr("The source provider of the resource.");
                 case SizeColumn:
                     return tr("The size of the resource.");
+                case LockUpdateCoumn:
+                    return tr("Should this mod be updated?");
                 default:
                     return {};
             }
@@ -830,4 +838,49 @@ QList<Resource*> ResourceFolderModel::selectedResources(const QModelIndexList& i
         result.append(&at(index.row()));
     }
     return result;
+}
+
+bool ResourceFolderModel::setModUpdate(const QModelIndexList& indexes, EnableAction action)
+{
+    if (indexes.isEmpty())
+        return true;
+
+    bool succeeded = true;
+    auto updateColumn = columnNames(false).indexOf("Update");
+    for (auto const& idx : indexes) {
+        if (!validateIndex(idx) || idx.column() != updateColumn)
+            continue;
+
+        int row = idx.row();
+        auto& resource = m_resources[row];
+
+        bool update = true;
+        switch (action) {
+            case EnableAction::ENABLE:
+                update = false;
+                break;
+            case EnableAction::DISABLE:
+                update = true;
+                break;
+            case EnableAction::TOGGLE:
+            default:
+                update = !resource->lockUpdate();
+                break;
+        }
+
+        if (resource->lockUpdate() == update) {
+            succeeded = false;
+            continue;
+        }
+
+        auto meta = resource->metadata();
+        if (meta) {
+            meta->lockUpdate = update;
+            Metadata::update(indexDir(), *meta.get());
+            resource->setMetadata(*meta.get());
+            emit dataChanged(index(row, updateColumn), index(row, columnCount(QModelIndex()) - 1));
+        }
+    }
+
+    return succeeded;
 }

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -16,6 +16,7 @@
 #include "Application.h"
 #include "FileSystem.h"
 
+#include "minecraft/mod/ModFolderModel.h"
 #include "minecraft/mod/tasks/ResourceFolderLoadTask.h"
 
 #include "Json.h"
@@ -482,6 +483,8 @@ QVariant ResourceFolderModel::data(const QModelIndex& index, int role) const
                     return m_resources[row]->provider();
                 case SizeColumn:
                     return m_resources[row]->sizeStr();
+                case CategoryColumn:
+                    return m_resources[row]->categories();
                 default:
                     return {};
             }
@@ -526,7 +529,7 @@ bool ResourceFolderModel::setData(const QModelIndex& index, [[maybe_unused]] con
 
     if (role == Qt::CheckStateRole) {
         if (columnNames(false).at(index.column()) == "Update") {
-            return setModUpdate({ index }, EnableAction::TOGGLE);
+            return setResourceUpdate({ index }, EnableAction::TOGGLE);
         }
         if (m_instance != nullptr && m_instance->isRunning()) {
             auto response =
@@ -555,6 +558,7 @@ QVariant ResourceFolderModel::headerData(int section, [[maybe_unused]] Qt::Orien
                 case DateColumn:
                 case ProviderColumn:
                 case SizeColumn:
+                case CategoryColumn:
                 case LockUpdateCoumn:
                     return columnNames().at(section);
                 default:
@@ -573,8 +577,10 @@ QVariant ResourceFolderModel::headerData(int section, [[maybe_unused]] Qt::Orien
                     return tr("The source provider of the resource.");
                 case SizeColumn:
                     return tr("The size of the resource.");
+                case CategoryColumn:
+                    return tr("The categories of the resource.");
                 case LockUpdateCoumn:
-                    return tr("Should this mod be updated?");
+                    return tr("Should this resource be updated?");
                 default:
                     return {};
             }
@@ -840,7 +846,7 @@ QList<Resource*> ResourceFolderModel::selectedResources(const QModelIndexList& i
     return result;
 }
 
-bool ResourceFolderModel::setModUpdate(const QModelIndexList& indexes, EnableAction action)
+bool ResourceFolderModel::setResourceUpdate(const QModelIndexList& indexes, EnableAction action)
 {
     if (indexes.isEmpty())
         return true;
@@ -883,4 +889,115 @@ bool ResourceFolderModel::setModUpdate(const QModelIndexList& indexes, EnableAct
     }
 
     return succeeded;
+}
+
+bool ResourceFolderModel::addResourceCategory(const QModelIndexList& indexes, QString category)
+{
+    if (indexes.isEmpty())
+        return true;
+
+    bool succeeded = true;
+    auto updateColumn = columnNames(false).indexOf("Update");
+    for (auto const& idx : indexes) {
+        if (!validateIndex(idx) || idx.column() != updateColumn)
+            continue;
+
+        int row = idx.row();
+        auto& resource = m_resources[row];
+
+        auto meta = resource->metadata();
+        if (!meta) {
+            continue;
+        }
+        if (meta->categories.contains(category)) {
+            succeeded = false;
+            continue;
+        }
+
+        meta->categories.append(category);
+        meta->categories.sort();
+        Metadata::update(indexDir(), *meta.get());
+        resource->setMetadata(*meta.get());
+        emit dataChanged(index(row, updateColumn), index(row, columnCount(QModelIndex()) - 1));
+    }
+
+    return succeeded;
+}
+
+bool ResourceFolderModel::removeResourceCategory(const QModelIndexList& indexes, QString category)
+{
+    if (indexes.isEmpty())
+        return true;
+
+    bool succeeded = true;
+    auto updateColumn = columnNames(false).indexOf("Update");
+    for (auto const& idx : indexes) {
+        if (!validateIndex(idx) || idx.column() != updateColumn)
+            continue;
+
+        int row = idx.row();
+        auto& resource = m_resources[row];
+
+        auto meta = resource->metadata();
+        if (!meta) {
+            continue;
+        }
+        if (!meta->categories.contains(category)) {
+            succeeded = false;
+            continue;
+        }
+
+        meta->categories.removeOne(category);
+        Metadata::update(indexDir(), *meta.get());
+        resource->setMetadata(*meta.get());
+        emit dataChanged(index(row, updateColumn), index(row, columnCount(QModelIndex()) - 1));
+    }
+
+    return succeeded;
+}
+
+bool ResourceFolderModel::removeAllResourceCategory(const QModelIndexList& indexes)
+{
+    if (indexes.isEmpty())
+        return true;
+
+    bool succeeded = true;
+    auto updateColumn = columnNames(false).indexOf("Update");
+    for (auto const& idx : indexes) {
+        if (!validateIndex(idx) || idx.column() != updateColumn)
+            continue;
+
+        int row = idx.row();
+        auto& resource = m_resources[row];
+
+        auto meta = resource->metadata();
+        if (!meta) {
+            continue;
+        }
+        if (meta->categories.isEmpty()) {
+            succeeded = false;
+            continue;
+        }
+
+        meta->categories.clear();
+        Metadata::update(indexDir(), *meta.get());
+        resource->setMetadata(*meta.get());
+        emit dataChanged(index(row, updateColumn), index(row, columnCount(QModelIndex()) - 1));
+    }
+
+    return succeeded;
+}
+
+QStringList ResourceFolderModel::categories()
+{
+    QSet<QString> cat;
+    for (auto res : m_resources) {
+        auto meta = res->metadata();
+        if (meta) {
+            for (auto c : meta->categories) {
+                cat.insert(c);
+            }
+        }
+    }
+    return cat.values();
 }

--- a/launcher/minecraft/mod/ResourceFolderModel.h
+++ b/launcher/minecraft/mod/ResourceFolderModel.h
@@ -137,7 +137,7 @@ class ResourceFolderModel : public QAbstractListModel {
     /* Qt behavior */
 
     /* Basic columns */
-    enum Columns { ActiveColumn = 0, NameColumn, DateColumn, ProviderColumn, SizeColumn, NUM_COLUMNS };
+    enum Columns { ActiveColumn = 0, NameColumn, DateColumn, ProviderColumn, SizeColumn, LockUpdateCoumn, NUM_COLUMNS };
 
     QStringList columnNames(bool translated = true) const { return translated ? m_column_names_translated : m_column_names; }
 
@@ -182,6 +182,8 @@ class ResourceFolderModel : public QAbstractListModel {
     };
 
     QString instDirPath() const;
+
+    bool setModUpdate(const QModelIndexList& indexes, EnableAction action);
 
    signals:
     void updateFinished();
@@ -238,12 +240,12 @@ class ResourceFolderModel : public QAbstractListModel {
     // Represents the relationship between a column's index (represented by the list index), and it's sorting key.
     // As such, the order in with they appear is very important!
     QList<SortType> m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::DATE, SortType::PROVIDER, SortType::SIZE };
-    QStringList m_column_names = { "Enable", "Name", "Last Modified", "Provider", "Size" };
-    QStringList m_column_names_translated = { tr("Enable"), tr("Name"), tr("Last Modified"), tr("Provider"), tr("Size") };
-    QList<QHeaderView::ResizeMode> m_column_resize_modes = { QHeaderView::Interactive, QHeaderView::Stretch, QHeaderView::Interactive,
-                                                             QHeaderView::Interactive, QHeaderView::Interactive };
-    QList<bool> m_columnsHideable = { false, false, true, true, true };
-    QList<bool> m_columnsHiddenByDefault = { false, false, false, false, true };
+    QStringList m_column_names = { "Enable", "Name", "Last Modified", "Provider", "Size", "Update" };
+    QStringList m_column_names_translated = { tr("Enable"), tr("Name"), tr("Last Modified"), tr("Provider"), tr("Size"), tr("Update") };
+    QList<QHeaderView::ResizeMode> m_column_resize_modes = { QHeaderView::Interactive, QHeaderView::Stretch,     QHeaderView::Interactive,
+                                                             QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive };
+    QList<bool> m_columnsHideable = { false, false, true, true, true, true };
+    QList<bool> m_columnsHiddenByDefault = { false, false, false, false, true, false };
 
     QDir m_dir;
     BaseInstance* m_instance;

--- a/launcher/minecraft/mod/ResourceFolderModel.h
+++ b/launcher/minecraft/mod/ResourceFolderModel.h
@@ -137,7 +137,7 @@ class ResourceFolderModel : public QAbstractListModel {
     /* Qt behavior */
 
     /* Basic columns */
-    enum Columns { ActiveColumn = 0, NameColumn, DateColumn, ProviderColumn, SizeColumn, LockUpdateCoumn, NUM_COLUMNS };
+    enum Columns { ActiveColumn = 0, NameColumn, DateColumn, ProviderColumn, SizeColumn, CategoryColumn, LockUpdateCoumn, NUM_COLUMNS };
 
     QStringList columnNames(bool translated = true) const { return translated ? m_column_names_translated : m_column_names; }
 
@@ -183,7 +183,11 @@ class ResourceFolderModel : public QAbstractListModel {
 
     QString instDirPath() const;
 
-    bool setModUpdate(const QModelIndexList& indexes, EnableAction action);
+    bool setResourceUpdate(const QModelIndexList& indexes, EnableAction action);
+    bool addResourceCategory(const QModelIndexList& indexes, QString category);
+    bool removeResourceCategory(const QModelIndexList& indexes, QString category);
+    bool removeAllResourceCategory(const QModelIndexList& indexes);
+    [[nodiscard]] QStringList categories();
 
    signals:
     void updateFinished();
@@ -239,13 +243,16 @@ class ResourceFolderModel : public QAbstractListModel {
    protected:
     // Represents the relationship between a column's index (represented by the list index), and it's sorting key.
     // As such, the order in with they appear is very important!
-    QList<SortType> m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::DATE, SortType::PROVIDER, SortType::SIZE };
-    QStringList m_column_names = { "Enable", "Name", "Last Modified", "Provider", "Size", "Update" };
-    QStringList m_column_names_translated = { tr("Enable"), tr("Name"), tr("Last Modified"), tr("Provider"), tr("Size"), tr("Update") };
+    QList<SortType> m_column_sort_keys = { SortType::ENABLED, SortType::NAME,     SortType::DATE,       SortType::PROVIDER,
+                                           SortType::SIZE,    SortType::CATEGORY, SortType::LOCK_UPDATE };
+    QStringList m_column_names = { "Enable", "Name", "Last Modified", "Provider", "Size", "Category", "Update" };
+    QStringList m_column_names_translated = { tr("Enable"), tr("Name"),     tr("Last Modified"), tr("Provider"),
+                                              tr("Size"),   tr("Category"), tr("Update") };
     QList<QHeaderView::ResizeMode> m_column_resize_modes = { QHeaderView::Interactive, QHeaderView::Stretch,     QHeaderView::Interactive,
-                                                             QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive };
-    QList<bool> m_columnsHideable = { false, false, true, true, true, true };
-    QList<bool> m_columnsHiddenByDefault = { false, false, false, false, true, false };
+                                                             QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive,
+                                                             QHeaderView::Interactive };
+    QList<bool> m_columnsHideable = { false, false, true, true, true, true, true };
+    QList<bool> m_columnsHiddenByDefault = { false, false, false, false, true, false, false };
 
     QDir m_dir;
     BaseInstance* m_instance;

--- a/launcher/minecraft/mod/ResourcePackFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourcePackFolderModel.cpp
@@ -44,19 +44,22 @@
 #include "Application.h"
 #include "Version.h"
 
+#include "minecraft/mod/Resource.h"
+#include "minecraft/mod/ResourceFolderModel.h"
 #include "minecraft/mod/tasks/LocalDataPackParseTask.h"
 
 ResourcePackFolderModel::ResourcePackFolderModel(const QDir& dir, BaseInstance* instance, bool is_indexed, bool create_dir, QObject* parent)
     : ResourceFolderModel(dir, instance, is_indexed, create_dir, parent)
 {
-    m_column_names = QStringList({ "Enable", "Image", "Name", "Pack Format", "Last Modified", "Provider", "Size" });
-    m_column_names_translated =
-        QStringList({ tr("Enable"), tr("Image"), tr("Name"), tr("Pack Format"), tr("Last Modified"), tr("Provider"), tr("Size") });
+    m_column_names = QStringList({ "Enable", "Image", "Name", "Pack Format", "Last Modified", "Provider", "Size", "Update" });
+    m_column_names_translated = QStringList(
+        { tr("Enable"), tr("Image"), tr("Name"), tr("Pack Format"), tr("Last Modified"), tr("Provider"), tr("Size"), tr("Update") });
     m_column_sort_keys = { SortType::ENABLED, SortType::NAME,     SortType::NAME, SortType::PACK_FORMAT,
-                           SortType::DATE,    SortType::PROVIDER, SortType::SIZE };
-    m_column_resize_modes = { QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Stretch,    QHeaderView::Interactive,
-                              QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive };
-    m_columnsHideable = { false, true, false, true, true, true, true };
+                           SortType::DATE,    SortType::PROVIDER, SortType::SIZE, SortType::LOCK_UPDATE };
+    m_column_resize_modes = { QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Stretch,     QHeaderView::Interactive,
+                              QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive };
+    m_columnsHideable = { false, true, false, true, true, true, true, true };
+    m_columnsHiddenByDefault = { false, false, false, false, false, false, false, false };
 }
 
 QVariant ResourcePackFolderModel::data(const QModelIndex& index, int role) const
@@ -130,6 +133,8 @@ QVariant ResourcePackFolderModel::data(const QModelIndex& index, int role) const
         case Qt::CheckStateRole:
             if (column == ActiveColumn)
                 return at(row).enabled() ? Qt::Checked : Qt::Unchecked;
+            else if (column == LockUpdateCoumn)
+                return !at(row).lockUpdate() ? Qt::Checked : Qt::Unchecked;
             return {};
         default:
             return {};
@@ -148,6 +153,7 @@ QVariant ResourcePackFolderModel::headerData(int section, [[maybe_unused]] Qt::O
                 case ImageColumn:
                 case ProviderColumn:
                 case SizeColumn:
+                case LockUpdateCoumn:
                     return columnNames().at(section);
                 default:
                     return {};
@@ -168,6 +174,8 @@ QVariant ResourcePackFolderModel::headerData(int section, [[maybe_unused]] Qt::O
                     return tr("The source provider of the resource pack.");
                 case SizeColumn:
                     return tr("The size of the resource pack.");
+                case LockUpdateCoumn:
+                    return tr("Should this mod be updated?");
                 default:
                     return {};
             }

--- a/launcher/minecraft/mod/ResourcePackFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourcePackFolderModel.cpp
@@ -51,15 +51,16 @@
 ResourcePackFolderModel::ResourcePackFolderModel(const QDir& dir, BaseInstance* instance, bool is_indexed, bool create_dir, QObject* parent)
     : ResourceFolderModel(dir, instance, is_indexed, create_dir, parent)
 {
-    m_column_names = QStringList({ "Enable", "Image", "Name", "Pack Format", "Last Modified", "Provider", "Size", "Update" });
-    m_column_names_translated = QStringList(
-        { tr("Enable"), tr("Image"), tr("Name"), tr("Pack Format"), tr("Last Modified"), tr("Provider"), tr("Size"), tr("Update") });
-    m_column_sort_keys = { SortType::ENABLED, SortType::NAME,     SortType::NAME, SortType::PACK_FORMAT,
-                           SortType::DATE,    SortType::PROVIDER, SortType::SIZE, SortType::LOCK_UPDATE };
-    m_column_resize_modes = { QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Stretch,     QHeaderView::Interactive,
-                              QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive };
-    m_columnsHideable = { false, true, false, true, true, true, true, true };
-    m_columnsHiddenByDefault = { false, false, false, false, false, false, false, false };
+    m_column_names = QStringList({ "Enable", "Image", "Name", "Pack Format", "Last Modified", "Provider", "Size", "Category", "Update" });
+    m_column_names_translated = QStringList({ tr("Enable"), tr("Image"), tr("Name"), tr("Pack Format"), tr("Last Modified"), tr("Provider"),
+                                              tr("Size"), tr("Category"), tr("Update") });
+    m_column_sort_keys = { SortType::ENABLED,  SortType::NAME, SortType::NAME,     SortType::PACK_FORMAT, SortType::DATE,
+                           SortType::PROVIDER, SortType::SIZE, SortType::CATEGORY, SortType::LOCK_UPDATE };
+    m_column_resize_modes = { QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Stretch,
+                              QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive,
+                              QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive };
+    m_columnsHideable = { false, true, false, true, true, true, true, true, true };
+    m_columnsHiddenByDefault = { false, false, false, false, false, false, false, false, false };
 }
 
 QVariant ResourcePackFolderModel::data(const QModelIndex& index, int role) const
@@ -94,6 +95,8 @@ QVariant ResourcePackFolderModel::data(const QModelIndex& index, int role) const
                     return m_resources[row]->provider();
                 case SizeColumn:
                     return m_resources[row]->sizeStr();
+                case CategoryColumn:
+                    return m_resources[row]->categories();
                 default:
                     return {};
             }
@@ -154,6 +157,7 @@ QVariant ResourcePackFolderModel::headerData(int section, [[maybe_unused]] Qt::O
                 case ProviderColumn:
                 case SizeColumn:
                 case LockUpdateCoumn:
+                case CategoryColumn:
                     return columnNames().at(section);
                 default:
                     return {};
@@ -174,8 +178,10 @@ QVariant ResourcePackFolderModel::headerData(int section, [[maybe_unused]] Qt::O
                     return tr("The source provider of the resource pack.");
                 case SizeColumn:
                     return tr("The size of the resource pack.");
+                case CategoryColumn:
+                    return tr("The categories of the resource pack.");
                 case LockUpdateCoumn:
-                    return tr("Should this mod be updated?");
+                    return tr("Should this resource pack be updated?");
                 default:
                     return {};
             }

--- a/launcher/minecraft/mod/ResourcePackFolderModel.h
+++ b/launcher/minecraft/mod/ResourcePackFolderModel.h
@@ -15,6 +15,7 @@ class ResourcePackFolderModel : public ResourceFolderModel {
         DateColumn,
         ProviderColumn,
         SizeColumn,
+        CategoryColumn,
         LockUpdateCoumn,
         NUM_COLUMNS
     };

--- a/launcher/minecraft/mod/ResourcePackFolderModel.h
+++ b/launcher/minecraft/mod/ResourcePackFolderModel.h
@@ -7,7 +7,17 @@
 class ResourcePackFolderModel : public ResourceFolderModel {
     Q_OBJECT
    public:
-    enum Columns { ActiveColumn = 0, ImageColumn, NameColumn, PackFormatColumn, DateColumn, ProviderColumn, SizeColumn, NUM_COLUMNS };
+    enum Columns {
+        ActiveColumn = 0,
+        ImageColumn,
+        NameColumn,
+        PackFormatColumn,
+        DateColumn,
+        ProviderColumn,
+        SizeColumn,
+        LockUpdateCoumn,
+        NUM_COLUMNS
+    };
 
     explicit ResourcePackFolderModel(const QDir& dir, BaseInstance* instance, bool is_indexed, bool create_dir, QObject* parent = nullptr);
 

--- a/launcher/minecraft/mod/TexturePackFolderModel.cpp
+++ b/launcher/minecraft/mod/TexturePackFolderModel.cpp
@@ -46,15 +46,15 @@
 TexturePackFolderModel::TexturePackFolderModel(const QDir& dir, BaseInstance* instance, bool is_indexed, bool create_dir, QObject* parent)
     : ResourceFolderModel(QDir(dir), instance, is_indexed, create_dir, parent)
 {
-    m_column_names = QStringList({ "Enable", "Image", "Name", "Last Modified", "Provider", "Size", "Update" });
-    m_column_names_translated =
-        QStringList({ tr("Enable"), tr("Image"), tr("Name"), tr("Last Modified"), tr("Provider"), tr("Size"), tr("Update") });
-    m_column_sort_keys = { SortType::ENABLED,  SortType::NAME, SortType::NAME,       SortType::DATE,
-                           SortType::PROVIDER, SortType::SIZE, SortType::LOCK_UPDATE };
-    m_column_resize_modes = { QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Stretch,    QHeaderView::Interactive,
-                              QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive };
-    m_columnsHideable = { false, true, false, true, true, true, true };
-    m_columnsHiddenByDefault = { false, false, false, false, false, true, false };
+    m_column_names = QStringList({ "Enable", "Image", "Name", "Last Modified", "Provider", "Size", "Category", "Update" });
+    m_column_names_translated = QStringList(
+        { tr("Enable"), tr("Image"), tr("Name"), tr("Last Modified"), tr("Provider"), tr("Size"), tr("Category"), tr("Update") });
+    m_column_sort_keys = { SortType::ENABLED,  SortType::NAME, SortType::NAME,     SortType::DATE,
+                           SortType::PROVIDER, SortType::SIZE, SortType::CATEGORY, SortType::LOCK_UPDATE };
+    m_column_resize_modes = { QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Stretch,     QHeaderView::Interactive,
+                              QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive };
+    m_columnsHideable = { false, true, false, true, true, true, true, true };
+    m_columnsHiddenByDefault = { false, false, false, false, false, true, false, false };
 }
 
 Task* TexturePackFolderModel::createParseTask(Resource& resource)
@@ -81,6 +81,8 @@ QVariant TexturePackFolderModel::data(const QModelIndex& index, int role) const
                     return m_resources[row]->provider();
                 case SizeColumn:
                     return m_resources[row]->sizeStr();
+                case CategoryColumn:
+                    return m_resources[row]->categories();
                 default:
                     return {};
             }
@@ -137,6 +139,7 @@ QVariant TexturePackFolderModel::headerData(int section, [[maybe_unused]] Qt::Or
                 case ProviderColumn:
                 case SizeColumn:
                 case LockUpdateCoumn:
+                case CategoryColumn:
                     return columnNames().at(section);
                 default:
                     return {};
@@ -153,8 +156,10 @@ QVariant TexturePackFolderModel::headerData(int section, [[maybe_unused]] Qt::Or
                     return tr("The source provider of the texture pack.");
                 case SizeColumn:
                     return tr("The size of the texture pack.");
+                case CategoryColumn:
+                    return tr("The categories of the texture pack.");
                 case LockUpdateCoumn:
-                    return tr("Should this mod be updated?");
+                    return tr("Should this texture pack be updated?");
                 default:
                     return {};
             }

--- a/launcher/minecraft/mod/TexturePackFolderModel.cpp
+++ b/launcher/minecraft/mod/TexturePackFolderModel.cpp
@@ -39,19 +39,22 @@
 
 #include "TexturePackFolderModel.h"
 
+#include "minecraft/mod/Resource.h"
 #include "minecraft/mod/tasks/LocalTexturePackParseTask.h"
 #include "minecraft/mod/tasks/ResourceFolderLoadTask.h"
 
 TexturePackFolderModel::TexturePackFolderModel(const QDir& dir, BaseInstance* instance, bool is_indexed, bool create_dir, QObject* parent)
     : ResourceFolderModel(QDir(dir), instance, is_indexed, create_dir, parent)
 {
-    m_column_names = QStringList({ "Enable", "Image", "Name", "Last Modified", "Provider", "Size" });
-    m_column_names_translated = QStringList({ tr("Enable"), tr("Image"), tr("Name"), tr("Last Modified"), tr("Provider"), tr("Size") });
-    m_column_sort_keys = { SortType::ENABLED, SortType::NAME, SortType::NAME, SortType::DATE, SortType::PROVIDER, SortType::SIZE };
-    m_column_resize_modes = { QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Stretch,
+    m_column_names = QStringList({ "Enable", "Image", "Name", "Last Modified", "Provider", "Size", "Update" });
+    m_column_names_translated =
+        QStringList({ tr("Enable"), tr("Image"), tr("Name"), tr("Last Modified"), tr("Provider"), tr("Size"), tr("Update") });
+    m_column_sort_keys = { SortType::ENABLED,  SortType::NAME, SortType::NAME,       SortType::DATE,
+                           SortType::PROVIDER, SortType::SIZE, SortType::LOCK_UPDATE };
+    m_column_resize_modes = { QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Stretch,    QHeaderView::Interactive,
                               QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive };
-    m_columnsHideable = { false, true, false, true, true, true };
-    m_columnsHiddenByDefault = { false, false, false, false, false, true };
+    m_columnsHideable = { false, true, false, true, true, true, true };
+    m_columnsHiddenByDefault = { false, false, false, false, false, true, false };
 }
 
 Task* TexturePackFolderModel::createParseTask(Resource& resource)
@@ -113,6 +116,8 @@ QVariant TexturePackFolderModel::data(const QModelIndex& index, int role) const
         case Qt::CheckStateRole:
             if (column == ActiveColumn) {
                 return m_resources[row]->enabled() ? Qt::Checked : Qt::Unchecked;
+            } else if (column == LockUpdateCoumn) {
+                return !m_resources[row]->lockUpdate() ? Qt::Checked : Qt::Unchecked;
             }
             return {};
         default:
@@ -131,6 +136,7 @@ QVariant TexturePackFolderModel::headerData(int section, [[maybe_unused]] Qt::Or
                 case ImageColumn:
                 case ProviderColumn:
                 case SizeColumn:
+                case LockUpdateCoumn:
                     return columnNames().at(section);
                 default:
                     return {};
@@ -147,6 +153,8 @@ QVariant TexturePackFolderModel::headerData(int section, [[maybe_unused]] Qt::Or
                     return tr("The source provider of the texture pack.");
                 case SizeColumn:
                     return tr("The size of the texture pack.");
+                case LockUpdateCoumn:
+                    return tr("Should this mod be updated?");
                 default:
                     return {};
             }

--- a/launcher/minecraft/mod/TexturePackFolderModel.h
+++ b/launcher/minecraft/mod/TexturePackFolderModel.h
@@ -44,7 +44,7 @@ class TexturePackFolderModel : public ResourceFolderModel {
     Q_OBJECT
 
    public:
-    enum Columns { ActiveColumn = 0, ImageColumn, NameColumn, DateColumn, ProviderColumn, SizeColumn, NUM_COLUMNS };
+    enum Columns { ActiveColumn = 0, ImageColumn, NameColumn, DateColumn, ProviderColumn, SizeColumn, LockUpdateCoumn, NUM_COLUMNS };
 
     explicit TexturePackFolderModel(const QDir& dir, BaseInstance* instance, bool is_indexed, bool create_dir, QObject* parent = nullptr);
 

--- a/launcher/minecraft/mod/TexturePackFolderModel.h
+++ b/launcher/minecraft/mod/TexturePackFolderModel.h
@@ -44,7 +44,17 @@ class TexturePackFolderModel : public ResourceFolderModel {
     Q_OBJECT
 
    public:
-    enum Columns { ActiveColumn = 0, ImageColumn, NameColumn, DateColumn, ProviderColumn, SizeColumn, LockUpdateCoumn, NUM_COLUMNS };
+    enum Columns {
+        ActiveColumn = 0,
+        ImageColumn,
+        NameColumn,
+        DateColumn,
+        ProviderColumn,
+        SizeColumn,
+        CategoryColumn,
+        LockUpdateCoumn,
+        NUM_COLUMNS
+    };
 
     explicit TexturePackFolderModel(const QDir& dir, BaseInstance* instance, bool is_indexed, bool create_dir, QObject* parent = nullptr);
 

--- a/launcher/minecraft/mod/tasks/LocalResourceUpdateTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalResourceUpdateTask.cpp
@@ -26,8 +26,11 @@
 #include <windows.h>
 #endif
 
-LocalResourceUpdateTask::LocalResourceUpdateTask(QDir index_dir, ModPlatform::IndexedPack& project, ModPlatform::IndexedVersion& version)
-    : m_index_dir(index_dir), m_project(project), m_version(version)
+LocalResourceUpdateTask::LocalResourceUpdateTask(QDir index_dir,
+                                                 ModPlatform::IndexedPack& project,
+                                                 ModPlatform::IndexedVersion& version,
+                                                 bool lockUpdate)
+    : m_index_dir(index_dir), m_project(project), m_version(version), m_lockUpdate(lockUpdate)
 {
     // Ensure a '.index' folder exists in the mods folder, and create it if it does not
     if (!FS::ensureFolderPathExists(index_dir.path())) {
@@ -52,6 +55,7 @@ void LocalResourceUpdateTask::executeTask()
 
     auto pw_mod = Metadata::create(m_index_dir, m_project, m_version);
     if (pw_mod.isValid()) {
+        pw_mod.lockUpdate = m_lockUpdate;
         Metadata::update(m_index_dir, pw_mod);
         emitSucceeded();
     } else {

--- a/launcher/minecraft/mod/tasks/LocalResourceUpdateTask.h
+++ b/launcher/minecraft/mod/tasks/LocalResourceUpdateTask.h
@@ -28,7 +28,10 @@ class LocalResourceUpdateTask : public Task {
    public:
     using Ptr = shared_qobject_ptr<LocalResourceUpdateTask>;
 
-    explicit LocalResourceUpdateTask(QDir index_dir, ModPlatform::IndexedPack& project, ModPlatform::IndexedVersion& version);
+    explicit LocalResourceUpdateTask(QDir index_dir,
+                                     ModPlatform::IndexedPack& project,
+                                     ModPlatform::IndexedVersion& version,
+                                     bool lockUpdate = false);
 
     auto canAbort() const -> bool override { return true; }
     auto abort() -> bool override;
@@ -44,4 +47,5 @@ class LocalResourceUpdateTask : public Task {
     QDir m_index_dir;
     ModPlatform::IndexedPack m_project;
     ModPlatform::IndexedVersion m_version;
+    bool m_lockUpdate = false;
 };

--- a/launcher/modplatform/EnsureMetadataTask.cpp
+++ b/launcher/modplatform/EnsureMetadataTask.cpp
@@ -487,7 +487,7 @@ void EnsureMetadataTask::updateMetadata(ModPlatform::IndexedPack& pack, ModPlatf
         if (ver.fileName.endsWith(".disabled"))
             ver.fileName.chop(9);
 
-        auto task = makeShared<LocalResourceUpdateTask>(m_indexDir, pack, ver);
+        auto task = makeShared<LocalResourceUpdateTask>(m_indexDir, pack, ver, m_lockUpdate);
 
         connect(task.get(), &Task::finished, this, [this, &pack, resource] { updateMetadataCallback(pack, resource); });
 

--- a/launcher/modplatform/EnsureMetadataTask.h
+++ b/launcher/modplatform/EnsureMetadataTask.h
@@ -22,6 +22,7 @@ class EnsureMetadataTask : public Task {
     ~EnsureMetadataTask() = default;
 
     Task::Ptr getHashingTask() { return m_hashingTask; }
+    void setLockUpdate(bool lockUpdate) { m_lockUpdate = lockUpdate; }
 
    public slots:
     bool abort() override;
@@ -62,4 +63,5 @@ class EnsureMetadataTask : public Task {
     Task::Ptr m_hashingTask;
     Task::Ptr m_currentTask;
     QHash<QString, Task::Ptr> m_updateMetadataTasks;
+    bool m_lockUpdate = false;
 };

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -698,7 +698,7 @@ void FlameCreationTask::validateOtherResources(QEventLoop& loop)
         if (file.targetFolder != "mods" || (file.version.fileName.endsWith(".zip") && !zipMods.contains(file.version.fileName))) {
             continue;
         }
-        task->addTask(makeShared<LocalResourceUpdateTask>(folder, file.pack, file.version));
+        task->addTask(makeShared<LocalResourceUpdateTask>(folder, file.pack, file.version, true));
     }
     connect(task.get(), &Task::finished, &loop, &QEventLoop::quit);
     m_processUpdateFileInfoJob = task;

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
@@ -319,6 +319,7 @@ bool ModrinthCreationTask::createInstance()
     QEventLoop ensureMetaLoop;
     QDir folder = FS::PathCombine(instance.modsRoot(), ".index");
     auto ensureMetadataTask = makeShared<EnsureMetadataTask>(resources, folder, ModPlatform::ResourceProvider::MODRINTH);
+    ensureMetadataTask->setLockUpdate(true);
     connect(ensureMetadataTask.get(), &Task::succeeded, this, [&ended_well]() { ended_well = true; });
     connect(ensureMetadataTask.get(), &Task::finished, &ensureMetaLoop, &QEventLoop::quit);
     connect(ensureMetadataTask.get(), &Task::progress, [this](qint64 current, qint64 total) {

--- a/launcher/modplatform/packwiz/Packwiz.cpp
+++ b/launcher/modplatform/packwiz/Packwiz.cpp
@@ -213,6 +213,7 @@ void V1::updateModIndex(const QDir& index_dir, Mod& mod)
                                 { "x-prismlauncher-mc-versions", mcVersions },
                                 { "x-prismlauncher-release-type", mod.releaseType.toString().toStdString() },
                                 { "x-prismlauncher-version-number", mod.version_number.toStdString() },
+                                { "x-prismlauncher-lock-update", mod.lockUpdate },
                                 { "download",
                                   toml::table{
                                       { "mode", mod.mode.toStdString() },
@@ -298,6 +299,7 @@ auto V1::getIndexForMod(const QDir& index_dir, QString slug) -> Mod
         mod.filename = stringEntry(table, "filename");
         mod.side = stringToSide(stringEntry(table, "side"));
         mod.releaseType = ModPlatform::IndexedVersionType(table["x-prismlauncher-release-type"].value_or(""));
+        mod.lockUpdate = table["x-prismlauncher-lock-update"].value_or(false);
         if (auto loaders = table["x-prismlauncher-loaders"]; loaders && loaders.is_array()) {
             for (auto&& loader : *loaders.as_array()) {
                 if (loader.is_string()) {

--- a/launcher/modplatform/packwiz/Packwiz.h
+++ b/launcher/modplatform/packwiz/Packwiz.h
@@ -60,6 +60,7 @@ class V1 {
         QVariant project_id{};
         QString version_number{};
 
+        QStringList categories;
         bool lockUpdate;
 
        public:

--- a/launcher/modplatform/packwiz/Packwiz.h
+++ b/launcher/modplatform/packwiz/Packwiz.h
@@ -60,6 +60,8 @@ class V1 {
         QVariant project_id{};
         QString version_number{};
 
+        bool lockUpdate;
+
        public:
         // This is a totally heuristic, but should work for now.
         auto isValid() const -> bool { return !slug.isEmpty() && !project_id.isNull(); }

--- a/launcher/net/ChecksumValidator.h
+++ b/launcher/net/ChecksumValidator.h
@@ -72,7 +72,7 @@ class ChecksumValidator : public Validator {
     auto validate(QNetworkReply&) -> bool override
     {
         if (m_expected.size() && m_expected != hash()) {
-            qWarning() << "Checksum mismatch, download is bad.";
+            qCritical() << "Checksum mismatch, download is bad.";
             return false;
         }
         return true;

--- a/launcher/ui/dialogs/ResourceUpdateDialog.cpp
+++ b/launcher/ui/dialogs/ResourceUpdateDialog.cpp
@@ -383,7 +383,7 @@ auto ResourceUpdateDialog::ensureMetadata() -> bool
 void ResourceUpdateDialog::onMetadataEnsured(Resource* resource)
 {
     // When the mod is a folder, for instance
-    if (!resource->metadata())
+    if (!resource->metadata() || resource->lockUpdate())
         return;
 
     switch (resource->metadata()->provider) {

--- a/launcher/ui/pages/instance/ExternalResourcesPage.cpp
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.cpp
@@ -43,6 +43,7 @@
 #include "ui/GuiUtil.h"
 
 #include <QHeaderView>
+#include <QInputDialog>
 #include <QKeyEvent>
 #include <QMenu>
 #include <algorithm>
@@ -83,6 +84,10 @@ ExternalResourcesPage::ExternalResourcesPage(BaseInstance* instance, std::shared
 
     connect(ui->actionEnableUpdates, &QAction::triggered, this, &ExternalResourcesPage::enableUpdates);
     connect(ui->actionDisableUpdates, &QAction::triggered, this, &ExternalResourcesPage::disableUpdates);
+
+    connect(ui->actionAddCategory, &QAction::triggered, this, &ExternalResourcesPage::addCategory);
+    connect(ui->actionRemoveCategory, &QAction::triggered, this, &ExternalResourcesPage::removeCategory);
+    connect(ui->actionRemoveAllCategory, &QAction::triggered, this, &ExternalResourcesPage::removeAllCategories);
 
     auto selection_model = ui->treeView->selectionModel();
 
@@ -345,6 +350,9 @@ void ExternalResourcesPage::updateActions()
 
     ui->actionEnableUpdates->setEnabled(hasMeta);
     ui->actionDisableUpdates->setEnabled(hasMeta);
+    ui->actionAddCategory->setEnabled(hasMeta);
+    ui->actionRemoveCategory->setEnabled(hasMeta);
+    ui->actionRemoveAllCategory->setEnabled(hasMeta);
     ui->actionExportMetadata->setEnabled(!m_model->empty());
 }
 
@@ -369,11 +377,42 @@ QString ExternalResourcesPage::extraHeaderInfoString()
 void ExternalResourcesPage::enableUpdates()
 {
     auto selection = m_filterModel->mapSelectionToSource(ui->treeView->selectionModel()->selection());
-    m_model->setModUpdate(selection.indexes(), EnableAction::ENABLE);
+    m_model->setResourceUpdate(selection.indexes(), EnableAction::ENABLE);
 }
 
 void ExternalResourcesPage::disableUpdates()
 {
     auto selection = m_filterModel->mapSelectionToSource(ui->treeView->selectionModel()->selection());
-    m_model->setModUpdate(selection.indexes(), EnableAction::DISABLE);
+    m_model->setResourceUpdate(selection.indexes(), EnableAction::DISABLE);
+}
+
+void ExternalResourcesPage::addCategory()
+{
+    auto cat = m_model->categories();
+    cat.prepend("");
+    bool ok = false;
+    QString dst = QInputDialog::getItem(this, tr("Category name"), tr("Enter a new category name."), cat, 0, true, &ok);
+    dst = dst.simplified();
+    if (ok) {
+        auto selection = m_filterModel->mapSelectionToSource(ui->treeView->selectionModel()->selection());
+        m_model->addResourceCategory(selection.indexes(), dst);
+    }
+}
+
+void ExternalResourcesPage::removeCategory()
+{
+    auto cat = m_model->categories();
+    bool ok = false;
+    QString dst = QInputDialog::getItem(this, tr("Category name"), tr("Enter a category name."), cat, 0, true, &ok);
+    dst = dst.simplified();
+    if (ok) {
+        auto selection = m_filterModel->mapSelectionToSource(ui->treeView->selectionModel()->selection());
+        m_model->removeResourceCategory(selection.indexes(), dst);
+    }
+}
+
+void ExternalResourcesPage::removeAllCategories()
+{
+    auto selection = m_filterModel->mapSelectionToSource(ui->treeView->selectionModel()->selection());
+    m_model->removeAllResourceCategory(selection.indexes());
 }

--- a/launcher/ui/pages/instance/ExternalResourcesPage.cpp
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.cpp
@@ -81,6 +81,9 @@ ExternalResourcesPage::ExternalResourcesPage(BaseInstance* instance, std::shared
     connect(ui->treeView, &ModListView::customContextMenuRequested, this, &ExternalResourcesPage::ShowContextMenu);
     connect(ui->treeView, &ModListView::activated, this, &ExternalResourcesPage::itemActivated);
 
+    connect(ui->actionEnableUpdates, &QAction::triggered, this, &ExternalResourcesPage::enableUpdates);
+    connect(ui->actionDisableUpdates, &QAction::triggered, this, &ExternalResourcesPage::disableUpdates);
+
     auto selection_model = ui->treeView->selectionModel();
 
     connect(selection_model, &QItemSelectionModel::currentChanged, this, [this](const QModelIndex& current, const QModelIndex& previous) {
@@ -325,6 +328,8 @@ void ExternalResourcesPage::updateActions()
     const bool hasSelection = ui->treeView->selectionModel()->hasSelection();
     const QModelIndexList selection = m_filterModel->mapSelectionToSource(ui->treeView->selectionModel()->selection()).indexes();
     const QList<Resource*> selectedResources = m_model->selectedResources(selection);
+    const bool hasMeta = hasSelection && std::any_of(selectedResources.begin(), selectedResources.end(),
+                                                     [](Resource* resource) { return resource->metadata(); });
 
     ui->actionUpdateItem->setEnabled(!m_model->empty());
     ui->actionResetItemMetadata->setEnabled(hasSelection);
@@ -337,6 +342,9 @@ void ExternalResourcesPage::updateActions()
 
     ui->actionViewHomepage->setEnabled(hasSelection && std::any_of(selectedResources.begin(), selectedResources.end(),
                                                                    [](Resource* resource) { return !resource->homepage().isEmpty(); }));
+
+    ui->actionEnableUpdates->setEnabled(hasMeta);
+    ui->actionDisableUpdates->setEnabled(hasMeta);
     ui->actionExportMetadata->setEnabled(!m_model->empty());
 }
 
@@ -356,4 +364,16 @@ QString ExternalResourcesPage::extraHeaderInfoString()
             return tr(" (%1 installed, %2 selected)").arg(m_model->size()).arg(count);
     }
     return tr(" (%1 installed)").arg(m_model->size());
+}
+
+void ExternalResourcesPage::enableUpdates()
+{
+    auto selection = m_filterModel->mapSelectionToSource(ui->treeView->selectionModel()->selection());
+    m_model->setModUpdate(selection.indexes(), EnableAction::ENABLE);
+}
+
+void ExternalResourcesPage::disableUpdates()
+{
+    auto selection = m_filterModel->mapSelectionToSource(ui->treeView->selectionModel()->selection());
+    m_model->setModUpdate(selection.indexes(), EnableAction::DISABLE);
 }

--- a/launcher/ui/pages/instance/ExternalResourcesPage.h
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.h
@@ -64,6 +64,9 @@ class ExternalResourcesPage : public QMainWindow, public BasePage {
     void ShowContextMenu(const QPoint& pos);
     void ShowHeaderContextMenu(const QPoint& pos);
 
+    void enableUpdates();
+    void disableUpdates();
+
    protected:
     BaseInstance* m_instance = nullptr;
 

--- a/launcher/ui/pages/instance/ExternalResourcesPage.h
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.h
@@ -67,6 +67,10 @@ class ExternalResourcesPage : public QMainWindow, public BasePage {
     void enableUpdates();
     void disableUpdates();
 
+    void addCategory();
+    void removeCategory();
+    void removeAllCategories();
+
    protected:
     BaseInstance* m_instance = nullptr;
 

--- a/launcher/ui/pages/instance/ExternalResourcesPage.ui
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.ui
@@ -226,6 +226,22 @@
     <string>View the homepages of all selected items.</string>
    </property>
   </action>
+  <action name="actionEnableUpdates">
+   <property name="text">
+    <string>Ena&amp;ble Updates</string>
+   </property>
+   <property name="toolTip">
+    <string>Mark resource to be updated</string>
+   </property>
+  </action>
+  <action name="actionDisableUpdates">
+   <property name="text">
+    <string>Disable U&amp;pdates</string>
+   </property>
+   <property name="toolTip">
+    <string>Mark resource to prevent it from being updated</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>

--- a/launcher/ui/pages/instance/ExternalResourcesPage.ui
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.ui
@@ -215,6 +215,30 @@
     <enum>QAction::NoRole</enum>
    </property>
   </action>
+  <action name="actionAddCategory">
+   <property name="text">
+    <string>Add Category</string>
+   </property>
+   <property name="toolTip">
+    <string>Add category to resource.</string>
+   </property>
+  </action>
+  <action name="actionRemoveCategory">
+   <property name="text">
+    <string>Remove Category</string>
+   </property>
+   <property name="toolTip">
+    <string>Remove category from resource.</string>
+   </property>
+  </action>
+  <action name="actionRemoveAllCategory">
+   <property name="text">
+    <string>Remove All Categories</string>
+   </property>
+   <property name="toolTip">
+    <string>Remove all categories from resource</string>
+   </property>
+  </action>
   <action name="actionViewHomepage">
    <property name="enabled">
     <bool>false</bool>

--- a/launcher/ui/pages/instance/ModFolderPage.cpp
+++ b/launcher/ui/pages/instance/ModFolderPage.cpp
@@ -106,6 +106,9 @@ ModFolderPage::ModFolderPage(BaseInstance* inst, std::shared_ptr<ModFolderModel>
     ui->actionExportMetadata->setToolTip(tr("Export mod's metadata to text."));
     connect(ui->actionExportMetadata, &QAction::triggered, this, &ModFolderPage::exportModMetadata);
     ui->actionsToolbar->insertActionAfter(ui->actionViewHomepage, ui->actionExportMetadata);
+
+    ui->actionsToolbar->insertActionAfter(ui->actionUpdateItem, ui->actionEnableUpdates);
+    ui->actionsToolbar->insertActionAfter(ui->actionEnableUpdates, ui->actionDisableUpdates);
 }
 
 bool ModFolderPage::shouldDisplay() const

--- a/launcher/ui/pages/instance/ModFolderPage.cpp
+++ b/launcher/ui/pages/instance/ModFolderPage.cpp
@@ -109,6 +109,10 @@ ModFolderPage::ModFolderPage(BaseInstance* inst, std::shared_ptr<ModFolderModel>
 
     ui->actionsToolbar->insertActionAfter(ui->actionUpdateItem, ui->actionEnableUpdates);
     ui->actionsToolbar->insertActionAfter(ui->actionEnableUpdates, ui->actionDisableUpdates);
+
+    ui->actionsToolbar->insertActionAfter(ui->actionDisableUpdates, ui->actionAddCategory);
+    ui->actionsToolbar->insertActionAfter(ui->actionAddCategory, ui->actionRemoveCategory);
+    ui->actionsToolbar->insertActionAfter(ui->actionRemoveCategory, ui->actionRemoveAllCategory);
 }
 
 bool ModFolderPage::shouldDisplay() const

--- a/launcher/ui/pages/instance/ResourcePackPage.cpp
+++ b/launcher/ui/pages/instance/ResourcePackPage.cpp
@@ -69,6 +69,9 @@ ResourcePackPage::ResourcePackPage(MinecraftInstance* instance, std::shared_ptr<
     ui->actionChangeVersion->setToolTip(tr("Change a mod's version."));
     connect(ui->actionChangeVersion, &QAction::triggered, this, &ResourcePackPage::changeResourcePackVersion);
     ui->actionsToolbar->insertActionAfter(ui->actionUpdateItem, ui->actionChangeVersion);
+
+    ui->actionsToolbar->insertActionAfter(ui->actionUpdateItem, ui->actionEnableUpdates);
+    ui->actionsToolbar->insertActionAfter(ui->actionEnableUpdates, ui->actionDisableUpdates);
 }
 
 void ResourcePackPage::updateFrame(const QModelIndex& current, [[maybe_unused]] const QModelIndex& previous)

--- a/launcher/ui/pages/instance/ResourcePackPage.cpp
+++ b/launcher/ui/pages/instance/ResourcePackPage.cpp
@@ -72,6 +72,10 @@ ResourcePackPage::ResourcePackPage(MinecraftInstance* instance, std::shared_ptr<
 
     ui->actionsToolbar->insertActionAfter(ui->actionUpdateItem, ui->actionEnableUpdates);
     ui->actionsToolbar->insertActionAfter(ui->actionEnableUpdates, ui->actionDisableUpdates);
+
+    ui->actionsToolbar->insertActionAfter(ui->actionDisableUpdates, ui->actionAddCategory);
+    ui->actionsToolbar->insertActionAfter(ui->actionAddCategory, ui->actionRemoveCategory);
+    ui->actionsToolbar->insertActionAfter(ui->actionRemoveCategory, ui->actionRemoveAllCategory);
 }
 
 void ResourcePackPage::updateFrame(const QModelIndex& current, [[maybe_unused]] const QModelIndex& previous)

--- a/launcher/ui/pages/instance/ShaderPackPage.cpp
+++ b/launcher/ui/pages/instance/ShaderPackPage.cpp
@@ -74,6 +74,9 @@ ShaderPackPage::ShaderPackPage(MinecraftInstance* instance, std::shared_ptr<Shad
     ui->actionChangeVersion->setToolTip(tr("Change a shader pack's version."));
     connect(ui->actionChangeVersion, &QAction::triggered, this, &ShaderPackPage::changeShaderPackVersion);
     ui->actionsToolbar->insertActionAfter(ui->actionUpdateItem, ui->actionChangeVersion);
+
+    ui->actionsToolbar->insertActionAfter(ui->actionUpdateItem, ui->actionEnableUpdates);
+    ui->actionsToolbar->insertActionAfter(ui->actionEnableUpdates, ui->actionDisableUpdates);
 }
 
 void ShaderPackPage::downloadShaderPack()

--- a/launcher/ui/pages/instance/ShaderPackPage.cpp
+++ b/launcher/ui/pages/instance/ShaderPackPage.cpp
@@ -77,6 +77,10 @@ ShaderPackPage::ShaderPackPage(MinecraftInstance* instance, std::shared_ptr<Shad
 
     ui->actionsToolbar->insertActionAfter(ui->actionUpdateItem, ui->actionEnableUpdates);
     ui->actionsToolbar->insertActionAfter(ui->actionEnableUpdates, ui->actionDisableUpdates);
+
+    ui->actionsToolbar->insertActionAfter(ui->actionDisableUpdates, ui->actionAddCategory);
+    ui->actionsToolbar->insertActionAfter(ui->actionAddCategory, ui->actionRemoveCategory);
+    ui->actionsToolbar->insertActionAfter(ui->actionRemoveCategory, ui->actionRemoveAllCategory);
 }
 
 void ShaderPackPage::downloadShaderPack()

--- a/launcher/ui/pages/instance/TexturePackPage.cpp
+++ b/launcher/ui/pages/instance/TexturePackPage.cpp
@@ -75,6 +75,9 @@ TexturePackPage::TexturePackPage(MinecraftInstance* instance, std::shared_ptr<Te
     ui->actionsToolbar->insertActionAfter(ui->actionUpdateItem, ui->actionChangeVersion);
 
     ui->actionViewHomepage->setToolTip(tr("View the homepages of all selected texture packs."));
+
+    ui->actionsToolbar->insertActionAfter(ui->actionUpdateItem, ui->actionEnableUpdates);
+    ui->actionsToolbar->insertActionAfter(ui->actionEnableUpdates, ui->actionDisableUpdates);
 }
 
 void TexturePackPage::updateFrame(const QModelIndex& current, [[maybe_unused]] const QModelIndex& previous)

--- a/launcher/ui/pages/instance/TexturePackPage.cpp
+++ b/launcher/ui/pages/instance/TexturePackPage.cpp
@@ -78,6 +78,10 @@ TexturePackPage::TexturePackPage(MinecraftInstance* instance, std::shared_ptr<Te
 
     ui->actionsToolbar->insertActionAfter(ui->actionUpdateItem, ui->actionEnableUpdates);
     ui->actionsToolbar->insertActionAfter(ui->actionEnableUpdates, ui->actionDisableUpdates);
+
+    ui->actionsToolbar->insertActionAfter(ui->actionDisableUpdates, ui->actionAddCategory);
+    ui->actionsToolbar->insertActionAfter(ui->actionAddCategory, ui->actionRemoveCategory);
+    ui->actionsToolbar->insertActionAfter(ui->actionRemoveCategory, ui->actionRemoveAllCategory);
 }
 
 void TexturePackPage::updateFrame(const QModelIndex& current, [[maybe_unused]] const QModelIndex& previous)


### PR DESCRIPTION
poor man categories fixes #154 fixes #880 fixes #1055
blocked by #3248
same reasoning as there only resources with metadata support categories
allows filtering the categories using `#` prefix e.g. `#categoryName` right now it only supports only one category 
