### PR TITLE
propagate load component error

### DIFF
--- a/launcher/minecraft/MinecraftLoadAndCheck.cpp
+++ b/launcher/minecraft/MinecraftLoadAndCheck.cpp
@@ -8,7 +8,10 @@ void MinecraftLoadAndCheck::executeTask()
 {
     // add offline metadata load task
     auto components = m_inst->getPackProfile();
-    components->reload(m_netmode);
+    if (auto result = components->reload(m_netmode); !result) {
+        emitFailed(result.error);
+        return;
+    }
     m_task = components->getCurrentTask();
 
     if (!m_task) {

--- a/launcher/minecraft/PackProfile.h
+++ b/launcher/minecraft/PackProfile.h
@@ -62,6 +62,19 @@ class PackProfile : public QAbstractListModel {
    public:
     enum Columns { NameColumn = 0, VersionColumn, NUM_COLUMNS };
 
+    struct Result {
+        bool success;
+        QString error;
+
+        // Implicit conversion to bool
+        operator bool() const { return success; }
+
+        // Factory methods for convenience
+        static Result Success() { return { true, "" }; }
+
+        static Result Error(const QString& errorMessage) { return { false, errorMessage }; }
+    };
+
     explicit PackProfile(MinecraftInstance* instance);
     virtual ~PackProfile();
 
@@ -102,7 +115,7 @@ class PackProfile : public QAbstractListModel {
     bool revertToBase(int index);
 
     /// reload the list, reload all components, resolve dependencies
-    void reload(Net::Mode netmode);
+    Result reload(Net::Mode netmode);
 
     // reload all components, resolve dependencies
     void resolve(Net::Mode netmode);
@@ -169,7 +182,7 @@ class PackProfile : public QAbstractListModel {
     void disableInteraction(bool disable);
 
    private:
-    bool load();
+    Result load();
     bool installJarMods_internal(QStringList filepaths);
     bool installCustomJar_internal(QString filepath);
     bool installAgents_internal(QStringList filepaths);

--- a/launcher/ui/pages/instance/VersionPage.cpp
+++ b/launcher/ui/pages/instance/VersionPage.cpp
@@ -252,8 +252,11 @@ void VersionPage::updateButtons(int row)
 bool VersionPage::reloadPackProfile()
 {
     try {
-        m_profile->reload(Net::Mode::Online);
-        return true;
+        auto result = m_profile->reload(Net::Mode::Online);
+        if (!result) {
+            QMessageBox::critical(this, tr("Error"), result.error);
+        }
+        return result;
     } catch (const Exception& e) {
         QMessageBox::critical(this, tr("Error"), e.cause());
         return false;


### PR DESCRIPTION
based on:  https://github.com/MultiMC/Launcher/commit/c7ba800bd43f2b9845aefd42d6f68b470f1b8726#diff-ac1e84fcb09e6dce353d7f546babf84fdb709af36c461d3019af60d31256ff6fR324
it should make the "Null.jar" error message more verbose (see https://github.com/PrismLauncher/PrismLauncher/issues/926)