### PR TITLE
[Backport release-9.x] Fix $INST_JAVA not being set for auto download java

### DIFF
--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -1083,6 +1083,12 @@ shared_qobject_ptr<LaunchTask> MinecraftInstance::createLaunchTask(AuthSessionPt
         process->appendStep(step);
     }
 
+    // check java
+    {
+        process->appendStep(makeShared<AutoInstallJava>(pptr));
+        process->appendStep(makeShared<CheckJava>(pptr));
+    }
+
     // run pre-launch command if that's needed
     if (getPreLaunchCommand().size()) {
         auto step = makeShared<PreLaunchCommand>(pptr);
@@ -1094,12 +1100,6 @@ shared_qobject_ptr<LaunchTask> MinecraftInstance::createLaunchTask(AuthSessionPt
     {
         auto mode = session->status != AuthSession::PlayableOffline ? Net::Mode::Online : Net::Mode::Offline;
         process->appendStep(makeShared<TaskStepWrapper>(pptr, makeShared<MinecraftLoadAndCheck>(this, mode)));
-    }
-
-    // check java
-    {
-        process->appendStep(makeShared<AutoInstallJava>(pptr));
-        process->appendStep(makeShared<CheckJava>(pptr));
     }
 
     // if we aren't in offline mode,.

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -1083,6 +1083,12 @@ shared_qobject_ptr<LaunchTask> MinecraftInstance::createLaunchTask(AuthSessionPt
         process->appendStep(step);
     }
 
+    // load meta
+    {
+        auto mode = session->status != AuthSession::PlayableOffline ? Net::Mode::Online : Net::Mode::Offline;
+        process->appendStep(makeShared<TaskStepWrapper>(pptr, makeShared<MinecraftLoadAndCheck>(this, mode)));
+    }
+
     // check java
     {
         process->appendStep(makeShared<AutoInstallJava>(pptr));
@@ -1094,12 +1100,6 @@ shared_qobject_ptr<LaunchTask> MinecraftInstance::createLaunchTask(AuthSessionPt
         auto step = makeShared<PreLaunchCommand>(pptr);
         step->setWorkingDirectory(gameRoot());
         process->appendStep(step);
-    }
-
-    // load meta
-    {
-        auto mode = session->status != AuthSession::PlayableOffline ? Net::Mode::Online : Net::Mode::Offline;
-        process->appendStep(makeShared<TaskStepWrapper>(pptr, makeShared<MinecraftLoadAndCheck>(this, mode)));
     }
 
     // if we aren't in offline mode,.


### PR DESCRIPTION
Manual backport of https://github.com/PrismLauncher/PrismLauncher/pull/3179
