### PR TITLE
Build Linux binaries for ARM64

### DIFF
--- a/.github/actions/package/linux/action.yml
+++ b/.github/actions/package/linux/action.yml
@@ -31,6 +31,28 @@ runs:
   using: composite
 
   steps:
+    - name: Setup build variables
+      shell: bash
+      run: |
+        # Fixup architecture naming for AppImages
+        dpkg_arch="$(dpkg-architecture -q DEB_HOST_ARCH_CPU)"
+        case "$dpkg_arch" in
+          "amd64")
+            APPIMAGE_ARCH="x86_64"
+            ;;
+          "arm64")
+            APPIMAGE_ARCH="aarch64"
+            ;;
+          *)
+            echo "# 🚨 The Debian architecture \"$deb_arch\" is not recognized!" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+            ;;
+        esac
+        echo "APPIMAGE_ARCH=$APPIMAGE_ARCH" >> "$GITHUB_ENV"
+
+        # Used for the file paths of libraries
+        echo "DEB_HOST_MULTIARCH=$(dpkg-architecture -q DEB_HOST_MULTIARCH)" >> "$GITHUB_ENV"
+
     - name: Package AppImage
       shell: bash
       env:
@@ -45,7 +67,7 @@ runs:
         mv ${{ env.INSTALL_APPIMAGE_DIR }}/usr/share/metainfo/org.prismlauncher.PrismLauncher.metainfo.xml ${{ env.INSTALL_APPIMAGE_DIR }}/usr/share/metainfo/org.prismlauncher.PrismLauncher.appdata.xml
         export "NO_APPSTREAM=1" # we have to skip appstream checking because appstream on ubuntu 20.04 is outdated
 
-        export OUTPUT="PrismLauncher-Linux-x86_64.AppImage"
+        export OUTPUT="PrismLauncher-Linux-$APPIMAGE_ARCH.AppImage"
 
         chmod +x linuxdeploy-*.AppImage
 
@@ -54,17 +76,17 @@ runs:
 
         cp -r ${{ runner.workspace }}/Qt/${{ inputs.qt-version }}/gcc_64/plugins/iconengines/* ${{ env.INSTALL_APPIMAGE_DIR }}/usr/plugins/iconengines
 
-        cp /usr/lib/x86_64-linux-gnu/libcrypto.so.* ${{ env.INSTALL_APPIMAGE_DIR }}/usr/lib/
-        cp /usr/lib/x86_64-linux-gnu/libssl.so.* ${{ env.INSTALL_APPIMAGE_DIR }}/usr/lib/
-        cp /usr/lib/x86_64-linux-gnu/libOpenGL.so.0* ${{ env.INSTALL_APPIMAGE_DIR }}/usr/lib/
+        cp /usr/lib/"$DEB_HOST_MULTIARCH"/libcrypto.so.* ${{ env.INSTALL_APPIMAGE_DIR }}/usr/lib/
+        cp /usr/lib/"$DEB_HOST_MULTIARCH"/libssl.so.* ${{ env.INSTALL_APPIMAGE_DIR }}/usr/lib/
+        cp /usr/lib/"$DEB_HOST_MULTIARCH"/libOpenGL.so.0* ${{ env.INSTALL_APPIMAGE_DIR }}/usr/lib/
 
         LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${{ env.INSTALL_APPIMAGE_DIR }}/usr/lib"
         export LD_LIBRARY_PATH
 
-        chmod +x AppImageUpdate-x86_64.AppImage
-        cp AppImageUpdate-x86_64.AppImage ${{ env.INSTALL_APPIMAGE_DIR }}/usr/bin
+        chmod +x AppImageUpdate-"$APPIMAGE_ARCH".AppImage
+        cp AppImageUpdate-"$APPIMAGE_ARCH".AppImage ${{ env.INSTALL_APPIMAGE_DIR }}/usr/bin
 
-        export UPDATE_INFORMATION="gh-releases-zsync|${{ github.repository_owner }}|${{ github.event.repository.name }}|latest|PrismLauncher-Linux-x86_64.AppImage.zsync" 
+        export UPDATE_INFORMATION="gh-releases-zsync|${{ github.repository_owner }}|${{ github.event.repository.name }}|latest|PrismLauncher-Linux-$APPIMAGE_ARCH.AppImage.zsync"
 
         if [ '${{ inputs.gpg-private-key-id }}' != '' ]; then
           export SIGN=1
@@ -76,9 +98,9 @@ runs:
           echo ":warning: Skipped code signing for Linux AppImage, as gpg key was not present." >> $GITHUB_STEP_SUMMARY
         fi
 
-        ./linuxdeploy-x86_64.AppImage --appdir ${{ env.INSTALL_APPIMAGE_DIR }} --output appimage --plugin qt -i ${{ env.INSTALL_APPIMAGE_DIR }}/usr/share/icons/hicolor/scalable/apps/org.prismlauncher.PrismLauncher.svg
+        ./linuxdeploy-"$APPIMAGE_ARCH".AppImage --appdir ${{ env.INSTALL_APPIMAGE_DIR }} --output appimage --plugin qt -i ${{ env.INSTALL_APPIMAGE_DIR }}/usr/share/icons/hicolor/scalable/apps/org.prismlauncher.PrismLauncher.svg
 
-        mv "PrismLauncher-Linux-x86_64.AppImage" "PrismLauncher-Linux-${{ env.VERSION }}-${{ inputs.build-type }}-x86_64.AppImage"
+        mv "PrismLauncher-Linux-$APPIMAGE_ARCH.AppImage" "PrismLauncher-Linux-${{ env.VERSION }}-${{ inputs.build-type }}-$APPIMAGE_ARCH.AppImage"
 
     - name: Package portable tarball
       shell: bash
@@ -94,11 +116,11 @@ runs:
         cmake --install ${{ env.BUILD_DIR }} --component portable
 
         mkdir  ${{ env.INSTALL_PORTABLE_DIR }}/lib
-        cp /lib/x86_64-linux-gnu/libbz2.so.1.0 ${{ env.INSTALL_PORTABLE_DIR }}/lib
-        cp /usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0 ${{ env.INSTALL_PORTABLE_DIR }}/lib
-        cp /usr/lib/x86_64-linux-gnu/libcrypto.so.* ${{ env.INSTALL_PORTABLE_DIR }}/lib
-        cp /usr/lib/x86_64-linux-gnu/libssl.so.* ${{ env.INSTALL_PORTABLE_DIR }}/lib
-        cp /usr/lib/x86_64-linux-gnu/libffi.so.*.* ${{ env.INSTALL_PORTABLE_DIR }}/lib
+        cp /lib/"$DEB_HOST_MULTIARCH"/libbz2.so.1.0 ${{ env.INSTALL_PORTABLE_DIR }}/lib
+        cp /usr/lib/"$DEB_HOST_MULTIARCH"/libgobject-2.0.so.0 ${{ env.INSTALL_PORTABLE_DIR }}/lib
+        cp /usr/lib/"$DEB_HOST_MULTIARCH"/libcrypto.so.* ${{ env.INSTALL_PORTABLE_DIR }}/lib
+        cp /usr/lib/"$DEB_HOST_MULTIARCH"/libssl.so.* ${{ env.INSTALL_PORTABLE_DIR }}/lib
+        cp /usr/lib/"$DEB_HOST_MULTIARCH"/libffi.so.*.* ${{ env.INSTALL_PORTABLE_DIR }}/lib
         mv ${{ env.INSTALL_PORTABLE_DIR }}/bin/*.so* ${{ env.INSTALL_PORTABLE_DIR }}/lib
 
         for l in $(find ${{ env.INSTALL_PORTABLE_DIR }} -type f); do l=${l#$(pwd)/}; l=${l#${{ env.INSTALL_PORTABLE_DIR }}/}; l=${l#./}; echo $l; done > ${{ env.INSTALL_PORTABLE_DIR }}/manifest.txt
@@ -114,11 +136,11 @@ runs:
     - name: Upload AppImage
       uses: actions/upload-artifact@v4
       with:
-        name: PrismLauncher-${{ inputs.artifact-name }}-${{ inputs.version }}-${{ inputs.build-type }}-x86_64.AppImage
-        path: PrismLauncher-${{ runner.os }}-${{ inputs.version }}-${{ inputs.build-type }}-x86_64.AppImage
+        name: PrismLauncher-${{ runner.os }}-${{ inputs.version }}-${{ inputs.build-type }}-${{ env.APPIMAGE_ARCH }}.AppImage
+        path: PrismLauncher-${{ runner.os }}-${{ inputs.version }}-${{ inputs.build-type }}-${{ env.APPIMAGE_ARCH }}.AppImage
 
     - name: Upload AppImage Zsync
       uses: actions/upload-artifact@v4
       with:
-        name: PrismLauncher-${{ inputs.artifact-name }}-${{ inputs.version }}-${{ inputs.build-type }}-x86_64.AppImage.zsync
-        path: PrismLauncher-Linux-x86_64.AppImage.zsync
+        name: PrismLauncher-${{ runner.os }}-${{ inputs.version }}-${{ inputs.build-type }}-${{ env.APPIMAGE_ARCH }}.AppImage.zsync
+        path: PrismLauncher-${{ runner.os }}-${{ env.APPIMAGE_ARCH }}.AppImage.zsync

--- a/.github/actions/package/linux/action.yml
+++ b/.github/actions/package/linux/action.yml
@@ -74,7 +74,7 @@ runs:
         mkdir -p ${{ env.INSTALL_APPIMAGE_DIR }}/usr/lib
         mkdir -p ${{ env.INSTALL_APPIMAGE_DIR }}/usr/plugins/iconengines
 
-        cp -r ${{ runner.workspace }}/Qt/${{ inputs.qt-version }}/gcc_64/plugins/iconengines/* ${{ env.INSTALL_APPIMAGE_DIR }}/usr/plugins/iconengines
+        cp -r ${{ runner.workspace }}/Qt/${{ inputs.qt-version }}/gcc_*64/plugins/iconengines/* ${{ env.INSTALL_APPIMAGE_DIR }}/usr/plugins/iconengines
 
         cp /usr/lib/"$DEB_HOST_MULTIARCH"/libcrypto.so.* ${{ env.INSTALL_APPIMAGE_DIR }}/usr/lib/
         cp /usr/lib/"$DEB_HOST_MULTIARCH"/libssl.so.* ${{ env.INSTALL_APPIMAGE_DIR }}/usr/lib/

--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -6,6 +6,9 @@ inputs:
     description: Type for the build
     required: true
     default: Debug
+  artifact-name:
+    description: Name of the uploaded artifact
+    required: true
   msystem:
     description: MSYS2 subsystem to use
     required: false
@@ -53,16 +56,16 @@ runs:
       if: ${{ (runner.os != 'Windows' || inputs.msystem == '') && inputs.build-type == 'Debug' }}
       uses: hendrikmuhs/ccache-action@v1.2.18
       with:
-        variant: ${{ runner.os == 'Windows' && 'sccache' || 'ccache' }}
+        variant: sccache
         create-symlink: ${{ runner.os != 'Windows' }}
-        key: ${{ runner.os }}-qt${{ inputs.qt_ver }}-${{ inputs.architecture }}
+        key: ${{ runner.os }}-${{ runner.arch }}-${{ inputs.artifact-name }}-sccache
 
     - name: Use ccache on debug builds
       if: ${{ inputs.build-type == 'Debug' }}
       shell: bash
       env:
-        # Only use sccache on MSVC
-        CCACHE_VARIANT: ${{ (runner.os == 'Windows' && inputs.msystem == '') && 'sccache' || 'ccache' }}
+        # Only use ccache on MSYS2
+        CCACHE_VARIANT: ${{ (runner.os == 'Windows' && inputs.msystem != '') && 'ccache' || 'sccache' }}
       run: |
         echo "CMAKE_C_COMPILER_LAUNCHER=$CCACHE_VARIANT" >> "$GITHUB_ENV"
         echo "CMAKE_CXX_COMPILER_LAUNCHER=$CCACHE_VARIANT" >> "$GITHUB_ENV"

--- a/.github/actions/setup-dependencies/linux/action.yml
+++ b/.github/actions/setup-dependencies/linux/action.yml
@@ -8,7 +8,10 @@ runs:
       shell: bash
       run: |
         sudo apt-get -y update
-        sudo apt-get -y install ninja-build extra-cmake-modules scdoc appstream libxcb-cursor-dev
+        sudo apt-get -y install \
+          dpkg-dev \
+          ninja-build extra-cmake-modules scdoc \
+          appstream libxcb-cursor-dev
 
     - name: Setup AppImage tooling
       shell: bash

--- a/.github/actions/setup-dependencies/linux/action.yml
+++ b/.github/actions/setup-dependencies/linux/action.yml
@@ -17,9 +17,24 @@ runs:
       shell: bash
       run: |
         declare -A appimage_deps
-        appimage_deps["https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20250213-2/linuxdeploy-x86_64.AppImage"]="4648f278ab3ef31f819e67c30d50f462640e5365a77637d7e6f2ad9fd0b4522a linuxdeploy-x86_64.AppImage"
-        appimage_deps["https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/1-alpha-20250213-1/linuxdeploy-plugin-qt-x86_64.AppImage"]="15106be885c1c48a021198e7e1e9a48ce9d02a86dd0a1848f00bdbf3c1c92724  linuxdeploy-plugin-qt-x86_64.AppImage"
-        appimage_deps["https://github.com/AppImageCommunity/AppImageUpdate/releases/download/2.0.0-alpha-1-20241225/AppImageUpdate-x86_64.AppImage"]="f1747cf60058e99f1bb9099ee9787d16c10241313b7acec81810ea1b1e568c11  AppImageUpdate-x86_64.AppImage"
+
+        deb_arch="$(dpkg-architecture -q DEB_HOST_ARCH)"
+        case "$deb_arch" in
+          "amd64")
+            appimage_deps["https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20250213-2/linuxdeploy-x86_64.AppImage"]="4648f278ab3ef31f819e67c30d50f462640e5365a77637d7e6f2ad9fd0b4522a linuxdeploy-x86_64.AppImage"
+            appimage_deps["https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/1-alpha-20250213-1/linuxdeploy-plugin-qt-x86_64.AppImage"]="15106be885c1c48a021198e7e1e9a48ce9d02a86dd0a1848f00bdbf3c1c92724  linuxdeploy-plugin-qt-x86_64.AppImage"
+            appimage_deps["https://github.com/AppImageCommunity/AppImageUpdate/releases/download/2.0.0-alpha-1-20241225/AppImageUpdate-x86_64.AppImage"]="f1747cf60058e99f1bb9099ee9787d16c10241313b7acec81810ea1b1e568c11  AppImageUpdate-x86_64.AppImage"
+            ;;
+          "arm64")
+            appimage_deps["https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20250213-2/linuxdeploy-aarch64.AppImage"]="06706ac8189797dccd36bd384105892cb5e6e71f784f4df526cc958adc223cd6  linuxdeploy-aarch64.AppImage"
+            appimage_deps["https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/1-alpha-20250213-1/linuxdeploy-plugin-qt-aarch64.AppImage"]="bf1c24aff6d749b5cf423afad6f15abd4440f81dec1aab95706b25f6667cdcf1  linuxdeploy-plugin-qt-aarch64.AppImage"
+            appimage_deps["https://github.com/AppImageCommunity/AppImageUpdate/releases/download/2.0.0-alpha-1-20241225/AppImageUpdate-aarch64.AppImage"]="cf27f810dfe5eda41f130769e4a4b562b9d93665371c15ebeffb84ee06a41550  AppImageUpdate-aarch64.AppImage"
+            ;;
+          *)
+            echo "# 🚨 The Debian architecture \"$deb_arch\" is not recognized!" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+            ;;
+        esac
 
         for url in "${!appimage_deps[@]}"; do
           curl -LO "$url"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,6 +73,14 @@ jobs:
             artifact-name: Linux
             base-cmake-preset: linux
 
+            # NOTE(@getchoo): Yes, we're intentionally using 24.04 here!!!
+            #
+            # It's not really documented anywhere AFAICT, but upstream Qt binaries
+            # *for the same version* are compiled against 24.04 on ARM, and *not* 22.04 like x64
+          - os: ubuntu-24.04-arm
+            artifact-name: Linux-aarch64
+            base-cmake-preset: linux
+
           - os: windows-2022
             artifact-name: Windows-MinGW-w64
             base-cmake-preset: windows_mingw

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,6 +126,7 @@ jobs:
         uses: ./.github/actions/setup-dependencies
         with:
           build-type: ${{ inputs.build-type || 'Debug' }}
+          artifact-name: ${{ matrix.artifact-name }}
           msystem: ${{ matrix.msystem }}
           vcvars-arch: ${{ matrix.vcvars-arch }}
           qt-architecture: ${{ matrix.qt-architecture }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,7 +146,9 @@ jobs:
       - name: Run CMake workflow
         env:
           CMAKE_PRESET: ${{ steps.cmake-preset.outputs.preset }}
+
           ARTIFACT_NAME: ${{ matrix.artifact-name }}-Qt6
+          BUILD_PLATFORM: official
         run: |
           cmake --workflow --preset "$CMAKE_PRESET"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,6 +146,7 @@ jobs:
       - name: Run CMake workflow
         env:
           CMAKE_PRESET: ${{ steps.cmake-preset.outputs.preset }}
+          ARTIFACT_NAME: ${{ matrix.artifact-name }}-Qt6
         run: |
           cmake --workflow --preset "$CMAKE_PRESET"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,6 +164,7 @@ jobs:
         with:
           version: ${{ steps.short-version.outputs.version }}
           build-type: ${{ steps.setup-dependencies.outputs.build-type }}
+          artifact-name: ${{ matrix.artifact-name }}
           cmake-preset: ${{ steps.cmake-preset.outputs.preset }}
           qt-version: ${{ steps.setup-dependencies.outputs.qt-version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,8 +34,10 @@ jobs:
         run: |
           mv ${{ github.workspace }}/PrismLauncher-source PrismLauncher-${{ env.VERSION }}
           mv PrismLauncher-Linux-Qt6-Portable*/PrismLauncher-portable.tar.gz PrismLauncher-Linux-Qt6-Portable-${{ env.VERSION }}.tar.gz
-          mv PrismLauncher-*.AppImage/PrismLauncher-*.AppImage PrismLauncher-Linux-x86_64.AppImage
-          mv PrismLauncher-*.AppImage.zsync/PrismLauncher-*.AppImage.zsync PrismLauncher-Linux-x86_64.AppImage.zsync
+          mv PrismLauncher-*.AppImage/PrismLauncher-*-x86_64.AppImage PrismLauncher-Linux-x86_64.AppImage
+          mv PrismLauncher-*.AppImage.zsync/PrismLauncher-*-x86_64.AppImage.zsync PrismLauncher-Linux-x86_64.AppImage.zsync
+          mv PrismLauncher-*.AppImage/PrismLauncher-*-aarch64.AppImage PrismLauncher-Linux-aarch64.AppImage
+          mv PrismLauncher-*.AppImage.zsync/PrismLauncher-*-aarch64.AppImage.zsync PrismLauncher-Linux-aarch64.AppImage.zsync
           mv PrismLauncher-macOS*/PrismLauncher.zip PrismLauncher-macOS-${{ env.VERSION }}.zip
 
           tar --exclude='.git' -czf PrismLauncher-${{ env.VERSION }}.tar.gz PrismLauncher-${{ env.VERSION }}
@@ -89,7 +91,10 @@ jobs:
           files: |
             PrismLauncher-Linux-x86_64.AppImage
             PrismLauncher-Linux-x86_64.AppImage.zsync
+            PrismLauncher-Linux-aarch64.AppImage
+            PrismLauncher-Linux-aarch64.AppImage.zsync
             PrismLauncher-Linux-Qt6-Portable-${{ env.VERSION }}.tar.gz
+            PrismLauncher-Linux-aarch64-Qt6-Portable-${{ env.VERSION }}.tar.gz
             PrismLauncher-Windows-MinGW-w64-${{ env.VERSION }}.zip
             PrismLauncher-Windows-MinGW-w64-Portable-${{ env.VERSION }}.zip
             PrismLauncher-Windows-MinGW-w64-Setup-${{ env.VERSION }}.exe

--- a/cmake/commonPresets.json
+++ b/cmake/commonPresets.json
@@ -8,6 +8,7 @@
 			"binaryDir": "build",
 			"installDir": "install",
 			"cacheVariables": {
+				"Launcher_BUILD_ARTIFACT": "$penv{ARTIFACT_NAME}",
 				"Launcher_BUILD_PLATFORM": "custom"
 			}
 		},

--- a/cmake/commonPresets.json
+++ b/cmake/commonPresets.json
@@ -9,7 +9,7 @@
 			"installDir": "install",
 			"cacheVariables": {
 				"Launcher_BUILD_ARTIFACT": "$penv{ARTIFACT_NAME}",
-				"Launcher_BUILD_PLATFORM": "custom"
+				"Launcher_BUILD_PLATFORM": "$penv{BUILD_PLATFORM}"
 			}
 		},
 		{
@@ -40,7 +40,6 @@
 				"base_release"
 			],
 			"cacheVariables": {
-				"Launcher_BUILD_PLATFORM": "official",
 				"Launcher_FORCE_BUNDLED_LIBS": "ON"
 			}
 		}

--- a/cmake/linuxPreset.json
+++ b/cmake/linuxPreset.json
@@ -15,7 +15,6 @@
 			},
 			"generator": "Ninja",
 			"cacheVariables": {
-				"Launcher_BUILD_ARTIFACT": "Linux-Qt6",
 				"Launcher_ENABLE_JAVA_DOWNLOADER": "ON"
 			}
 		},
@@ -42,9 +41,6 @@
 				"linux_base"
 			],
 			"displayName": "Linux (CI)",
-			"cacheVariables": {
-				"Launcher_BUILD_ARTIFACT": "Linux-Qt6"
-			},
 			"installDir": "/usr"
 		}
 	],

--- a/cmake/macosPreset.json
+++ b/cmake/macosPreset.json
@@ -22,8 +22,7 @@
 				"macos_base"
 			],
 			"cacheVariables": {
-				"CMAKE_OSX_ARCHITECTURES": "x86_64;arm64",
-				"Launcher_BUILD_ARTIFACT": "macOS-Qt6"
+				"CMAKE_OSX_ARCHITECTURES": "x86_64;arm64"
 			}
 		},
 		{
@@ -64,10 +63,7 @@
 				"base_ci",
 				"macos_universal_base"
 			],
-			"displayName": "macOS (CI)",
-			"cacheVariables": {
-				"Launcher_BUILD_ARTIFACT": "macOS-Qt6"
-			}
+			"displayName": "macOS (CI)"
 		}
 	],
 	"buildPresets": [

--- a/cmake/windowsMSVCPreset.json
+++ b/cmake/windowsMSVCPreset.json
@@ -12,9 +12,6 @@
 				"type": "equals",
 				"lhs": "${hostSystemName}",
 				"rhs": "Windows"
-			},
-			"cacheVariables": {
-				"Launcher_BUILD_ARTIFACT": "Windows-MSVC-Qt6"
 			}
 		},
 		{
@@ -23,10 +20,7 @@
 			"inherits": [
 				"windows_msvc_base"
 			],
-			"architecture": "arm64",
-			"cacheVariables": {
-				"Launcher_BUILD_ARTIFACT": "Windows-MSVC-arm64-Qt6"
-			}
+			"architecture": "arm64"
 		},
 		{
 			"name": "windows_msvc_debug",
@@ -67,10 +61,7 @@
 				"base_ci",
 				"windows_msvc_base"
 			],
-			"displayName": "Windows MSVC (CI)",
-			"cacheVariables": {
-				"Launcher_BUILD_ARTIFACT": "Windows-MSVC-Qt6"
-			}
+			"displayName": "Windows MSVC (CI)"
 		},
 		{
 			"name": "windows_msvc_arm64_cross_ci",
@@ -78,10 +69,7 @@
 				"base_ci",
 				"windows_msvc_arm64_cross_base"
 			],
-			"displayName": "Windows MSVC (ARM64 cross, CI)",
-			"cacheVariables": {
-				"Launcher_BUILD_ARTIFACT": "Windows-MSVC-arm64-Qt6"
-			}
+			"displayName": "Windows MSVC (ARM64 cross, CI)"
 		}
 	],
 	"buildPresets": [

--- a/cmake/windowsMinGWPreset.json
+++ b/cmake/windowsMinGWPreset.json
@@ -13,10 +13,7 @@
 				"lhs": "${hostSystemName}",
 				"rhs": "Windows"
 			},
-			"generator": "Ninja",
-			"cacheVariables": {
-				"Launcher_BUILD_ARTIFACT": "Windows-MinGW-w64-Qt6"
-			}
+			"generator": "Ninja"
 		},
 		{
 			"name": "windows_mingw_debug",
@@ -40,10 +37,7 @@
 				"base_ci",
 				"windows_mingw_base"
 			],
-			"displayName": "Windows MinGW (CI)",
-			"cacheVariables": {
-				"Launcher_BUILD_ARTIFACT": "Windows-MinGW-w64-Qt6"
-			}
+			"displayName": "Windows MinGW (CI)"
 		}
 	],
 	"buildPresets": [


### PR DESCRIPTION
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

Hopefully this can be released with 9.3, but we should let it sit for a bit and get tested before that

Some caveats:

- ~~AppImage builds are currently blocked by upstream ARM support in the [linuxdeploy AppImage plugin](https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/issues/32). It'd be good to build against ARM in the meantime though :)~~

- Qt >= 6.7 is required (Binary arm64 builds are not available for prior versions)

- Ubuntu 24.04 is the minimum required target (this is due to the Qt binaries depending on glibc >= 2.37)

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
