### PR TITLE
Build Nix packages for aarch64-linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -665,6 +665,9 @@ jobs:
           - os: ubuntu-22.04
             system: x86_64-linux
 
+          - os: ubuntu-22.04-arm
+            system: aarch64-linux
+
           - os: macos-13
             system: x86_64-darwin
 


### PR DESCRIPTION
This is already done in Nixpkgs, now we can do it here
