### PR TITLE
[Backport release-9.x] chore: update to qt 6.8.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
             qt_ver: 6
             qt_host: windows
             qt_arch: ""
-            qt_version: "6.7.3"
+            qt_version: "6.8.0"
             qt_modules: "qt5compat qtimageformats qtnetworkauth"
             nscurl_tag: "v24.9.26.122"
             nscurl_sha256: "AEE6C4BE3CB6455858E9C1EE4B3AFE0DB9960FA03FE99CCDEDC28390D57CCBB0"
@@ -95,7 +95,7 @@ jobs:
             qt_ver: 6
             qt_host: windows
             qt_arch: "win64_msvc2019_arm64"
-            qt_version: "6.7.3"
+            qt_version: "6.8.0"
             qt_modules: "qt5compat qtimageformats qtnetworkauth"
             nscurl_tag: "v24.9.26.122"
             nscurl_sha256: "AEE6C4BE3CB6455858E9C1EE4B3AFE0DB9960FA03FE99CCDEDC28390D57CCBB0"
@@ -106,7 +106,7 @@ jobs:
             qt_ver: 6
             qt_host: mac
             qt_arch: ""
-            qt_version: "6.7.3"
+            qt_version: "6.8.0"
             qt_modules: "qt5compat qtimageformats qtnetworkauth"
 
           - os: macos-14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,7 +216,7 @@ jobs:
 
       - name: Install host Qt (Windows MSVC arm64)
         if: runner.os == 'Windows' && matrix.architecture == 'arm64'
-        uses: jurplel/install-qt-action@v3
+        uses: jurplel/install-qt-action@v4
         with:
           aqtversion: "==3.1.*"
           py7zrversion: ">=0.20.2"
@@ -232,7 +232,7 @@ jobs:
 
       - name: Install Qt (macOS, Linux & Windows MSVC)
         if: matrix.msystem == ''
-        uses: jurplel/install-qt-action@v3
+        uses: jurplel/install-qt-action@v4
         with:
           aqtversion: "==3.1.*"
           py7zrversion: ">=0.20.2"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,8 +80,8 @@ jobs:
             architecture: "x64"
             vcvars_arch: "amd64"
             qt_ver: 6
-            qt_host: windows
-            qt_arch: ""
+            qt_host: "windows"
+            qt_arch: "win64_msvc2022_64"
             qt_version: "6.8.0"
             qt_modules: "qt5compat qtimageformats qtnetworkauth"
             nscurl_tag: "v24.9.26.122"
@@ -93,8 +93,8 @@ jobs:
             architecture: "arm64"
             vcvars_arch: "amd64_arm64"
             qt_ver: 6
-            qt_host: windows
-            qt_arch: "win64_msvc2019_arm64"
+            qt_host: "windows"
+            qt_arch: "win64_msvc2022_arm64_cross_compiled"
             qt_version: "6.8.0"
             qt_modules: "qt5compat qtimageformats qtnetworkauth"
             nscurl_tag: "v24.9.26.122"
@@ -223,7 +223,7 @@ jobs:
           version: ${{ matrix.qt_version }}
           host: "windows"
           target: "desktop"
-          arch: ""
+          arch: ${{ matrix.qt_arch }}
           modules: ${{ matrix.qt_modules }}
           cache: ${{ inputs.is_qt_cached }}
           cache-key-prefix: host-qt-arm64-windows
@@ -264,7 +264,7 @@ jobs:
       - name: Add QT_HOST_PATH var (Windows MSVC arm64)
         if: runner.os == 'Windows' && matrix.architecture == 'arm64'
         run: |
-          echo "QT_HOST_PATH=${{ github.workspace }}\HostQt\Qt\${{ matrix.qt_version }}\msvc2019_64" >> $env:GITHUB_ENV
+          echo "QT_HOST_PATH=${{ github.workspace }}\HostQt\Qt\${{ matrix.qt_version }}\msvc2022_64" >> $env:GITHUB_ENV
 
       - name: Setup java (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,7 +82,7 @@ jobs:
             qt_ver: 6
             qt_host: "windows"
             qt_arch: "win64_msvc2022_64"
-            qt_version: "6.8.0"
+            qt_version: "6.8.1"
             qt_modules: "qt5compat qtimageformats qtnetworkauth"
             nscurl_tag: "v24.9.26.122"
             nscurl_sha256: "AEE6C4BE3CB6455858E9C1EE4B3AFE0DB9960FA03FE99CCDEDC28390D57CCBB0"
@@ -95,7 +95,7 @@ jobs:
             qt_ver: 6
             qt_host: "windows"
             qt_arch: "win64_msvc2022_arm64_cross_compiled"
-            qt_version: "6.8.0"
+            qt_version: "6.8.1"
             qt_modules: "qt5compat qtimageformats qtnetworkauth"
             nscurl_tag: "v24.9.26.122"
             nscurl_sha256: "AEE6C4BE3CB6455858E9C1EE4B3AFE0DB9960FA03FE99CCDEDC28390D57CCBB0"
@@ -106,7 +106,7 @@ jobs:
             qt_ver: 6
             qt_host: mac
             qt_arch: ""
-            qt_version: "6.8.0"
+            qt_version: "6.8.1"
             qt_modules: "qt5compat qtimageformats qtnetworkauth"
 
           - os: macos-14


### PR DESCRIPTION
Manual backport of https://github.com/PrismLauncher/PrismLauncher/pull/2895
