### PR TITLE
Use better compile flags for MINGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,13 @@ else()
     # ATL's pack list needs more than the default 1 Mib stack on windows
     if(WIN32)
         set(CMAKE_EXE_LINKER_FLAGS "-Wl,--stack,8388608 ${CMAKE_EXE_LINKER_FLAGS}")
+
+        # -ffunction-sections and -fdata-sections help reduce binary size
+        # -mguard=cf enables Control Flow Guard
+        # TODO: Look into -gc-sections to further reduce binary size
+        foreach(lang C CXX)
+            set("CMAKE_${lang}_FLAGS_RELEASE" "-ffunction-sections -fdata-sections -mguard=cf")
+        endforeach()
     endif()
 endif()
 


### PR DESCRIPTION
(Finally) bringing over some of the equivalent flags from https://github.com/PrismLauncher/PrismLauncher/pull/631 to our MINGW builds. Biggest highlight is enabling [Control Flow Guard](https://learn.microsoft.com/en-us/windows/win32/secbp/control-flow-guard), which is a pretty nice security feature; however **MINGW GCC toolchains will no longer be able to compile our release builds due to this**. I believe this should be fine though, as we don't use it nor recommend it. Feel free to remove the backport label if this is too much of a change :p

This should also shave off ~1mb from release builds
