### PR TITLE
add setting to update minecraft instance setting to the latest available version

### DIFF
--- a/launcher/meta/VersionList.cpp
+++ b/launcher/meta/VersionList.cpp
@@ -317,4 +317,21 @@ Version::Ptr VersionList::getLatestForParent(const QString& uid, const QString& 
     return latestCompat;
 }
 
+static const Meta::Version::Ptr& getLatestVersion(const Meta::Version::Ptr& a, const Meta::Version::Ptr& b)
+{
+    if (!a)
+        return b;
+    if (!b)
+        return a;
+    return (a->rawTime() > b->rawTime() ? a : b);
+}
+
+Version::Ptr VersionList::getLatest()
+{
+    Version::Ptr latestCompat = nullptr;
+    for (auto ver : m_versions) {
+        latestCompat = getLatestVersion(latestCompat, ver);
+    }
+    return latestCompat;
+}
 }  // namespace Meta

--- a/launcher/meta/VersionList.cpp
+++ b/launcher/meta/VersionList.cpp
@@ -326,11 +326,12 @@ static const Meta::Version::Ptr& getLatestVersion(const Meta::Version::Ptr& a, c
     return (a->rawTime() > b->rawTime() ? a : b);
 }
 
-Version::Ptr VersionList::getLatest()
+Version::Ptr VersionList::getLatest(bool onlyRelease)
 {
     Version::Ptr latestCompat = nullptr;
     for (auto ver : m_versions) {
-        latestCompat = getLatestVersion(latestCompat, ver);
+        if (!onlyRelease || ver->type() == "release")
+            latestCompat = getLatestVersion(latestCompat, ver);
     }
     return latestCompat;
 }

--- a/launcher/meta/VersionList.h
+++ b/launcher/meta/VersionList.h
@@ -45,6 +45,7 @@ class VersionList : public BaseVersionList, public BaseEntity {
     BaseVersion::Ptr getRecommended() const override;
     Version::Ptr getRecommendedForParent(const QString& uid, const QString& version);
     Version::Ptr getLatestForParent(const QString& uid, const QString& version);
+    Version::Ptr getLatest();
 
     QVariant data(const QModelIndex& index, int role) const override;
     RoleList providesRoles() const override;

--- a/launcher/meta/VersionList.h
+++ b/launcher/meta/VersionList.h
@@ -45,7 +45,7 @@ class VersionList : public BaseVersionList, public BaseEntity {
     BaseVersion::Ptr getRecommended() const override;
     Version::Ptr getRecommendedForParent(const QString& uid, const QString& version);
     Version::Ptr getLatestForParent(const QString& uid, const QString& version);
-    Version::Ptr getLatest();
+    Version::Ptr getLatest(bool onlyRelease = true);
 
     QVariant data(const QModelIndex& index, int role) const override;
     RoleList providesRoles() const override;

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -186,6 +186,7 @@ void MinecraftInstance::loadSpecificSettings()
     auto locationOverride = m_settings->registerSetting("OverrideJavaLocation", false);
     auto argsOverride = m_settings->registerSetting("OverrideJavaArgs", false);
     m_settings->registerSetting("AutomaticJava", false);
+    m_settings->registerSetting("UseLatestMinecraftVersion", false);
 
     if (auto global_settings = globalSettings()) {
         m_settings->registerOverride(global_settings->getSetting("JavaPath"), locationOverride);

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -187,6 +187,7 @@ void MinecraftInstance::loadSpecificSettings()
     auto argsOverride = m_settings->registerSetting("OverrideJavaArgs", false);
     m_settings->registerSetting("AutomaticJava", false);
     m_settings->registerSetting("UseLatestMinecraftVersion", false);
+    m_settings->registerSetting("UseLatestMinecraftVersionType", "release");
 
     if (auto global_settings = globalSettings()) {
         m_settings->registerOverride(global_settings->getSetting("JavaPath"), locationOverride);

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -184,6 +184,7 @@ void MinecraftInstance::loadSpecificSettings()
     auto locationOverride = m_settings->registerSetting("OverrideJavaLocation", false);
     auto argsOverride = m_settings->registerSetting("OverrideJavaArgs", false);
     m_settings->registerSetting("AutomaticJava", false);
+    m_settings->registerSetting("UseLatestMinecraftVersion", false);
 
     if (auto global_settings = globalSettings()) {
         m_settings->registerOverride(global_settings->getSetting("JavaPath"), locationOverride);

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -185,6 +185,7 @@ void MinecraftInstance::loadSpecificSettings()
     auto argsOverride = m_settings->registerSetting("OverrideJavaArgs", false);
     m_settings->registerSetting("AutomaticJava", false);
     m_settings->registerSetting("UseLatestMinecraftVersion", false);
+    m_settings->registerSetting("UseLatestMinecraftVersionType", "release");
 
     if (auto global_settings = globalSettings()) {
         m_settings->registerOverride(global_settings->getSetting("JavaPath"), locationOverride);

--- a/launcher/minecraft/MinecraftLoadAndCheck.cpp
+++ b/launcher/minecraft/MinecraftLoadAndCheck.cpp
@@ -1,4 +1,5 @@
 #include "MinecraftLoadAndCheck.h"
+#include "Application.h"
 #include "MinecraftInstance.h"
 #include "PackProfile.h"
 
@@ -8,6 +9,14 @@ void MinecraftLoadAndCheck::executeTask()
 {
     // add offline metadata load task
     auto components = m_inst->getPackProfile();
+    if (m_inst->settings()->get("UseLatestMinecraftVersion").toBool()) {
+        if (APPLICATION->settings()->get("AutomaticJavaSwitch").toBool() && m_inst->settings()->get("AutomaticJava").toBool() &&
+            m_inst->settings()->get("OverrideJavaLocation").toBool()) {
+            m_inst->settings()->set("OverrideJavaLocation", false);
+            m_inst->settings()->set("JavaPath", "");
+        }
+        components->updateLatestMinecraft();
+    }
     if (auto result = components->reload(m_netmode); !result) {
         emitFailed(result.error);
         return;

--- a/launcher/minecraft/MinecraftLoadAndCheck.cpp
+++ b/launcher/minecraft/MinecraftLoadAndCheck.cpp
@@ -10,12 +10,12 @@ void MinecraftLoadAndCheck::executeTask()
     // add offline metadata load task
     auto components = m_inst->getPackProfile();
     if (m_inst->settings()->get("UseLatestMinecraftVersion").toBool()) {
-        if (APPLICATION->settings()->get("AutomaticJavaSwitch").toBool() && m_inst->settings()->get("AutomaticJava").toBool() &&
-            m_inst->settings()->get("OverrideJavaLocation").toBool()) {
+        auto releaseType = m_inst->settings()->get("UseLatestMinecraftVersionType").toString();
+        if (components->updateLatestMinecraft(releaseType == "release") && APPLICATION->settings()->get("AutomaticJavaSwitch").toBool() &&
+            m_inst->settings()->get("AutomaticJava").toBool() && m_inst->settings()->get("OverrideJavaLocation").toBool()) {
             m_inst->settings()->set("OverrideJavaLocation", false);
             m_inst->settings()->set("JavaPath", "");
         }
-        components->updateLatestMinecraft();
     }
     if (auto result = components->reload(m_netmode); !result) {
         emitFailed(result.error);

--- a/launcher/minecraft/MinecraftLoadAndCheck.cpp
+++ b/launcher/minecraft/MinecraftLoadAndCheck.cpp
@@ -8,8 +8,8 @@ MinecraftLoadAndCheck::MinecraftLoadAndCheck(MinecraftInstance* inst, Net::Mode 
 void MinecraftLoadAndCheck::executeTask()
 {
     // add offline metadata load task
-    auto components = m_inst->getPackProfile();
-    if (m_inst->settings()->get("UseLatestMinecraftVersion").toBool()) {
+    auto* components = m_inst->getPackProfile();
+    if (m_netmode == Net::Mode::Online && m_inst->settings()->get("UseLatestMinecraftVersion").toBool()) {
         auto releaseType = m_inst->settings()->get("UseLatestMinecraftVersionType").toString();
         if (components->updateLatestMinecraft(releaseType == "release") && APPLICATION->settings()->get("AutomaticJavaSwitch").toBool() &&
             m_inst->settings()->get("AutomaticJava").toBool() && m_inst->settings()->get("OverrideJavaLocation").toBool()) {

--- a/launcher/minecraft/PackProfile.cpp
+++ b/launcher/minecraft/PackProfile.cpp
@@ -1072,19 +1072,23 @@ QList<ModPlatform::ModLoaderType> PackProfile::getModLoadersList()
     return result;
 }
 
-void PackProfile::updateLatestMinecraft()
+bool PackProfile::updateLatestMinecraft(bool onlyRelease)
 {
     const QString uid = "net.minecraft";
     auto patch = getComponent(uid);
+    auto oldVersion = patch->getVersion();
     patch->waitLoadMeta();  // make sure we have latest versions
     auto list = patch->getVersionList();
     if (!list) {
-        return;
+        return false;
     }
 
-    auto latest = list->getLatest();
+    auto latest = list->getLatest(onlyRelease);
 
-    qDebug() << "Change" << uid << "to" << latest.get();
-    setComponentVersion(uid, latest->descriptor(), true);
-    resolve(Net::Mode::Online);
+    if (oldVersion != latest->descriptor()) {
+        qDebug() << "Change" << uid << "to" << latest.get();
+        setComponentVersion(uid, latest->descriptor(), true);
+        resolve(Net::Mode::Online);
+    }
+    return oldVersion != latest->descriptor();
 }

--- a/launcher/minecraft/PackProfile.cpp
+++ b/launcher/minecraft/PackProfile.cpp
@@ -1071,3 +1071,20 @@ QList<ModPlatform::ModLoaderType> PackProfile::getModLoadersList()
     }
     return result;
 }
+
+void PackProfile::updateLatestMinecraft()
+{
+    const QString uid = "net.minecraft";
+    auto patch = getComponent(uid);
+    patch->waitLoadMeta();  // make sure we have latest versions
+    auto list = patch->getVersionList();
+    if (!list) {
+        return;
+    }
+
+    auto latest = list->getLatest();
+
+    qDebug() << "Change" << uid << "to" << latest.get();
+    setComponentVersion(uid, latest->descriptor(), true);
+    resolve(Net::Mode::Online);
+}

--- a/launcher/minecraft/PackProfile.cpp
+++ b/launcher/minecraft/PackProfile.cpp
@@ -48,6 +48,7 @@
 #include <QTimer>
 #include <QUuid>
 #include <algorithm>
+#include <memory>
 #include <utility>
 
 #include "Application.h"
@@ -68,17 +69,28 @@
 
 #include "minecraft/Logging.h"
 
-#include "ui/dialogs/CustomMessageBox.h"
+#include "settings/Setting.h"
 
-PackProfile::PackProfile(MinecraftInstance* instance) : QAbstractListModel()
+PackProfile::PackProfile(MinecraftInstance* instance)
 {
-    d.reset(new PackProfileData);
+    d = std::make_unique<PackProfileData>();
     d->m_instance = instance;
     d->m_saveTimer.setSingleShot(true);
     d->m_saveTimer.setInterval(5000);
     d->interactionDisabled = instance->isRunning();
     connect(d->m_instance, &BaseInstance::runningStatusChanged, this, &PackProfile::disableInteraction);
     connect(&d->m_saveTimer, &QTimer::timeout, this, &PackProfile::save_internal);
+    QTimer::singleShot(0, this, [this] {
+        auto latestVersion = d->m_instance->settings()->getSetting("UseLatestMinecraftVersion");
+        connect(latestVersion.get(), &Setting::SettingChanged, this, [this](const Setting&, const QVariant&) {
+            for (int i = 0; i < d->components.size(); i++) {
+                if (d->components.at(i)->getID() == "net.minecraft") {
+                    emit dataChanged(createIndex(i, 0), createIndex(i, columnCount(QModelIndex()) - 1));
+                    break;
+                }
+            }
+        });
+    });
 }
 
 PackProfile::~PackProfile()
@@ -514,22 +526,25 @@ ComponentPtr PackProfile::getComponent(size_t index)
 
 QVariant PackProfile::data(const QModelIndex& index, int role) const
 {
-    if (!index.isValid())
-        return QVariant();
+    if (!index.isValid()) {
+        return {};
+    }
 
     int row = index.row();
     int column = index.column();
 
-    if (row < 0 || row >= d->components.size())
-        return QVariant();
+    if (row < 0 || row >= d->components.size()) {
+        return {};
+    }
 
     auto patch = d->components.at(row);
 
     switch (role) {
         case Qt::CheckStateRole: {
-            if (column == NameColumn)
+            if (column == NameColumn) {
                 return patch->isEnabled() ? Qt::Checked : Qt::Unchecked;
-            return QVariant();
+            }
+            return {};
         }
         case Qt::DisplayRole: {
             switch (column) {
@@ -538,12 +553,14 @@ QVariant PackProfile::data(const QModelIndex& index, int role) const
                 case VersionColumn: {
                     if (patch->isCustom()) {
                         return QString("%1 (Custom)").arg(patch->getVersion());
-                    } else {
-                        return patch->getVersion();
                     }
+                    if (patch->getID() == "net.minecraft" && d->m_instance->settings()->get("UseLatestMinecraftVersion").toBool()) {
+                        return QString("%1 (auto-update)").arg(patch->getVersion());
+                    }
+                    return patch->getVersion();
                 }
                 default:
-                    return QVariant();
+                    return {};
             }
         }
         case Qt::DecorationRole: {
@@ -555,13 +572,15 @@ QVariant PackProfile::data(const QModelIndex& index, int role) const
                     case ProblemSeverity::Error:
                         return "error";
                     default:
-                        return QVariant();
+                        return {};
                 }
             }
-            return QVariant();
+            return {};
         }
+        default:
+            break;
     }
-    return QVariant();
+    return {};
 }
 
 bool PackProfile::setData(const QModelIndex& index, [[maybe_unused]] const QVariant& value, int role)
@@ -925,7 +944,7 @@ bool PackProfile::installAgents_internal(QStringList filepaths)
         agent->setDisplayName(sourceInfo.completeBaseName());
         agent->setHint("local");
 
-        versionFile->agents.append(Agent{agent, QString()});
+        versionFile->agents.append(Agent{ .library = agent, .argument = QString() });
 
         versionFile->name = targetName;
         versionFile->uid = targetId;
@@ -1088,7 +1107,6 @@ bool PackProfile::updateLatestMinecraft(bool onlyRelease)
     if (oldVersion != latest->descriptor()) {
         qDebug() << "Change" << uid << "to" << latest.get();
         setComponentVersion(uid, latest->descriptor(), true);
-        resolve(Net::Mode::Online);
     }
     return oldVersion != latest->descriptor();
 }

--- a/launcher/minecraft/PackProfile.cpp
+++ b/launcher/minecraft/PackProfile.cpp
@@ -1063,3 +1063,20 @@ QList<ModPlatform::ModLoaderType> PackProfile::getModLoadersList()
     }
     return result;
 }
+
+void PackProfile::updateLatestMinecraft()
+{
+    const QString uid = "net.minecraft";
+    auto patch = getComponent(uid);
+    patch->waitLoadMeta();  // make sure we have latest versions
+    auto list = patch->getVersionList();
+    if (!list) {
+        return;
+    }
+
+    auto latest = list->getLatest();
+
+    qDebug() << "Change" << uid << "to" << latest.get();
+    setComponentVersion(uid, latest->descriptor(), true);
+    resolve(Net::Mode::Online);
+}

--- a/launcher/minecraft/PackProfile.cpp
+++ b/launcher/minecraft/PackProfile.cpp
@@ -1064,19 +1064,23 @@ QList<ModPlatform::ModLoaderType> PackProfile::getModLoadersList()
     return result;
 }
 
-void PackProfile::updateLatestMinecraft()
+bool PackProfile::updateLatestMinecraft(bool onlyRelease)
 {
     const QString uid = "net.minecraft";
     auto patch = getComponent(uid);
+    auto oldVersion = patch->getVersion();
     patch->waitLoadMeta();  // make sure we have latest versions
     auto list = patch->getVersionList();
     if (!list) {
-        return;
+        return false;
     }
 
-    auto latest = list->getLatest();
+    auto latest = list->getLatest(onlyRelease);
 
-    qDebug() << "Change" << uid << "to" << latest.get();
-    setComponentVersion(uid, latest->descriptor(), true);
-    resolve(Net::Mode::Online);
+    if (oldVersion != latest->descriptor()) {
+        qDebug() << "Change" << uid << "to" << latest.get();
+        setComponentVersion(uid, latest->descriptor(), true);
+        resolve(Net::Mode::Online);
+    }
+    return oldVersion != latest->descriptor();
 }

--- a/launcher/minecraft/PackProfile.h
+++ b/launcher/minecraft/PackProfile.h
@@ -164,6 +164,8 @@ class PackProfile : public QAbstractListModel {
     /// apply the component patches. Catches all the errors and returns true/false for success/failure
     void invalidateLaunchProfile();
 
+    void updateLatestMinecraft();
+
    private:
     void scheduleSave();
     bool saveIsScheduled() const;

--- a/launcher/minecraft/PackProfile.h
+++ b/launcher/minecraft/PackProfile.h
@@ -164,7 +164,7 @@ class PackProfile : public QAbstractListModel {
     /// apply the component patches. Catches all the errors and returns true/false for success/failure
     void invalidateLaunchProfile();
 
-    void updateLatestMinecraft();
+    bool updateLatestMinecraft(bool onlyRelease = true);
 
    private:
     void scheduleSave();

--- a/launcher/ui/pages/instance/VersionPage.cpp
+++ b/launcher/ui/pages/instance/VersionPage.cpp
@@ -123,7 +123,7 @@ void VersionPage::retranslate()
 
 void VersionPage::openedImpl()
 {
-    auto const setting_name = QString("WideBarVisibility_%1").arg(id());
+    const auto setting_name = QString("WideBarVisibility_%1").arg(id());
     m_wide_bar_setting = APPLICATION->settings()->getOrRegisterSetting(setting_name);
 
     ui->toolBar->setVisibilityState(QByteArray::fromBase64(m_wide_bar_setting->get().toString().toUtf8()));
@@ -402,8 +402,9 @@ void VersionPage::on_actionChange_version_triggered()
     if (!currentVersion.isEmpty()) {
         vselect.setCurrentVersion(currentVersion);
     }
-    if (!vselect.exec() || !vselect.selectedVersion())
+    if ((vselect.exec() == 0) || !vselect.selectedVersion()) {
         return;
+    }
 
     qDebug() << "Change" << uid << "to" << vselect.selectedVersion()->descriptor();
     bool important = false;
@@ -413,6 +414,9 @@ void VersionPage::on_actionChange_version_triggered()
             m_inst->settings()->get("OverrideJavaLocation").toBool()) {
             m_inst->settings()->set("OverrideJavaLocation", false);
             m_inst->settings()->set("JavaPath", "");
+        }
+        if (m_inst->settings()->get("UseLatestMinecraftVersion").toBool()) {
+            m_inst->settings()->set("UseLatestMinecraftVersion", false);
         }
     }
     m_profile->setComponentVersion(uid, vselect.selectedVersion()->descriptor(), important);

--- a/launcher/ui/widgets/MinecraftSettingsWidget.cpp
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.cpp
@@ -62,7 +62,7 @@ MinecraftSettingsWidget::MinecraftSettingsWidget(MinecraftInstance* instance, QW
         m_ui->globalDataPacksGroupBox->hide();
         m_ui->loaderGroup->hide();
         m_ui->countGameTime->hide();
-        m_ui->latestMCVersionCheckBox->hide();
+        m_ui->latestMCVersionGroupBox->hide();
     } else {
         m_javaSettings = new JavaSettingsWidget(m_instance, this);
         m_ui->javaScrollArea->setWidget(m_javaSettings);
@@ -304,7 +304,11 @@ void MinecraftSettingsWidget::loadSettings()
         for (auto c : blockSignalsCheckBoxes) {
             c->blockSignals(false);
         }
-        m_ui->latestMCVersionCheckBox->setChecked(settings->get("UseLatestMinecraftVersion").toBool());
+
+        m_ui->latestMCVersionGroupBox->setChecked(settings->get("UseLatestMinecraftVersion").toBool());
+        auto autoUpdateType = settings->get("UseLatestMinecraftVersionType").toString() == "release";
+        m_ui->releaseRadioButton->setChecked(autoUpdateType);
+        m_ui->anyRadioButton->setChecked(!autoUpdateType);
     }
 
     m_ui->legacySettingsGroupBox->setChecked(settings->get("OverrideLegacySettings").toBool());
@@ -490,7 +494,8 @@ void MinecraftSettingsWidget::saveSettings()
             settings->reset("InstanceAccountId");
         }
 
-        settings->set("UseLatestMinecraftVersion", m_ui->latestMCVersionCheckBox->isChecked());
+        settings->set("UseLatestMinecraftVersion", m_ui->latestMCVersionGroupBox->isChecked());
+        settings->set("UseLatestMinecraftVersionType", m_ui->releaseRadioButton->isChecked() ? "release" : "any");
     }
 
     bool overrideLegacySettings = m_instance == nullptr || m_ui->legacySettingsGroupBox->isChecked();

--- a/launcher/ui/widgets/MinecraftSettingsWidget.cpp
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.cpp
@@ -62,6 +62,7 @@ MinecraftSettingsWidget::MinecraftSettingsWidget(MinecraftInstance* instance, QW
         m_ui->globalDataPacksGroupBox->hide();
         m_ui->loaderGroup->hide();
         m_ui->countGameTime->hide();
+        m_ui->latestMCVersionCheckBox->hide();
     } else {
         m_javaSettings = new JavaSettingsWidget(m_instance, this);
         m_ui->javaScrollArea->setWidget(m_javaSettings);
@@ -303,6 +304,7 @@ void MinecraftSettingsWidget::loadSettings()
         for (auto c : blockSignalsCheckBoxes) {
             c->blockSignals(false);
         }
+        m_ui->latestMCVersionCheckBox->setChecked(settings->get("UseLatestMinecraftVersion").toBool());
     }
 
     m_ui->legacySettingsGroupBox->setChecked(settings->get("OverrideLegacySettings").toBool());
@@ -487,6 +489,8 @@ void MinecraftSettingsWidget::saveSettings()
         } else {
             settings->reset("InstanceAccountId");
         }
+
+        settings->set("UseLatestMinecraftVersion", m_ui->latestMCVersionCheckBox->isChecked());
     }
 
     bool overrideLegacySettings = m_instance == nullptr || m_ui->legacySettingsGroupBox->isChecked();

--- a/launcher/ui/widgets/MinecraftSettingsWidget.cpp
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.cpp
@@ -85,7 +85,7 @@ MinecraftSettingsWidget::MinecraftSettingsWidget(MinecraftInstance* instance, QW
 
         m_quickPlaySingleplayer = m_instance->traits().contains("feature:is_quick_play_singleplayer");
         if (m_quickPlaySingleplayer) {
-            auto worlds = m_instance->worldList();
+            auto* worlds = m_instance->worldList();
             worlds->update();
             for (const auto& world : worlds->allWorlds()) {
                 m_ui->worldsCb->addItem(world.folderName());
@@ -104,24 +104,30 @@ MinecraftSettingsWidget::MinecraftSettingsWidget(MinecraftInstance* instance, QW
 
         connect(m_ui->globalDataPacksGroupBox, &QGroupBox::toggled, this, [this](bool value) {
             m_instance->settings()->set("GlobalDataPacksEnabled", value);
-            if (!value)
+            if (!value) {
                 m_instance->settings()->reset("GlobalDataPacksPath");
+            }
         });
         connect(m_ui->dataPacksPathEdit, &QLineEdit::editingFinished, this, &MinecraftSettingsWidget::saveDataPacksPath);
         connect(m_ui->dataPacksPathBrowse, &QPushButton::clicked, this, &MinecraftSettingsWidget::selectDataPacksFolder);
 
         connect(m_ui->loaderGroup, &QGroupBox::toggled, this, [this](bool value) {
             m_instance->settings()->set("OverrideModDownloadLoaders", value);
-            if (value)
+            if (value) {
                 saveSelectedLoaders();
-            else
+            } else {
                 m_instance->settings()->reset("ModDownloadLoaders");
+            }
         });
 
-        for (auto c : { m_ui->neoForge, m_ui->forge, m_ui->fabric, m_ui->quilt, m_ui->liteLoader, m_ui->babric, m_ui->btaBabric,
-                        m_ui->legacyFabric, m_ui->ornithe, m_ui->rift }) {
+        for (auto* c : { m_ui->neoForge, m_ui->forge, m_ui->fabric, m_ui->quilt, m_ui->liteLoader, m_ui->babric, m_ui->btaBabric,
+                         m_ui->legacyFabric, m_ui->ornithe, m_ui->rift }) {
             connect(c, &QCheckBox::stateChanged, this, &MinecraftSettingsWidget::saveSelectedLoaders);
         }
+        auto latestVersion = m_instance->settings()->getSetting("UseLatestMinecraftVersion");
+        connect(latestVersion.get(), &Setting::SettingChanged, this, [this](const Setting&, const QVariant&) {
+            m_ui->latestMCVersionGroupBox->setChecked(m_instance->settings()->get("UseLatestMinecraftVersion").toBool());
+        });
     }
 
     m_ui->maximizedWarning->hide();

--- a/launcher/ui/widgets/MinecraftSettingsWidget.cpp
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.cpp
@@ -62,6 +62,7 @@ MinecraftSettingsWidget::MinecraftSettingsWidget(MinecraftInstance* instance, QW
         m_ui->globalDataPacksGroupBox->hide();
         m_ui->loaderGroup->hide();
         m_ui->countGameTime->hide();
+        m_ui->latestMCVersionCheckBox->hide();
     } else {
         m_javaSettings = new JavaSettingsWidget(m_instance, this);
         m_ui->javaScrollArea->setWidget(m_javaSettings);
@@ -295,6 +296,7 @@ void MinecraftSettingsWidget::loadSettings()
         for (auto c : blockSignalsCheckBoxes) {
             c->blockSignals(false);
         }
+        m_ui->latestMCVersionCheckBox->setChecked(settings->get("UseLatestMinecraftVersion").toBool());
     }
 
     m_ui->legacySettingsGroupBox->setChecked(settings->get("OverrideLegacySettings").toBool());
@@ -475,6 +477,8 @@ void MinecraftSettingsWidget::saveSettings()
         } else {
             settings->reset("InstanceAccountId");
         }
+
+        settings->set("UseLatestMinecraftVersion", m_ui->latestMCVersionCheckBox->isChecked());
     }
 
     bool overrideLegacySettings = m_instance == nullptr || m_ui->legacySettingsGroupBox->isChecked();

--- a/launcher/ui/widgets/MinecraftSettingsWidget.cpp
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.cpp
@@ -62,7 +62,7 @@ MinecraftSettingsWidget::MinecraftSettingsWidget(MinecraftInstance* instance, QW
         m_ui->globalDataPacksGroupBox->hide();
         m_ui->loaderGroup->hide();
         m_ui->countGameTime->hide();
-        m_ui->latestMCVersionCheckBox->hide();
+        m_ui->latestMCVersionGroupBox->hide();
     } else {
         m_javaSettings = new JavaSettingsWidget(m_instance, this);
         m_ui->javaScrollArea->setWidget(m_javaSettings);
@@ -296,7 +296,11 @@ void MinecraftSettingsWidget::loadSettings()
         for (auto c : blockSignalsCheckBoxes) {
             c->blockSignals(false);
         }
-        m_ui->latestMCVersionCheckBox->setChecked(settings->get("UseLatestMinecraftVersion").toBool());
+
+        m_ui->latestMCVersionGroupBox->setChecked(settings->get("UseLatestMinecraftVersion").toBool());
+        auto autoUpdateType = settings->get("UseLatestMinecraftVersionType").toString() == "release";
+        m_ui->releaseRadioButton->setChecked(autoUpdateType);
+        m_ui->anyRadioButton->setChecked(!autoUpdateType);
     }
 
     m_ui->legacySettingsGroupBox->setChecked(settings->get("OverrideLegacySettings").toBool());
@@ -478,7 +482,8 @@ void MinecraftSettingsWidget::saveSettings()
             settings->reset("InstanceAccountId");
         }
 
-        settings->set("UseLatestMinecraftVersion", m_ui->latestMCVersionCheckBox->isChecked());
+        settings->set("UseLatestMinecraftVersion", m_ui->latestMCVersionGroupBox->isChecked());
+        settings->set("UseLatestMinecraftVersionType", m_ui->releaseRadioButton->isChecked() ? "release" : "any");
     }
 
     bool overrideLegacySettings = m_instance == nullptr || m_ui->legacySettingsGroupBox->isChecked();

--- a/launcher/ui/widgets/MinecraftSettingsWidget.cpp
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.cpp
@@ -61,7 +61,7 @@ MinecraftSettingsWidget::MinecraftSettingsWidget(MinecraftInstance* instance, QW
         m_ui->serverJoinGroupBox->hide();
         m_ui->globalDataPacksGroupBox->hide();
         m_ui->loaderGroup->hide();
-        m_ui->latestMCVersionCheckBox->hide();
+        m_ui->latestMCVersionGroupBox->hide();
     } else {
         m_javaSettings = new JavaSettingsWidget(m_instance, this);
         m_ui->javaScrollArea->setWidget(m_javaSettings);
@@ -294,7 +294,11 @@ void MinecraftSettingsWidget::loadSettings()
         for (auto c : blockSignalsCheckBoxes) {
             c->blockSignals(false);
         }
-        m_ui->latestMCVersionCheckBox->setChecked(settings->get("UseLatestMinecraftVersion").toBool());
+
+        m_ui->latestMCVersionGroupBox->setChecked(settings->get("UseLatestMinecraftVersion").toBool());
+        auto autoUpdateType = settings->get("UseLatestMinecraftVersionType").toString() == "release";
+        m_ui->releaseRadioButton->setChecked(autoUpdateType);
+        m_ui->anyRadioButton->setChecked(!autoUpdateType);
     }
 
     m_ui->legacySettingsGroupBox->setChecked(settings->get("OverrideLegacySettings").toBool());
@@ -472,7 +476,8 @@ void MinecraftSettingsWidget::saveSettings()
                 settings->reset("InstanceAccountId");
             }
 
-            settings->set("UseLatestMinecraftVersion", m_ui->latestMCVersionCheckBox->isChecked());
+            settings->set("UseLatestMinecraftVersion", m_ui->latestMCVersionGroupBox->isChecked());
+            settings->set("UseLatestMinecraftVersionType", m_ui->releaseRadioButton->isChecked() ? "release" : "any");
         }
 
         bool overrideLegacySettings = m_instance == nullptr || m_ui->legacySettingsGroupBox->isChecked();

--- a/launcher/ui/widgets/MinecraftSettingsWidget.cpp
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.cpp
@@ -61,6 +61,7 @@ MinecraftSettingsWidget::MinecraftSettingsWidget(MinecraftInstance* instance, QW
         m_ui->serverJoinGroupBox->hide();
         m_ui->globalDataPacksGroupBox->hide();
         m_ui->loaderGroup->hide();
+        m_ui->latestMCVersionCheckBox->hide();
     } else {
         m_javaSettings = new JavaSettingsWidget(m_instance, this);
         m_ui->javaScrollArea->setWidget(m_javaSettings);
@@ -293,6 +294,7 @@ void MinecraftSettingsWidget::loadSettings()
         for (auto c : blockSignalsCheckBoxes) {
             c->blockSignals(false);
         }
+        m_ui->latestMCVersionCheckBox->setChecked(settings->get("UseLatestMinecraftVersion").toBool());
     }
 
     m_ui->legacySettingsGroupBox->setChecked(settings->get("OverrideLegacySettings").toBool());
@@ -469,6 +471,8 @@ void MinecraftSettingsWidget::saveSettings()
             } else {
                 settings->reset("InstanceAccountId");
             }
+
+            settings->set("UseLatestMinecraftVersion", m_ui->latestMCVersionCheckBox->isChecked());
         }
 
         bool overrideLegacySettings = m_instance == nullptr || m_ui->legacySettingsGroupBox->isChecked();

--- a/launcher/ui/widgets/MinecraftSettingsWidget.ui
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.ui
@@ -562,10 +562,35 @@ It is most likely you will need to change the path - please refer to the mod's w
             </widget>
            </item>
            <item>
-            <widget class="QCheckBox" name="latestMCVersionCheckBox">
-             <property name="text">
+            <widget class="QGroupBox" name="latestMCVersionGroupBox">
+             <property name="title">
               <string>Always use the latest minecraft version</string>
              </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_9">
+              <item>
+               <widget class="QRadioButton" name="releaseRadioButton">
+                <property name="text">
+                 <string>Release</string>
+                </property>
+                <attribute name="buttonGroup">
+                 <string notr="true">latestVersionModeGroup</string>
+                </attribute>
+               </widget>
+              </item>
+              <item>
+               <widget class="QRadioButton" name="anyRadioButton">
+                <property name="text">
+                 <string>Any</string>
+                </property>
+                <attribute name="buttonGroup">
+                 <string notr="true">latestVersionModeGroup</string>
+                </attribute>
+               </widget>
+              </item>
+             </layout>
             </widget>
            </item>
            <item>
@@ -991,4 +1016,7 @@ It is most likely you will need to change the path - please refer to the mod's w
  </tabstops>
  <resources/>
  <connections/>
+ <buttongroups>
+  <buttongroup name="latestVersionModeGroup"/>
+ </buttongroups>
 </ui>

--- a/launcher/ui/widgets/MinecraftSettingsWidget.ui
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.ui
@@ -562,6 +562,13 @@ It is most likely you will need to change the path - please refer to the mod's w
             </widget>
            </item>
            <item>
+            <widget class="QCheckBox" name="latestMCVersionCheckBox">
+             <property name="text">
+              <string>Allways use the latest minecraft version</string>
+             </property>
+            </widget>
+           </item>
+           <item>
             <spacer name="verticalSpacer_2">
              <property name="orientation">
               <enum>Qt::Vertical</enum>

--- a/launcher/ui/widgets/MinecraftSettingsWidget.ui
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.ui
@@ -564,7 +564,7 @@ It is most likely you will need to change the path - please refer to the mod's w
            <item>
             <widget class="QCheckBox" name="latestMCVersionCheckBox">
              <property name="text">
-              <string>Allways use the latest minecraft version</string>
+              <string>Always use the latest minecraft version</string>
              </property>
             </widget>
            </item>

--- a/launcher/ui/widgets/MinecraftSettingsWidget.ui
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.ui
@@ -562,10 +562,35 @@ It is most likely you will need to change the path - please refer to the mod's w
             </widget>
            </item>
            <item>
-            <widget class="QCheckBox" name="latestMCVersionCheckBox">
-             <property name="text">
+            <widget class="QGroupBox" name="latestMCVersionGroupBox">
+             <property name="title">
               <string>Always use the latest minecraft version</string>
              </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_9">
+              <item>
+               <widget class="QRadioButton" name="releaseRadioButton">
+                <property name="text">
+                 <string>Release</string>
+                </property>
+                <attribute name="buttonGroup">
+                 <string notr="true">latestVersionModeGroup</string>
+                </attribute>
+               </widget>
+              </item>
+              <item>
+               <widget class="QRadioButton" name="anyRadioButton">
+                <property name="text">
+                 <string>Any</string>
+                </property>
+                <attribute name="buttonGroup">
+                 <string notr="true">latestVersionModeGroup</string>
+                </attribute>
+               </widget>
+              </item>
+             </layout>
             </widget>
            </item>
            <item>
@@ -944,4 +969,7 @@ It is most likely you will need to change the path - please refer to the mod's w
  </tabstops>
  <resources/>
  <connections/>
+ <buttongroups>
+  <buttongroup name="latestVersionModeGroup"/>
+ </buttongroups>
 </ui>

--- a/launcher/ui/widgets/MinecraftSettingsWidget.ui
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.ui
@@ -555,10 +555,35 @@ It is most likely you will need to change the path - please refer to the mod's w
             </widget>
            </item>
            <item>
-            <widget class="QCheckBox" name="latestMCVersionCheckBox">
-             <property name="text">
+            <widget class="QGroupBox" name="latestMCVersionGroupBox">
+             <property name="title">
               <string>Always use the latest minecraft version</string>
              </property>
+             <property name="checkable">
+              <bool>true</bool>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_9">
+              <item>
+               <widget class="QRadioButton" name="releaseRadioButton">
+                <property name="text">
+                 <string>Release</string>
+                </property>
+                <attribute name="buttonGroup">
+                 <string notr="true">latestVersionModeGroup</string>
+                </attribute>
+               </widget>
+              </item>
+              <item>
+               <widget class="QRadioButton" name="anyRadioButton">
+                <property name="text">
+                 <string>Any</string>
+                </property>
+                <attribute name="buttonGroup">
+                 <string notr="true">latestVersionModeGroup</string>
+                </attribute>
+               </widget>
+              </item>
+             </layout>
             </widget>
            </item>
            <item>
@@ -898,4 +923,7 @@ It is most likely you will need to change the path - please refer to the mod's w
  </tabstops>
  <resources/>
  <connections/>
+ <buttongroups>
+  <buttongroup name="latestVersionModeGroup"/>
+ </buttongroups>
 </ui>

--- a/launcher/ui/widgets/MinecraftSettingsWidget.ui
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.ui
@@ -557,7 +557,7 @@ It is most likely you will need to change the path - please refer to the mod's w
            <item>
             <widget class="QCheckBox" name="latestMCVersionCheckBox">
              <property name="text">
-              <string>Allways use the latest minecraft version</string>
+              <string>Always use the latest minecraft version</string>
              </property>
             </widget>
            </item>

--- a/launcher/ui/widgets/MinecraftSettingsWidget.ui
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.ui
@@ -555,6 +555,13 @@ It is most likely you will need to change the path - please refer to the mod's w
             </widget>
            </item>
            <item>
+            <widget class="QCheckBox" name="latestMCVersionCheckBox">
+             <property name="text">
+              <string>Allways use the latest minecraft version</string>
+             </property>
+            </widget>
+           </item>
+           <item>
             <spacer name="verticalSpacer_2">
              <property name="orientation">
               <enum>Qt::Vertical</enum>


### PR DESCRIPTION
fixes #550
How? by adding a hidden setting(in the last instance setting tab) that will always pull the latest mc version available
this doesn't work well if you have a loader that doesn't yet have a version for that snapshot.

Stuff that I may consider if this approach is ok with other maintainers:
- do not reset java if the version did not change
- the setting localization
- maybe a warning/ tooltip regarding loaders 
- change the setting so it allows users to select if they want snapshots or releases(https://github.com/PrismLauncher/PrismLauncher/issues/1014)