### PR TITLE
Publish on FlakeHub

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,6 +8,28 @@ permissions:
   contents: read
 
 jobs:
+  flakehub:
+    name: FlakeHub
+
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          
+      - name: Install Nix
+        uses: cachix/install-nix-action@v30
+
+      - name: Publish on FlakeHub
+        uses: determinatesystems/flakehub-push@v5
+        with:
+          visibility: "public"
+
   winget:
     name: Winget
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,21 @@
-name: Publish to WinGet
+name: Publish
+
 on:
   release:
-    types: [released]
+    types: [ released ]
+
+permissions:
+  contents: read
 
 jobs:
-  publish:
+  winget:
+    name: Winget
+
     runs-on: windows-latest
+
     steps:
-      - uses: vedantmgoyal2009/winget-releaser@v2
+      - name: Publish on Winget
+        uses: vedantmgoyal2009/winget-releaser@v2
         with:
           identifier: PrismLauncher.PrismLauncher
           version: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
https://flakehub.com/

This gives Nix users an easier way to both discover our Flake and track our stable releases, with some examples being

```nix
{
  inputs.prismlauncher.url = "https://flakehub.com/f/PrismLauncher/PrismLauncher/9.*";
}
```

Tracking all releases in the 9.x series, and

```nix
{
  inputs.prismlauncher.url = "https://flakehub.com/f/PrismLauncher/PrismLauncher/*";
}
```

Tracking our latest stable release

See the [docs](https://docs.determinate.systems/flakehub) for more if you're curious
