### PR TITLE
ci: use flakehub cache

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -10,7 +10,7 @@ on:
       - "flatpak/**"
     tags:
       - "*"
-  pull_request:
+  pull_request_target:
     paths-ignore:
       - "**.md"
       - "**/LICENSE"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -24,6 +24,7 @@ permissions:
 
 env:
   DEBUG: ${{ github.ref_type != 'tag' }}
+  USE_DETERMINATE: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -47,19 +48,26 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    permissions:
+      id-token: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v30
+        uses: DeterminateSystems/nix-installer-action@v16
+        with:
+          determinate: ${{ env.USE_DETERMINATE }}
 
         # For PRs
       - name: Setup Nix Magic Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v9
+        if: ${{ env.USE_DETERMINATE }}
+        uses: DeterminateSystems/flakehub-cache-action@v1
 
         # For in-tree builds
       - name: Setup Cachix
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
         uses: cachix/cachix-action@v15
         with:
           name: prismlauncher


### PR DESCRIPTION
Let's leverage the FlakeHub plan we got :)

Small warning: the Nix workflow will now run in the context of our repository. We need to make sure we don't let arbitrary code run here; currently none of these Nix commands actually execute anything, so we should be good