### PR TITLE
Add stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,29 @@
+name: Close stale issues and PRs
+
+on:
+  schedule:
+    # run weekly on sunday
+    - cron: "0 0 * * 0"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 14
+          days-before-pr-stale: 360 # a year
+          days-before-close: -1
+          days-before-issue-close: 360 # update the issue once a year
+          days-before-pr-close: -1
+          stale-issue-message: "This issue has been inactive for a while. Please add a comment or provide an update if it's still relevant."
+          stale-pr-message: "This PR has had no recent activity. Please update it if it's still relevant."
+          close-issue-message: "Closing this issue as it has been marked stale and no further activity was detected. Feel free to reopen if needed."
+          exempt-issue-labels: rfc,noslate
+          exempt-all-milestones: true
+          exempt-all-assignees: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-name: Close stale issues and PRs
+name: Stale
 
 on:
   schedule:
@@ -11,19 +11,23 @@ permissions:
   pull-requests: write
 
 jobs:
-  stale:
+  label:
+    name: Label issues and PRs
+
     runs-on: ubuntu-latest
+
+    permissions:
+      issues: write
+      pull-requests: write
+
     steps:
       - uses: actions/stale@v9
         with:
-          days-before-issue-stale: 14
-          days-before-pr-stale: 360 # a year
-          days-before-close: -1
-          days-before-issue-close: -1
-          days-before-pr-close: -1
+          days-before-issue-stale: 30
+          days-before-pr-stale: 30
+          days-before-close: -1 # Don't close anything
           stale-issue-message: "This issue has been inactive for a while. Please add a comment or provide an update if it's still relevant."
           stale-pr-message: "This PR has had no recent activity. Please update it if it's still relevant."
-          close-issue-message: "Closing this issue as it has been marked stale and no further activity was detected. Feel free to reopen if needed."
-          exempt-issue-labels: rfc,noslate
+          exempt-issue-labels: rfc,nostale
           exempt-all-milestones: true
           exempt-all-assignees: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,9 +6,6 @@ on:
     - cron: "0 0 * * 0"
   workflow_dispatch:
 
-permissions:
-  issues: write
-  pull-requests: write
 
 jobs:
   label:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,8 +20,7 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          days-before-issue-stale: 30
-          days-before-pr-stale: 30
+          days-before-stale: 30
           days-before-close: -1 # Don't close anything
           stale-issue-message: "This issue has been inactive for a while. Please add a comment or provide an update if it's still relevant."
           stale-pr-message: "This PR has had no recent activity. Please update it if it's still relevant."

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,7 +19,7 @@ jobs:
           days-before-issue-stale: 14
           days-before-pr-stale: 360 # a year
           days-before-close: -1
-          days-before-issue-close: 360 # update the issue once a year
+          days-before-issue-close: -1
           days-before-pr-close: -1
           stale-issue-message: "This issue has been inactive for a while. Please add a comment or provide an update if it's still relevant."
           stale-pr-message: "This PR has had no recent activity. Please update it if it's still relevant."


### PR DESCRIPTION
I discussed this with @getchoo on Discord. At that time no other maintainer voiced their opinion on this, but it looked easy so I ended up implementing it.
Let's discuss this based on this PR.
Right now I configured as follows:
- runs weekly (similar to flake update)
- it marks issues as a stale in 30 days 
- it marks PRs as stale in 30 days
- if the issue/PR is part of a milestone or is assigned then stalebot will not run on it
- if it has the tags: rfc or nostalate then stalebot will not run on it
- messages for when each change is made