### PR TITLE
[Backport release-9.x] make sure if user changes java path also disable java management

### DIFF
--- a/launcher/ui/pages/instance/InstanceSettingsPage.cpp
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.cpp
@@ -93,6 +93,11 @@ InstanceSettingsPage::InstanceSettingsPage(BaseInstance* inst, QWidget* parent)
         ui->serverJoinAddress->setEnabled(true);
         ui->serverJoinAddressButton->setStyleSheet("QRadioButton::indicator { width: 0px; height: 0px; }");
     }
+    connect(ui->javaPathTextBox, &QLineEdit::textChanged, [this](QString newValue) {
+        if (m_instance->settings()->get("JavaPath").toString() != newValue) {
+            m_instance->settings()->set("AutomaticJava", false);
+        }
+    });
 
     loadSettings();
 

--- a/launcher/ui/widgets/JavaSettingsWidget.cpp
+++ b/launcher/ui/widgets/JavaSettingsWidget.cpp
@@ -171,11 +171,6 @@ void JavaSettingsWidget::setupUi()
                 m_verticalLayout->addSpacerItem(m_verticalSpacer);
             }
         });
-        connect(m_ui->javaPathTextBox, &QLineEdit::textChanged, [this](QString newValue) {
-            if (m_instance->settings()->get("JavaPath").toString() != newValue) {
-                m_instance->settings()->set("AutomaticJava", false);
-            }
-        });
     }
     m_verticalLayout->addWidget(m_autoJavaGroupBox);
 


### PR DESCRIPTION
This should fix the automatic backport of https://github.com/PrismLauncher/PrismLauncher/pull/3417
Human-based backport to `release-9 for #3414, triggered by build crash