### PR TITLE
Default to Fusion based Dark/Bright themes on Windows

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -154,6 +154,7 @@
 
 #if defined Q_OS_WIN32
 #include <windows.h>
+#include <QStyleHints>
 #include "WindowsConsole.h"
 #endif
 
@@ -1109,8 +1110,16 @@ bool Application::createSetupWizard()
         // set default theme after going into theme wizard
         if (!validIcons)
             settings()->set("IconTheme", QString("pe_colored"));
-        if (!validWidgets)
-            settings()->set("ApplicationTheme", QString("system"));
+        if (!validWidgets) {
+#if defined(Q_OS_WIN32) && QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+            const QString style =
+                QGuiApplication::styleHints()->colorScheme() == Qt::ColorScheme::Dark ? QStringLiteral("dark") : QStringLiteral("bright");
+#else
+            const QString style = QStringLiteral("system");
+#endif
+
+            settings()->set("ApplicationTheme", style);
+        }
 
         m_themeManager->applyCurrentlySelectedTheme(true);
 


### PR DESCRIPTION
The default theme on Windows 10 does not follow dark mode
The default theme on Windows 11 does not work very well (striped lists don't look right, black icons on black background, probably more things I can't remember)