### PR TITLE
feat: add updater dialogues

### DIFF
--- a/launcher/ui/pages/instance/ManagedPackPage.cpp
+++ b/launcher/ui/pages/instance/ManagedPackPage.cpp
@@ -348,7 +348,7 @@ void ManagedPackPage::onUpdateTaskCompleted(bool did_succeed) const
         CustomMessageBox::selectable(nullptr, tr("Update Successful"), tr("The instance updated to pack version %1 successfully.").arg(m_inst->getManagedPackVersionName()), QMessageBox::Information)
            ->show();
     } else if (!did_succeed) {
-        CustomMessageBox::selectable(nullptr, tr("Update Failed"), tr("The instance failed to update to pack version %1. -- Please check launcher logs for more information.").arg(m_inst->getManagedPackVersionName()), QMessageBox::Critical)
+        CustomMessageBox::selectable(nullptr, tr("Update Failed"), tr("The instance failed to update to pack version %1. Please check launcher logs for more information.").arg(m_inst->getManagedPackVersionName()), QMessageBox::Critical)
            ->show();
       qWarning() << "onUpdateTaskCompleted: unknown state encountered: did_succeed=" << did_succeed << " m_instance_window=" << m_instance_window;
     }

--- a/launcher/ui/pages/instance/ManagedPackPage.cpp
+++ b/launcher/ui/pages/instance/ManagedPackPage.cpp
@@ -343,14 +343,15 @@ void ModrinthManagedPackPage::suggestVersion()
 void ManagedPackPage::onUpdateTaskCompleted(bool did_succeed) const
 {
     // Close the window if the update was successful
-    if (m_instance_window && did_succeed) {
-        m_instance_window->close();
+    if (did_succeed) {
+        if (m_instance_window != nullptr)
+            m_instance_window->close();
+
         CustomMessageBox::selectable(nullptr, tr("Update Successful"), tr("The instance updated to pack version %1 successfully.").arg(m_inst->getManagedPackVersionName()), QMessageBox::Information)
            ->show();
-    } else if (!did_succeed) {
+    } else {
         CustomMessageBox::selectable(nullptr, tr("Update Failed"), tr("The instance failed to update to pack version %1. Please check launcher logs for more information.").arg(m_inst->getManagedPackVersionName()), QMessageBox::Critical)
            ->show();
-      qWarning() << "onUpdateTaskCompleted: unknown state encountered: did_succeed=" << did_succeed << " m_instance_window=" << m_instance_window;
     }
 
 }

--- a/launcher/ui/pages/instance/ManagedPackPage.cpp
+++ b/launcher/ui/pages/instance/ManagedPackPage.cpp
@@ -245,7 +245,6 @@ ModrinthManagedPackPage::ModrinthManagedPackPage(BaseInstance* inst, InstanceWin
 }
 
 // MODRINTH
-
 void ModrinthManagedPackPage::parseManagedPack()
 {
     qDebug() << "Parsing Modrinth pack";
@@ -338,6 +337,24 @@ void ModrinthManagedPackPage::suggestVersion()
     ManagedPackPage::suggestVersion();
 }
 
+/// @brief Called when the update task has completed.
+/// Internally handles the closing of the instance window if the update was successful and shows a message box.
+/// @param did_succeed Whether the update task was successful.
+void ManagedPackPage::onUpdateTaskCompleted(bool did_succeed) const
+{
+    // Close the window if the update was successful
+    if (m_instance_window && did_succeed) {
+        m_instance_window->close();
+        CustomMessageBox::selectable(nullptr, tr("Update Successful"), tr("The instance updated to pack version %1 successfully.").arg(m_inst->getManagedPackVersionName()), QMessageBox::Information)
+           ->show();
+    } else if (!did_succeed) {
+        CustomMessageBox::selectable(nullptr, tr("Update Failed"), tr("The instance failed to update to pack version %1. -- Please check launcher logs for more information.").arg(m_inst->getManagedPackVersionName()), QMessageBox::Critical)
+           ->show();
+      qWarning() << "onUpdateTaskCompleted: unknown state encountered: did_succeed=" << did_succeed << " m_instance_window=" << m_instance_window;
+    }
+
+}
+
 void ModrinthManagedPackPage::update()
 {
     auto index = ui->versionsComboBox->currentIndex();
@@ -363,10 +380,9 @@ void ModrinthManagedPackPage::update()
     extracted->setIcon(m_inst->iconKey());
     extracted->setConfirmUpdate(false);
 
+    // Run our task then handle the result
     auto did_succeed = runUpdateTask(extracted);
-
-    if (m_instance_window && did_succeed)
-        m_instance_window->close();
+    onUpdateTaskCompleted(did_succeed);
 }
 
 void ModrinthManagedPackPage::updateFromFile()
@@ -386,14 +402,12 @@ void ModrinthManagedPackPage::updateFromFile()
     extracted->setIcon(m_inst->iconKey());
     extracted->setConfirmUpdate(false);
 
+    // Run our task then handle the result
     auto did_succeed = runUpdateTask(extracted);
-
-    if (m_instance_window && did_succeed)
-        m_instance_window->close();
+    onUpdateTaskCompleted(did_succeed);
 }
 
 // FLAME
-
 FlameManagedPackPage::FlameManagedPackPage(BaseInstance* inst, InstanceWindow* instance_window, QWidget* parent)
     : ManagedPackPage(inst, instance_window, parent)
 {
@@ -531,9 +545,7 @@ void FlameManagedPackPage::update()
     extracted->setConfirmUpdate(false);
 
     auto did_succeed = runUpdateTask(extracted);
-
-    if (m_instance_window && did_succeed)
-        m_instance_window->close();
+    onUpdateTaskCompleted(did_succeed);
 }
 
 void FlameManagedPackPage::updateFromFile()
@@ -555,8 +567,6 @@ void FlameManagedPackPage::updateFromFile()
     extracted->setConfirmUpdate(false);
 
     auto did_succeed = runUpdateTask(extracted);
-
-    if (m_instance_window && did_succeed)
-        m_instance_window->close();
+    onUpdateTaskCompleted(did_succeed);
 }
 #include "ManagedPackPage.moc"

--- a/launcher/ui/pages/instance/ManagedPackPage.h
+++ b/launcher/ui/pages/instance/ManagedPackPage.h
@@ -94,6 +94,8 @@ class ManagedPackPage : public QWidget, public BasePage {
     BaseInstance* m_inst;
 
     bool m_loaded = false;
+
+    void onUpdateTaskCompleted(bool did_succeed) const;
 };
 
 /** Simple page for when we aren't a managed pack. */


### PR DESCRIPTION
This commit adds updater dialogues when a managed pack update completes.  This is thanks to the new ` ManagedPackPage::onUpdateTaskCompleted` function which now handles this logic for all managed packs. 

If successful. it will close the instance window and display a success dialogue. If not, it will only display an error dialogue and keep the window open to allow retries. 

Closes #3435
