### PR TITLE
fix mod load with empty gameversions

### DIFF
--- a/launcher/modplatform/flame/FileResolvingTask.cpp
+++ b/launcher/modplatform/flame/FileResolvingTask.cpp
@@ -136,6 +136,8 @@ void Flame::FileResolvingTask::netJobFinished()
             auto obj = Json::requireObject(file);
             auto version = FlameMod::loadIndexedPackVersion(obj);
             auto fileid = version.fileId.toInt();
+            Q_ASSERT(fileid != 0);
+            Q_ASSERT(m_manifest.files.contains(fileid));
             m_manifest.files[fileid].version = version;
             auto url = QUrl(version.downloadUrl, QUrl::TolerantMode);
             if (!url.isValid() && "sha1" == version.hash_type && !version.hash.isEmpty()) {

--- a/launcher/modplatform/flame/FlameModIndex.cpp
+++ b/launcher/modplatform/flame/FlameModIndex.cpp
@@ -105,9 +105,6 @@ void FlameMod::loadIndexedPackVersions(ModPlatform::IndexedPack& pack,
 auto FlameMod::loadIndexedPackVersion(QJsonObject& obj, bool load_changelog) -> ModPlatform::IndexedVersion
 {
     auto versionArray = Json::requireArray(obj, "gameVersions");
-    if (versionArray.isEmpty()) {
-        return {};
-    }
 
     ModPlatform::IndexedVersion file;
     for (auto mcVer : versionArray) {

--- a/launcher/modplatform/flame/PackManifest.cpp
+++ b/launcher/modplatform/flame/PackManifest.cpp
@@ -45,7 +45,7 @@ static void loadManifestV1(Flame::Manifest& pack, QJsonObject& manifest)
 
         Flame::File file;
         loadFileV1(file, obj);
-
+        Q_ASSERT(file.projectId != 0);
         pack.files.insert(file.fileId, file);
     }
 


### PR DESCRIPTION
try to install https://www.curseforge.com/minecraft/modpacks/srp-qz/download/5997058
reported here https://discord.com/channels/1031648380885147709/1118165588200657006/1345474580915028070
the mod Sledgehammer reports no `gameVersions`
see the curseforge response:
```
{
  "alternateFileId": 0,
  "dependencies": [],
  "displayName": "Sledgehammer-1.12.2-2.0.26-thin.jar",
  "downloadCount": 33788,
  "downloadUrl": "https://edge.forgecdn.net/files/5264/331/Sledgehammer-1.12.2-2.0.26-thin.jar",
  "fileDate": "2024-04-15T05:08:17.097Z",
  "fileFingerprint": 3734086640,
  "fileLength": 1354215,
  "fileName": "Sledgehammer-1.12.2-2.0.26-thin.jar",
  "fileStatus": 4,
  "gameId": 432,
  "gameVersions": [],
  "hashes": [
    { "algo": 1, "value": "69ba5b6efd6590ae837749976d1142c74e74bc94" },
    { "algo": 2, "value": "498cd0182e237aac16721516cf0c42b3" }
  ],
  "id": 5264331,
  "isAvailable": true,
  "isServerPack": false,
  "modId": 319175,
  "modules": ["<omited>" ],
  "parentProjectFileId": 5264329,
  "releaseType": 1,
  "sortableGameVersions": []
}

```

Removed the empty check and added some asserts that should not happen(I can remove them if needed, but if either one of the mentioned asserts is triggered, something went extremely wrong)