### PR TITLE
fix null mainwindow in case of login on setup

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -225,7 +225,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
     setApplicationDisplayName(QString("%1 %2").arg(BuildConfig.LAUNCHER_DISPLAYNAME, BuildConfig.printableVersionString()));
     setApplicationVersion(BuildConfig.printableVersionString() + "\n" + BuildConfig.GIT_COMMIT);
     setDesktopFileName(BuildConfig.LAUNCHER_DESKTOPFILENAME);
-    startTime = QDateTime::currentDateTime();
+    m_startTime = QDateTime::currentDateTime();
 
     // Don't quit on hiding the last window
     this->setQuitOnLastWindowClosed(false);

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -1177,6 +1177,9 @@ bool Application::event(QEvent* event)
 #endif
 
     if (event->type() == QEvent::FileOpen) {
+        if (!m_mainWindow) {
+            showMainWindow(false);
+        }
         auto ev = static_cast<QFileOpenEvent*>(event);
         m_mainWindow->processURLs({ ev->url() });
     }
@@ -1309,6 +1312,9 @@ void Application::messageReceived(const QByteArray& message)
         if (url.isEmpty()) {
             qWarning() << "Received" << command << "message without a zip path/URL.";
             return;
+        }
+        if (!m_mainWindow) {
+            showMainWindow(false);
         }
         m_mainWindow->processURLs({ normalizeImportUrl(url) });
     } else if (command == "launch") {

--- a/launcher/Application.h
+++ b/launcher/Application.h
@@ -112,7 +112,7 @@ class Application : public QApplication {
 
     std::shared_ptr<SettingsObject> settings() const { return m_settings; }
 
-    qint64 timeSinceStart() const { return startTime.msecsTo(QDateTime::currentDateTime()); }
+    qint64 timeSinceStart() const { return m_startTime.msecsTo(QDateTime::currentDateTime()); }
 
     QIcon getThemedIcon(const QString& name);
 
@@ -237,7 +237,7 @@ class Application : public QApplication {
     bool shouldExitNow() const;
 
    private:
-    QDateTime startTime;
+    QDateTime m_startTime;
 
     shared_qobject_ptr<QNetworkAccessManager> m_network;
 

--- a/launcher/minecraft/auth/steps/MSAStep.h
+++ b/launcher/minecraft/auth/steps/MSAStep.h
@@ -55,5 +55,5 @@ class MSAStep : public AuthStep {
    private:
     bool m_silent;
     QString m_clientId;
-    QOAuth2AuthorizationCodeFlow oauth2;
+    QOAuth2AuthorizationCodeFlow m_oauth2;
 };


### PR DESCRIPTION
Affected all builds that use the auth that open prism instead of opening a new tab in browser
Steps:
- start prism with no msa
- at the end of the setup login with the button
- in the open browser login and select prism to open the auth link
- now it should crash on ` m_mainWindow->processURLs({ normalizeImportUrl(url) });` as m_mainWindow is not yet initialized(null), but it doesn't crash for some weird reason and logs in normally

This was detected with asan and ub stuff from cmake enabled.
error returned when this happens:
`PrismLauncher/launcher/Application.cpp:1313:34: runtime error: member call on null pointer of type 'struct MainWindow'`

Yeah I have commit with some renames (add `m_` to some member variables) ignore it
