### PR TITLE
fix beginResetModel called before endResetModel

### DIFF
--- a/launcher/VersionProxyModel.cpp
+++ b/launcher/VersionProxyModel.cpp
@@ -307,6 +307,7 @@ void VersionProxyModel::setSourceModel(QAbstractItemModel* replacingRaw)
     if (!replacing) {
         roles.clear();
         filterModel->setSourceModel(replacing);
+        endResetModel();
         return;
     }
 


### PR DESCRIPTION
yeah nothing to say here other than:
`W | beginResetModel called on VersionProxyModel without calling endResetModel first`