### PR TITLE
Improve clangd support (in Nix development shell)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ CMakeCache.txt
 /.vs
 cmake-build-*/
 Debug
+compile_commands.json
 
 # Build dirs
 build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,12 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DTOML_ENABLE_FLOAT16=0")
 # set CXXFLAGS for build targets
 set(CMAKE_CXX_FLAGS_RELEASE "-O2 -D_FORTIFY_SOURCE=2 ${CMAKE_CXX_FLAGS_RELEASE}")
 
+# Export compile commands for debug builds if we can (useful in LSPs like clangd)
+# https://cmake.org/cmake/help/v3.31/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html
+if(CMAKE_GENERATOR STREQUAL "Unix Makefiles" OR CMAKE_GENERATOR STREQUAL "Ninja" AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+endif()
+
 option(DEBUG_ADDRESS_SANITIZER "Enable Address Sanitizer in Debug builds" OFF)
 
 # If this is a Debug build turn on address sanitiser

--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,16 @@
               ccache
               ninja
             ];
+
+            cmakeFlags = self.packages.${system}.prismlauncher-unwrapped.cmakeFlags ++ [
+              "-GNinja"
+              "-Bbuild"
+            ];
+
+            shellHook = ''
+              cmake $cmakeFlags -D CMAKE_BUILD_TYPE=Debug
+              ln -s {build/,}compile_commands.json
+            '';
           };
         }
       );

--- a/flake.nix
+++ b/flake.nix
@@ -78,6 +78,7 @@
             buildInputs = with pkgs; [
               ccache
               ninja
+              llvmPackages_19.clang-tools
             ];
 
             cmakeFlags = self.packages.${system}.prismlauncher-unwrapped.cmakeFlags ++ [


### PR DESCRIPTION
CMake will now generate it's own compile_commands.json to be consumed by clangd, etc. whenever configuring debug builds
We can use this directly in our Nix shell to make clangd work completely OOTB

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
