### PR TITLE
Use correct colours for all system themes 

### DIFF
--- a/launcher/ui/themes/SystemTheme.cpp
+++ b/launcher/ui/themes/SystemTheme.cpp
@@ -40,23 +40,11 @@
 #include "HintOverrideProxyStyle.h"
 #include "ThemeManager.h"
 
-SystemTheme::SystemTheme(const QString& styleName, const QPalette& palette, bool isDefaultTheme)
+SystemTheme::SystemTheme(const QString& styleName, bool isDefaultTheme)
 {
     themeName = isDefaultTheme ? "system" : styleName;
     widgetTheme = styleName;
-    colorPalette = palette;
-}
-
-void SystemTheme::apply(bool initial)
-{
-    // See https://github.com/MultiMC/Launcher/issues/1790
-    // or https://github.com/PrismLauncher/PrismLauncher/issues/490
-    if (initial) {
-        QApplication::setStyle(new HintOverrideProxyStyle(QStyleFactory::create(qtTheme())));
-        return;
-    }
-
-    ITheme::apply(initial);
+    colorPalette = QStyleFactory::create(styleName)->standardPalette();
 }
 
 QString SystemTheme::id()

--- a/launcher/ui/themes/SystemTheme.cpp
+++ b/launcher/ui/themes/SystemTheme.cpp
@@ -47,6 +47,18 @@ SystemTheme::SystemTheme(const QString& styleName, bool isDefaultTheme)
     colorPalette = QStyleFactory::create(styleName)->standardPalette();
 }
 
+void SystemTheme::apply(bool initial)
+{
+    // See https://github.com/MultiMC/Launcher/issues/1790
+    // or https://github.com/PrismLauncher/PrismLauncher/issues/490
+    if (initial && themeName == "system") {
+        QApplication::setStyle(new HintOverrideProxyStyle(QStyleFactory::create(qtTheme())));
+        return;
+    }
+
+    ITheme::apply(initial);
+}
+
 QString SystemTheme::id()
 {
     return themeName;

--- a/launcher/ui/themes/SystemTheme.h
+++ b/launcher/ui/themes/SystemTheme.h
@@ -40,6 +40,7 @@ class SystemTheme : public ITheme {
    public:
     SystemTheme(const QString& styleName, bool isDefaultTheme);
     virtual ~SystemTheme() {}
+    void apply(bool initial) override;
 
     QString id() override;
     QString name() override;

--- a/launcher/ui/themes/SystemTheme.h
+++ b/launcher/ui/themes/SystemTheme.h
@@ -38,9 +38,8 @@
 
 class SystemTheme : public ITheme {
    public:
-    SystemTheme(const QString& styleName, const QPalette& palette, bool isDefaultTheme);
+    SystemTheme(const QString& styleName, bool isDefaultTheme);
     virtual ~SystemTheme() {}
-    void apply(bool initial) override;
 
     QString id() override;
     QString name() override;

--- a/launcher/ui/themes/ThemeManager.cpp
+++ b/launcher/ui/themes/ThemeManager.cpp
@@ -44,8 +44,6 @@ ThemeManager::ThemeManager()
     m_defaultStyle = style->objectName();
     themeDebugLog() << "System theme seems to be:" << m_defaultStyle;
 
-    m_defaultPalette = QApplication::palette();
-
     initializeThemes();
     initializeCatPacks();
 }
@@ -128,7 +126,7 @@ void ThemeManager::initializeIcons()
 void ThemeManager::initializeWidgets()
 {
     themeDebugLog() << "<> Initializing Widget Themes";
-    themeDebugLog() << "Loading Built-in Theme:" << addTheme(std::make_unique<SystemTheme>(m_defaultStyle, m_defaultPalette, true));
+    themeDebugLog() << "Loading Built-in Theme:" << addTheme(std::make_unique<SystemTheme>(m_defaultStyle, true));
     auto darkThemeId = addTheme(std::make_unique<DarkTheme>());
     themeDebugLog() << "Loading Built-in Theme:" << darkThemeId;
     themeDebugLog() << "Loading Built-in Theme:" << addTheme(std::make_unique<BrightTheme>());
@@ -141,7 +139,7 @@ void ThemeManager::initializeWidgets()
             continue;
         }
 #endif
-        themeDebugLog() << "Loading System Theme:" << addTheme(std::make_unique<SystemTheme>(st, m_defaultPalette, false));
+        themeDebugLog() << "Loading System Theme:" << addTheme(std::make_unique<SystemTheme>(st, false));
     }
 
     // TODO: need some way to differentiate same name themes in different subdirectories

--- a/launcher/ui/themes/ThemeManager.h
+++ b/launcher/ui/themes/ThemeManager.h
@@ -69,7 +69,6 @@ class ThemeManager {
     QDir m_catPacksFolder{ "catpacks" };
     std::map<QString, std::unique_ptr<CatPack>> m_catPacks;
     QString m_defaultStyle;
-    QPalette m_defaultPalette;
     LogColors m_logColors;
 
     void initializeThemes();


### PR DESCRIPTION
Right now we try to use the default system palette on other styles which creates issues when these styles ignore this palette anyway (like breeze, lightly (you get a mixture of different accent colours in different places as I believe KDE has an extended palette), kvantum (it just ignores it))