### PR TITLE
Pin AppImage tooling in CI, drop libfuse2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,7 +251,6 @@ jobs:
         if: runner.os == 'Linux' && matrix.qt_ver != 5
         run: |
           wget "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
-          wget "https://github.com/linuxdeploy/linuxdeploy-plugin-appimage/releases/download/continuous/linuxdeploy-plugin-appimage-x86_64.AppImage"
           wget "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage"
 
           wget "https://github.com/AppImageCommunity/AppImageUpdate/releases/download/continuous/AppImageUpdate-x86_64.AppImage"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -266,7 +266,7 @@ jobs:
           sha256sum -c - <<< "$LINUXDEPLOY_QT_HASH"
           sha256sum -c - <<< "$APPIMAGEUPDATE_HASH"
 
-          sudo apt install libopengl0 libfuse2
+          sudo apt install libopengl0
 
       - name: Add QT_HOST_PATH var (Windows MSVC arm64)
         if: runner.os == 'Windows' && matrix.architecture == 'arm64'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,9 @@ jobs:
             qt_arch: ""
             qt_version: "6.5.3"
             qt_modules: "qt5compat qtimageformats qtnetworkauth"
+            linuxdeploy_hash: "4648f278ab3ef31f819e67c30d50f462640e5365a77637d7e6f2ad9fd0b4522a linuxdeploy-x86_64.AppImage"
+            linuxdeploy_qt_hash: "15106be885c1c48a021198e7e1e9a48ce9d02a86dd0a1848f00bdbf3c1c92724  linuxdeploy-plugin-qt-x86_64.AppImage"
+            appimageupdate_hash: "f1747cf60058e99f1bb9099ee9787d16c10241313b7acec81810ea1b1e568c11  AppImageUpdate-x86_64.AppImage"
 
           - os: windows-2022
             name: "Windows-MinGW-w64"
@@ -249,11 +252,19 @@ jobs:
 
       - name: Prepare AppImage (Linux)
         if: runner.os == 'Linux' && matrix.qt_ver != 5
+        env:
+          APPIMAGEUPDATE_HASH: ${{ matrix.appimageupdate_hash }}
+          LINUXDEPLOY_HASH: ${{ matrix.linuxdeploy_hash }}
+          LINUXDEPLOY_QT_HASH: ${{ matrix.linuxdeploy_qt_hash }}
         run: |
-          wget "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage"
-          wget "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/continuous/linuxdeploy-plugin-qt-x86_64.AppImage"
+          wget "https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20250213-2/linuxdeploy-x86_64.AppImage"
+          wget "https://github.com/linuxdeploy/linuxdeploy-plugin-qt/releases/download/1-alpha-20250213-1/linuxdeploy-plugin-qt-x86_64.AppImage"
 
-          wget "https://github.com/AppImageCommunity/AppImageUpdate/releases/download/continuous/AppImageUpdate-x86_64.AppImage"
+          wget "https://github.com/AppImageCommunity/AppImageUpdate/releases/download/2.0.0-alpha-1-20241225/AppImageUpdate-x86_64.AppImage"
+
+          sha256sum -c - <<< "$LINUXDEPLOY_HASH"
+          sha256sum -c - <<< "$LINUXDEPLOY_QT_HASH"
+          sha256sum -c - <<< "$APPIMAGEUPDATE_HASH"
 
           sudo apt install libopengl0 libfuse2
 


### PR DESCRIPTION
I believe this is the last of our completely unpinned CI deps, and it should help us in the future if breaking changes are made upstream again

This also removes the libfuse2 dep, as since https://github.com/linuxdeploy/linuxdeploy/releases/tag/1-alpha-20250213-2, we've been building against the static [Type 2 runtime](https://github.com/AppImage/type2-runtime) which doesn't require it

Supersedes https://github.com/PrismLauncher/PrismLauncher/pull/3542

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
