### PR TITLE
Changed 3rd column in ModFolder to Interactive for easier visability

### DIFF
--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -63,7 +63,7 @@ ModFolderModel::ModFolderModel(const QDir& dir, BaseInstance* instance, bool is_
     m_column_sort_keys = { SortType::ENABLED, SortType::NAME,        SortType::NAME,        SortType::VERSION,
                            SortType::DATE,    SortType::PROVIDER,    SortType::SIZE,        SortType::SIDE,
                            SortType::LOADERS, SortType::MC_VERSIONS, SortType::RELEASE_TYPE };
-    m_column_resize_modes = { QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Stretch,     QHeaderView::Interactive,
+    m_column_resize_modes = { QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive,     QHeaderView::Interactive,
                               QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive,
                               QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive };
     m_columnsHideable = { false, true, false, true, true, true, true, true, true, true, true };


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->

Changed 3rd column in ModFolder to Interactive for viability. Currently, users are unable resize the 3rd column manually leading to annoyances when trying to read long text.

A current work around is to move the 3rd column to another column location in order to see long text.
