### PR TITLE
Use default palette on all system themes

### DIFF
--- a/launcher/ui/themes/SystemTheme.h
+++ b/launcher/ui/themes/SystemTheme.h
@@ -38,7 +38,7 @@
 
 class SystemTheme : public ITheme {
    public:
-    SystemTheme(const QString& styleName, bool isDefaultTheme);
+    SystemTheme(const QString& styleName, const QPalette& defaultPalette, bool isDefaultTheme);
     virtual ~SystemTheme() {}
     void apply(bool initial) override;
 

--- a/launcher/ui/themes/ThemeManager.cpp
+++ b/launcher/ui/themes/ThemeManager.cpp
@@ -44,6 +44,8 @@ ThemeManager::ThemeManager()
     m_defaultStyle = style->objectName();
     themeDebugLog() << "System theme seems to be:" << m_defaultStyle;
 
+    m_defaultPalette = QApplication::palette();
+
     initializeThemes();
     initializeCatPacks();
 }
@@ -126,7 +128,7 @@ void ThemeManager::initializeIcons()
 void ThemeManager::initializeWidgets()
 {
     themeDebugLog() << "<> Initializing Widget Themes";
-    themeDebugLog() << "Loading Built-in Theme:" << addTheme(std::make_unique<SystemTheme>(m_defaultStyle, true));
+    themeDebugLog() << "Loading Built-in Theme:" << addTheme(std::make_unique<SystemTheme>(m_defaultStyle, m_defaultPalette, true));
     auto darkThemeId = addTheme(std::make_unique<DarkTheme>());
     themeDebugLog() << "Loading Built-in Theme:" << darkThemeId;
     themeDebugLog() << "Loading Built-in Theme:" << addTheme(std::make_unique<BrightTheme>());
@@ -139,7 +141,7 @@ void ThemeManager::initializeWidgets()
             continue;
         }
 #endif
-        themeDebugLog() << "Loading System Theme:" << addTheme(std::make_unique<SystemTheme>(st, false));
+        themeDebugLog() << "Loading System Theme:" << addTheme(std::make_unique<SystemTheme>(st, m_defaultPalette, false));
     }
 
     // TODO: need some way to differentiate same name themes in different subdirectories

--- a/launcher/ui/themes/ThemeManager.h
+++ b/launcher/ui/themes/ThemeManager.h
@@ -68,6 +68,7 @@ class ThemeManager {
     QDir m_applicationThemeFolder{ "themes" };
     QDir m_catPacksFolder{ "catpacks" };
     std::map<QString, std::unique_ptr<CatPack>> m_catPacks;
+    QPalette m_defaultPalette;
     QString m_defaultStyle;
     LogColors m_logColors;
 


### PR DESCRIPTION
Partial revert of https://github.com/PrismLauncher/PrismLauncher/pull/3530

Forcing the standard palette on system themes kinda breaks them. This makes sure that doesn't happen by letting them use their default palette