### PR TITLE
Add Popup for metacache clear failures

### DIFF
--- a/launcher/FileSystem.cpp
+++ b/launcher/FileSystem.cpp
@@ -55,7 +55,6 @@
 #include "DesktopServices.h"
 #include "PSaveFile.h"
 #include "StringUtils.h"
-#include "ui/dialogs/CustomMessageBox.h"
 
 #if defined Q_OS_WIN32
 #define NOMINMAX

--- a/launcher/FileSystem.cpp
+++ b/launcher/FileSystem.cpp
@@ -55,6 +55,7 @@
 #include "DesktopServices.h"
 #include "PSaveFile.h"
 #include "StringUtils.h"
+#include "ui/dialogs/CustomMessageBox.h"
 
 #if defined Q_OS_WIN32
 #define NOMINMAX

--- a/launcher/net/HttpMetaCache.cpp
+++ b/launcher/net/HttpMetaCache.cpp
@@ -166,8 +166,9 @@ auto HttpMetaCache::evictEntry(MetaEntryPtr entry) -> bool
     return true;
 }
 
-void HttpMetaCache::evictAll()
+bool HttpMetaCache::evictAll()
 {
+    bool ret;
     for (QString& base : m_entries.keys()) {
         EntryMap& map = m_entries[base];
         qCDebug(taskHttpMetaCacheLogC) << "Evicting base" << base;
@@ -176,8 +177,9 @@ void HttpMetaCache::evictAll()
                 qCWarning(taskHttpMetaCacheLogC) << "Unexpected missing cache entry" << entry->m_basePath;
         }
         map.entry_list.clear();
-        FS::deletePath(map.base_path);
+        ret = FS::deletePath(map.base_path);
     }
+    return ret;
 }
 
 auto HttpMetaCache::staleEntry(QString base, QString resource_path) -> MetaEntryPtr

--- a/launcher/net/HttpMetaCache.cpp
+++ b/launcher/net/HttpMetaCache.cpp
@@ -166,9 +166,10 @@ auto HttpMetaCache::evictEntry(MetaEntryPtr entry) -> bool
     return true;
 }
 
-bool HttpMetaCache::evictAll()
+//returns true on success, false otherwise
+auto HttpMetaCache::evictAll() -> bool
 {
-    bool ret;
+    bool ret = true;
     for (QString& base : m_entries.keys()) {
         EntryMap& map = m_entries[base];
         qCDebug(taskHttpMetaCacheLogC) << "Evicting base" << base;
@@ -177,7 +178,8 @@ bool HttpMetaCache::evictAll()
                 qCWarning(taskHttpMetaCacheLogC) << "Unexpected missing cache entry" << entry->m_basePath;
         }
         map.entry_list.clear();
-        ret = FS::deletePath(map.base_path);
+        //AND all return codes together so the result is true iff all runs of deletePath() are true
+        ret &= FS::deletePath(map.base_path);
     }
     return ret;
 }

--- a/launcher/net/HttpMetaCache.h
+++ b/launcher/net/HttpMetaCache.h
@@ -113,7 +113,7 @@ class HttpMetaCache : public QObject {
 
     // evict selected entry from cache
     auto evictEntry(MetaEntryPtr entry) -> bool;
-    void evictAll();
+    bool evictAll();
 
     void addBase(QString base, QString base_root);
 

--- a/launcher/net/HttpMetaCache.h
+++ b/launcher/net/HttpMetaCache.h
@@ -113,7 +113,7 @@ class HttpMetaCache : public QObject {
 
     // evict selected entry from cache
     auto evictEntry(MetaEntryPtr entry) -> bool;
-    bool evictAll();
+    auto evictAll() -> bool;
 
     void addBase(QString base, QString base_root);
 

--- a/launcher/net/HttpMetaCache.h
+++ b/launcher/net/HttpMetaCache.h
@@ -113,7 +113,7 @@ class HttpMetaCache : public QObject {
 
     // evict selected entry from cache
     auto evictEntry(MetaEntryPtr entry) -> bool;
-    auto evictAll() -> bool;
+    bool evictAll();
 
     void addBase(QString base, QString base_root);
 

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -1318,7 +1318,10 @@ void MainWindow::on_actionReportBug_triggered()
 
 void MainWindow::on_actionClearMetadata_triggered()
 {
-    APPLICATION->metacache()->evictAll();
+    if(!APPLICATION->metacache()->evictAll()){
+        CustomMessageBox::selectable(this, tr("Error"), tr("Metadata cache clear Failed!\n To clear the metadata cache manually, press Folders -> View Launcher Root Folder, and after closing the launcher delete the folder named \"meta\"\n"), QMessageBox::Warning)->show();
+    }
+
     APPLICATION->metacache()->SaveNow();
 }
 

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -1318,8 +1318,13 @@ void MainWindow::on_actionReportBug_triggered()
 
 void MainWindow::on_actionClearMetadata_triggered()
 {
-    if(!APPLICATION->metacache()->evictAll()){
-        CustomMessageBox::selectable(this, tr("Error"), tr("Metadata cache clear Failed!\n To clear the metadata cache manually, press Folders -> View Launcher Root Folder, and after closing the launcher delete the folder named \"meta\"\n"), QMessageBox::Warning)->show();
+    //This if contains side effects!
+    if (!APPLICATION->metacache()->evictAll()) {
+        CustomMessageBox::selectable(this, tr("Error"),
+                                     tr("Metadata cache clear Failed!\nTo clear the metadata cache manually, press Folders -> View "
+                                        "Launcher Root Folder, and after closing the launcher delete the folder named \"meta\"\n"),
+                                     QMessageBox::Warning)
+            ->show();
     }
 
     APPLICATION->metacache()->SaveNow();


### PR DESCRIPTION
This commit adds a popup alerting the end user when the Metadata cache clear button fails to fully erase the cache, as well as displaying actionable text to clear the cache manually (shamelessly ripped from Refraction's help text).