### PR TITLE
Fix compatibility with macOS 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
             qt_ver: 6
             qt_host: mac
             qt_arch: ""
-            qt_version: "6.8.1"
+            qt_version: "6.7.3"
             qt_modules: "qt5compat qtimageformats qtnetworkauth"
 
           - os: macos-14


### PR DESCRIPTION
Qt 6.8 dropped support for macOS 11 and didn't include it in their primary changelog :/

Fixes: https://github.com/PrismLauncher/PrismLauncher/issues/3592