### PR TITLE
Start using patch versioning for launcher

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ set(CMAKE_CXX_FLAGS_RELEASE "-O2 -D_FORTIFY_SOURCE=2 ${CMAKE_CXX_FLAGS_RELEASE}"
 # Export compile commands for debug builds if we can (useful in LSPs like clangd)
 # https://cmake.org/cmake/help/v3.31/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html
 if(CMAKE_GENERATOR STREQUAL "Unix Makefiles" OR CMAKE_GENERATOR STREQUAL "Ninja" AND CMAKE_BUILD_TYPE STREQUAL "Debug")
-  set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+    set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 endif()
 
 option(DEBUG_ADDRESS_SANITIZER "Enable Address Sanitizer in Debug builds" OFF)
@@ -195,10 +195,11 @@ set(Launcher_FMLLIBS_BASE_URL "https://files.prismlauncher.org/fmllibs/" CACHE S
 ######## Set version numbers ########
 set(Launcher_VERSION_MAJOR 10)
 set(Launcher_VERSION_MINOR 0)
+set(Launcher_VERSION_PATCH 0)
 
-set(Launcher_VERSION_NAME "${Launcher_VERSION_MAJOR}.${Launcher_VERSION_MINOR}")
-set(Launcher_VERSION_NAME4 "${Launcher_VERSION_MAJOR}.${Launcher_VERSION_MINOR}.0.0")
-set(Launcher_VERSION_NAME4_COMMA "${Launcher_VERSION_MAJOR},${Launcher_VERSION_MINOR},0,0")
+set(Launcher_VERSION_NAME "${Launcher_VERSION_MAJOR}.${Launcher_VERSION_MINOR}.${Launcher_VERSION_PATCH}")
+set(Launcher_VERSION_NAME4 "${Launcher_VERSION_MAJOR}.${Launcher_VERSION_MINOR}.${Launcher_VERSION_PATCH}.0")
+set(Launcher_VERSION_NAME4_COMMA "${Launcher_VERSION_MAJOR},${Launcher_VERSION_MINOR},${Launcher_VERSION_PATCH},0")
 
 # Build platform.
 set(Launcher_BUILD_PLATFORM "unknown" CACHE STRING "A short string identifying the platform that this build was built for. Only used to display in the about dialog.")
@@ -242,7 +243,7 @@ set(Launcher_ENABLE_JAVA_DOWNLOADER_DEFAULT ON)
 # differing Linux/BSD/etc distributions. Downstream packagers should be explicitly opt-ing into this
 # feature if they know it will work with their distribution.
 if(UNIX AND NOT APPLE)
-  set(Launcher_ENABLE_JAVA_DOWNLOADER_DEFAULT OFF)
+    set(Launcher_ENABLE_JAVA_DOWNLOADER_DEFAULT OFF)
 endif()
 
 # Java downloader
@@ -383,7 +384,7 @@ set(Launcher_ENABLE_UPDATER NO)
 set(Launcher_BUILD_UPDATER NO)
 
 if (NOT APPLE AND (NOT Launcher_UPDATER_GITHUB_REPO STREQUAL "" AND NOT Launcher_BUILD_ARTIFACT STREQUAL ""))
-	set(Launcher_BUILD_UPDATER YES)
+    set(Launcher_BUILD_UPDATER YES)
 endif()
 
 if(NOT (UNIX AND APPLE))

--- a/buildconfig/BuildConfig.cpp.in
+++ b/buildconfig/BuildConfig.cpp.in
@@ -34,8 +34,8 @@
  */
 
 #include <qstringliteral.h>
-#include "BuildConfig.h"
 #include <QObject>
+#include "BuildConfig.h"
 
 const Config BuildConfig;
 
@@ -58,6 +58,7 @@ Config::Config()
     // Version information
     VERSION_MAJOR = @Launcher_VERSION_MAJOR@;
     VERSION_MINOR = @Launcher_VERSION_MINOR@;
+    VERSION_PATCH = @Launcher_VERSION_PATCH@;
 
     BUILD_PLATFORM = "@Launcher_BUILD_PLATFORM@";
     BUILD_ARTIFACT = "@Launcher_BUILD_ARTIFACT@";
@@ -74,14 +75,13 @@ Config::Config()
     MAC_SPARKLE_PUB_KEY = "@MACOSX_SPARKLE_UPDATE_PUBLIC_KEY@";
     MAC_SPARKLE_APPCAST_URL = "@MACOSX_SPARKLE_UPDATE_FEED_URL@";
 
-    if (!MAC_SPARKLE_PUB_KEY.isEmpty() && !MAC_SPARKLE_APPCAST_URL.isEmpty())
-    {
+    if (!MAC_SPARKLE_PUB_KEY.isEmpty() && !MAC_SPARKLE_APPCAST_URL.isEmpty()) {
         UPDATER_ENABLED = true;
-    } else if(!UPDATER_GITHUB_REPO.isEmpty() && !BUILD_ARTIFACT.isEmpty()) {
+    } else if (!UPDATER_GITHUB_REPO.isEmpty() && !BUILD_ARTIFACT.isEmpty()) {
         UPDATER_ENABLED = true;
     }
 
-    #cmakedefine01 Launcher_ENABLE_JAVA_DOWNLOADER
+#cmakedefine01 Launcher_ENABLE_JAVA_DOWNLOADER
     JAVA_DOWNLOADER_ENABLED = Launcher_ENABLE_JAVA_DOWNLOADER;
 
     GIT_COMMIT = "@Launcher_GIT_COMMIT@";
@@ -89,27 +89,19 @@ Config::Config()
     GIT_REFSPEC = "@Launcher_GIT_REFSPEC@";
 
     // Assume that builds outside of Git repos are "stable"
-    if (GIT_REFSPEC == QStringLiteral("GITDIR-NOTFOUND")
-        || GIT_TAG == QStringLiteral("GITDIR-NOTFOUND")
-        || GIT_REFSPEC == QStringLiteral("")
-        || GIT_TAG == QStringLiteral("GIT-NOTFOUND"))
-    {
+    if (GIT_REFSPEC == QStringLiteral("GITDIR-NOTFOUND") || GIT_TAG == QStringLiteral("GITDIR-NOTFOUND") ||
+        GIT_REFSPEC == QStringLiteral("") || GIT_TAG == QStringLiteral("GIT-NOTFOUND")) {
         GIT_REFSPEC = "refs/heads/stable";
         GIT_TAG = versionString();
         GIT_COMMIT = "";
     }
 
-    if (GIT_REFSPEC.startsWith("refs/heads/"))
-    {
+    if (GIT_REFSPEC.startsWith("refs/heads/")) {
         VERSION_CHANNEL = GIT_REFSPEC;
-        VERSION_CHANNEL.remove("refs/heads/"); 
-    }
-    else if (!GIT_COMMIT.isEmpty())
-    {
+        VERSION_CHANNEL.remove("refs/heads/");
+    } else if (!GIT_COMMIT.isEmpty()) {
         VERSION_CHANNEL = GIT_COMMIT.mid(0, 8);
-    }
-    else
-    {
+    } else {
         VERSION_CHANNEL = "unknown";
     }
 
@@ -136,7 +128,7 @@ Config::Config()
 
 QString Config::versionString() const
 {
-    return QString("%1.%2").arg(VERSION_MAJOR).arg(VERSION_MINOR);
+    return QString("%1.%2.%3").arg(VERSION_MAJOR).arg(VERSION_MINOR).arg(VERSION_PATCH);
 }
 
 QString Config::printableVersionString() const
@@ -144,8 +136,7 @@ QString Config::printableVersionString() const
     QString vstr = versionString();
 
     // If the build is not a main release, append the channel
-    if(VERSION_CHANNEL != "stable" && GIT_TAG != vstr)
-    {
+    if (VERSION_CHANNEL != "stable" && GIT_TAG != vstr) {
         vstr += "-" + VERSION_CHANNEL;
     }
     return vstr;
@@ -162,4 +153,3 @@ QString Config::systemID() const
 {
     return QStringLiteral("%1 %2 %3").arg(COMPILER_TARGET_SYSTEM, COMPILER_TARGET_SYSTEM_VERSION, COMPILER_TARGET_SYSTEM_PROCESSOR);
 }
-

--- a/buildconfig/BuildConfig.h
+++ b/buildconfig/BuildConfig.h
@@ -59,6 +59,8 @@ class Config {
     int VERSION_MAJOR;
     /// The minor version number.
     int VERSION_MINOR;
+    /// The patch version number.
+    int VERSION_PATCH;
 
     /**
      * The version channel

--- a/launcher/updater/prismupdater/PrismUpdater.cpp
+++ b/launcher/updater/prismupdater/PrismUpdater.cpp
@@ -298,6 +298,10 @@ PrismUpdaterApp::PrismUpdaterApp(int& argc, char** argv) : QApplication(argc, ar
         auto version_parts = version.split('.');
         m_prismVersionMajor = version_parts.takeFirst().toInt();
         m_prismVersionMinor = version_parts.takeFirst().toInt();
+        if (!version_parts.isEmpty())
+            m_prismVersionPatch = version_parts.takeFirst().toInt();
+        else
+            m_prismVersionPatch = 0;
     }
 
     m_allowPreRelease = parser.isSet("pre-release");
@@ -556,6 +560,7 @@ void PrismUpdaterApp::run()
         m_prismVersion = BuildConfig.printableVersionString();
         m_prismVersionMajor = BuildConfig.VERSION_MAJOR;
         m_prismVersionMinor = BuildConfig.VERSION_MINOR;
+        m_prismVersionPatch = BuildConfig.VERSION_PATCH;
         m_prsimVersionChannel = BuildConfig.VERSION_CHANNEL;
         m_prismGitCommit = BuildConfig.GIT_COMMIT;
     }
@@ -564,6 +569,7 @@ void PrismUpdaterApp::run()
     qDebug() << "Executable reports as:" << m_prismBinaryName << "version:" << m_prismVersion;
     qDebug() << "Version major:" << m_prismVersionMajor;
     qDebug() << "Version minor:" << m_prismVersionMinor;
+    qDebug() << "Version minor:" << m_prismVersionPatch;
     qDebug() << "Version channel:" << m_prsimVersionChannel;
     qDebug() << "Git Commit:" << m_prismGitCommit;
 
@@ -1277,6 +1283,10 @@ bool PrismUpdaterApp::loadPrismVersionFromExe(const QString& exe_path)
         return false;
     m_prismVersionMajor = version_parts.takeFirst().toInt();
     m_prismVersionMinor = version_parts.takeFirst().toInt();
+    if (!version_parts.isEmpty())
+        m_prismVersionPatch = version_parts.takeFirst().toInt();
+    else
+        m_prismVersionPatch = 0;
     m_prismGitCommit = lines.takeFirst().simplified();
     return true;
 }
@@ -1400,7 +1410,7 @@ GitHubRelease PrismUpdaterApp::getLatestRelease()
 
 bool PrismUpdaterApp::needUpdate(const GitHubRelease& release)
 {
-    auto current_ver = Version(QString("%1.%2").arg(QString::number(m_prismVersionMajor)).arg(QString::number(m_prismVersionMinor)));
+    auto current_ver = Version(QString("%1.%2.%3").arg(m_prismVersionMajor).arg(m_prismVersionMinor).arg(m_prismVersionPatch));
     return current_ver < release.version;
 }
 

--- a/launcher/updater/prismupdater/PrismUpdater.h
+++ b/launcher/updater/prismupdater/PrismUpdater.h
@@ -121,6 +121,7 @@ class PrismUpdaterApp : public QApplication {
     QString m_prismVersion;
     int m_prismVersionMajor = -1;
     int m_prismVersionMinor = -1;
+    int m_prismVersionPatch = -1;
     QString m_prsimVersionChannel;
     QString m_prismGitCommit;
 

--- a/program_info/win_install.nsi.in
+++ b/program_info/win_install.nsi.in
@@ -398,6 +398,7 @@ Section "@Launcher_DisplayName@"
   WriteRegStr HKCU Software\Classes\prismlauncher\shell\open\command "" '"$INSTDIR\@Launcher_APP_BINARY_NAME@.exe" "%1"'
 
   ; Write the uninstall keys for Windows
+  ; https://learn.microsoft.com/en-us/windows/win32/msi/uninstall-registry-key
   ${GetParameters} $R0
   ${GetOptions} $R0 "/NoUninstaller" $R1
   ${If} ${Errors}


### PR DESCRIPTION
 ~~semver~~  This *really* shouldn't break anything.

EDIT:  To clarify we should start using three numbers. this does *not* mean we should treat them like semantic versioning.

Please read https://antfu.me/posts/epoch-semver on why that's not such a great idea.
We will be treating the major and minor version numbers the same as we have been but add the concept of a patch version back.