### PR TITLE
fix: crash when the instance window is closed before download dialog is open

### DIFF
--- a/launcher/ui/pages/instance/ModFolderPage.cpp
+++ b/launcher/ui/pages/instance/ModFolderPage.cpp
@@ -145,9 +145,10 @@ void ModFolderPage::downloadMods()
         QMessageBox::critical(this, tr("Error"), tr("Please install a mod loader first!"));
         return;
     }
-
-    ResourceDownload::ModDownloadDialog mdownload(this, m_model, m_instance);
-    if (mdownload.exec()) {
+    auto mdownload = new ResourceDownload::ModDownloadDialog(this, m_model, m_instance);
+    mdownload->setAttribute(Qt::WA_DeleteOnClose);
+    connect(this, &QObject::destroyed, mdownload, &QDialog::close);
+    if (mdownload->exec()) {
         auto tasks = new ConcurrentTask(tr("Download Mods"), APPLICATION->settings()->get("NumberOfConcurrentDownloads").toInt());
         connect(tasks, &Task::failed, [this, tasks](QString reason) {
             CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show();
@@ -165,7 +166,7 @@ void ModFolderPage::downloadMods()
             tasks->deleteLater();
         });
 
-        for (auto& task : mdownload.getTasks()) {
+        for (auto& task : mdownload->getTasks()) {
             tasks->addTask(task);
         }
 
@@ -300,9 +301,11 @@ void ModFolderPage::changeModVersion()
     if (mods_list.length() != 1 || mods_list[0]->metadata() == nullptr)
         return;
 
-    ResourceDownload::ModDownloadDialog mdownload(this, m_model, m_instance);
-    mdownload.setResourceMetadata((*mods_list.begin())->metadata());
-    if (mdownload.exec()) {
+    auto mdownload = new ResourceDownload::ModDownloadDialog(this, m_model, m_instance);
+    mdownload->setAttribute(Qt::WA_DeleteOnClose);
+    connect(this, &QObject::destroyed, mdownload, &QDialog::close);
+    mdownload->setResourceMetadata((*mods_list.begin())->metadata());
+    if (mdownload->exec()) {
         auto tasks = new ConcurrentTask("Download Mods", APPLICATION->settings()->get("NumberOfConcurrentDownloads").toInt());
         connect(tasks, &Task::failed, [this, tasks](QString reason) {
             CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show();
@@ -320,7 +323,7 @@ void ModFolderPage::changeModVersion()
             tasks->deleteLater();
         });
 
-        for (auto& task : mdownload.getTasks()) {
+        for (auto& task : mdownload->getTasks()) {
             tasks->addTask(task);
         }
 

--- a/launcher/ui/pages/instance/ResourcePackPage.cpp
+++ b/launcher/ui/pages/instance/ResourcePackPage.cpp
@@ -84,8 +84,10 @@ void ResourcePackPage::downloadResourcePacks()
     if (m_instance->typeName() != "Minecraft")
         return;  // this is a null instance or a legacy instance
 
-    ResourceDownload::ResourcePackDownloadDialog mdownload(this, m_model, m_instance);
-    if (mdownload.exec()) {
+    auto mdownload = new ResourceDownload::ResourcePackDownloadDialog(this, m_model, m_instance);
+    mdownload->setAttribute(Qt::WA_DeleteOnClose);
+    connect(this, &QObject::destroyed, mdownload, &QDialog::close);
+    if (mdownload->exec()) {
         auto tasks = new ConcurrentTask("Download Resource Pack", APPLICATION->settings()->get("NumberOfConcurrentDownloads").toInt());
         connect(tasks, &Task::failed, [this, tasks](QString reason) {
             CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show();
@@ -103,7 +105,7 @@ void ResourcePackPage::downloadResourcePacks()
             tasks->deleteLater();
         });
 
-        for (auto& task : mdownload.getTasks()) {
+        for (auto& task : mdownload->getTasks()) {
             tasks->addTask(task);
         }
 
@@ -235,9 +237,11 @@ void ResourcePackPage::changeResourcePackVersion()
     if (resource.metadata() == nullptr)
         return;
 
-    ResourceDownload::ResourcePackDownloadDialog mdownload(this, m_model, m_instance);
-    mdownload.setResourceMetadata(resource.metadata());
-    if (mdownload.exec()) {
+    auto mdownload = new ResourceDownload::ResourcePackDownloadDialog(this, m_model, m_instance);
+    mdownload->setAttribute(Qt::WA_DeleteOnClose);
+    connect(this, &QObject::destroyed, mdownload, &QDialog::close);
+    mdownload->setResourceMetadata(resource.metadata());
+    if (mdownload->exec()) {
         auto tasks = new ConcurrentTask("Download Resource Packs", APPLICATION->settings()->get("NumberOfConcurrentDownloads").toInt());
         connect(tasks, &Task::failed, [this, tasks](QString reason) {
             CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show();
@@ -255,7 +259,7 @@ void ResourcePackPage::changeResourcePackVersion()
             tasks->deleteLater();
         });
 
-        for (auto& task : mdownload.getTasks()) {
+        for (auto& task : mdownload->getTasks()) {
             tasks->addTask(task);
         }
 

--- a/launcher/ui/pages/instance/ShaderPackPage.cpp
+++ b/launcher/ui/pages/instance/ShaderPackPage.cpp
@@ -81,8 +81,10 @@ void ShaderPackPage::downloadShaderPack()
     if (m_instance->typeName() != "Minecraft")
         return;  // this is a null instance or a legacy instance
 
-    ResourceDownload::ShaderPackDownloadDialog mdownload(this, m_model, m_instance);
-    if (mdownload.exec()) {
+    auto mdownload = new ResourceDownload::ShaderPackDownloadDialog(this, m_model, m_instance);
+    mdownload->setAttribute(Qt::WA_DeleteOnClose);
+    connect(this, &QObject::destroyed, mdownload, &QDialog::close);
+    if (mdownload->exec()) {
         auto tasks = new ConcurrentTask("Download Shader Packs", APPLICATION->settings()->get("NumberOfConcurrentDownloads").toInt());
         connect(tasks, &Task::failed, [this, tasks](QString reason) {
             CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show();
@@ -100,7 +102,7 @@ void ShaderPackPage::downloadShaderPack()
             tasks->deleteLater();
         });
 
-        for (auto& task : mdownload.getTasks()) {
+        for (auto& task : mdownload->getTasks()) {
             tasks->addTask(task);
         }
 
@@ -232,9 +234,11 @@ void ShaderPackPage::changeShaderPackVersion()
     if (resource.metadata() == nullptr)
         return;
 
-    ResourceDownload::ShaderPackDownloadDialog mdownload(this, m_model, m_instance);
-    mdownload.setResourceMetadata(resource.metadata());
-    if (mdownload.exec()) {
+    auto mdownload = new ResourceDownload::ShaderPackDownloadDialog(this, m_model, m_instance);
+    mdownload->setAttribute(Qt::WA_DeleteOnClose);
+    connect(this, &QObject::destroyed, mdownload, &QDialog::close);
+    mdownload->setResourceMetadata(resource.metadata());
+    if (mdownload->exec()) {
         auto tasks = new ConcurrentTask("Download Shader Packs", APPLICATION->settings()->get("NumberOfConcurrentDownloads").toInt());
         connect(tasks, &Task::failed, [this, tasks](QString reason) {
             CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show();
@@ -252,7 +256,7 @@ void ShaderPackPage::changeShaderPackVersion()
             tasks->deleteLater();
         });
 
-        for (auto& task : mdownload.getTasks()) {
+        for (auto& task : mdownload->getTasks()) {
             tasks->addTask(task);
         }
 

--- a/launcher/ui/pages/instance/TexturePackPage.cpp
+++ b/launcher/ui/pages/instance/TexturePackPage.cpp
@@ -90,8 +90,10 @@ void TexturePackPage::downloadTexturePacks()
     if (m_instance->typeName() != "Minecraft")
         return;  // this is a null instance or a legacy instance
 
-    ResourceDownload::TexturePackDownloadDialog mdownload(this, m_model, m_instance);
-    if (mdownload.exec()) {
+    auto mdownload = new ResourceDownload::TexturePackDownloadDialog(this, m_model, m_instance);
+    mdownload->setAttribute(Qt::WA_DeleteOnClose);
+    connect(this, &QObject::destroyed, mdownload, &QDialog::close);
+    if (mdownload->exec()) {
         auto tasks = new ConcurrentTask("Download Texture Packs", APPLICATION->settings()->get("NumberOfConcurrentDownloads").toInt());
         connect(tasks, &Task::failed, [this, tasks](QString reason) {
             CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show();
@@ -109,7 +111,7 @@ void TexturePackPage::downloadTexturePacks()
             tasks->deleteLater();
         });
 
-        for (auto& task : mdownload.getTasks()) {
+        for (auto& task : mdownload->getTasks()) {
             tasks->addTask(task);
         }
 
@@ -241,9 +243,11 @@ void TexturePackPage::changeTexturePackVersion()
     if (resource.metadata() == nullptr)
         return;
 
-    ResourceDownload::TexturePackDownloadDialog mdownload(this, m_model, m_instance);
-    mdownload.setResourceMetadata(resource.metadata());
-    if (mdownload.exec()) {
+    auto mdownload = new ResourceDownload::TexturePackDownloadDialog(this, m_model, m_instance);
+    mdownload->setAttribute(Qt::WA_DeleteOnClose);
+    connect(this, &QObject::destroyed, mdownload, &QDialog::close);
+    mdownload->setResourceMetadata(resource.metadata());
+    if (mdownload->exec()) {
         auto tasks = new ConcurrentTask("Download Texture Packs", APPLICATION->settings()->get("NumberOfConcurrentDownloads").toInt());
         connect(tasks, &Task::failed, [this, tasks](QString reason) {
             CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show();
@@ -261,7 +265,7 @@ void TexturePackPage::changeTexturePackVersion()
             tasks->deleteLater();
         });
 
-        for (auto& task : mdownload.getTasks()) {
+        for (auto& task : mdownload->getTasks()) {
             tasks->addTask(task);
         }
 

--- a/launcher/ui/widgets/ModFilterWidget.cpp
+++ b/launcher/ui/widgets/ModFilterWidget.cpp
@@ -291,7 +291,6 @@ void ModFilterWidget::onSideFilterChanged()
         side = "";
     }
 
-
     m_filter_changed = side != m_filter->side;
     m_filter->side = side;
     if (m_filter_changed)


### PR DESCRIPTION
fixes #3604

so based on the issue description:
- try to download mods
- before the mods download dialog is open close the instance window
- it will crash because of double deletion

No I was unable to reproduce it(the dialog is always instant) but by changing the code(adding ` QTimer::singleShot(5000, nullptr, [this]() { static_cast<InstanceWindow*>(parent()->parent())->close(); });` before creating the resource download dialog did the trick).
Double deletion happens because, first, the dialog is on stack(not a pointer), and we pass the parent dialog.
It is deleted by parent closing and then because the function code arrives at the end. 