### PR TITLE
Use security-scoped bookmarks for directory settings on macOS

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -709,6 +709,16 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         m_settings->registerSetting("SkinsDir", "skins");
         m_settings->registerSetting("JavaDir", "java");
 
+#ifdef Q_OS_MACOS
+        // Folder security-scoped bookmarks
+        m_settings->registerSetting("InstanceDirBookmark", "");
+        m_settings->registerSetting("CentralModsDirBookmark", "");
+        m_settings->registerSetting("IconsDirBookmark", "");
+        m_settings->registerSetting("DownloadsDirBookmark", "");
+        m_settings->registerSetting("SkinsDirBookmark", "");
+        m_settings->registerSetting("JavaDirBookmark", "");
+#endif
+
         // Editors
         m_settings->registerSetting("JsonEditor", QString());
 
@@ -964,7 +974,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         auto InstDirSetting = m_settings->getSetting("InstanceDir");
         // instance path: check for problems with '!' in instance path and warn the user in the log
         // and remember that we have to show him a dialog when the gui starts (if it does so)
-        QString instDir = InstDirSetting->get().toString();
+        QString instDir = m_settings->get("InstanceDir").toString();
         qInfo() << "Instance path              : " << instDir;
         if (FS::checkProblemticPathJava(QDir(instDir))) {
             qWarning() << "Your instance path contains \'!\' and this is known to cause java problems!";

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -969,6 +969,21 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
     // Themes
     m_themeManager = std::make_unique<ThemeManager>();
 
+#ifdef Q_OS_MACOS
+    // for macOS: getting directory settings will generate URL security-scoped bookmarks if needed and not present
+    // this facilitates a smooth transition from a non-sandboxed version of the launcher, that likely can access the directory,
+    // and a sandboxed version that can't access the directory without a bookmark
+    // this section can likely be removed once the sandboxed version has been released for a while and migrations aren't done anymore
+    {
+        m_settings->get("InstanceDir");
+        m_settings->get("CentralModsDir");
+        m_settings->get("IconsDir");
+        m_settings->get("DownloadsDir");
+        m_settings->get("SkinsDir");
+        m_settings->get("JavaDir");
+    }
+#endif
+
     // initialize and load all instances
     {
         auto InstDirSetting = m_settings->getSetting("InstanceDir");

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -1177,8 +1177,8 @@ if (APPLE)
     set(LAUNCHER_SOURCES
         ${LAUNCHER_SOURCES}
 
-            macsandbox/SecurityBookmarkFileAccess.h
-            macsandbox/SecurityBookmarkFileAccess.mm
+        macsandbox/SecurityBookmarkFileAccess.h
+        macsandbox/SecurityBookmarkFileAccess.mm
     )
 endif()
 

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -1173,6 +1173,15 @@ if (NOT Apple)
 )
 endif()
 
+if (APPLE)
+    set(LAUNCHER_SOURCES
+        ${LAUNCHER_SOURCES}
+
+            macsandbox/SecurityBookmarkFileAccess.h
+            macsandbox/SecurityBookmarkFileAccess.mm
+    )
+endif()
+
 if(WIN32)
     set(LAUNCHER_SOURCES
         console/WindowsConsole.h

--- a/launcher/macsandbox/SecurityBookmarkFileAccess.h
+++ b/launcher/macsandbox/SecurityBookmarkFileAccess.h
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2024 Kenneth Chew <79120643+kthchew@users.noreply.github.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef FILEACCESS_H
+#define FILEACCESS_H
+
+#include <QtCore/QMap>
+#include <QtCore/QSet>
+Q_FORWARD_DECLARE_OBJC_CLASS(NSData);
+Q_FORWARD_DECLARE_OBJC_CLASS(NSURL);
+Q_FORWARD_DECLARE_OBJC_CLASS(NSString);
+Q_FORWARD_DECLARE_OBJC_CLASS(NSAutoreleasePool);
+Q_FORWARD_DECLARE_OBJC_CLASS(NSMutableDictionary);
+Q_FORWARD_DECLARE_OBJC_CLASS(NSMutableSet);
+class QString;
+class QByteArray;
+class QUrl;
+
+class SecurityBookmarkFileAccess {
+    /// The keys are bookmarks and the values are URLs.
+    NSMutableDictionary* m_bookmarks;
+    /// The keys are paths and the values are bookmarks.
+    NSMutableDictionary* m_paths;
+    /// Contains URLs that are currently being accessed.
+    NSMutableSet* m_activeURLs;
+
+    NSURL* securityScopedBookmarkToNSURL(QByteArray& bookmark, bool& isStale);
+public:
+    SecurityBookmarkFileAccess();
+    ~SecurityBookmarkFileAccess();
+
+    /// Get a security scoped bookmark from a URL.
+    ///
+    /// The URL must be accessible before calling this function. That is, call `startAccessingSecurityScopedResource()` before calling
+    /// this function. Note that this is called implicitly if the user selects the directory from a file picker.
+    /// \param url The URL to get the security scoped bookmark from.
+    /// \return A QByteArray containing the security scoped bookmark.
+    QByteArray urlToSecurityScopedBookmark(const QUrl& url);
+    /// Get a security scoped bookmark from a path.
+    ///
+    /// The path must be accessible before calling this function. That is, call `startAccessingSecurityScopedResource()` before calling
+    /// this function. Note that this is called implicitly if the user selects the directory from a file picker.
+    /// \param path The path to get the security scoped bookmark from.
+    /// \return A QByteArray containing the security scoped bookmark.
+    QByteArray pathToSecurityScopedBookmark(const QString& path);
+    /// Get a QUrl from a security scoped bookmark. If the bookmark is stale, isStale will be set to true and the bookmark will be updated.
+    ///
+    /// You must check whether the URL is valid before using it.
+    /// \param bookmark The security scoped bookmark to get the URL from.
+    /// \param isStale A boolean that will be set to true if the bookmark is stale.
+    /// \return The URL from the security scoped bookmark.
+    QUrl securityScopedBookmarkToURL(QByteArray& bookmark, bool& isStale);
+
+    /// Makes the file or directory at the path pointed to by the bookmark accessible. Unlike `startAccessingSecurityScopedResource()`, this
+    /// class ensures that only one "access" is active at a time. Calling this function again after the security-scoped resource has
+    /// already been used will do nothing, and a single call to `stopUsingSecurityScopedBookmark()` will release the resource provided that
+    /// this is the only `SecurityBookmarkFileAccess` accessing the resource.
+    ///
+    /// If the bookmark is stale, `isStale` will be set to true and the bookmark will be updated. Stored copies of the bookmark need to be
+    /// updated.
+    /// \param bookmark The security scoped bookmark to start accessing.
+    /// \param isStale A boolean that will be set to true if the bookmark is stale.
+    /// \return A boolean indicating whether the bookmark was successfully accessed.
+    bool startUsingSecurityScopedBookmark(QByteArray& bookmark, bool& isStale);
+    void stopUsingSecurityScopedBookmark(QByteArray& bookmark);
+};
+
+#endif //FILEACCESS_H

--- a/launcher/macsandbox/SecurityBookmarkFileAccess.h
+++ b/launcher/macsandbox/SecurityBookmarkFileAccess.h
@@ -39,9 +39,12 @@ class SecurityBookmarkFileAccess {
     /// Contains URLs that are currently being accessed.
     NSMutableSet* m_activeURLs;
 
+    bool m_readOnly;
+
     NSURL* securityScopedBookmarkToNSURL(QByteArray& bookmark, bool& isStale);
 public:
-    SecurityBookmarkFileAccess();
+    /// \param readOnly A boolean indicating whether the bookmark should be read-only.
+    SecurityBookmarkFileAccess(bool readOnly = false);
     ~SecurityBookmarkFileAccess();
 
     /// Get a security scoped bookmark from a URL.
@@ -78,6 +81,9 @@ public:
     /// \return A boolean indicating whether the bookmark was successfully accessed.
     bool startUsingSecurityScopedBookmark(QByteArray& bookmark, bool& isStale);
     void stopUsingSecurityScopedBookmark(QByteArray& bookmark);
+
+    /// Returns true if access to the `path` is currently being maintained by this object.
+    bool isAccessingPath(const QString& path);
 };
 
 #endif //FILEACCESS_H

--- a/launcher/macsandbox/SecurityBookmarkFileAccess.mm
+++ b/launcher/macsandbox/SecurityBookmarkFileAccess.mm
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2024 Kenneth Chew <79120643+kthchew@users.noreply.github.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "SecurityBookmarkFileAccess.h"
+
+#include <Foundation/Foundation.h>
+#include <QByteArray>
+#include <QUrl>
+
+QByteArray SecurityBookmarkFileAccess::urlToSecurityScopedBookmark(const QUrl& url)
+{
+    if (!url.isLocalFile())
+        return {};
+
+    NSError* error = nil;
+    NSURL* nsurl = [url.toNSURL() absoluteURL];
+    if ([m_paths objectForKey:[nsurl path]]) {
+        return QByteArray::fromNSData(m_paths[[nsurl path]]);
+    }
+    [m_activeURLs addObject:nsurl];
+    NSData* bookmark = [nsurl bookmarkDataWithOptions:NSURLBookmarkCreationWithSecurityScope
+                       includingResourceValuesForKeys:nil
+                                        relativeToURL:nil
+                                                error:&error];
+    if (error) {
+        return {};
+    }
+    m_paths[[nsurl path]] = bookmark;
+    m_bookmarks[bookmark] = nsurl;
+    [m_activeURLs addObject:nsurl];
+
+    return QByteArray::fromNSData(bookmark);
+}
+
+SecurityBookmarkFileAccess::SecurityBookmarkFileAccess()
+{
+    m_bookmarks = [NSMutableDictionary new];
+    m_paths = [NSMutableDictionary new];
+    m_activeURLs = [NSMutableSet new];
+}
+
+SecurityBookmarkFileAccess::~SecurityBookmarkFileAccess()
+{
+    for (NSURL* url : m_activeURLs) {
+        [url stopAccessingSecurityScopedResource];
+    }
+    [m_bookmarks release];
+    [m_paths release];
+    [m_activeURLs release];
+}
+
+QByteArray SecurityBookmarkFileAccess::pathToSecurityScopedBookmark(const QString& path)
+{
+    return urlToSecurityScopedBookmark(QUrl::fromLocalFile(path));
+}
+
+NSURL* SecurityBookmarkFileAccess::securityScopedBookmarkToNSURL(QByteArray& bookmark, bool& isStale)
+{
+    NSError* error = nil;
+    BOOL localStale = NO;
+    NSURL* nsurl = [NSURL URLByResolvingBookmarkData:bookmark.toNSData()
+                                             options:NSURLBookmarkResolutionWithSecurityScope
+                                       relativeToURL:nil
+                                 bookmarkDataIsStale:&localStale
+                                               error:&error];
+    if (error) {
+        return nil;
+    }
+    isStale = localStale;
+    if (isStale) {
+        NSData* nsBookmark = [nsurl bookmarkDataWithOptions:NSURLBookmarkCreationWithSecurityScope
+                             includingResourceValuesForKeys:nil
+                                              relativeToURL:nil
+                                                      error:&error];
+        if (error) {
+            return nil;
+        }
+        m_paths[[nsurl path]] = nsBookmark;
+        m_bookmarks[nsBookmark] = nsurl;
+        bookmark = QByteArray::fromNSData(nsBookmark);
+    }
+
+    return nsurl;
+}
+
+QUrl SecurityBookmarkFileAccess::securityScopedBookmarkToURL(QByteArray& bookmark, bool& isStale)
+{
+    if (bookmark.isEmpty())
+        return {};
+
+    NSURL* url = securityScopedBookmarkToNSURL(bookmark, isStale);
+    if (!url)
+        return {};
+
+    return QUrl::fromNSURL(url);
+}
+
+bool SecurityBookmarkFileAccess::startUsingSecurityScopedBookmark(QByteArray& bookmark, bool& isStale)
+{
+    NSURL* url = [m_bookmarks objectForKey:bookmark.toNSData()] ? m_bookmarks[bookmark.toNSData()] : securityScopedBookmarkToNSURL(bookmark, isStale);
+    if ([m_activeURLs containsObject:url])
+        return false;
+
+    if ([url startAccessingSecurityScopedResource]) {
+        [m_activeURLs addObject:url];
+        return true;
+    }
+    return false;
+}
+
+void SecurityBookmarkFileAccess::stopUsingSecurityScopedBookmark(QByteArray& bookmark)
+{
+    if (![m_bookmarks objectForKey:bookmark.toNSData()])
+        return;
+    NSURL* url = m_bookmarks[bookmark.toNSData()];
+
+    if ([m_activeURLs containsObject:url]) {
+        [url stopAccessingSecurityScopedResource];
+        [m_activeURLs removeObject:url];
+        [m_bookmarks removeObjectForKey:bookmark.toNSData()];
+        [m_paths removeObjectForKey:[url path]];
+    }
+}

--- a/launcher/macsandbox/SecurityBookmarkFileAccess.mm
+++ b/launcher/macsandbox/SecurityBookmarkFileAccess.mm
@@ -29,25 +29,41 @@ QByteArray SecurityBookmarkFileAccess::urlToSecurityScopedBookmark(const QUrl& u
 
     NSError* error = nil;
     NSURL* nsurl = [url.toNSURL() absoluteURL];
+    NSData* bookmark;
     if ([m_paths objectForKey:[nsurl path]]) {
-        return QByteArray::fromNSData(m_paths[[nsurl path]]);
+        bookmark = m_paths[[nsurl path]];
+    } else {
+        bookmark = [nsurl bookmarkDataWithOptions:NSURLBookmarkCreationWithSecurityScope |
+                                                  (m_readOnly ? NSURLBookmarkCreationSecurityScopeAllowOnlyReadAccess : 0)
+                   includingResourceValuesForKeys:nil
+                                    relativeToURL:nil
+                                            error:&error];
     }
-    [m_activeURLs addObject:nsurl];
-    NSData* bookmark = [nsurl bookmarkDataWithOptions:NSURLBookmarkCreationWithSecurityScope
-                       includingResourceValuesForKeys:nil
-                                        relativeToURL:nil
-                                                error:&error];
     if (error) {
         return {};
     }
+
+    // remove/reapply access to ensure that write access is immediately cut off for read-only bookmarks
+    // sometimes you need to call this twice to actually stop access (extra calls aren't harmful)
+    [nsurl stopAccessingSecurityScopedResource];
+    [nsurl stopAccessingSecurityScopedResource];
+    nsurl = [NSURL URLByResolvingBookmarkData:bookmark
+                                      options:NSURLBookmarkResolutionWithSecurityScope |
+                                              (m_readOnly ? NSURLBookmarkCreationSecurityScopeAllowOnlyReadAccess : 0)
+                                relativeToURL:nil
+                          bookmarkDataIsStale:nil
+                                        error:&error];
     m_paths[[nsurl path]] = bookmark;
     m_bookmarks[bookmark] = nsurl;
-    [m_activeURLs addObject:nsurl];
 
-    return QByteArray::fromNSData(bookmark);
+    QByteArray qBookmark = QByteArray::fromNSData(bookmark);
+    bool isStale = false;
+    startUsingSecurityScopedBookmark(qBookmark, isStale);
+
+    return qBookmark;
 }
 
-SecurityBookmarkFileAccess::SecurityBookmarkFileAccess()
+SecurityBookmarkFileAccess::SecurityBookmarkFileAccess(bool readOnly) : m_readOnly(readOnly)
 {
     m_bookmarks = [NSMutableDictionary new];
     m_paths = [NSMutableDictionary new];
@@ -59,9 +75,6 @@ SecurityBookmarkFileAccess::~SecurityBookmarkFileAccess()
     for (NSURL* url : m_activeURLs) {
         [url stopAccessingSecurityScopedResource];
     }
-    [m_bookmarks release];
-    [m_paths release];
-    [m_activeURLs release];
 }
 
 QByteArray SecurityBookmarkFileAccess::pathToSecurityScopedBookmark(const QString& path)
@@ -74,7 +87,8 @@ NSURL* SecurityBookmarkFileAccess::securityScopedBookmarkToNSURL(QByteArray& boo
     NSError* error = nil;
     BOOL localStale = NO;
     NSURL* nsurl = [NSURL URLByResolvingBookmarkData:bookmark.toNSData()
-                                             options:NSURLBookmarkResolutionWithSecurityScope
+                                             options:NSURLBookmarkResolutionWithSecurityScope |
+                                                     (m_readOnly ? NSURLBookmarkCreationSecurityScopeAllowOnlyReadAccess : 0)
                                        relativeToURL:nil
                                  bookmarkDataIsStale:&localStale
                                                error:&error];
@@ -83,17 +97,20 @@ NSURL* SecurityBookmarkFileAccess::securityScopedBookmarkToNSURL(QByteArray& boo
     }
     isStale = localStale;
     if (isStale) {
-        NSData* nsBookmark = [nsurl bookmarkDataWithOptions:NSURLBookmarkCreationWithSecurityScope
+        NSData* nsBookmark = [nsurl bookmarkDataWithOptions:NSURLBookmarkCreationWithSecurityScope |
+                                                            (m_readOnly ? NSURLBookmarkCreationSecurityScopeAllowOnlyReadAccess : 0)
                              includingResourceValuesForKeys:nil
                                               relativeToURL:nil
                                                       error:&error];
         if (error) {
             return nil;
         }
-        m_paths[[nsurl path]] = nsBookmark;
-        m_bookmarks[nsBookmark] = nsurl;
         bookmark = QByteArray::fromNSData(nsBookmark);
     }
+
+    NSData* nsBookmark = bookmark.toNSData();
+    m_paths[[nsurl path]] = nsBookmark;
+    m_bookmarks[nsBookmark] = nsurl;
 
     return nsurl;
 }
@@ -112,10 +129,12 @@ QUrl SecurityBookmarkFileAccess::securityScopedBookmarkToURL(QByteArray& bookmar
 
 bool SecurityBookmarkFileAccess::startUsingSecurityScopedBookmark(QByteArray& bookmark, bool& isStale)
 {
-    NSURL* url = [m_bookmarks objectForKey:bookmark.toNSData()] ? m_bookmarks[bookmark.toNSData()] : securityScopedBookmarkToNSURL(bookmark, isStale);
+    NSURL* url = [m_bookmarks objectForKey:bookmark.toNSData()] ? m_bookmarks[bookmark.toNSData()]
+                                                                : securityScopedBookmarkToNSURL(bookmark, isStale);
     if ([m_activeURLs containsObject:url])
         return false;
 
+    [url stopAccessingSecurityScopedResource];
     if ([url startAccessingSecurityScopedResource]) {
         [m_activeURLs addObject:url];
         return true;
@@ -131,8 +150,23 @@ void SecurityBookmarkFileAccess::stopUsingSecurityScopedBookmark(QByteArray& boo
 
     if ([m_activeURLs containsObject:url]) {
         [url stopAccessingSecurityScopedResource];
+        [url stopAccessingSecurityScopedResource];
+
         [m_activeURLs removeObject:url];
-        [m_bookmarks removeObjectForKey:bookmark.toNSData()];
         [m_paths removeObjectForKey:[url path]];
+        [m_bookmarks removeObjectForKey:bookmark.toNSData()];
     }
+}
+
+bool SecurityBookmarkFileAccess::isAccessingPath(const QString& path)
+{
+    NSData* bookmark = [m_paths objectForKey:path.toNSString()];
+    if (!bookmark && path.endsWith('/')) {
+        bookmark = [m_paths objectForKey:path.left(path.length() - 1).toNSString()];
+    }
+    if (!bookmark) {
+        return false;
+    }
+    NSURL* url = [m_bookmarks objectForKey:bookmark];
+    return [m_activeURLs containsObject:url];
 }

--- a/launcher/settings/SettingsObject.h
+++ b/launcher/settings/SettingsObject.h
@@ -23,6 +23,10 @@
 #include <QVariant>
 #include <memory>
 
+#ifdef Q_OS_MACOS
+#include "macsandbox/SecurityBookmarkFileAccess.h"
+#endif
+
 class Setting;
 class SettingsObject;
 
@@ -119,7 +123,27 @@ class SettingsObject : public QObject {
      * \return The setting's value as a QVariant.
      * If no setting with the given ID exists, returns an invalid QVariant.
      */
-    QVariant get(const QString& id) const;
+    QVariant get(const QString& id);
+
+#ifdef Q_OS_MACOS
+    /*!
+     * \brief Get the path to the file or directory represented by the bookmark stored in the associated setting.
+     * \param id The setting ID of the relevant directory - this should not include "Bookmark" at the end.
+     * \return A path to the file or directory represented by the bookmark.
+     * If a bookmark is not valid or stored, use default logic (directly return the stored path).
+     * This can attempt to create a bookmark if the path is accessible and the bookmark is not valid.
+     */
+    QString getPathFromBookmark(const QString& id);
+    /*!
+     * \brief Set a security-scoped bookmark to the provided path for the associated setting.
+     * \param id The setting ID of the relevant directory - this should not include "Bookmark" at the end.
+     * \param path The new desired path.
+     * \return A boolean indicating whether a bookmark was successfully set.
+     * The path needs to be accessible to the launcher before calling this function. For example,
+     * it could come from a user selection in an open panel.
+     */
+    bool setPathWithBookmark(const QString& id, const QString& path);
+#endif
 
     /*!
      * \brief Sets the value of the setting with the given ID.
@@ -207,6 +231,9 @@ class SettingsObject : public QObject {
 
    private:
     QMap<QString, std::shared_ptr<Setting>> m_settings;
+#ifdef Q_OS_MACOS
+    SecurityBookmarkFileAccess m_sandboxedFileAccess;
+#endif
 
    protected:
     bool m_suspendSave = false;

--- a/launcher/ui/widgets/MinecraftSettingsWidget.cpp
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.cpp
@@ -488,7 +488,7 @@ void MinecraftSettingsWidget::openGlobalSettings()
         APPLICATION->ShowGlobalSettings(this, "minecraft-settings");
 }
 
-void MinecraftSettingsWidget::updateAccountsMenu(const SettingsObject& settings)
+void MinecraftSettingsWidget::updateAccountsMenu(SettingsObject& settings)
 {
     m_ui->instanceAccountSelector->clear();
     auto accounts = APPLICATION->accounts();

--- a/launcher/ui/widgets/MinecraftSettingsWidget.h
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.h
@@ -54,7 +54,7 @@ class MinecraftSettingsWidget : public QWidget {
 
    private:
     void openGlobalSettings();
-    void updateAccountsMenu(const SettingsObject& settings);
+    void updateAccountsMenu(SettingsObject& settings);
     bool isQuickPlaySupported();
    private slots:
     void saveSelectedLoaders();


### PR DESCRIPTION
Related to #3149, and overall related to #1146

As #3149 gets closer to being ready for review, this PR lays the groundwork for merging it in the future by cherry picking the parts of it that use security-scoped bookmarks to keep track of user-selected data directories, such as the instances directory they choose in settings. Security-scoped bookmarks allow sandboxed apps to maintain access to a file or directory selected by the user in a system file picker even after it is quit and reopened.

The reason this part is being cherry picked before the rest of the macOS sandbox PR is because the current non-sandboxed app presumably has access to the currently used directories, and it can thus "pre-generate" these bookmarks before it actually adopts the App Sandbox. If/when a future Prism Launcher update adopts the App Sandbox, these bookmarks can be used to avoid disruption to the user. Without this pre-generation of the bookmarks, users will need to reselect any customized directories in a file picker if they are outside of the sandbox container.

I thus would suggest merging this at some point before merging #3149 and then giving sufficient time between then and the release containing #3149 for people to update and automatically and transparently "migrate" to using bookmarks as needed.

Almost no direct changes to the user experience are expected by this PR, but there may be minor differences. If a directory (or its parent directory, such as the name of a volume) is renamed or moved, the bookmark should still point to the same directory. This is unlike a simple path. However, bookmarks are only used if the selected directory is **not** the default directory or in the default data directory, so you won't see this behavior when renaming the default `instances` directory, for example.

To make things easier, `SettingsObject::get` and `SettingsObject::set` will still return paths as normal for `*Dir` settings, and use/activate the bookmarks as needed. Both the path and the bookmark will be stored in the settings file for backward compatibility.

---
Testing steps:

1. Use current release version of Prism Launcher
2. In settings, change instances, etc. directories to some directory that is not in `~/Library/Application Support/PrismLauncher`
3. Use version of Prism Launcher from this PR, ensure old directory settings are still present and working
4. Use version of Prism Launcher from #3149 [1], ensure old directory settings are still present and working

[1] Using the sandboxed version of Prism Launcher will move all data files into a sandbox container at `~/Library/Containers/org.prismlauncher.PrismLauncher/Data/Library/Application Support/PrismLauncher`. Move them back out to the original location after done with testing, then delete the `~/Library/Containers/org.prismlauncher.PrismLauncher` directory. I also recommend making a backup beforehand