### PR TITLE
Fix compatibility with Qt 6.9

### DIFF
--- a/launcher/FileSystem.cpp
+++ b/launcher/FileSystem.cpp
@@ -934,7 +934,7 @@ bool createShortcut(QString destination, QString target, QStringList args, QStri
     QDir content = application.path() + "/Contents/";
     QDir resources = content.path() + "/Resources/";
     QDir binaryDir = content.path() + "/MacOS/";
-    QFile info = content.path() + "/Info.plist";
+    QFile info(content.path() + "/Info.plist");
 
     if (!(content.mkpath(".") && resources.mkpath(".") && binaryDir.mkpath("."))) {
         qWarning() << "Couldn't create directories within application";


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
Qt 6.9 [makes](https://doc-snapshots.qt.io/qt6-dev/qfile.html#QFile-2) the construction of `QFile` from `QString` (and `std::filesystem::path`) explicit, meaning that the usage of `=` will no longer compile. Although we are probably not upgrading to 6.9 just yet, there is no harm in fixing this beforehand given that explicit construction is already used everywhere else a `QFile` is constructed.