### PR TITLE
Shorten LocalPeer socket names to fix CLI not working if an instance of the launcher is already running

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -375,19 +375,20 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         m_peerInstance = new LocalPeer(this, appID);
         connect(m_peerInstance, &LocalPeer::messageReceived, this, &Application::messageReceived);
         if (m_peerInstance->isClient()) {
+            bool sentMessage = false;
             int timeout = 2000;
 
             if (m_instanceIdToLaunch.isEmpty()) {
                 ApplicationMessage activate;
                 activate.command = "activate";
-                m_peerInstance->sendMessage(activate.serialize(), timeout);
+                sentMessage = m_peerInstance->sendMessage(activate.serialize(), timeout);
 
                 if (!m_urlsToImport.isEmpty()) {
                     for (auto url : m_urlsToImport) {
                         ApplicationMessage import;
                         import.command = "import";
                         import.args.insert("url", url.toString());
-                        m_peerInstance->sendMessage(import.serialize(), timeout);
+                        sentMessage = m_peerInstance->sendMessage(import.serialize(), timeout);
                     }
                 }
             } else {
@@ -407,10 +408,16 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
                     launch.args["offline_enabled"] = "true";
                     launch.args["offline_name"] = m_offlineName;
                 }
-                m_peerInstance->sendMessage(launch.serialize(), timeout);
+                sentMessage = m_peerInstance->sendMessage(launch.serialize(), timeout);
             }
-            m_status = Application::Succeeded;
-            return;
+            if (sentMessage) {
+                m_status = Application::Succeeded;
+                return;
+            } else {
+                std::cerr << "Unable to redirect command to already running instance\n";
+                // C function not Qt function - event loop not started yet
+                ::exit(1);
+            }
         }
     }
 

--- a/libraries/LocalPeer/src/LocalPeer.cpp
+++ b/libraries/LocalPeer/src/LocalPeer.cpp
@@ -76,7 +76,7 @@ ApplicationId ApplicationId::fromTraditionalApp()
     prefix.truncate(6);
     QByteArray idc = protoId.toUtf8();
     quint16 idNum = qChecksum(idc.constData(), idc.size());
-    auto socketName = QLatin1String("qtsingleapp-") + prefix + QLatin1Char('-') + QString::number(idNum, 16);
+    auto socketName = QLatin1String("pl") + prefix + QLatin1Char('-') + QString::number(idNum, 16).left(12);
 #if defined(Q_OS_WIN)
     if (!pProcessIdToSessionId) {
         QLibrary lib("kernel32");
@@ -98,12 +98,12 @@ ApplicationId ApplicationId::fromPathAndVersion(const QString& dataPath, const Q
     QCryptographicHash shasum(QCryptographicHash::Algorithm::Sha1);
     QString result = dataPath + QLatin1Char('-') + version;
     shasum.addData(result.toUtf8());
-    return ApplicationId(QLatin1String("qtsingleapp-") + QString::fromLatin1(shasum.result().toHex()));
+    return ApplicationId(QLatin1String("pl") + QString::fromLatin1(shasum.result().toHex()).left(12));
 }
 
 ApplicationId ApplicationId::fromCustomId(const QString& id)
 {
-    return ApplicationId(QLatin1String("qtsingleapp-") + id);
+    return ApplicationId(QLatin1String("pl") + id);
 }
 
 ApplicationId ApplicationId::fromRawString(const QString& id)
@@ -139,7 +139,7 @@ bool LocalPeer::isClient()
 #if defined(Q_OS_UNIX)
     // ### Workaround
     if (!res && server->serverError() == QAbstractSocket::AddressInUseError) {
-        QFile::remove(QDir::cleanPath(QDir::tempPath()) + QLatin1Char('/') + socketName);
+        QLocalServer::removeServer(socketName);
         res = server->listen(socketName);
     }
 #endif


### PR DESCRIPTION
On most systems supporting Unix sockets, the maximum length of a socket name is quite low (e.g. on macOS 104 characters and on Linux 108). If the name is too long, the sockets will not work and thus sending messages to a running instance of the launcher will not work.

For example, running `prismlauncher -l instance_name` may do nothing if another instance of Prism Launcher is running. To the user, this appears as the new instance of the program immediately closing with no feedback, which is confusing.

The socket names it attempts to use currently look like
```
qtsingleapp-cc2b873d56e405acdf99e0acdacc831daa1a3633
```

This shortens them to something like
```
pl9c79e688629e
```

It also adds a message in case the second instance fails to send a message to the already running instance before exiting to avoid confusion.

This issue theoretically affects both Linux and macOS but is more likely to appear on macOS due to its long default `$TMPDIR` path (for example, `/var/folders/vz/hhls4rhd7rd26ntljp45fwpr0000gn/T/`), which combined with the long socket name above, creates the possibility of going over the limit.
