### PR TITLE
Use nix-shell over nix develop in .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,2 @@
-use flake
+use nix
 watch_file nix/*.nix

--- a/flake.nix
+++ b/flake.nix
@@ -132,6 +132,8 @@
 
         {
           default = pkgs.mkShell {
+            name = "prism-launcher";
+
             inputsFrom = [ packages'.prismlauncher-unwrapped ];
 
             packages = with pkgs; [

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,4 @@
+(import (fetchTarball {
+  url = "https://github.com/edolstra/flake-compat/archive/ff81ac966bb2cae68946d5ed5fc4994f96d0ffec.tar.gz";
+  sha256 = "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=";
+}) { src = ./.; }).shellNix


### PR DESCRIPTION
This will break less things and not need people to enable "experimental" commands
