### PR TITLE
Harmonizing "Other Log" page with "Minecraft Log"

### DIFF
--- a/launcher/InstancePageProvider.h
+++ b/launcher/InstancePageProvider.h
@@ -46,7 +46,7 @@ class InstancePageProvider : protected QObject, public BasePageProvider {
         values.append(new InstanceSettingsPage(onesix));
         auto logMatcher = inst->getLogFileMatcher();
         if (logMatcher) {
-            values.append(new OtherLogsPage(inst->getLogFileRoot(), logMatcher));
+            values.append(new OtherLogsPage(inst, logMatcher));
         }
         return values;
     }

--- a/launcher/launch/LogModel.cpp
+++ b/launcher/launch/LogModel.cpp
@@ -149,3 +149,15 @@ bool LogModel::wrapLines() const
 {
     return m_lineWrap;
 }
+
+void LogModel::setColorLines(bool state)
+{
+    if (m_colorLines != state) {
+        m_colorLines = state;
+    }
+}
+
+bool LogModel::colorLines() const
+{
+    return m_colorLines;
+}

--- a/launcher/launch/LogModel.h
+++ b/launcher/launch/LogModel.h
@@ -27,6 +27,8 @@ class LogModel : public QAbstractListModel {
 
     void setLineWrap(bool state);
     bool wrapLines() const;
+    void setColorLines(bool state);
+    bool colorLines() const;
 
     enum Roles { LevelRole = Qt::UserRole };
 
@@ -47,6 +49,7 @@ class LogModel : public QAbstractListModel {
     QString m_overflowMessage = "OVERFLOW";
     bool m_suspended = false;
     bool m_lineWrap = true;
+    bool m_colorLines = true;
 
    private:
     Q_DISABLE_COPY(LogModel)

--- a/launcher/ui/pages/instance/LogPage.cpp
+++ b/launcher/ui/pages/instance/LogPage.cpp
@@ -180,6 +180,13 @@ void LogPage::modelStateToUI()
         ui->text->setWordWrap(false);
         ui->wrapCheckbox->setCheckState(Qt::Unchecked);
     }
+    if (m_model->colorLines()) {
+        ui->text->setColorLines(true);
+        ui->colorCheckbox->setCheckState(Qt::Checked);
+    } else {
+        ui->text->setColorLines(false);
+        ui->colorCheckbox->setCheckState(Qt::Unchecked);
+    }
     if (m_model->suspended()) {
         ui->trackLogCheckbox->setCheckState(Qt::Unchecked);
     } else {
@@ -193,6 +200,7 @@ void LogPage::UIToModelState()
         return;
     }
     m_model->setLineWrap(ui->wrapCheckbox->checkState() == Qt::Checked);
+    m_model->setColorLines(ui->colorCheckbox->checkState() == Qt::Checked);
     m_model->suspend(ui->trackLogCheckbox->checkState() != Qt::Checked);
 }
 
@@ -280,6 +288,14 @@ void LogPage::on_wrapCheckbox_clicked(bool checked)
     if (!m_model)
         return;
     m_model->setLineWrap(checked);
+}
+
+void LogPage::on_colorCheckbox_clicked(bool checked)
+{
+    ui->text->setColorLines(checked);
+    if (!m_model)
+        return;
+    m_model->setColorLines(checked);
 }
 
 void LogPage::on_findButton_clicked()

--- a/launcher/ui/pages/instance/LogPage.h
+++ b/launcher/ui/pages/instance/LogPage.h
@@ -82,6 +82,7 @@ class LogPage : public QWidget, public BasePage {
 
     void on_trackLogCheckbox_clicked(bool checked);
     void on_wrapCheckbox_clicked(bool checked);
+    void on_colorCheckbox_clicked(bool checked);
 
     void on_findButton_clicked();
     void findActivated();

--- a/launcher/ui/pages/instance/LogPage.h
+++ b/launcher/ui/pages/instance/LogPage.h
@@ -35,6 +35,7 @@
 
 #pragma once
 
+#include <QIdentityProxyModel>
 #include <QWidget>
 
 #include <Application.h>
@@ -46,7 +47,18 @@ namespace Ui {
 class LogPage;
 }
 class QTextCharFormat;
-class LogFormatProxyModel;
+
+class LogFormatProxyModel : public QIdentityProxyModel {
+   public:
+    LogFormatProxyModel(QObject* parent = nullptr) : QIdentityProxyModel(parent) {}
+    QVariant data(const QModelIndex& index, int role) const override;
+    QFont getFont() const { return m_font; }
+    void setFont(QFont font) { m_font = font; }
+    QModelIndex find(const QModelIndex& start, const QString& value, bool reverse) const;
+
+   private:
+    QFont m_font;
+};
 
 class LogPage : public QWidget, public BasePage {
     Q_OBJECT

--- a/launcher/ui/pages/instance/LogPage.ui
+++ b/launcher/ui/pages/instance/LogPage.ui
@@ -75,6 +75,16 @@
           </widget>
          </item>
          <item>
+          <widget class="QCheckBox" name="colorCheckbox">
+           <property name="text">
+            <string>Color lines</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
           <spacer name="horizontalSpacer">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
@@ -170,6 +180,7 @@
   <tabstop>tabWidget</tabstop>
   <tabstop>trackLogCheckbox</tabstop>
   <tabstop>wrapCheckbox</tabstop>
+  <tabstop>colorCheckbox</tabstop>
   <tabstop>btnCopy</tabstop>
   <tabstop>btnPaste</tabstop>
   <tabstop>btnClear</tabstop>

--- a/launcher/ui/pages/instance/OtherLogsPage.cpp
+++ b/launcher/ui/pages/instance/OtherLogsPage.cpp
@@ -204,6 +204,7 @@ void OtherLogsPage::on_btnReload_clicked()
         if (content.back() == '\n')
             content = content.remove(content.size() - 1, 1);
         ui->text->clear();
+        ui->text->setModel(nullptr);
         m_model->clear();
         for (auto& line : content.split('\n')) {
             MessageLevel::Enum level = MessageLevel::Unknown;
@@ -221,6 +222,8 @@ void OtherLogsPage::on_btnReload_clicked()
 
             m_model->append(level, line);
         }
+        ui->text->setModel(m_proxy);
+        ui->text->scrollToBottom();
     }
 }
 

--- a/launcher/ui/pages/instance/OtherLogsPage.cpp
+++ b/launcher/ui/pages/instance/OtherLogsPage.cpp
@@ -202,7 +202,7 @@ void OtherLogsPage::on_btnReload_clicked()
 
         // Try to determine a level for each line
         if (content.back() == '\n')
-            content = content.removeLast();
+            content = content.remove(content.size() - 1, 1);
         ui->text->clear();
         m_model->clear();
         for (auto& line : content.split('\n')) {

--- a/launcher/ui/pages/instance/OtherLogsPage.cpp
+++ b/launcher/ui/pages/instance/OtherLogsPage.cpp
@@ -53,7 +53,7 @@ OtherLogsPage::OtherLogsPage(InstancePtr instance, IPathMatcher::Ptr fileFilter,
     , m_path(instance->getLogFileRoot())
     , m_fileFilter(fileFilter)
     , m_watcher(new RecursiveFileSystemWatcher(this))
-    , m_model(new LogModel())
+    , m_model(new LogModel(this))
 {
     ui->setupUi(this);
     ui->tabWidget->tabBar()->hide();

--- a/launcher/ui/pages/instance/OtherLogsPage.cpp
+++ b/launcher/ui/pages/instance/OtherLogsPage.cpp
@@ -203,6 +203,8 @@ void OtherLogsPage::on_btnReload_clicked()
         // Try to determine a level for each line
         if (content.back() == '\n')
             content = content.removeLast();
+        ui->text->clear();
+        m_model->clear();
         for (auto& line : content.split('\n')) {
             MessageLevel::Enum level = MessageLevel::Unknown;
 
@@ -230,6 +232,11 @@ void OtherLogsPage::on_btnPaste_clicked()
 void OtherLogsPage::on_btnCopy_clicked()
 {
     GuiUtil::setClipboardText(ui->text->toPlainText());
+}
+
+void OtherLogsPage::on_btnBottom_clicked()
+{
+    ui->text->scrollToBottom();
 }
 
 void OtherLogsPage::on_btnDelete_clicked()
@@ -306,6 +313,24 @@ void OtherLogsPage::on_btnClean_clicked()
         messageBoxFailure->setTextInteractionFlags(Qt::TextBrowserInteraction);
         messageBoxFailure->exec();
     }
+}
+
+void OtherLogsPage::on_wrapCheckbox_clicked(bool checked)
+{
+    ui->text->setWordWrap(checked);
+    if (!m_model)
+        return;
+    m_model->setLineWrap(checked);
+    ui->text->scrollToBottom();
+}
+
+void OtherLogsPage::on_colorCheckbox_clicked(bool checked)
+{
+    ui->text->setColorLines(checked);
+    if (!m_model)
+        return;
+    m_model->setColorLines(checked);
+    ui->text->scrollToBottom();
 }
 
 void OtherLogsPage::setControlsEnabled(const bool enabled)

--- a/launcher/ui/pages/instance/OtherLogsPage.h
+++ b/launcher/ui/pages/instance/OtherLogsPage.h
@@ -39,6 +39,7 @@
 
 #include <Application.h>
 #include <pathmatcher/IPathMatcher.h>
+#include "LogPage.h"
 #include "ui/pages/BasePage.h"
 
 namespace Ui {
@@ -51,7 +52,7 @@ class OtherLogsPage : public QWidget, public BasePage {
     Q_OBJECT
 
    public:
-    explicit OtherLogsPage(QString path, IPathMatcher::Ptr fileFilter, QWidget* parent = 0);
+    explicit OtherLogsPage(InstancePtr instance, IPathMatcher::Ptr fileFilter, QWidget* parent = 0);
     ~OtherLogsPage();
 
     QString id() const override { return "logs"; }
@@ -82,8 +83,12 @@ class OtherLogsPage : public QWidget, public BasePage {
 
    private:
     Ui::OtherLogsPage* ui;
+    InstancePtr m_instance;
     QString m_path;
     QString m_currentFile;
     IPathMatcher::Ptr m_fileFilter;
     RecursiveFileSystemWatcher* m_watcher;
+
+    LogFormatProxyModel* m_proxy;
+    shared_qobject_ptr<LogModel> m_model;
 };

--- a/launcher/ui/pages/instance/OtherLogsPage.h
+++ b/launcher/ui/pages/instance/OtherLogsPage.h
@@ -72,6 +72,10 @@ class OtherLogsPage : public QWidget, public BasePage {
     void on_btnCopy_clicked();
     void on_btnDelete_clicked();
     void on_btnClean_clicked();
+    void on_btnBottom_clicked();
+
+    void on_wrapCheckbox_clicked(bool checked);
+    void on_colorCheckbox_clicked(bool checked);
 
     void on_findButton_clicked();
     void findActivated();

--- a/launcher/ui/pages/instance/OtherLogsPage.ui
+++ b/launcher/ui/pages/instance/OtherLogsPage.ui
@@ -33,17 +33,41 @@
        <string notr="true">Tab 1</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_2">
+       <item row="2" column="0">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Search:</string>
+         </property>
+        </widget>
+       </item>
        <item row="2" column="1">
         <widget class="QLineEdit" name="searchBar"/>
        </item>
        <item row="2" column="2">
         <widget class="QPushButton" name="findButton">
          <property name="text">
-          <string>Find</string>
+          <string>&amp;Find</string>
          </property>
         </widget>
        </item>
-       <item row="1" column="0" colspan="4">
+       <item row="2" column="3">
+        <widget class="Line" name="line">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="4">
+        <widget class="QPushButton" name="btnBottom">
+         <property name="toolTip">
+          <string>Scroll all the way to bottom</string>
+         </property>
+         <property name="text">
+          <string>&amp;Bottom</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0" colspan="5">
         <widget class="LogView" name="text">
          <property name="enabled">
           <bool>false</bool>
@@ -65,54 +89,98 @@
          </property>
         </widget>
        </item>
-       <item row="0" column="0" colspan="4">
+       <item row="0" column="0" colspan="5">
         <layout class="QGridLayout" name="gridLayout">
-         <item row="3" column="1">
-          <widget class="QPushButton" name="btnCopy">
-           <property name="toolTip">
-            <string>Copy the whole log into the clipboard</string>
-           </property>
-           <property name="text">
-            <string>&amp;Copy</string>
-           </property>
-          </widget>
+         <item row="2" column="0" colspan="5">
+          <layout class="QHBoxLayout" name="horizontalLayout">
+           <item>
+            <widget class="QPushButton" name="btnDelete">
+             <property name="toolTip">
+              <string>Delete the selected log</string>
+             </property>
+             <property name="text">
+              <string>&amp;Delete This</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="btnClean">
+             <property name="toolTip">
+              <string>Delete all the logs</string>
+             </property>
+             <property name="text">
+              <string>Delete &amp;All</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
-         <item row="3" column="3">
-          <widget class="QPushButton" name="btnDelete">
-           <property name="toolTip">
-            <string>Clear the log</string>
-           </property>
-           <property name="text">
-            <string>Delete</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="2">
-          <widget class="QPushButton" name="btnPaste">
-           <property name="toolTip">
-            <string>Upload the log to the paste service configured in preferences.</string>
-           </property>
-           <property name="text">
-            <string>Upload</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="4">
-          <widget class="QPushButton" name="btnClean">
-           <property name="toolTip">
-            <string>Clear the log</string>
-           </property>
-           <property name="text">
-            <string>Clean</string>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
-          <widget class="QPushButton" name="btnReload">
-           <property name="text">
-            <string>Reload</string>
-           </property>
-          </widget>
+         <item row="3" column="0" colspan="5">
+          <layout class="QHBoxLayout" name="horizontalLayout">
+           <item>
+            <widget class="QCheckBox" name="wrapCheckbox">
+             <property name="text">
+              <string>Wrap lines</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QCheckBox" name="colorCheckbox">
+             <property name="text">
+              <string>Color lines</string>
+             </property>
+             <property name="checked">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QPushButton" name="btnCopy">
+             <property name="toolTip">
+              <string>Copy the whole log into the clipboard</string>
+             </property>
+             <property name="text">
+              <string>&amp;Copy</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="btnPaste">
+             <property name="toolTip">
+              <string>Upload the log to the paste service configured in preferences</string>
+             </property>
+             <property name="text">
+              <string>Upload</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="btnReload">
+             <property name="toolTip">
+              <string>Reload the contents of the log from the disk</string>
+             </property>
+             <property name="text">
+              <string>&amp;Reload</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
          <item row="0" column="0" colspan="5">
           <widget class="QComboBox" name="selectLogBox">
@@ -125,13 +193,6 @@
           </widget>
          </item>
         </layout>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="label">
-         <property name="text">
-          <string>Search:</string>
-         </property>
-        </widget>
        </item>
       </layout>
      </widget>
@@ -154,6 +215,8 @@
   <tabstop>btnPaste</tabstop>
   <tabstop>btnDelete</tabstop>
   <tabstop>btnClean</tabstop>
+  <tabstop>wrapCheckbox</tabstop>
+  <tabstop>colorCheckbox</tabstop>
   <tabstop>text</tabstop>
   <tabstop>searchBar</tabstop>
   <tabstop>findButton</tabstop>

--- a/launcher/ui/pages/instance/OtherLogsPage.ui
+++ b/launcher/ui/pages/instance/OtherLogsPage.ui
@@ -44,15 +44,24 @@
         </widget>
        </item>
        <item row="1" column="0" colspan="4">
-        <widget class="QPlainTextEdit" name="text">
+        <widget class="LogView" name="text">
          <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="undoRedoEnabled">
           <bool>false</bool>
          </property>
          <property name="readOnly">
           <bool>true</bool>
          </property>
+         <property name="plainText">
+          <string notr="true"/>
+         </property>
          <property name="textInteractionFlags">
           <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+         <property name="centerOnScroll">
+          <bool>false</bool>
          </property>
         </widget>
        </item>
@@ -130,6 +139,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>LogView</class>
+   <extends>QPlainTextEdit</extends>
+   <header>ui/widgets/LogView.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>tabWidget</tabstop>
   <tabstop>selectLogBox</tabstop>

--- a/launcher/ui/pages/instance/OtherLogsPage.ui
+++ b/launcher/ui/pages/instance/OtherLogsPage.ui
@@ -91,15 +91,25 @@
        </item>
        <item row="0" column="0" colspan="5">
         <layout class="QGridLayout" name="gridLayout">
-         <item row="2" column="0" colspan="5">
+         <item row="0" column="0" colspan="5">
           <layout class="QHBoxLayout" name="horizontalLayout">
+           <item>
+            <widget class="QComboBox" name="selectLogBox">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+            </widget>
+           </item>
            <item>
             <widget class="QPushButton" name="btnDelete">
              <property name="toolTip">
               <string>Delete the selected log</string>
              </property>
              <property name="text">
-              <string>&amp;Delete This</string>
+              <string>&amp;Delete Selected</string>
              </property>
             </widget>
            </item>
@@ -115,7 +125,7 @@
            </item>
           </layout>
          </item>
-         <item row="3" column="0" colspan="5">
+         <item row="1" column="0" colspan="5">
           <layout class="QHBoxLayout" name="horizontalLayout">
            <item>
             <widget class="QCheckBox" name="wrapCheckbox">
@@ -166,7 +176,7 @@
               <string>Upload the log to the paste service configured in preferences</string>
              </property>
              <property name="text">
-              <string>Upload</string>
+              <string>&amp;Upload</string>
              </property>
             </widget>
            </item>
@@ -181,16 +191,6 @@
             </widget>
            </item>
           </layout>
-         </item>
-         <item row="0" column="0" colspan="5">
-          <widget class="QComboBox" name="selectLogBox">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
          </item>
         </layout>
        </item>

--- a/launcher/ui/widgets/LogView.cpp
+++ b/launcher/ui/widgets/LogView.cpp
@@ -60,6 +60,14 @@ void LogView::setWordWrap(bool wrapping)
     }
 }
 
+void LogView::setColorLines(bool colorLines)
+{
+    if (m_colorLines == colorLines)
+        return;
+    m_colorLines = colorLines;
+    repopulate();
+}
+
 void LogView::setModel(QAbstractItemModel* model)
 {
     if (m_model) {
@@ -130,11 +138,11 @@ void LogView::rowsInserted(const QModelIndex& parent, int first, int last)
             format.setFont(font.value<QFont>());
         }
         auto fg = m_model->data(idx, Qt::ForegroundRole);
-        if (fg.isValid()) {
+        if (fg.isValid() && m_colorLines) {
             format.setForeground(fg.value<QColor>());
         }
         auto bg = m_model->data(idx, Qt::BackgroundRole);
-        if (bg.isValid()) {
+        if (bg.isValid() && m_colorLines) {
             format.setBackground(bg.value<QColor>());
         }
         cursor.movePosition(QTextCursor::End);

--- a/launcher/ui/widgets/LogView.h
+++ b/launcher/ui/widgets/LogView.h
@@ -15,6 +15,7 @@ class LogView : public QPlainTextEdit {
 
    public slots:
     void setWordWrap(bool wrapping);
+    void setColorLines(bool colorLines);
     void findNext(const QString& what, bool reverse);
     void scrollToBottom();
 
@@ -32,4 +33,5 @@ class LogView : public QPlainTextEdit {
     QTextCharFormat* m_defaultFormat = nullptr;
     bool m_scroll = false;
     bool m_scrolling = false;
+    bool m_colorLines = true;
 };


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
These two pages in the instance settings both display logs but have slightly different interfaces. Specifically, the other logs page does not support the following functionality present in the Minecraft log page:
- Colored lines based on message levels
- Enable/disable line wrapping
- Jump to bottom
- Also, the current Delete/Clean button is very unclear in what they actually do; they have the same tooltip ("Clear the log"), but do different things, which further confuses the readers. This PR thus proposes to change their names to "Delete This"/"Delete All" (without any functionality changes).

Therefore this PR proposes to bring those features to the other log window to to achieve feature parity. After the change, the window looks like this:
![CleanShot 2025-04-15 at 06 03 47@2x](https://github.com/user-attachments/assets/32501938-ffd7-427e-87d7-8b6c9d3c5bbd)
Notice that the UI is now identical to the Minecraft log page, with small tweaks such as exchanging the Clear button with the Reload button. (Clear may still be useful here if the functionality is extended to also clear the physical log files, but I don't think it's still needed in this window given that Delete This exists). Keep Updating is also removed as that does not makes much sense when reading past logs.
Also, an additional checkbox for "color lines" is added to both Minecraft logs and other logs windows, to allow users to turn on/off the coloring.

Internally this is achieved by using `LogView` in `OtherLogsPage` too, which also eliminated a FIXME in the file.

One further enhancement possible is to change the dropdown for the log file to become a table (QTreeView), similar to the world/mod/resource pack pages, which shows the filename, last modified date, and size. This change will address #258, since the table will be sortable by column. However, it seems that these kinds of changes need to treat the log files as a kind of resource (or at least, write a model for log lists), which is more complicated than UI changes so I'm not doing that in this PR. Also, the limited vertical space may be a problem if we make the dropdown a table.