### PR TITLE
chore: sync cmake version with the one used in the launcher

### DIFF
--- a/libraries/LocalPeer/CMakeLists.txt
+++ b/libraries/LocalPeer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9.4)
+cmake_minimum_required(VERSION 3.15)
 project(LocalPeer)
 
 if(QT_VERSION_MAJOR EQUAL 5)

--- a/libraries/gamemode/CMakeLists.txt
+++ b/libraries/gamemode/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9.4)
+cmake_minimum_required(VERSION 3.15)
 project(gamemode
     VERSION 1.6.1)
 

--- a/libraries/javacheck/CMakeLists.txt
+++ b/libraries/javacheck/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9.4)
+cmake_minimum_required(VERSION 3.15)
 project(launcher Java)
 find_package(Java 1.7 REQUIRED COMPONENTS Development)
 

--- a/libraries/launcher/CMakeLists.txt
+++ b/libraries/launcher/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9.4)
+cmake_minimum_required(VERSION 3.15)
 project(launcher Java)
 find_package(Java 1.7 REQUIRED COMPONENTS Development)
 

--- a/libraries/murmur2/CMakeLists.txt
+++ b/libraries/murmur2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9.4)
+cmake_minimum_required(VERSION 3.15)
 project(murmur2)
 
 set(MURMUR_SOURCES

--- a/libraries/qdcss/CMakeLists.txt
+++ b/libraries/qdcss/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9.4)
+cmake_minimum_required(VERSION 3.15)
 project(qdcss)
 
 if(QT_VERSION_MAJOR EQUAL 5)

--- a/libraries/rainbow/CMakeLists.txt
+++ b/libraries/rainbow/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.9.4)
+cmake_minimum_required(VERSION 3.15)
 project(rainbow)
 
 if(QT_VERSION_MAJOR EQUAL 5)


### PR DESCRIPTION
example of warning I get:
```
CMake Deprecation Warning at libraries/qdcss/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.
  ```