### PR TITLE
fix: load world size async 

### DIFF
--- a/launcher/minecraft/World.cpp
+++ b/launcher/minecraft/World.cpp
@@ -198,22 +198,6 @@ bool putLevelDatDataToFS(const QFileInfo& file, QByteArray& data)
     return f.commit();
 }
 
-int64_t calculateWorldSize(const QFileInfo& file)
-{
-    if (file.isFile() && file.suffix() == "zip") {
-        return file.size();
-    } else if (file.isDir()) {
-        QDirIterator it(file.absoluteFilePath(), QDir::Files, QDirIterator::Subdirectories);
-        int64_t total = 0;
-        while (it.hasNext()) {
-            it.next();
-            total += it.fileInfo().size();
-        }
-        return total;
-    }
-    return -1;
-}
-
 World::World(const QFileInfo& file)
 {
     repath(file);
@@ -223,7 +207,6 @@ void World::repath(const QFileInfo& file)
 {
     m_containerFile = file;
     m_folderName = file.fileName();
-    m_size = calculateWorldSize(file);
     if (file.isFile() && file.suffix() == "zip") {
         m_iconFile = QString();
         readFromZip(file);
@@ -530,4 +513,9 @@ bool World::isMoreThanOneHardLink() const
         return FS::hardLinkCount(QDir(m_containerFile.absoluteFilePath()).filePath("level.dat")) > 1;
     }
     return FS::hardLinkCount(m_containerFile.absoluteFilePath()) > 1;
+}
+
+void World::setSize(int64_t size)
+{
+    m_size = size;
 }

--- a/launcher/minecraft/World.h
+++ b/launcher/minecraft/World.h
@@ -39,7 +39,7 @@ class World {
     QDateTime lastPlayed() const { return m_lastPlayed; }
     GameType gameType() const { return m_gameType; }
     int64_t seed() const { return m_randomSeed; }
-    bool isValid() const { return is_valid; }
+    bool isValid() const { return m_isValid; }
     bool isOnFS() const { return m_containerFile.isDir(); }
     QFileInfo container() const { return m_containerFile; }
     // delete all the files of this world
@@ -83,10 +83,10 @@ class World {
     QString m_folderName;
     QString m_actualName;
     QString m_iconFile;
-    QDateTime levelDatTime;
+    QDateTime m_levelDatTime;
     QDateTime m_lastPlayed;
     int64_t m_size;
     int64_t m_randomSeed = 0;
     GameType m_gameType;
-    bool is_valid = false;
+    bool m_isValid = false;
 };

--- a/launcher/minecraft/World.h
+++ b/launcher/minecraft/World.h
@@ -54,6 +54,8 @@ class World {
     bool rename(const QString& to);
     bool install(const QString& to, const QString& name = QString());
 
+    void setSize(int64_t size);
+
     // WEAK compare operator - used for replacing worlds
     bool operator==(const World& other) const;
 

--- a/launcher/minecraft/WorldList.cpp
+++ b/launcher/minecraft/WorldList.cpp
@@ -51,18 +51,18 @@ WorldList::WorldList(const QString& dir, BaseInstance* instance) : QAbstractList
     m_dir.setFilter(QDir::Readable | QDir::NoDotAndDotDot | QDir::Files | QDir::Dirs);
     m_dir.setSorting(QDir::Name | QDir::IgnoreCase | QDir::LocaleAware);
     m_watcher = new QFileSystemWatcher(this);
-    is_watching = false;
+    m_isWatching = false;
     connect(m_watcher, &QFileSystemWatcher::directoryChanged, this, &WorldList::directoryChanged);
 }
 
 void WorldList::startWatching()
 {
-    if (is_watching) {
+    if (m_isWatching) {
         return;
     }
     update();
-    is_watching = m_watcher->addPath(m_dir.absolutePath());
-    if (is_watching) {
+    m_isWatching = m_watcher->addPath(m_dir.absolutePath());
+    if (m_isWatching) {
         qDebug() << "Started watching " << m_dir.absolutePath();
     } else {
         qDebug() << "Failed to start watching " << m_dir.absolutePath();
@@ -71,11 +71,11 @@ void WorldList::startWatching()
 
 void WorldList::stopWatching()
 {
-    if (!is_watching) {
+    if (!m_isWatching) {
         return;
     }
-    is_watching = !m_watcher->removePath(m_dir.absolutePath());
-    if (!is_watching) {
+    m_isWatching = !m_watcher->removePath(m_dir.absolutePath());
+    if (!m_isWatching) {
         qDebug() << "Stopped watching " << m_dir.absolutePath();
     } else {
         qDebug() << "Failed to stop watching " << m_dir.absolutePath();
@@ -101,12 +101,12 @@ bool WorldList::update()
         }
     }
     beginResetModel();
-    worlds.swap(newWorlds);
+    m_worlds.swap(newWorlds);
     endResetModel();
     return true;
 }
 
-void WorldList::directoryChanged(QString path)
+void WorldList::directoryChanged(QString)
 {
     update();
 }
@@ -123,12 +123,12 @@ QString WorldList::instDirPath() const
 
 bool WorldList::deleteWorld(int index)
 {
-    if (index >= worlds.size() || index < 0)
+    if (index >= m_worlds.size() || index < 0)
         return false;
-    World& m = worlds[index];
+    World& m = m_worlds[index];
     if (m.destroy()) {
         beginRemoveRows(QModelIndex(), index, index);
-        worlds.removeAt(index);
+        m_worlds.removeAt(index);
         endRemoveRows();
         emit changed();
         return true;
@@ -139,11 +139,11 @@ bool WorldList::deleteWorld(int index)
 bool WorldList::deleteWorlds(int first, int last)
 {
     for (int i = first; i <= last; i++) {
-        World& m = worlds[i];
+        World& m = m_worlds[i];
         m.destroy();
     }
     beginRemoveRows(QModelIndex(), first, last);
-    worlds.erase(worlds.begin() + first, worlds.begin() + last + 1);
+    m_worlds.erase(m_worlds.begin() + first, m_worlds.begin() + last + 1);
     endRemoveRows();
     emit changed();
     return true;
@@ -151,9 +151,9 @@ bool WorldList::deleteWorlds(int first, int last)
 
 bool WorldList::resetIcon(int row)
 {
-    if (row >= worlds.size() || row < 0)
+    if (row >= m_worlds.size() || row < 0)
         return false;
-    World& m = worlds[row];
+    World& m = m_worlds[row];
     if (m.resetIcon()) {
         emit dataChanged(index(row), index(row), { WorldList::IconFileRole });
         return true;
@@ -174,12 +174,12 @@ QVariant WorldList::data(const QModelIndex& index, int role) const
     int row = index.row();
     int column = index.column();
 
-    if (row < 0 || row >= worlds.size())
+    if (row < 0 || row >= m_worlds.size())
         return QVariant();
 
     QLocale locale;
 
-    auto& world = worlds[row];
+    auto& world = m_worlds[row];
     switch (role) {
         case Qt::DisplayRole:
             switch (column) {
@@ -339,9 +339,9 @@ QMimeData* WorldList::mimeData(const QModelIndexList& indexes) const
         if (idx.column() != 0)
             continue;
         int row = idx.row();
-        if (row < 0 || row >= this->worlds.size())
+        if (row < 0 || row >= this->m_worlds.size())
             continue;
-        worlds_.append(this->worlds[row]);
+        worlds_.append(this->m_worlds[row]);
     }
     if (!worlds_.size()) {
         return new QMimeData();
@@ -393,7 +393,7 @@ bool WorldList::dropMimeData(const QMimeData* data,
         return false;
     // files dropped from outside?
     if (data->hasUrls()) {
-        bool was_watching = is_watching;
+        bool was_watching = m_isWatching;
         if (was_watching)
             stopWatching();
         auto urls = data->urls();

--- a/launcher/minecraft/WorldList.h
+++ b/launcher/minecraft/WorldList.h
@@ -86,6 +86,7 @@ class WorldList : public QAbstractListModel {
 
    private slots:
     void directoryChanged(QString path);
+    void loadWorldsAsync();
 
    signals:
     void changed();

--- a/launcher/minecraft/WorldList.h
+++ b/launcher/minecraft/WorldList.h
@@ -40,9 +40,9 @@ class WorldList : public QAbstractListModel {
     virtual QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
     virtual int columnCount(const QModelIndex& parent) const;
 
-    size_t size() const { return worlds.size(); };
+    size_t size() const { return m_worlds.size(); };
     bool empty() const { return size() == 0; }
-    World& operator[](size_t index) { return worlds[index]; }
+    World& operator[](size_t index) { return m_worlds[index]; }
 
     /// Reloads the mod list and returns true if the list changed.
     virtual bool update();
@@ -82,7 +82,7 @@ class WorldList : public QAbstractListModel {
 
     QString instDirPath() const;
 
-    const QList<World>& allWorlds() const { return worlds; }
+    const QList<World>& allWorlds() const { return m_worlds; }
 
    private slots:
     void directoryChanged(QString path);
@@ -93,7 +93,7 @@ class WorldList : public QAbstractListModel {
    protected:
     BaseInstance* m_instance;
     QFileSystemWatcher* m_watcher;
-    bool is_watching;
+    bool m_isWatching;
     QDir m_dir;
-    QList<World> worlds;
+    QList<World> m_worlds;
 };


### PR DESCRIPTION
This should speed up the loading of big worlds a bit
Right now, if the size of the saves is big enough, the instance editor will try to calculate that size the first time it pops up.
The reason why:
- On the instance settings, we need to load the words folder name
- To do that there the  wordlist::update function is called
- That just initialized each save and blocks until the size is calculated

The code for the settings widget is here:https://github.com/Trial97/PrismLauncher/blob/efeaefbf2e50b06d7c09a20e384d63b94b1f0699/launcher/ui/widgets/MinecraftSettingsWidget.cpp#L84-L88

This is just one step to improve the loading speed mentioned in https://github.com/PrismLauncher/PrismLauncher/issues/3650 but still doesn't completely fix it