### PR TITLE
fix: 6.2 deprecation warning regard the QScopedPointer::swap function 

### DIFF
--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -62,22 +62,24 @@ ModPage::ModPage(ModDownloadDialog* dialog, BaseInstance& instance) : ResourcePa
     connect(m_ui->packView, &QListView::doubleClicked, this, &ModPage::onResourceSelected);
 }
 
-void ModPage::setFilterWidget(unique_qobject_ptr<ModFilterWidget>& widget)
+void ModPage::setFilterWidget(ModFilterWidget* widget)
 {
     if (m_filter_widget)
-        disconnect(m_filter_widget.get(), nullptr, nullptr, nullptr);
+        disconnect(m_filter_widget, nullptr, nullptr, nullptr);
 
-    auto old = m_ui->splitter->replaceWidget(0, widget.get());
+    auto old = m_ui->splitter->replaceWidget(0, widget);
     // because we replaced the widget we also need to delete it
     if (old) {
-        delete old;
+        old->deleteLater();
     }
 
-    m_filter_widget.swap(widget);
-
+    m_filter_widget = widget;
+    if (m_filter_widget) {
+        m_filter_widget->deleteLater();
+    }
     m_filter = m_filter_widget->getFilter();
 
-    connect(m_filter_widget.get(), &ModFilterWidget::filterChanged, this, &ModPage::triggerSearch);
+    connect(m_filter_widget, &ModFilterWidget::filterChanged, this, &ModPage::triggerSearch);
     prepareProviderCategories();
 }
 

--- a/launcher/ui/pages/modplatform/ModPage.h
+++ b/launcher/ui/pages/modplatform/ModPage.h
@@ -50,11 +50,11 @@ class ModPage : public ResourcePage {
 
     void addResourceToPage(ModPlatform::IndexedPack::Ptr, ModPlatform::IndexedVersion&, std::shared_ptr<ResourceFolderModel>) override;
 
-    virtual unique_qobject_ptr<ModFilterWidget> createFilterWidget() = 0;
+    virtual ModFilterWidget* createFilterWidget() = 0;
 
     [[nodiscard]] bool supportsFiltering() const override { return true; };
     auto getFilter() const -> const std::shared_ptr<ModFilterWidget::Filter> { return m_filter; }
-    void setFilterWidget(unique_qobject_ptr<ModFilterWidget>&);
+    void setFilterWidget(ModFilterWidget*);
 
    protected:
     ModPage(ModDownloadDialog* dialog, BaseInstance& instance);
@@ -66,7 +66,7 @@ class ModPage : public ResourcePage {
     void triggerSearch() override;
 
    protected:
-    unique_qobject_ptr<ModFilterWidget> m_filter_widget;
+    ModFilterWidget* m_filter_widget = nullptr;
     std::shared_ptr<ModFilterWidget::Filter> m_filter;
 };
 

--- a/launcher/ui/pages/modplatform/flame/FlamePage.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.cpp
@@ -341,17 +341,20 @@ void FlamePage::setSearchTerm(QString term)
 
 void FlamePage::createFilterWidget()
 {
-    auto widget = ModFilterWidget::create(nullptr, false, this);
-    m_filterWidget.swap(widget);
-    auto old = ui->splitter->replaceWidget(0, m_filterWidget.get());
+    auto widget = new ModFilterWidget(nullptr, false, this);
+    if (m_filterWidget) {
+        m_filterWidget->deleteLater();
+    }
+    m_filterWidget = (widget);
+    auto old = ui->splitter->replaceWidget(0, m_filterWidget);
     // because we replaced the widget we also need to delete it
     if (old) {
-        delete old;
+        old->deleteLater();
     }
 
     connect(ui->filterButton, &QPushButton::clicked, this, [this] { m_filterWidget->setHidden(!m_filterWidget->isHidden()); });
 
-    connect(m_filterWidget.get(), &ModFilterWidget::filterChanged, this, &FlamePage::triggerSearch);
+    connect(m_filterWidget, &ModFilterWidget::filterChanged, this, &FlamePage::triggerSearch);
     auto response = std::make_shared<QByteArray>();
     m_categoriesTask = FlameAPI::getCategories(response, ModPlatform::ResourceType::MODPACK);
     QObject::connect(m_categoriesTask.get(), &Task::succeeded, [this, response]() {

--- a/launcher/ui/pages/modplatform/flame/FlamePage.h
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.h
@@ -100,6 +100,6 @@ class FlamePage : public QWidget, public ModpackProviderBasePage {
     // Used to do instant searching with a delay to cache quick changes
     QTimer m_search_timer;
 
-    unique_qobject_ptr<ModFilterWidget> m_filterWidget;
+    ModFilterWidget* m_filterWidget;
     Task::Ptr m_categoriesTask;
 };

--- a/launcher/ui/pages/modplatform/flame/FlameResourcePages.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameResourcePages.cpp
@@ -207,9 +207,9 @@ auto FlameShaderPackPage::shouldDisplay() const -> bool
     return true;
 }
 
-unique_qobject_ptr<ModFilterWidget> FlameModPage::createFilterWidget()
+ModFilterWidget* FlameModPage::createFilterWidget()
 {
-    return ModFilterWidget::create(&static_cast<MinecraftInstance&>(m_baseInstance), false, this);
+    return new ModFilterWidget(&static_cast<MinecraftInstance&>(m_baseInstance), false, this);
 }
 
 void FlameModPage::prepareProviderCategories()

--- a/launcher/ui/pages/modplatform/flame/FlameResourcePages.h
+++ b/launcher/ui/pages/modplatform/flame/FlameResourcePages.h
@@ -96,7 +96,7 @@ class FlameModPage : public ModPage {
     [[nodiscard]] inline auto helpPage() const -> QString override { return "Mod-platform"; }
 
     void openUrl(const QUrl& url) override;
-    unique_qobject_ptr<ModFilterWidget> createFilterWidget() override;
+    ModFilterWidget* createFilterWidget() override;
 
    protected:
     virtual void prepareProviderCategories() override;

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
@@ -391,17 +391,19 @@ QString ModrinthPage::getSerachTerm() const
 
 void ModrinthPage::createFilterWidget()
 {
-    auto widget = ModFilterWidget::create(nullptr, true, this);
-    m_filterWidget.swap(widget);
-    auto old = ui->splitter->replaceWidget(0, m_filterWidget.get());
+    auto widget = new ModFilterWidget(nullptr, true, this);
+    if (m_filterWidget)
+        m_filterWidget->deleteLater();
+    m_filterWidget = widget;
+    auto old = ui->splitter->replaceWidget(0, m_filterWidget);
     // because we replaced the widget we also need to delete it
     if (old) {
-        delete old;
+        old->deleteLater();
     }
 
     connect(ui->filterButton, &QPushButton::clicked, this, [this] { m_filterWidget->setHidden(!m_filterWidget->isHidden()); });
 
-    connect(m_filterWidget.get(), &ModFilterWidget::filterChanged, this, &ModrinthPage::triggerSearch);
+    connect(m_filterWidget, &ModFilterWidget::filterChanged, this, &ModrinthPage::triggerSearch);
     auto response = std::make_shared<QByteArray>();
     m_categoriesTask = ModrinthAPI::getModCategories(response);
     QObject::connect(m_categoriesTask.get(), &Task::succeeded, [this, response]() {

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.h
@@ -103,6 +103,6 @@ class ModrinthPage : public QWidget, public ModpackProviderBasePage {
     // Used to do instant searching with a delay to cache quick changes
     QTimer m_search_timer;
 
-    unique_qobject_ptr<ModFilterWidget> m_filterWidget;
+    ModFilterWidget* m_filterWidget;
     Task::Ptr m_categoriesTask;
 };

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.cpp
@@ -142,9 +142,9 @@ auto ModrinthShaderPackPage::shouldDisplay() const -> bool
     return true;
 }
 
-unique_qobject_ptr<ModFilterWidget> ModrinthModPage::createFilterWidget()
+ModFilterWidget* ModrinthModPage::createFilterWidget()
 {
-    return ModFilterWidget::create(&static_cast<MinecraftInstance&>(m_baseInstance), true, this);
+    return new ModFilterWidget(&static_cast<MinecraftInstance&>(m_baseInstance), true, this);
 }
 
 void ModrinthModPage::prepareProviderCategories()

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.h
@@ -94,7 +94,7 @@ class ModrinthModPage : public ModPage {
 
     [[nodiscard]] inline auto helpPage() const -> QString override { return "Mod-platform"; }
 
-    unique_qobject_ptr<ModFilterWidget> createFilterWidget() override;
+    ModFilterWidget* createFilterWidget() override;
 
    protected:
     virtual void prepareProviderCategories() override;

--- a/launcher/ui/widgets/ModFilterWidget.cpp
+++ b/launcher/ui/widgets/ModFilterWidget.cpp
@@ -49,11 +49,6 @@
 #include "Application.h"
 #include "minecraft/PackProfile.h"
 
-unique_qobject_ptr<ModFilterWidget> ModFilterWidget::create(MinecraftInstance* instance, bool extended, QWidget* parent)
-{
-    return unique_qobject_ptr<ModFilterWidget>(new ModFilterWidget(instance, extended, parent));
-}
-
 class VersionBasicModel : public QIdentityProxyModel {
     Q_OBJECT
 

--- a/launcher/ui/widgets/ModFilterWidget.h
+++ b/launcher/ui/widgets/ModFilterWidget.h
@@ -83,7 +83,7 @@ class ModFilterWidget : public QTabWidget {
         }
     };
 
-    static unique_qobject_ptr<ModFilterWidget> create(MinecraftInstance* instance, bool extended, QWidget* parent = nullptr);
+    ModFilterWidget(MinecraftInstance* instance, bool extendedSupport, QWidget* parent = nullptr);
     virtual ~ModFilterWidget();
 
     auto getFilter() -> std::shared_ptr<Filter>;
@@ -96,8 +96,6 @@ class ModFilterWidget : public QTabWidget {
     void setCategories(const QList<ModPlatform::Category>&);
 
    private:
-    ModFilterWidget(MinecraftInstance* instance, bool extendedSupport, QWidget* parent = nullptr);
-
     void loadVersionList();
     void prepareBasicFilter();
 


### PR DESCRIPTION
~~blocked by #2174~~
This should fix all deprecation warnings enabled with 6.2
Not sure why that was not already a simple pointer, as it always has a parent.