### PR TITLE
fix: beginResetModel called before endResetModel

### DIFF
--- a/launcher/VersionProxyModel.cpp
+++ b/launcher/VersionProxyModel.cpp
@@ -295,13 +295,11 @@ void VersionProxyModel::sourceDataChanged(const QModelIndex& source_top_left, co
 void VersionProxyModel::setSourceModel(QAbstractItemModel* replacingRaw)
 {
     auto replacing = dynamic_cast<BaseVersionList*>(replacingRaw);
-    beginResetModel();
 
     m_columns.clear();
     if (!replacing) {
         roles.clear();
         filterModel->setSourceModel(replacing);
-        endResetModel();
         return;
     }
 
@@ -343,8 +341,6 @@ void VersionProxyModel::setSourceModel(QAbstractItemModel* replacingRaw)
         hasLatest = true;
     }
     filterModel->setSourceModel(replacing);
-
-    endResetModel();
 }
 
 QModelIndex VersionProxyModel::getRecommended() const


### PR DESCRIPTION
this should fix same thing that #3470 tried to fix.
Cause found:
- VersionProxyModel::setSourceModel is called
- the beginResetModel is called first line
- filterModel->setSourceModel triggers QAbstractItemModel::modelAboutToBeReset signal that calls on beginResetModel (indirectly via VersionProxyModel::sourceAboutToBeReset)

Solution do not beginResetModel in setSourceModel at all(it will be called by signals)