### PR TITLE
Fix: Use after free collecting tasks from ResourceDownloadDialogs

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -96,6 +96,7 @@
 #include <QList>
 #include <QNetworkAccessManager>
 #include <QStringList>
+#include <QStringLiteral>
 #include <QStyleFactory>
 #include <QTranslator>
 #include <QWindow>
@@ -125,7 +126,6 @@
 #include <FileSystem.h>
 #include <LocalPeer.h>
 
-#include <QStringLiteral>
 #include <stdlib.h>
 #include <sys.h>
 #include "SysInfo.h"

--- a/launcher/qtlogging.ini
+++ b/launcher/qtlogging.ini
@@ -3,6 +3,9 @@
 # prevent log spam and strange bugs
 # qt.qpa.drawing in particular causes theme artifacts on MacOS
 qt.*.debug=false
+# supress image format noise
+kf.imageformats.plugins.hdr=false
+kf.imageformats.plugins.xcf=false
 # don't log credentials by default
 launcher.auth.credentials.debug=false
 # remove the debug lines, other log levels still get through

--- a/launcher/ui/pages/instance/ModFolderPage.h
+++ b/launcher/ui/pages/instance/ModFolderPage.h
@@ -38,7 +38,9 @@
 
 #pragma once
 
+#include <QPointer>
 #include "ExternalResourcesPage.h"
+#include "ui/dialogs/ResourceDownloadDialog.h"
 
 class ModFolderPage : public ExternalResourcesPage {
     Q_OBJECT
@@ -63,6 +65,7 @@ class ModFolderPage : public ExternalResourcesPage {
     void removeItems(const QItemSelection& selection) override;
 
     void downloadMods();
+    void downloadDialogFinished(int result);
     void updateMods(bool includeDeps = false);
     void deleteModMetadata();
     void exportModMetadata();
@@ -70,6 +73,7 @@ class ModFolderPage : public ExternalResourcesPage {
 
    protected:
     std::shared_ptr<ModFolderModel> m_model;
+    QPointer<ResourceDownload::ModDownloadDialog> m_downloadDialog;
 };
 
 class CoreModFolderPage : public ModFolderPage {

--- a/launcher/ui/pages/instance/ResourcePackPage.h
+++ b/launcher/ui/pages/instance/ResourcePackPage.h
@@ -37,7 +37,10 @@
 
 #pragma once
 
+#include <QPointer>
+
 #include "ExternalResourcesPage.h"
+#include "ui/dialogs/ResourceDownloadDialog.h"
 #include "ui_ExternalResourcesPage.h"
 
 #include "minecraft/mod/ResourcePackFolderModel.h"
@@ -62,10 +65,12 @@ class ResourcePackPage : public ExternalResourcesPage {
 
    private slots:
     void downloadResourcePacks();
+    void downloadDialogFinished(int result);
     void updateResourcePacks();
     void deleteResourcePackMetadata();
     void changeResourcePackVersion();
 
    protected:
     std::shared_ptr<ResourcePackFolderModel> m_model;
+    QPointer<ResourceDownload::ResourceDownloadDialog> m_downloadDialog;
 };

--- a/launcher/ui/pages/instance/ShaderPackPage.cpp
+++ b/launcher/ui/pages/instance/ShaderPackPage.cpp
@@ -81,10 +81,15 @@ void ShaderPackPage::downloadShaderPack()
     if (m_instance->typeName() != "Minecraft")
         return;  // this is a null instance or a legacy instance
 
-    auto mdownload = new ResourceDownload::ShaderPackDownloadDialog(this, m_model, m_instance);
-    mdownload->setAttribute(Qt::WA_DeleteOnClose);
-    connect(this, &QObject::destroyed, mdownload, &QDialog::close);
-    if (mdownload->exec()) {
+    m_downloadDialog = new ResourceDownload::ShaderPackDownloadDialog(this, m_model, m_instance);
+    m_downloadDialog->setAttribute(Qt::WA_DeleteOnClose);
+    connect(this, &QObject::destroyed, m_downloadDialog, &QDialog::close);
+    connect(m_downloadDialog, &QDialog::finished, this, &ShaderPackPage::downloadDialogFinished);
+    m_downloadDialog->open();
+}
+
+void ShaderPackPage::downloadDialogFinished(int result) {
+    if (result) {
         auto tasks = new ConcurrentTask("Download Shader Packs", APPLICATION->settings()->get("NumberOfConcurrentDownloads").toInt());
         connect(tasks, &Task::failed, [this, tasks](QString reason) {
             CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show();
@@ -102,8 +107,12 @@ void ShaderPackPage::downloadShaderPack()
             tasks->deleteLater();
         });
 
-        for (auto& task : mdownload->getTasks()) {
-            tasks->addTask(task);
+        if (m_downloadDialog) {
+            for (auto& task : m_downloadDialog->getTasks()) {
+                tasks->addTask(task);
+            }
+        } else {
+            qWarning() << "ResourceDownloadDialog vanished before we could collect tasks!";
         }
 
         ProgressDialog loadDialog(this);

--- a/launcher/ui/pages/instance/ShaderPackPage.cpp
+++ b/launcher/ui/pages/instance/ShaderPackPage.cpp
@@ -82,13 +82,14 @@ void ShaderPackPage::downloadShaderPack()
         return;  // this is a null instance or a legacy instance
 
     m_downloadDialog = new ResourceDownload::ShaderPackDownloadDialog(this, m_model, m_instance);
-    m_downloadDialog->setAttribute(Qt::WA_DeleteOnClose);
     connect(this, &QObject::destroyed, m_downloadDialog, &QDialog::close);
     connect(m_downloadDialog, &QDialog::finished, this, &ShaderPackPage::downloadDialogFinished);
+
     m_downloadDialog->open();
 }
 
-void ShaderPackPage::downloadDialogFinished(int result) {
+void ShaderPackPage::downloadDialogFinished(int result)
+{
     if (result) {
         auto tasks = new ConcurrentTask("Download Shader Packs", APPLICATION->settings()->get("NumberOfConcurrentDownloads").toInt());
         connect(tasks, &Task::failed, [this, tasks](QString reason) {
@@ -121,6 +122,8 @@ void ShaderPackPage::downloadDialogFinished(int result) {
 
         m_model->update();
     }
+    if (m_downloadDialog)
+        m_downloadDialog->deleteLater();
 }
 
 void ShaderPackPage::updateShaderPacks()
@@ -243,36 +246,10 @@ void ShaderPackPage::changeShaderPackVersion()
     if (resource.metadata() == nullptr)
         return;
 
-    auto mdownload = new ResourceDownload::ShaderPackDownloadDialog(this, m_model, m_instance);
-    mdownload->setAttribute(Qt::WA_DeleteOnClose);
-    connect(this, &QObject::destroyed, mdownload, &QDialog::close);
-    mdownload->setResourceMetadata(resource.metadata());
-    if (mdownload->exec()) {
-        auto tasks = new ConcurrentTask("Download Shader Packs", APPLICATION->settings()->get("NumberOfConcurrentDownloads").toInt());
-        connect(tasks, &Task::failed, [this, tasks](QString reason) {
-            CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show();
-            tasks->deleteLater();
-        });
-        connect(tasks, &Task::aborted, [this, tasks]() {
-            CustomMessageBox::selectable(this, tr("Aborted"), tr("Download stopped by user."), QMessageBox::Information)->show();
-            tasks->deleteLater();
-        });
-        connect(tasks, &Task::succeeded, [this, tasks]() {
-            QStringList warnings = tasks->warnings();
-            if (warnings.count())
-                CustomMessageBox::selectable(this, tr("Warnings"), warnings.join('\n'), QMessageBox::Warning)->show();
+    m_downloadDialog = new ResourceDownload::ShaderPackDownloadDialog(this, m_model, m_instance);
+    connect(this, &QObject::destroyed, m_downloadDialog, &QDialog::close);
+    connect(m_downloadDialog, &QDialog::finished, this, &ShaderPackPage::downloadDialogFinished);
 
-            tasks->deleteLater();
-        });
-
-        for (auto& task : mdownload->getTasks()) {
-            tasks->addTask(task);
-        }
-
-        ProgressDialog loadDialog(this);
-        loadDialog.setSkipButton(true, tr("Abort"));
-        loadDialog.execWithTask(tasks);
-
-        m_model->update();
-    }
+    m_downloadDialog->setResourceMetadata(resource.metadata());
+    m_downloadDialog->open();
 }

--- a/launcher/ui/pages/instance/ShaderPackPage.h
+++ b/launcher/ui/pages/instance/ShaderPackPage.h
@@ -37,7 +37,9 @@
 
 #pragma once
 
+#include <QPointer>
 #include "ExternalResourcesPage.h"
+#include "ui/dialogs/ResourceDownloadDialog.h"
 
 class ShaderPackPage : public ExternalResourcesPage {
     Q_OBJECT
@@ -54,10 +56,12 @@ class ShaderPackPage : public ExternalResourcesPage {
 
    public slots:
     void downloadShaderPack();
+    void downloadDialogFinished(int result);
     void updateShaderPacks();
     void deleteShaderPackMetadata();
     void changeShaderPackVersion();
 
    private:
     std::shared_ptr<ShaderPackFolderModel> m_model;
+    QPointer<ResourceDownload::ShaderPackDownloadDialog> m_downloadDialog;
 };

--- a/launcher/ui/pages/instance/TexturePackPage.cpp
+++ b/launcher/ui/pages/instance/TexturePackPage.cpp
@@ -90,9 +90,10 @@ void TexturePackPage::downloadTexturePacks()
     if (m_instance->typeName() != "Minecraft")
         return;  // this is a null instance or a legacy instance
 
-    auto m_downloadDialog = new ResourceDownload::TexturePackDownloadDialog(this, m_model, m_instance);
-    m_downloadDialog->setAttribute(Qt::WA_DeleteOnClose);
+    m_downloadDialog = new ResourceDownload::TexturePackDownloadDialog(this, m_model, m_instance);
     connect(this, &QObject::destroyed, m_downloadDialog, &QDialog::close);
+    connect(m_downloadDialog, &QDialog::finished, this, &TexturePackPage::downloadDialogFinished);
+    m_downloadDialog->open();
 }
 
 void TexturePackPage::downloadDialogFinished(int result)
@@ -129,6 +130,8 @@ void TexturePackPage::downloadDialogFinished(int result)
 
         m_model->update();
     }
+    if (m_downloadDialog)
+        m_downloadDialog->deleteLater();
 }
 
 void TexturePackPage::updateTexturePacks()
@@ -251,36 +254,10 @@ void TexturePackPage::changeTexturePackVersion()
     if (resource.metadata() == nullptr)
         return;
 
-    auto mdownload = new ResourceDownload::TexturePackDownloadDialog(this, m_model, m_instance);
-    mdownload->setAttribute(Qt::WA_DeleteOnClose);
-    connect(this, &QObject::destroyed, mdownload, &QDialog::close);
-    mdownload->setResourceMetadata(resource.metadata());
-    if (mdownload->exec()) {
-        auto tasks = new ConcurrentTask("Download Texture Packs", APPLICATION->settings()->get("NumberOfConcurrentDownloads").toInt());
-        connect(tasks, &Task::failed, [this, tasks](QString reason) {
-            CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show();
-            tasks->deleteLater();
-        });
-        connect(tasks, &Task::aborted, [this, tasks]() {
-            CustomMessageBox::selectable(this, tr("Aborted"), tr("Download stopped by user."), QMessageBox::Information)->show();
-            tasks->deleteLater();
-        });
-        connect(tasks, &Task::succeeded, [this, tasks]() {
-            QStringList warnings = tasks->warnings();
-            if (warnings.count())
-                CustomMessageBox::selectable(this, tr("Warnings"), warnings.join('\n'), QMessageBox::Warning)->show();
+    m_downloadDialog = new ResourceDownload::TexturePackDownloadDialog(this, m_model, m_instance);
+    connect(this, &QObject::destroyed, m_downloadDialog, &QDialog::close);
+    connect(m_downloadDialog, &QDialog::finished, this, &TexturePackPage::downloadDialogFinished);
 
-            tasks->deleteLater();
-        });
-
-        for (auto& task : mdownload->getTasks()) {
-            tasks->addTask(task);
-        }
-
-        ProgressDialog loadDialog(this);
-        loadDialog.setSkipButton(true, tr("Abort"));
-        loadDialog.execWithTask(tasks);
-
-        m_model->update();
-    }
+    m_downloadDialog->setResourceMetadata(resource.metadata());
+    m_downloadDialog->open();
 }

--- a/launcher/ui/pages/instance/TexturePackPage.h
+++ b/launcher/ui/pages/instance/TexturePackPage.h
@@ -37,7 +37,10 @@
 
 #pragma once
 
+#include <QPointer>
+
 #include "ExternalResourcesPage.h"
+#include "ui/dialogs/ResourceDownloadDialog.h"
 #include "ui_ExternalResourcesPage.h"
 
 #include "minecraft/mod/TexturePackFolderModel.h"
@@ -57,10 +60,12 @@ class TexturePackPage : public ExternalResourcesPage {
    public slots:
     void updateFrame(const QModelIndex& current, const QModelIndex& previous) override;
     void downloadTexturePacks();
+    void downloadDialogFinished(int result);
     void updateTexturePacks();
     void deleteTexturePackMetadata();
     void changeTexturePackVersion();
 
    private:
     std::shared_ptr<TexturePackFolderModel> m_model;
+    QPointer<ResourceDownload::TexturePackDownloadDialog> m_downloadDialog;
 };


### PR DESCRIPTION
Originally reported on[ discord](https://discordapp.com/channels/1031648380885147709/1362723641191567481)

Fix implemented in #3614 left us open to a data race, could the tasks be collected before the dialog was freed from the usage of exec?

Employ the guarded `QPointer` to catch such a free in the future.
we should probably also be avoiding exec on dialogs more.
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
