### PR TITLE
fix: nullptr access

### DIFF
--- a/launcher/ui/themes/SystemTheme.cpp
+++ b/launcher/ui/themes/SystemTheme.cpp
@@ -54,7 +54,7 @@ SystemTheme::SystemTheme(const QString& styleName, const QPalette& defaultPalett
         m_colorPalette = defaultPalette;
     } else {
         auto style = QStyleFactory::create(styleName);
-        m_colorPalette = style->standardPalette();
+        m_colorPalette = style != nullptr ? style->standardPalette() : defaultPalette;
         delete style;
     }
 }


### PR DESCRIPTION
style can't always be created (could have sworn I fixed this previously)

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
