### PR TITLE
Add support for CMake presets and workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,7 @@ jobs:
       matrix:
         include:
           - os: ubuntu-22.04
+            cmake_preset: linux
             qt_ver: 6
             qt_host: linux
             qt_arch: ""
@@ -64,11 +65,13 @@ jobs:
 
           - os: windows-2022
             name: "Windows-MinGW-w64"
+            cmake_preset: windows_mingw
             msystem: clang64
             vcvars_arch: "amd64_x86"
 
           - os: windows-2022
             name: "Windows-MSVC"
+            cmake_preset: windows_msvc 
             msystem: ""
             architecture: "x64"
             vcvars_arch: "amd64"
@@ -82,6 +85,7 @@ jobs:
 
           - os: windows-2022
             name: "Windows-MSVC-arm64"
+            cmake_preset: windows_msvc_arm64_cross
             msystem: ""
             architecture: "arm64"
             vcvars_arch: "amd64_arm64"
@@ -95,6 +99,7 @@ jobs:
 
           - os: macos-14
             name: macOS
+            cmake_preset: ${{ inputs.build_type == 'Debug' && 'macos_universal' || 'macos' }}
             macosx_deployment_target: 11.0
             qt_ver: 6
             qt_host: mac
@@ -275,75 +280,30 @@ jobs:
         with:
           distribution: "temurin"
           java-version: "17"
+
       ##
-      # CONFIGURE
+      # SOURCE BUILD
       ##
 
-      - name: Configure CMake (macOS)
-        if: runner.os == 'macOS'
+      - name: Run CMake workflow
+        if: ${{ runner.os != 'Windows' || matrix.msystem == '' }}
+        shell: bash
+        env:
+          CMAKE_PRESET: ${{ matrix.cmake_preset }}
+          PRESET_TYPE: ${{ inputs.build_type == 'Debug' && 'debug' || 'ci' }}
         run: |
-          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DENABLE_LTO=ON -DLauncher_ENABLE_JAVA_DOWNLOADER=ON -DLauncher_BUILD_PLATFORM=official -DCMAKE_C_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DLauncher_QT_VERSION_MAJOR=${{ matrix.qt_ver }} -DCMAKE_OSX_ARCHITECTURES="x86_64;arm64" -G Ninja
+          cmake --workflow --preset "$CMAKE_PRESET"_"$PRESET_TYPE"
 
-      - name: Configure CMake (Windows MinGW-w64)
-        if: runner.os == 'Windows' && matrix.msystem != ''
+        # NOTE: Split due to the `shell` requirement for msys2
+        # TODO(@getchoo): Get ccache working!
+      - name: Run CMake workflow (Windows MinGW-w64)
+        if: ${{ runner.os == 'Windows' && matrix.msystem != '' }}
         shell: msys2 {0}
+        env:
+          CMAKE_PRESET: ${{ matrix.cmake_preset }}
+          PRESET_TYPE: ${{ inputs.build_type == 'Debug' && 'debug' || 'ci' }}
         run: |
-          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DENABLE_LTO=ON -DLauncher_ENABLE_JAVA_DOWNLOADER=ON -DLauncher_BUILD_PLATFORM=official -DCMAKE_C_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DLauncher_QT_VERSION_MAJOR=6 -DCMAKE_OBJDUMP=/mingw64/bin/objdump.exe -DLauncher_BUILD_ARTIFACT=${{ matrix.name }}-Qt${{ matrix.qt_ver }} -G Ninja
-
-      - name: Configure CMake (Windows MSVC)
-        if: runner.os == 'Windows' && matrix.msystem == '' && matrix.architecture != 'arm64'
-        run: |
-          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DENABLE_LTO=ON -DLauncher_ENABLE_JAVA_DOWNLOADER=ON -DLauncher_BUILD_PLATFORM=official -DLauncher_QT_VERSION_MAJOR=${{ matrix.qt_ver }} -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreadedDLL" -DLauncher_FORCE_BUNDLED_LIBS=ON  -DLauncher_BUILD_ARTIFACT=${{ matrix.name }}-Qt${{ matrix.qt_ver }} -G Ninja
-
-      - name: Configure CMake (Windows MSVC arm64)
-        if: runner.os == 'Windows' && matrix.msystem == '' && matrix.architecture == 'arm64'
-        run: |
-          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_DIR }} -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DENABLE_LTO=ON -DLauncher_ENABLE_JAVA_DOWNLOADER=ON -DLauncher_BUILD_PLATFORM=official -DLauncher_QT_VERSION_MAJOR=${{ matrix.qt_ver }} -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreadedDLL" -A${{ matrix.architecture}} -DLauncher_FORCE_BUNDLED_LIBS=ON  -DLauncher_BUILD_ARTIFACT=${{ matrix.name }}-Qt${{ matrix.qt_ver }}
-
-      - name: Configure CMake (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DENABLE_LTO=ON -DLauncher_ENABLE_JAVA_DOWNLOADER=ON -DLauncher_BUILD_PLATFORM=official -DCMAKE_C_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DLauncher_QT_VERSION_MAJOR=${{ matrix.qt_ver }} -DLauncher_BUILD_ARTIFACT=Linux-Qt${{ matrix.qt_ver }} -G Ninja
-
-      ##
-      # BUILD
-      ##
-
-      - name: Build
-        if: runner.os != 'Windows'
-        run: |
-          cmake --build ${{ env.BUILD_DIR }}
-
-      - name: Build (Windows MinGW-w64)
-        if: runner.os == 'Windows' && matrix.msystem != ''
-        shell: msys2 {0}
-        run: |
-          cmake --build ${{ env.BUILD_DIR }}
-
-      - name: Build (Windows MSVC)
-        if: runner.os == 'Windows' && matrix.msystem == ''
-        run: |
-          cmake --build ${{ env.BUILD_DIR }} --config ${{ inputs.build_type }}
-
-      ##
-      # TEST
-      ##
-
-      - name: Test
-        if: runner.os != 'Windows'
-        run: |
-          ctest -E "^example64|example$" --test-dir build --output-on-failure
-
-      - name: Test (Windows MinGW-w64)
-        if: runner.os == 'Windows' && matrix.msystem != ''
-        shell: msys2 {0}
-        run: |
-          ctest -E "^example64|example$" --test-dir build --output-on-failure
-
-      - name: Test (Windows MSVC)
-        if: runner.os == 'Windows' && matrix.msystem == '' && matrix.architecture != 'arm64'
-        run: |
-          ctest -E "^example64|example$" --test-dir build --output-on-failure -C ${{ inputs.build_type }}
+          cmake --workflow --preset "$CMAKE_PRESET"_"$PRESET_TYPE"
 
       ##
       # PACKAGE BUILDS
@@ -542,8 +502,11 @@ jobs:
 
       - name: Package (Linux, portable)
         if: runner.os == 'Linux'
+        env:
+          CMAKE_PRESET: ${{ matrix.cmake_preset }}
+          PRESET_TYPE: ${{ inputs.build_type == 'Debug' && 'debug' || 'ci' }}
         run: |
-          cmake -S . -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_PORTABLE_DIR }} -DCMAKE_BUILD_TYPE=${{ inputs.build_type }} -DENABLE_LTO=ON -DLauncher_BUILD_PLATFORM=official -DCMAKE_C_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DCMAKE_CXX_COMPILER_LAUNCHER=${{ env.CCACHE_VAR }} -DLauncher_QT_VERSION_MAJOR=${{ matrix.qt_ver }} -DLauncher_BUILD_ARTIFACT=Linux-Qt${{ matrix.qt_ver }} -DINSTALL_BUNDLE=full -G Ninja
+          cmake --preset "$CMAKE_PRESET"_"$PRESET_TYPE" -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_PORTABLE_DIR }} -DINSTALL_BUNDLE=full
           cmake --install ${{ env.BUILD_DIR }}
           cmake --install ${{ env.BUILD_DIR }} --component portable
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,6 +159,7 @@ jobs:
         if: (runner.os != 'Windows' || matrix.msystem == '') && inputs.build_type == 'Debug'
         uses: hendrikmuhs/ccache-action@v1.2.18
         with:
+          create-symlink: ${{ runner.os != 'Windows' }}
           key: ${{ matrix.os }}-qt${{ matrix.qt_ver }}-${{ matrix.architecture }}
 
       - name: Use ccache on Debug builds only

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,9 +71,8 @@ jobs:
 
       - name: Configure and Build
         run: |
-          cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/usr -G Ninja
-
-          cmake --build build
+          cmake --preset linux_debug
+          cmake --build --preset linux_debug
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ CMakeLists.txt.user.*
 CMakeSettings.json
 /CMakeFiles
 CMakeCache.txt
+CMakeUserPresets.json
 /.project
 /.settings
 /.idea

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "https://cmake.org/cmake/help/latest/_downloads/3e2d73bff478d88a7de0de736ba5e361/schema.json",
+	"version": 8,
+	"cmakeMinimumRequired": {
+		"major": 3,
+		"minor": 28
+	},
+	"include": [
+		"cmake/linuxPreset.json",
+		"cmake/macosPreset.json",
+		"cmake/windowsMinGWPreset.json",
+		"cmake/windowsMSVCPreset.json"
+	]
+}

--- a/cmake/commonPresets.json
+++ b/cmake/commonPresets.json
@@ -1,0 +1,70 @@
+{
+	"$schema": "https://cmake.org/cmake/help/latest/_downloads/3e2d73bff478d88a7de0de736ba5e361/schema.json",
+	"version": 8,
+	"configurePresets": [
+		{
+			"name": "base",
+			"hidden": true,
+			"binaryDir": "build",
+			"installDir": "install",
+			"cacheVariables": {
+				"Launcher_BUILD_PLATFORM": "custom"
+			}
+		},
+		{
+			"name": "base_debug",
+			"hidden": true,
+			"inherits": [
+				"base"
+			],
+			"cacheVariables": {
+				"CMAKE_BUILD_TYPE": "Debug"
+			}
+		},
+		{
+			"name": "base_release",
+			"hidden": true,
+			"inherits": [
+				"base"
+			],
+			"cacheVariables": {
+				"CMAKE_BUILD_TYPE": "Release",
+				"ENABLE_LTO": "ON"
+			}
+		}
+	],
+	"testPresets": [
+		{
+			"name": "base",
+			"hidden": true,
+			"output": {
+				"outputOnFailure": true
+			},
+			"execution": {
+				"noTestsAction": "error"
+			},
+			"filter": {
+				"exclude": {
+					"name": "^example64|example$"
+				}
+			}
+		},
+		{
+			"name": "base_debug",
+			"hidden": true,
+			"inherits": [
+				"base"
+			],
+			"output": {
+				"debug": true
+			}
+		},
+		{
+			"name": "base_release",
+			"hidden": true,
+			"inherits": [
+				"base"
+			]
+		}
+	]
+}

--- a/cmake/commonPresets.json
+++ b/cmake/commonPresets.json
@@ -31,6 +31,17 @@
 				"CMAKE_BUILD_TYPE": "Release",
 				"ENABLE_LTO": "ON"
 			}
+		},
+		{
+			"name": "base_ci",
+			"hidden": true,
+			"inherits": [
+				"base_release"
+			],
+			"cacheVariables": {
+				"Launcher_BUILD_PLATFORM": "official",
+				"Launcher_FORCE_BUNDLED_LIBS": "ON"
+			}
 		}
 	],
 	"testPresets": [

--- a/cmake/linuxPreset.json
+++ b/cmake/linuxPreset.json
@@ -1,0 +1,95 @@
+{
+	"$schema": "https://cmake.org/cmake/help/latest/_downloads/3e2d73bff478d88a7de0de736ba5e361/schema.json",
+	"version": 8,
+	"include": [
+		"commonPresets.json"
+	],
+	"configurePresets": [
+		{
+			"name": "linux_base",
+			"hidden": true,
+			"condition": {
+				"type": "equals",
+				"lhs": "${hostSystemName}",
+				"rhs": "Linux"
+			},
+			"generator": "Ninja",
+			"cacheVariables": {
+				"Launcher_BUILD_ARTIFACT": "Linux-Qt6",
+				"Launcher_ENABLE_JAVA_DOWNLOADER": "ON"
+			}
+		},
+		{
+			"name": "linux_debug",
+			"inherits": [
+				"base_debug",
+				"linux_base"
+			],
+			"displayName": "Linux (Debug)"
+		},
+		{
+			"name": "linux_release",
+			"inherits": [
+				"base_release",
+				"linux_base"
+			],
+			"displayName": "Linux (Release)"
+		}
+	],
+	"buildPresets": [
+		{
+			"name": "linux_base",
+			"hidden": true,
+			"condition": {
+				"type": "equals",
+				"lhs": "${hostSystemName}",
+				"rhs": "Linux"
+			}
+		},
+		{
+			"name": "linux_debug",
+			"inherits": [
+				"linux_base"
+			],
+			"displayName": "Linux (Debug)",
+			"configurePreset": "linux_debug"
+		},
+		{
+			"name": "linux_release",
+			"inherits": [
+				"linux_base"
+			],
+			"displayName": "Linux (Release)",
+			"configurePreset": "linux_release"
+		}
+	],
+	"testPresets": [
+		{
+			"name": "linux_base",
+			"hidden": true,
+			"condition": {
+				"type": "equals",
+				"lhs": "${hostSystemName}",
+				"rhs": "Linux"
+			}
+		},
+		{
+			"name": "linux_debug",
+			"inherits": [
+				"base_debug",
+				"linux_base"
+			],
+			"displayName": "Linux (Debug)",
+			"configurePreset": "linux_debug"
+		},
+		{
+			"name": "linux_release",
+			"inherits": [
+				"base_release",
+				"linux_base"
+			],
+			"displayName": "Linux (Release)",
+			"configurePreset": "linux_release"
+		}
+	]
+}

--- a/cmake/linuxPreset.json
+++ b/cmake/linuxPreset.json
@@ -34,6 +34,18 @@
 				"linux_base"
 			],
 			"displayName": "Linux (Release)"
+		},
+		{
+			"name": "linux_ci",
+			"inherits": [
+				"base_ci",
+				"linux_base"
+			],
+			"displayName": "Linux (CI)",
+			"cacheVariables": {
+				"Launcher_BUILD_ARTIFACT": "Linux-Qt6"
+			},
+			"installDir": "/usr"
 		}
 	],
 	"buildPresets": [
@@ -61,6 +73,14 @@
 			],
 			"displayName": "Linux (Release)",
 			"configurePreset": "linux_release"
+		},
+		{
+			"name": "linux_ci",
+			"inherits": [
+				"linux_base"
+			],
+			"displayName": "Linux (CI)",
+			"configurePreset": "linux_ci"
 		}
 	],
 	"testPresets": [
@@ -90,6 +110,71 @@
 			],
 			"displayName": "Linux (Release)",
 			"configurePreset": "linux_release"
+		},
+		{
+			"name": "linux_ci",
+			"inherits": [
+				"base_release",
+				"linux_base"
+			],
+			"displayName": "Linux (CI)",
+			"configurePreset": "linux_ci"
+		}
+	],
+	"workflowPresets": [
+		{
+			"name": "linux_debug",
+			"displayName": "Linux (Debug)",
+			"steps": [
+				{
+					"type": "configure",
+					"name": "linux_debug"
+				},
+				{
+					"type": "build",
+					"name": "linux_debug"
+				},
+				{
+					"type": "test",
+					"name": "linux_debug"
+				}
+			]
+		},
+		{
+			"name": "linux",
+			"displayName": "Linux (Release)",
+			"steps": [
+				{
+					"type": "configure",
+					"name": "linux_release"
+				},
+				{
+					"type": "build",
+					"name": "linux_release"
+				},
+				{
+					"type": "test",
+					"name": "linux_release"
+				}
+			]
+		},
+		{
+			"name": "linux_ci",
+			"displayName": "Linux (CI)",
+			"steps": [
+				{
+					"type": "configure",
+					"name": "linux_ci"
+				},
+				{
+					"type": "build",
+					"name": "linux_ci"
+				},
+				{
+					"type": "test",
+					"name": "linux_ci"
+				}
+			]
 		}
 	]
 }

--- a/cmake/macosPreset.json
+++ b/cmake/macosPreset.json
@@ -1,0 +1,152 @@
+{
+	"$schema": "https://cmake.org/cmake/help/latest/_downloads/3e2d73bff478d88a7de0de736ba5e361/schema.json",
+	"version": 8,
+	"include": [
+		"commonPresets.json"
+	],
+	"configurePresets": [
+		{
+			"name": "macos_base",
+			"hidden": true,
+			"condition": {
+				"type": "equals",
+				"lhs": "${hostSystemName}",
+				"rhs": "Darwin"
+			},
+			"generator": "Ninja"
+		},
+		{
+			"name": "macos_universal_base",
+			"hidden": true,
+			"inherits": [
+				"macos_base"
+			],
+			"cacheVariables": {
+				"CMAKE_OSX_ARCHITECTURES": "x86_64;arm64",
+				"Launcher_BUILD_ARTIFACT": "macOS-Qt6"
+			}
+		},
+		{
+			"name": "macos_debug",
+			"inherits": [
+				"base_debug",
+				"macos_base"
+			],
+			"displayName": "macOS (Debug)"
+		},
+		{
+			"name": "macos_release",
+			"inherits": [
+				"base_release",
+				"macos_base"
+			],
+			"displayName": "macOS (Release)"
+		},
+		{
+			"name": "macos_universal_debug",
+			"inherits": [
+				"base_debug",
+				"macos_universal_base"
+			],
+			"displayName": "macOS (Universal Binary, Debug)"
+		},
+		{
+			"name": "macos_universal_release",
+			"inherits": [
+				"base_release",
+				"macos_universal_base"
+			],
+			"displayName": "macOS (Universal Binary, Release)"
+		}
+	],
+	"buildPresets": [
+		{
+			"name": "macos_base",
+			"hidden": true,
+			"condition": {
+				"type": "equals",
+				"lhs": "${hostSystemName}",
+				"rhs": "Darwin"
+			}
+		},
+		{
+			"name": "macos_debug",
+			"inherits": [
+				"macos_base"
+			],
+			"displayName": "macOS (Debug)",
+			"configurePreset": "macos_debug"
+		},
+		{
+			"name": "macos_release",
+			"inherits": [
+				"macos_base"
+			],
+			"displayName": "macOS (Release)",
+			"configurePreset": "macos_release"
+		},
+		{
+			"name": "macos_universal_debug",
+			"inherits": [
+				"macos_base"
+			],
+			"displayName": "macOS (Universal Binary, Debug)",
+			"configurePreset": "macos_universal_debug"
+		},
+		{
+			"name": "macos_universal_release",
+			"inherits": [
+				"macos_base"
+			],
+			"displayName": "macOS (Universal Binary, Release)",
+			"configurePreset": "macos_universal_release"
+		}
+	],
+	"testPresets": [
+		{
+			"name": "macos_base",
+			"hidden": true,
+			"condition": {
+				"type": "equals",
+				"lhs": "${hostSystemName}",
+				"rhs": "Darwin"
+			}
+		},
+		{
+			"name": "macos_debug",
+			"inherits": [
+				"base_debug",
+				"macos_base"
+			],
+			"displayName": "MacOS (Debug)",
+			"configurePreset": "macos_debug"
+		},
+		{
+			"name": "macos_release",
+			"inherits": [
+				"base_release",
+				"macos_base"
+			],
+			"displayName": "macOS (Release)",
+			"configurePreset": "macos_release"
+		},
+		{
+			"name": "macos_universal_debug",
+			"inherits": [
+				"base_debug",
+				"macos_base"
+			],
+			"displayName": "MacOS (Universal Binary, Debug)",
+			"configurePreset": "macos_universal_debug"
+		},
+		{
+			"name": "macos_universal_release",
+			"inherits": [
+				"base_release",
+				"macos_base"
+			],
+			"displayName": "macOS (Universal Binary, Release)",
+			"configurePreset": "macos_universal_release"
+		}
+	]
+}

--- a/cmake/macosPreset.json
+++ b/cmake/macosPreset.json
@@ -57,6 +57,17 @@
 				"macos_universal_base"
 			],
 			"displayName": "macOS (Universal Binary, Release)"
+		},
+		{
+			"name": "macos_ci",
+			"inherits": [
+				"base_ci",
+				"macos_universal_base"
+			],
+			"displayName": "macOS (CI)",
+			"cacheVariables": {
+				"Launcher_BUILD_ARTIFACT": "macOS-Qt6"
+			}
 		}
 	],
 	"buildPresets": [
@@ -100,6 +111,14 @@
 			],
 			"displayName": "macOS (Universal Binary, Release)",
 			"configurePreset": "macos_universal_release"
+		},
+		{
+			"name": "macos_ci",
+			"inherits": [
+				"macos_base"
+			],
+			"displayName": "macOS (CI)",
+			"configurePreset": "macos_ci"
 		}
 	],
 	"testPresets": [
@@ -147,6 +166,107 @@
 			],
 			"displayName": "macOS (Universal Binary, Release)",
 			"configurePreset": "macos_universal_release"
+		},
+		{
+			"name": "macos_ci",
+			"inherits": [
+				"base_release",
+				"macos_base"
+			],
+			"displayName": "macOS (CI)",
+			"configurePreset": "macos_ci"
+		}
+	],
+	"workflowPresets": [
+		{
+			"name": "macos_debug",
+			"displayName": "macOS (Debug)",
+			"steps": [
+				{
+					"type": "configure",
+					"name": "macos_debug"
+				},
+				{
+					"type": "build",
+					"name": "macos_debug"
+				},
+				{
+					"type": "test",
+					"name": "macos_debug"
+				}
+			]
+		},
+		{
+			"name": "macos",
+			"displayName": "macOS (Release)",
+			"steps": [
+				{
+					"type": "configure",
+					"name": "macos_release"
+				},
+				{
+					"type": "build",
+					"name": "macos_release"
+				},
+				{
+					"type": "test",
+					"name": "macos_release"
+				}
+			]
+		},
+		{
+			"name": "macos_universal_debug",
+			"displayName": "macOS (Universal Binary, Debug)",
+			"steps": [
+				{
+					"type": "configure",
+					"name": "macos_universal_debug"
+				},
+				{
+					"type": "build",
+					"name": "macos_universal_debug"
+				},
+				{
+					"type": "test",
+					"name": "macos_universal_debug"
+				}
+			]
+		},
+		{
+			"name": "macos_universal",
+			"displayName": "macOS (Universal Binary, Release)",
+			"steps": [
+				{
+					"type": "configure",
+					"name": "macos_universal_release"
+				},
+				{
+					"type": "build",
+					"name": "macos_universal_release"
+				},
+				{
+					"type": "test",
+					"name": "macos_universal_release"
+				}
+			]
+		},
+		{
+			"name": "macos_ci",
+			"displayName": "macOS (CI)",
+			"steps": [
+				{
+					"type": "configure",
+					"name": "macos_ci"
+				},
+				{
+					"type": "build",
+					"name": "macos_ci"
+				},
+				{
+					"type": "test",
+					"name": "macos_ci"
+				}
+			]
 		}
 	]
 }

--- a/cmake/windowsMSVCPreset.json
+++ b/cmake/windowsMSVCPreset.json
@@ -1,0 +1,155 @@
+{
+	"$schema": "https://cmake.org/cmake/help/latest/_downloads/3e2d73bff478d88a7de0de736ba5e361/schema.json",
+	"version": 8,
+	"include": [
+		"commonPresets.json"
+	],
+	"configurePresets": [
+		{
+			"name": "windows_msvc_base",
+			"hidden": true,
+			"condition": {
+				"type": "equals",
+				"lhs": "${hostSystemName}",
+				"rhs": "Windows"
+			},
+			"cacheVariables": {
+				"Launcher_BUILD_ARTIFACT": "Windows-MSVC-Qt6"
+			}
+		},
+		{
+			"name": "windows_msvc_arm64_cross_base",
+			"hidden": true,
+			"inherits": [
+				"windows_msvc_base"
+			],
+			"architecture": "arm64",
+			"cacheVariables": {
+				"Launcher_BUILD_ARTIFACT": "Windows-MSVC-arm64-Qt6"
+			}
+		},
+		{
+			"name": "windows_msvc_debug",
+			"inherits": [
+				"base_debug",
+				"windows_msvc_base"
+			],
+			"displayName": "Windows MSVC (Debug)",
+			"generator": "Ninja"
+		},
+		{
+			"name": "windows_msvc_release",
+			"inherits": [
+				"base_release",
+				"windows_msvc_base"
+			],
+			"displayName": "Windows MSVC (Release)"
+		},
+		{
+			"name": "windows_msvc_arm64_cross_debug",
+			"inherits": [
+				"base_debug",
+				"windows_msvc_arm64_cross_base"
+			],
+			"displayName": "Windows MSVC (ARM64 cross, Debug)"
+		},
+		{
+			"name": "windows_msvc_arm64_cross_release",
+			"inherits": [
+				"base_release",
+				"windows_msvc_arm64_cross_base"
+			],
+			"displayName": "Windows MSVC (ARM64 cross, Release)"
+		}
+	],
+	"buildPresets": [
+		{
+			"name": "windows_msvc_base",
+			"hidden": true,
+			"condition": {
+				"type": "equals",
+				"lhs": "${hostSystemName}",
+				"rhs": "Windows"
+			}
+		},
+		{
+			"name": "windows_msvc_debug",
+			"inherits": [
+				"windows_msvc_base"
+			],
+			"displayName": "Windows MSVC (Debug)",
+			"configurePreset": "windows_msvc_debug",
+			"configuration": "Debug"
+		},
+		{
+			"name": "windows_msvc_release",
+			"inherits": [
+				"windows_msvc_base"
+			],
+			"displayName": "Windows MSVC (Release)",
+			"configurePreset": "windows_msvc_release",
+			"configuration": "Release",
+			"nativeToolOptions": [
+				"/p:UseMultiToolTask=true",
+				"/p:EnforceProcessCountAcrossBuilds=true"
+			]
+		},
+		{
+			"name": "windows_msvc_arm64_cross_debug",
+			"inherits": [
+				"windows_msvc_base"
+			],
+			"displayName": "Windows MSVC (ARM64 cross, Debug)",
+			"configurePreset": "windows_msvc_arm64_cross_debug",
+			"configuration": "Debug",
+			"nativeToolOptions": [
+				"/p:UseMultiToolTask=true",
+				"/p:EnforceProcessCountAcrossBuilds=true"
+			]
+		},
+		{
+			"name": "windows_msvc_arm64_cross_release",
+			"inherits": [
+				"windows_msvc_base"
+			],
+			"displayName": "Windows MSVC (ARM64 cross, Release)",
+			"configurePreset": "windows_msvc_arm64_cross_release",
+			"configuration": "Release",
+			"nativeToolOptions": [
+				"/p:UseMultiToolTask=true",
+				"/p:EnforceProcessCountAcrossBuilds=true"
+			]
+		}
+	],
+	"testPresets": [
+		{
+			"name": "windows_msvc_base",
+			"hidden": true,
+			"condition": {
+				"type": "equals",
+				"lhs": "${hostSystemName}",
+				"rhs": "Windows"
+			}
+		},
+		{
+			"name": "windows_msvc_debug",
+			"inherits": [
+				"base_debug",
+				"windows_msvc_base"
+			],
+			"displayName": "Windows MSVC (Debug)",
+			"configurePreset": "windows_msvc_debug",
+			"configuration": "Debug"
+		},
+		{
+			"name": "windows_msvc_release",
+			"inherits": [
+				"base_release",
+				"windows_msvc_base"
+			],
+			"displayName": "Windows MSVC (Release)",
+			"configurePreset": "windows_msvc_release",
+			"configuration": "Release"
+		}
+	]
+}

--- a/cmake/windowsMSVCPreset.json
+++ b/cmake/windowsMSVCPreset.json
@@ -60,6 +60,28 @@
 				"windows_msvc_arm64_cross_base"
 			],
 			"displayName": "Windows MSVC (ARM64 cross, Release)"
+		},
+		{
+			"name": "windows_msvc_ci",
+			"inherits": [
+				"base_ci",
+				"windows_msvc_base"
+			],
+			"displayName": "Windows MSVC (CI)",
+			"cacheVariables": {
+				"Launcher_BUILD_ARTIFACT": "Windows-MSVC-Qt6"
+			}
+		},
+		{
+			"name": "windows_msvc_arm64_cross_ci",
+			"inherits": [
+				"base_ci",
+				"windows_msvc_arm64_cross_base"
+			],
+			"displayName": "Windows MSVC (ARM64 cross, CI)",
+			"cacheVariables": {
+				"Launcher_BUILD_ARTIFACT": "Windows-MSVC-arm64-Qt6"
+			}
 		}
 	],
 	"buildPresets": [
@@ -119,6 +141,32 @@
 				"/p:UseMultiToolTask=true",
 				"/p:EnforceProcessCountAcrossBuilds=true"
 			]
+		},
+		{
+			"name": "windows_msvc_ci",
+			"inherits": [
+				"windows_msvc_base"
+			],
+			"displayName": "Windows MSVC (CI)",
+			"configurePreset": "windows_msvc_ci",
+			"configuration": "Release",
+			"nativeToolOptions": [
+				"/p:UseMultiToolTask=true",
+				"/p:EnforceProcessCountAcrossBuilds=true"
+			]
+		},
+		{
+			"name": "windows_msvc_arm64_cross_ci",
+			"inherits": [
+				"windows_msvc_base"
+			],
+			"displayName": "Windows MSVC (ARM64 cross, CI)",
+			"configurePreset": "windows_msvc_arm64_cross_ci",
+			"configuration": "Release",
+			"nativeToolOptions": [
+				"/p:UseMultiToolTask=true",
+				"/p:EnforceProcessCountAcrossBuilds=true"
+			]
 		}
 	],
 	"testPresets": [
@@ -150,6 +198,114 @@
 			"displayName": "Windows MSVC (Release)",
 			"configurePreset": "windows_msvc_release",
 			"configuration": "Release"
+		},
+		{
+			"name": "windows_msvc_ci",
+			"inherits": [
+				"base_release",
+				"windows_msvc_base"
+			],
+			"displayName": "Windows MSVC (CI)",
+			"configurePreset": "windows_msvc_ci",
+			"configuration": "Release"
+		}
+	],
+	"workflowPresets": [
+		{
+			"name": "windows_msvc_debug",
+			"displayName": "Windows MSVC (Debug)",
+			"steps": [
+				{
+					"type": "configure",
+					"name": "windows_msvc_debug"
+				},
+				{
+					"type": "build",
+					"name": "windows_msvc_debug"
+				},
+				{
+					"type": "test",
+					"name": "windows_msvc_debug"
+				}
+			]
+		},
+		{
+			"name": "windows_msvc",
+			"displayName": "Windows MSVC (Release)",
+			"steps": [
+				{
+					"type": "configure",
+					"name": "windows_msvc_release"
+				},
+				{
+					"type": "build",
+					"name": "windows_msvc_release"
+				},
+				{
+					"type": "test",
+					"name": "windows_msvc_release"
+				}
+			]
+		},
+		{
+			"name": "windows_msvc_arm64_cross_debug",
+			"displayName": "Windows MSVC (ARM64 cross, Debug)",
+			"steps": [
+				{
+					"type": "configure",
+					"name": "windows_msvc_arm64_cross_debug"
+				},
+				{
+					"type": "build",
+					"name": "windows_msvc_arm64_cross_debug"
+				}
+			]
+		},
+		{
+			"name": "windows_msvc_arm64_cross",
+			"displayName": "Windows MSVC (ARM64 cross, Release)",
+			"steps": [
+				{
+					"type": "configure",
+					"name": "windows_msvc_arm64_cross_release"
+				},
+				{
+					"type": "build",
+					"name": "windows_msvc_arm64_cross_release"
+				}
+			]
+		},
+		{
+			"name": "windows_msvc_ci",
+			"displayName": "Windows MSVC (CI)",
+			"steps": [
+				{
+					"type": "configure",
+					"name": "windows_msvc_ci"
+				},
+				{
+					"type": "build",
+					"name": "windows_msvc_ci"
+				},
+				{
+					"type": "test",
+					"name": "windows_msvc_ci"
+				}
+			]
+		},
+		{
+			"name": "windows_msvc_arm64_cross_ci",
+			"displayName": "Windows MSVC (ARM64 cross, CI)",
+			"steps": [
+				{
+					"type": "configure",
+					"name": "windows_msvc_arm64_cross_ci"
+				},
+				{
+					"type": "build",
+					"name": "windows_msvc_arm64_cross_ci"
+				}
+			]
 		}
 	]
 }

--- a/cmake/windowsMinGWPreset.json
+++ b/cmake/windowsMinGWPreset.json
@@ -33,6 +33,17 @@
 				"windows_mingw_base"
 			],
 			"displayName": "Windows MinGW (Release)"
+		},
+		{
+			"name": "windows_mingw_ci",
+			"inherits": [
+				"base_ci",
+				"windows_mingw_base"
+			],
+			"displayName": "Windows MinGW (CI)",
+			"cacheVariables": {
+				"Launcher_BUILD_ARTIFACT": "Windows-MinGW-w64-Qt6"
+			}
 		}
 	],
 	"buildPresets": [
@@ -60,6 +71,14 @@
 			],
 			"displayName": "Windows MinGW (Release)",
 			"configurePreset": "windows_mingw_release"
+		},
+		{
+			"name": "windows_mingw_ci",
+			"inherits": [
+				"windows_mingw_base"
+			],
+			"displayName": "Windows MinGW (CI)",
+			"configurePreset": "windows_mingw_ci"
 		}
 	],
 	"testPresets": [
@@ -94,6 +113,71 @@
 			],
 			"displayName": "Windows MinGW (Release)",
 			"configurePreset": "windows_mingw_release"
+		},
+		{
+			"name": "windows_mingw_ci",
+			"inherits": [
+				"base_release",
+				"windows_mingw_base"
+			],
+			"displayName": "Windows MinGW (CI)",
+			"configurePreset": "windows_mingw_ci"
+		}
+	],
+	"workflowPresets": [
+		{
+			"name": "windows_mingw_debug",
+			"displayName": "Windows MinGW (Debug)",
+			"steps": [
+				{
+					"type": "configure",
+					"name": "windows_mingw_debug"
+				},
+				{
+					"type": "build",
+					"name": "windows_mingw_debug"
+				},
+				{
+					"type": "test",
+					"name": "windows_mingw_debug"
+				}
+			]
+		},
+		{
+			"name": "windows_mingw",
+			"displayName": "Windows MinGW (Release)",
+			"steps": [
+				{
+					"type": "configure",
+					"name": "windows_mingw_release"
+				},
+				{
+					"type": "build",
+					"name": "windows_mingw_release"
+				},
+				{
+					"type": "test",
+					"name": "windows_mingw_release"
+				}
+			]
+		},
+		{
+			"name": "windows_mingw_ci",
+			"displayName": "Windows MinGW (CI)",
+			"steps": [
+				{
+					"type": "configure",
+					"name": "windows_mingw_ci"
+				},
+				{
+					"type": "build",
+					"name": "windows_mingw_ci"
+				},
+				{
+					"type": "test",
+					"name": "windows_mingw_ci"
+				}
+			]
 		}
 	]
 }

--- a/cmake/windowsMinGWPreset.json
+++ b/cmake/windowsMinGWPreset.json
@@ -1,0 +1,99 @@
+{
+	"$schema": "https://cmake.org/cmake/help/latest/_downloads/3e2d73bff478d88a7de0de736ba5e361/schema.json",
+	"version": 8,
+	"include": [
+		"commonPresets.json"
+	],
+	"configurePresets": [
+		{
+			"name": "windows_mingw_base",
+			"hidden": true,
+			"condition": {
+				"type": "equals",
+				"lhs": "${hostSystemName}",
+				"rhs": "Windows"
+			},
+			"generator": "Ninja",
+			"cacheVariables": {
+				"Launcher_BUILD_ARTIFACT": "Windows-MinGW-w64-Qt6"
+			}
+		},
+		{
+			"name": "windows_mingw_debug",
+			"inherits": [
+				"base_debug",
+				"windows_mingw_base"
+			],
+			"displayName": "Windows MinGW (Debug)"
+		},
+		{
+			"name": "windows_mingw_release",
+			"inherits": [
+				"base_release",
+				"windows_mingw_base"
+			],
+			"displayName": "Windows MinGW (Release)"
+		}
+	],
+	"buildPresets": [
+		{
+			"name": "windows_mingw_base",
+			"hidden": true,
+			"condition": {
+				"type": "equals",
+				"lhs": "${hostSystemName}",
+				"rhs": "Windows"
+			}
+		},
+		{
+			"name": "windows_mingw_debug",
+			"inherits": [
+				"windows_mingw_base"
+			],
+			"displayName": "Windows MinGW (Debug)",
+			"configurePreset": "windows_mingw_debug"
+		},
+		{
+			"name": "windows_mingw_release",
+			"inherits": [
+				"windows_mingw_base"
+			],
+			"displayName": "Windows MinGW (Release)",
+			"configurePreset": "windows_mingw_release"
+		}
+	],
+	"testPresets": [
+		{
+			"name": "windows_mingw_base",
+			"hidden": true,
+			"condition": {
+				"type": "equals",
+				"lhs": "${hostSystemName}",
+				"rhs": "Windows"
+			},
+			"filter": {
+				"exclude": {
+					"name": "^example64|example$"
+				}
+			}
+		},
+		{
+			"name": "windows_mingw_debug",
+			"inherits": [
+				"base_debug",
+				"windows_mingw_base"
+			],
+			"displayName": "Windows MinGW (Debug)",
+			"configurePreset": "windows_mingw_debug"
+		},
+		{
+			"name": "windows_mingw_release",
+			"inherits": [
+				"base_release",
+				"windows_mingw_base"
+			],
+			"displayName": "Windows MinGW (Release)",
+			"configurePreset": "windows_mingw_release"
+		}
+	]
+}


### PR DESCRIPTION
Succesor of #1466

The primary purpose of introducing this is to:

- Improve out of the box support in IDEs
- Automate the traditional CMake configure -> build -> test workflow
- Create a single source of truth for our CMake workflow in CI
- Allow us to easily fine tune CMake options at a global level, by operating system, release mode, etc.
- Avoid duplicating a ton of flags endlessly on one line in a YAML file

Our current defaults are not duplicated here; **only our more opinionated upstream options are declared here**. It's unlikely this will be used by third party packagers, but it's great for CI and local development

## TODOS

- [x] MINGW support (I forgor)
