### PR TITLE
ci(nix): fix the PR number

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -72,7 +72,7 @@ jobs:
         id: merge-commit
         uses: PrismLauncher/PrismLauncher/.github/actions/get-merge-commit@develop
         with:
-          pull-request-id: ${{ github.event.pull_request.id }}
+          pull-request-id: ${{ github.event.number }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
in https://github.com/NixOS/nixpkgs/blob/096451d0c0d2a8d539f46b7c7064d05072748f47/.github/workflows/get-merge-commit.yml#L34 they use `github.event.number`