### PR TITLE
fix: file filtering on modpack export

### DIFF
--- a/launcher/FileIgnoreProxy.cpp
+++ b/launcher/FileIgnoreProxy.cpp
@@ -269,9 +269,9 @@ bool FileIgnoreProxy::ignoreFile(QFileInfo fileInfo) const
     return m_ignoreFiles.contains(fileInfo.fileName()) || m_ignoreFilePaths.covers(relPath(fileInfo.absoluteFilePath()));
 }
 
-bool FileIgnoreProxy::filterFile(const QString& fileName) const
+bool FileIgnoreProxy::filterFile(const QFileInfo& file) const
 {
-    return m_blocked.covers(fileName) || ignoreFile(QFileInfo(QDir(m_root), fileName));
+    return m_blocked.covers(relPath(file.absoluteFilePath())) || ignoreFile(file);
 }
 
 void FileIgnoreProxy::loadBlockedPathsFromFile(const QString& fileName)

--- a/launcher/FileIgnoreProxy.h
+++ b/launcher/FileIgnoreProxy.h
@@ -69,7 +69,7 @@ class FileIgnoreProxy : public QSortFilterProxyModel {
     // list of relative paths that need to be removed completely from model
     inline SeparatorPrefixTree<'/'>& ignoreFilesWithPath() { return m_ignoreFilePaths; }
 
-    bool filterFile(const QString& fileName) const;
+    bool filterFile(const QFileInfo& fileName) const;
 
     void loadBlockedPathsFromFile(const QString& fileName);
 

--- a/launcher/MMCZip.cpp
+++ b/launcher/MMCZip.cpp
@@ -418,7 +418,7 @@ bool extractFile(QString fileCompressed, QString file, QString target)
     return extractRelFile(&zip, file, target);
 }
 
-bool collectFileListRecursively(const QString& rootDir, const QString& subDir, QFileInfoList* files, FilterFunction excludeFilter)
+bool collectFileListRecursively(const QString& rootDir, const QString& subDir, QFileInfoList* files, FilterFileFunction excludeFilter)
 {
     QDir rootDirectory(rootDir);
     if (!rootDirectory.exists())
@@ -443,8 +443,8 @@ bool collectFileListRecursively(const QString& rootDir, const QString& subDir, Q
     // collect files
     entries = directory.entryInfoList(QDir::Files);
     for (const auto& e : entries) {
-        QString relativeFilePath = rootDirectory.relativeFilePath(e.absoluteFilePath());
-        if (excludeFilter && excludeFilter(relativeFilePath)) {
+        if (excludeFilter && excludeFilter(e)) {
+            QString relativeFilePath = rootDirectory.relativeFilePath(e.absoluteFilePath());
             qDebug() << "Skipping file " << relativeFilePath;
             continue;
         }

--- a/launcher/MMCZip.h
+++ b/launcher/MMCZip.h
@@ -56,6 +56,7 @@
 
 namespace MMCZip {
 using FilterFunction = std::function<bool(const QString&)>;
+using FilterFileFunction = std::function<bool(const QFileInfo&)>;
 
 /**
  * Merge two zip files, using a filter function
@@ -149,7 +150,7 @@ bool extractFile(QString fileCompressed, QString file, QString dir);
  * \param excludeFilter function to excludeFilter which files shouldn't be included (returning true means to excude)
  * \return true for success or false for failure
  */
-bool collectFileListRecursively(const QString& rootDir, const QString& subDir, QFileInfoList* files, FilterFunction excludeFilter);
+bool collectFileListRecursively(const QString& rootDir, const QString& subDir, QFileInfoList* files, FilterFileFunction excludeFilter);
 
 #if defined(LAUNCHER_APPLICATION)
 class ExportToZipTask : public Task {

--- a/launcher/modplatform/flame/FlamePackExportTask.cpp
+++ b/launcher/modplatform/flame/FlamePackExportTask.cpp
@@ -47,7 +47,7 @@ FlamePackExportTask::FlamePackExportTask(const QString& name,
                                          bool optionalFiles,
                                          InstancePtr instance,
                                          const QString& output,
-                                         MMCZip::FilterFunction filter)
+                                         MMCZip::FilterFileFunction filter)
     : name(name)
     , version(version)
     , author(author)

--- a/launcher/modplatform/flame/FlamePackExportTask.h
+++ b/launcher/modplatform/flame/FlamePackExportTask.h
@@ -34,7 +34,7 @@ class FlamePackExportTask : public Task {
                         bool optionalFiles,
                         InstancePtr instance,
                         const QString& output,
-                        MMCZip::FilterFunction filter);
+                        MMCZip::FilterFileFunction filter);
 
    protected:
     void executeTask() override;
@@ -51,7 +51,7 @@ class FlamePackExportTask : public Task {
     MinecraftInstance* mcInstance;
     const QDir gameRoot;
     const QString output;
-    const MMCZip::FilterFunction filter;
+    const MMCZip::FilterFileFunction filter;
 
     struct ResolvedFile {
         int addonId;

--- a/launcher/modplatform/modrinth/ModrinthPackExportTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackExportTask.cpp
@@ -40,7 +40,7 @@ ModrinthPackExportTask::ModrinthPackExportTask(const QString& name,
                                                bool optionalFiles,
                                                InstancePtr instance,
                                                const QString& output,
-                                               MMCZip::FilterFunction filter)
+                                               MMCZip::FilterFileFunction filter)
     : name(name)
     , version(version)
     , summary(summary)

--- a/launcher/modplatform/modrinth/ModrinthPackExportTask.h
+++ b/launcher/modplatform/modrinth/ModrinthPackExportTask.h
@@ -35,7 +35,7 @@ class ModrinthPackExportTask : public Task {
                            bool optionalFiles,
                            InstancePtr instance,
                            const QString& output,
-                           MMCZip::FilterFunction filter);
+                           MMCZip::FilterFileFunction filter);
 
    protected:
     void executeTask() override;
@@ -58,7 +58,7 @@ class ModrinthPackExportTask : public Task {
     MinecraftInstance* mcInstance;
     const QDir gameRoot;
     const QString output;
-    const MMCZip::FilterFunction filter;
+    const MMCZip::FilterFileFunction filter;
 
     ModrinthAPI api;
     QFileInfoList files;


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
