### PR TITLE
Support for CurseForge recommended memory

### DIFF
--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -212,6 +212,7 @@ void InstanceImportTask::processZipPack()
         progressStep->status = status;
         stepProgress(*progressStep);
     });
+    connect(zipTask.get(), &Task::warningLogged, this, [this](const QString& line) { m_Warnings.append(line); });
     m_task.reset(zipTask);
     zipTask->start();
 }
@@ -307,6 +308,8 @@ void InstanceImportTask::processFlame()
 
     connect(inst_creation_task.get(), &Task::aborted, this, &Task::abort);
     connect(inst_creation_task.get(), &Task::abortStatusChanged, this, &Task::setAbortable);
+
+    connect(inst_creation_task.get(), &Task::warningLogged, this, [this](const QString& line) { m_Warnings.append(line); });
 
     m_task.reset(inst_creation_task);
     setAbortable(true);
@@ -406,6 +409,8 @@ void InstanceImportTask::processModrinth()
 
     connect(inst_creation_task.get(), &Task::aborted, this, &Task::abort);
     connect(inst_creation_task.get(), &Task::abortStatusChanged, this, &Task::setAbortable);
+
+    connect(inst_creation_task.get(), &Task::warningLogged, this, [this](const QString& line) { m_Warnings.append(line); });
 
     m_task.reset(inst_creation_task);
     setAbortable(true);

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -248,6 +248,7 @@ void MinecraftInstance::loadSpecificSettings()
     m_settings->registerSetting("ExportSummary", "");
     m_settings->registerSetting("ExportAuthor", "");
     m_settings->registerSetting("ExportOptionalFiles", true);
+    m_settings->registerSetting("ExportRecommendedRAM");
 
     qDebug() << "Instance-type specific settings were loaded!";
 

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -54,6 +54,7 @@
 
 #include "settings/INISettingsObject.h"
 
+#include "sys.h"
 #include "tasks/ConcurrentTask.h"
 #include "ui/dialogs/BlockedModsDialog.h"
 #include "ui/dialogs/CustomMessageBox.h"
@@ -416,6 +417,24 @@ bool FlameCreationTask::createInstance()
         } else {
             instance.setIconKey("flame");
         }
+    }
+
+    int recommendedRAM = m_pack.minecraft.recommendedRAM;
+
+    // only set memory if this is a fresh instance
+    if (m_instance == nullptr && recommendedRAM > 0) {
+        const uint64_t sysMiB = Sys::getSystemRam() / Sys::mebibyte;
+        const uint64_t max = sysMiB * 0.9;
+
+        if (recommendedRAM > max) {
+            logWarning(tr("The recommended memory of the modpack exceeds 90% of your system RAM—reducing it from %1 MiB to %2 MiB!")
+                           .arg(recommendedRAM)
+                           .arg(max));
+            recommendedRAM = max;
+        }
+
+        instance.settings()->set("OverrideMemory", true);
+        instance.settings()->set("MaxMemAlloc", recommendedRAM);
     }
 
     QString jarmodsPath = FS::PathCombine(m_stagingPath, "minecraft", "jarmods");

--- a/launcher/modplatform/flame/FlamePackExportTask.cpp
+++ b/launcher/modplatform/flame/FlamePackExportTask.cpp
@@ -47,7 +47,8 @@ FlamePackExportTask::FlamePackExportTask(const QString& name,
                                          bool optionalFiles,
                                          InstancePtr instance,
                                          const QString& output,
-                                         MMCZip::FilterFunction filter)
+                                         MMCZip::FilterFunction filter,
+                                         int recommendedRAM)
     : name(name)
     , version(version)
     , author(author)
@@ -57,6 +58,7 @@ FlamePackExportTask::FlamePackExportTask(const QString& name,
     , gameRoot(instance->gameRoot())
     , output(output)
     , filter(filter)
+    , m_recommendedRAM(recommendedRAM)
 {}
 
 void FlamePackExportTask::executeTask()
@@ -411,6 +413,10 @@ QByteArray FlamePackExportTask::generateIndex()
             loader["primary"] = true;
             version["modLoaders"] = QJsonArray({ loader });
         }
+
+        if (m_recommendedRAM > 0)
+            version["recommendedRam"] = m_recommendedRAM;
+
         obj["minecraft"] = version;
     }
 

--- a/launcher/modplatform/flame/FlamePackExportTask.h
+++ b/launcher/modplatform/flame/FlamePackExportTask.h
@@ -19,23 +19,26 @@
 
 #pragma once
 
-#include "BaseInstance.h"
 #include "MMCZip.h"
 #include "minecraft/MinecraftInstance.h"
 #include "modplatform/flame/FlameAPI.h"
 #include "tasks/Task.h"
 
+struct FlamePackExportOptions {
+    QString name;
+    QString version;
+    QString author;
+    bool optionalFiles;
+    MinecraftInstancePtr instance;
+    QString output;
+    MMCZip::FilterFileFunction filter;
+    int recommendedRAM;
+};
+
 class FlamePackExportTask : public Task {
     Q_OBJECT
    public:
-    FlamePackExportTask(const QString& name,
-                        const QString& version,
-                        const QString& author,
-                        bool optionalFiles,
-                        InstancePtr instance,
-                        const QString& output,
-                        MMCZip::FilterFileFunction filter,
-                        int recommendedRAM);
+    FlamePackExportTask(FlamePackExportOptions&& options);
 
    protected:
     void executeTask() override;
@@ -46,14 +49,6 @@ class FlamePackExportTask : public Task {
     static const QStringList FILE_EXTENSIONS;
 
     // inputs
-    const QString name, version, author;
-    const bool optionalFiles;
-    const InstancePtr instance;
-    MinecraftInstance* mcInstance;
-    const QDir gameRoot;
-    const QString output;
-    const MMCZip::FilterFileFunction filter;
-    const int m_recommendedRAM;
 
     struct ResolvedFile {
         int addonId;
@@ -71,6 +66,9 @@ class FlamePackExportTask : public Task {
         bool enabled;
         bool isMod;
     };
+
+    FlamePackExportOptions m_options;
+    QDir m_gameRoot;
 
     FlameAPI api;
 

--- a/launcher/modplatform/flame/FlamePackExportTask.h
+++ b/launcher/modplatform/flame/FlamePackExportTask.h
@@ -34,7 +34,8 @@ class FlamePackExportTask : public Task {
                         bool optionalFiles,
                         InstancePtr instance,
                         const QString& output,
-                        MMCZip::FilterFunction filter);
+                        MMCZip::FilterFunction filter,
+                        int recommendedRAM);
 
    protected:
     void executeTask() override;
@@ -52,6 +53,7 @@ class FlamePackExportTask : public Task {
     const QDir gameRoot;
     const QString output;
     const MMCZip::FilterFunction filter;
+    const int m_recommendedRAM;
 
     struct ResolvedFile {
         int addonId;

--- a/launcher/modplatform/flame/PackManifest.cpp
+++ b/launcher/modplatform/flame/PackManifest.cpp
@@ -27,6 +27,7 @@ static void loadMinecraftV1(Flame::Minecraft& m, QJsonObject& minecraft)
         loadModloaderV1(loader, obj);
         m.modLoaders.append(loader);
     }
+    m.recommendedRAM = Json::ensureInteger(minecraft, "recommendedRam", 0);
 }
 
 static void loadManifestV1(Flame::Manifest& pack, QJsonObject& manifest)

--- a/launcher/modplatform/flame/PackManifest.h
+++ b/launcher/modplatform/flame/PackManifest.h
@@ -67,6 +67,7 @@ struct Minecraft {
     QString version;
     QString libraries;
     QList<Flame::Modloader> modLoaders;
+    int recommendedRAM;
 };
 
 struct Manifest {

--- a/launcher/tasks/Task.cpp
+++ b/launcher/tasks/Task.cpp
@@ -196,6 +196,8 @@ void Task::logWarning(const QString& line)
 {
     qWarning() << line;
     m_Warnings.append(line);
+
+    emit warningLogged(line);
 }
 
 QStringList Task::warnings() const

--- a/launcher/tasks/Task.h
+++ b/launcher/tasks/Task.h
@@ -145,6 +145,7 @@ class Task : public QObject, public QRunnable {
     void failed(QString reason);
     void status(QString status);
     void details(QString details);
+    void warningLogged(const QString& warning);
     void stepProgress(TaskStepProgress const& task_progress);
 
     //! Emitted when the canAbort() status has changed. */

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -71,6 +71,7 @@
 #include <QToolButton>
 #include <QWidget>
 #include <QWidgetAction>
+#include <memory>
 
 #include <BaseInstance.h>
 #include <BuildConfig.h>
@@ -1419,15 +1420,18 @@ void MainWindow::on_actionExportInstanceZip_triggered()
 void MainWindow::on_actionExportInstanceMrPack_triggered()
 {
     if (m_selectedInstance) {
-        ExportPackDialog dlg(m_selectedInstance, this);
-        dlg.exec();
+        auto instance = std::dynamic_pointer_cast<MinecraftInstance>(m_selectedInstance);
+        if (instance != nullptr) {
+            ExportPackDialog dlg(instance, this);
+            dlg.exec();
+        }
     }
 }
 
 void MainWindow::on_actionExportInstanceFlamePack_triggered()
 {
     if (m_selectedInstance) {
-        auto instance = dynamic_cast<MinecraftInstance*>(m_selectedInstance.get());
+        auto instance = std::dynamic_pointer_cast<MinecraftInstance>(m_selectedInstance);
         if (instance) {
             if (auto cmp = instance->getPackProfile()->getComponent("net.minecraft");
                 cmp && cmp->getVersionFile() && cmp->getVersionFile()->type == "snapshot") {
@@ -1436,7 +1440,7 @@ void MainWindow::on_actionExportInstanceFlamePack_triggered()
                 msgBox.exec();
                 return;
             }
-            ExportPackDialog dlg(m_selectedInstance, this, ModPlatform::ResourceProvider::FLAME);
+            ExportPackDialog dlg(instance, this, ModPlatform::ResourceProvider::FLAME);
             dlg.exec();
         }
     }

--- a/launcher/ui/dialogs/ExportPackDialog.cpp
+++ b/launcher/ui/dialogs/ExportPackDialog.cpp
@@ -172,8 +172,10 @@ void ExportPackDialog::done(int result)
             task = new ModrinthPackExportTask(name, m_ui->version->text(), m_ui->summary->toPlainText(), m_ui->optionalFiles->isChecked(),
                                               m_instance, output, std::bind(&FileIgnoreProxy::filterFile, m_proxy, std::placeholders::_1));
         } else {
+            int recommendedRAM = m_ui->recommendedMemoryCheckBox->isChecked() ? m_ui->recommendedMemory->value() : 0;
+
             task = new FlamePackExportTask(name, m_ui->version->text(), m_ui->author->text(), m_ui->optionalFiles->isChecked(), m_instance,
-                                           output, std::bind(&FileIgnoreProxy::filterFile, m_proxy, std::placeholders::_1));
+                                           output, std::bind(&FileIgnoreProxy::filterFile, m_proxy, std::placeholders::_1), recommendedRAM);
         }
 
         connect(task, &Task::failed,

--- a/launcher/ui/dialogs/ExportPackDialog.h
+++ b/launcher/ui/dialogs/ExportPackDialog.h
@@ -22,6 +22,7 @@
 #include "BaseInstance.h"
 #include "FastFileIconProvider.h"
 #include "FileIgnoreProxy.h"
+#include "minecraft/MinecraftInstance.h"
 #include "modplatform/ModIndex.h"
 
 namespace Ui {
@@ -32,7 +33,7 @@ class ExportPackDialog : public QDialog {
     Q_OBJECT
 
    public:
-    explicit ExportPackDialog(InstancePtr instance,
+    explicit ExportPackDialog(MinecraftInstancePtr instance,
                               QWidget* parent = nullptr,
                               ModPlatform::ResourceProvider provider = ModPlatform::ResourceProvider::MODRINTH);
     ~ExportPackDialog();
@@ -44,7 +45,7 @@ class ExportPackDialog : public QDialog {
     QString ignoreFileName();
 
    private:
-    const InstancePtr m_instance;
+    const MinecraftInstancePtr m_instance;
     Ui::ExportPackDialog* m_ui;
     FileIgnoreProxy* m_proxy;
     FastFileIconProvider m_icons;

--- a/launcher/ui/dialogs/ExportPackDialog.ui
+++ b/launcher/ui/dialogs/ExportPackDialog.ui
@@ -19,36 +19,56 @@
      <property name="title">
       <string>&amp;Description</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
+     <layout class="QVBoxLayout" name="verticalLayout">
       <item>
-       <widget class="QLabel" name="nameLabel">
-        <property name="text">
-         <string>&amp;Name</string>
+       <layout class="QFormLayout" name="formLayout">
+        <property name="labelAlignment">
+         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
         </property>
-        <property name="buddy">
-         <cstring>name</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLineEdit" name="name"/>
-      </item>
-      <item>
-       <widget class="QLabel" name="versionLabel">
-        <property name="text">
-         <string>&amp;Version</string>
-        </property>
-        <property name="buddy">
-         <cstring>version</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLineEdit" name="version">
-        <property name="text">
-         <string>1.0.0</string>
-        </property>
-       </widget>
+        <item row="0" column="0">
+         <widget class="QLabel" name="nameLabel">
+          <property name="text">
+           <string>&amp;Name:</string>
+          </property>
+          <property name="buddy">
+           <cstring>name</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QLineEdit" name="name"/>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="versionLabel">
+          <property name="text">
+           <string>&amp;Version:</string>
+          </property>
+          <property name="buddy">
+           <cstring>version</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QLineEdit" name="version">
+          <property name="text">
+           <string>1.0.0</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="authorLabel">
+          <property name="text">
+           <string>&amp;Author:</string>
+          </property>
+          <property name="buddy">
+           <cstring>author</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="QLineEdit" name="author"/>
+        </item>
+       </layout>
       </item>
       <item>
        <widget class="QLabel" name="summaryLabel">
@@ -62,23 +82,28 @@
       </item>
       <item>
        <widget class="QPlainTextEdit" name="summary">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>100</height>
+         </size>
+        </property>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>100</height>
+         </size>
+        </property>
         <property name="tabChangesFocus">
          <bool>true</bool>
         </property>
        </widget>
-      </item>
-      <item>
-       <widget class="QLabel" name="authorLabel">
-        <property name="text">
-         <string>&amp;Author</string>
-        </property>
-        <property name="buddy">
-         <cstring>author</cstring>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QLineEdit" name="author"/>
       </item>
      </layout>
     </widget>
@@ -88,7 +113,70 @@
      <property name="title">
       <string>&amp;Options</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <item>
+       <widget class="QWidget" name="recommendedMemoryWidget" native="true">
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QCheckBox" name="recommendedMemoryCheckBox">
+           <property name="text">
+            <string>&amp;Recommended Memory:</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="recommendedMemory">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="suffix">
+            <string> MiB</string>
+           </property>
+           <property name="minimum">
+            <number>8</number>
+           </property>
+           <property name="maximum">
+            <number>32768</number>
+           </property>
+           <property name="singleStep">
+            <number>128</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+      </item>
       <item>
        <widget class="QLabel" name="filesLabel">
         <property name="text">
@@ -138,10 +226,6 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>name</tabstop>
-  <tabstop>version</tabstop>
-  <tabstop>summary</tabstop>
-  <tabstop>author</tabstop>
   <tabstop>files</tabstop>
   <tabstop>optionalFiles</tabstop>
  </tabstops>


### PR DESCRIPTION
CurseForge has this now

![image](https://github.com/user-attachments/assets/113f0a9e-a656-4da1-b206-c3ba1da6c7d4)
![image](https://github.com/user-attachments/assets/9d66f88a-0c6f-41c0-b335-abe124e8d1b7)

This PR implements it in import and export!

For import the maximum memory usage is set automatically (limited to 90% of your system memory)
.
For export you must opt into setting recommended memory - and it defaults to the instance's max memory setting. However, it will initially be set no higher than 12 GiB, and can only be adjusted up to 32 GiB (beyond that point is insanity :trollface: - and I wouldn't want to break CurseForge app interop by setting the limit *too* high)