### PR TITLE
fix: crash when task was canceled and abort signal was fired early

### DIFF
--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -72,7 +72,6 @@ bool InstanceImportTask::abort()
     bool wasAborted = false;
     if (m_task)
         wasAborted = m_task->abort();
-    Task::abort();
     return wasAborted;
 }
 
@@ -305,7 +304,7 @@ void InstanceImportTask::processFlame()
     connect(inst_creation_task.get(), &Task::status, this, &InstanceImportTask::setStatus);
     connect(inst_creation_task.get(), &Task::details, this, &InstanceImportTask::setDetails);
 
-    connect(inst_creation_task.get(), &Task::aborted, this, &Task::abort);
+    connect(inst_creation_task.get(), &Task::aborted, this, &InstanceImportTask::emitAborted);
     connect(inst_creation_task.get(), &Task::abortStatusChanged, this, &Task::setAbortable);
 
     m_task.reset(inst_creation_task);
@@ -404,7 +403,7 @@ void InstanceImportTask::processModrinth()
     connect(inst_creation_task.get(), &Task::status, this, &InstanceImportTask::setStatus);
     connect(inst_creation_task.get(), &Task::details, this, &InstanceImportTask::setDetails);
 
-    connect(inst_creation_task.get(), &Task::aborted, this, &Task::abort);
+    connect(inst_creation_task.get(), &Task::aborted, this, &InstanceImportTask::emitAborted);
     connect(inst_creation_task.get(), &Task::abortStatusChanged, this, &Task::setAbortable);
 
     m_task.reset(inst_creation_task);

--- a/launcher/java/download/ArchiveDownloadTask.cpp
+++ b/launcher/java/download/ArchiveDownloadTask.cpp
@@ -55,6 +55,7 @@ void ArchiveDownloadTask::executeTask()
     connect(download.get(), &Task::stepProgress, this, &ArchiveDownloadTask::propagateStepProgress);
     connect(download.get(), &Task::status, this, &ArchiveDownloadTask::setStatus);
     connect(download.get(), &Task::details, this, &ArchiveDownloadTask::setDetails);
+    connect(download.get(), &Task::aborted, this, &ArchiveDownloadTask::emitAborted);
     connect(download.get(), &Task::succeeded, [this, fullPath] {
         // This should do all of the extracting and creating folders
         extractJava(fullPath);
@@ -135,7 +136,6 @@ bool ArchiveDownloadTask::abort()
     auto aborted = canAbort();
     if (m_task)
         aborted = m_task->abort();
-    emitAborted();
     return aborted;
 };
 }  // namespace Java

--- a/launcher/modplatform/flame/FlamePackExportTask.cpp
+++ b/launcher/modplatform/flame/FlamePackExportTask.cpp
@@ -70,7 +70,6 @@ bool FlamePackExportTask::abort()
 {
     if (task) {
         task->abort();
-        emitAborted();
         return true;
     }
     return false;
@@ -171,6 +170,7 @@ void FlamePackExportTask::collectHashes()
         progressStep->status = status;
         stepProgress(*progressStep);
     });
+    connect(hashingTask.get(), &Task::aborted, this, &FlamePackExportTask::emitAborted);
     hashingTask->start();
 }
 
@@ -246,6 +246,7 @@ void FlamePackExportTask::makeApiRequest()
         getProjectsInfo();
     });
     connect(task.get(), &Task::failed, this, &FlamePackExportTask::getProjectsInfo);
+    connect(task.get(), &Task::aborted, this, &FlamePackExportTask::emitAborted);
     task->start();
 }
 
@@ -324,6 +325,7 @@ void FlamePackExportTask::getProjectsInfo()
         buildZip();
     });
     connect(projTask.get(), &Task::failed, this, &FlamePackExportTask::emitFailed);
+    connect(task.get(), &Task::aborted, this, &FlamePackExportTask::emitAborted);
     task.reset(projTask);
     task->start();
 }

--- a/launcher/modplatform/modrinth/ModrinthPackExportTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackExportTask.cpp
@@ -63,7 +63,6 @@ bool ModrinthPackExportTask::abort()
 {
     if (task) {
         task->abort();
-        emitAborted();
         return true;
     }
     return false;
@@ -158,6 +157,7 @@ void ModrinthPackExportTask::makeApiRequest()
         task = api.currentVersions(pendingHashes.values(), "sha512", response);
         connect(task.get(), &Task::succeeded, [this, response]() { parseApiResponse(response); });
         connect(task.get(), &Task::failed, this, &ModrinthPackExportTask::emitFailed);
+        connect(task.get(), &Task::aborted, this, &ModrinthPackExportTask::emitAborted);
         task->start();
     }
 }


### PR DESCRIPTION
To test:
- export modrinth/curseforge (something big, as in saves folder) and do not let it finish, and cancel once it starts adding files to the zip
- import instance (similar,r if possible,e something big) and cancel when it writes files from zip
- download Java (but unlikely to be able to reproduce)

This happens because when we click abort for the InstanceImport/Export the signal is called immediately and doesn't wait a few seconds for the zip import/export to finish it's future causing the progress dialog to be closed and the parent task deleted, deleting the zip task and making any member variable that is used in the zip future function invalid and crashes the app.
(only tested modrinth export)