### PR TITLE
ci: only run on specific paths

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,37 +2,48 @@ name: "CodeQL Code Scanning"
 
 on:
   push:
-    # NOTE: `!` doesn't work with `paths-ignore` :(
-    # So we a catch-all glob instead
-    # https://github.com/orgs/community/discussions/25369#discussioncomment-3247674
     paths:
-      - "**"
-      - "!.github/**"
-      - ".github/workflows/codeql.yml"
-      - "!flatpak/"
-      - "!nix/"
-      - "!scripts/"
+      # File types
+      - "**.cpp"
+      - "**.h"
+      - "**.java"
 
-      - "!.git*"
-      - "!.envrc"
-      - "!**.md"
+      # Directories
+      - "buildconfig/"
+      - "cmake/"
+      - "launcher/"
+      - "libraries/"
+      - "program_info/"
+      - "tests/"
+
+      # Files
+      - "CMakeLists.txt"
       - "COPYING.md"
-      - "!renovate.json"
+
+      # Workflows
+      - ".github/codeql"
+      - ".github/workflows/codeql.yml"
   pull_request:
-    # See above
     paths:
-      - "**"
-      - "!.github/**"
-      - ".github/workflows/codeql.yml"
-      - "!flatpak/"
-      - "!nix/"
-      - "!scripts/"
+      # File types
+      - "**.cpp"
+      - "**.h"
 
-      - "!.git*"
-      - "!.envrc"
-      - "!**.md"
+      # Directories
+      - "buildconfig/"
+      - "cmake/"
+      - "launcher/"
+      - "libraries/"
+      - "program_info/"
+      - "tests/"
+
+      # Files
+      - "CMakeLists.txt"
       - "COPYING.md"
-      - "!renovate.json"
+
+      # Workflows
+      - ".github/codeql"
+      - ".github/workflows/codeql.yml"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -5,35 +5,52 @@ on:
     # We don't do anything with these artifacts on releases. They go to Flathub
     tags-ignore:
       - "*"
-    # NOTE: `!` doesn't work with `paths-ignore` :(
-    # So we a catch-all glob instead
-    # https://github.com/orgs/community/discussions/25369#discussioncomment-3247674
     paths:
-      - "**"
-      - "!.github/**"
-      - ".github/workflows/flatpak.yml"
-      - "!nix/"
-      - "!scripts/"
+      # File types
+      - "**.cpp"
+      - "**.h"
+      - "**.java"
 
-      - "!.git*"
-      - "!.envrc"
-      - "!**.md"
+      # Build files
+      - "flatpak/"
+
+      # Directories
+      - "buildconfig/"
+      - "cmake/"
+      - "launcher/"
+      - "libraries/"
+      - "program_info/"
+      - "tests/"
+
+      # Files
+      - "CMakeLists.txt"
       - "COPYING.md"
-      - "!renovate.json"
+
+      # Workflows
+      - ".github/workflows/flatpak.yml"
   pull_request:
-    # See above
     paths:
-      - "**"
-      - "!.github/**"
-      - ".github/workflows/flatpak.yml"
-      - "!nix/"
-      - "!scripts/"
+      # File types
+      - "**.cpp"
+      - "**.h"
 
-      - "!.git*"
-      - "!.envrc"
-      - "!**.md"
+      # Build files
+      - "flatpak/"
+
+      # Directories
+      - "buildconfig/"
+      - "cmake/"
+      - "launcher/"
+      - "libraries/"
+      - "program_info/"
+      - "tests/"
+
+      # Files
+      - "CMakeLists.txt"
       - "COPYING.md"
-      - "!renovate.json"
+
+      # Workflows
+      - ".github/workflows/flatpak.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -4,34 +4,56 @@ on:
   push:
     tags:
       - "*"
-    # NOTE: `!` doesn't work with `paths-ignore` :(
-    # So we a catch-all glob instead
-    # https://github.com/orgs/community/discussions/25369#discussioncomment-3247674
     paths:
-      - "**"
-      - "!.github/**"
-      - ".github/workflows/nix.yml"
-      - "!flatpak/"
-      - "!scripts/"
+      # File types
+      - "**.cpp"
+      - "**.h"
+      - "**.java"
 
-      - "!.git*"
-      - "!.envrc"
-      - "!**.md"
+      # Build files
+      - "**.nix"
+      - "nix/"
+      - "flake.lock"
+
+      # Directories
+      - "buildconfig/"
+      - "cmake/"
+      - "launcher/"
+      - "libraries/"
+      - "program_info/"
+      - "tests/"
+
+      # Files
+      - "CMakeLists.txt"
       - "COPYING.md"
-      - "!renovate.json"
+
+      # Workflows
+      - ".github/workflows/nix.yml"
   pull_request_target:
     paths:
-      - "**"
-      - "!.github/**"
-      - ".github/workflows/nix.yml"
-      - "!flatpak/"
-      - "!scripts/"
+      # File types
+      - "**.cpp"
+      - "**.h"
 
-      - "!.git*"
-      - "!.envrc"
-      - "!**.md"
+      # Build files
+      - "**.nix"
+      - "nix/"
+      - "flake.lock"
+
+      # Directories
+      - "buildconfig/"
+      - "cmake/"
+      - "launcher/"
+      - "libraries/"
+      - "program_info/"
+      - "tests/"
+
+      # Files
+      - "CMakeLists.txt"
       - "COPYING.md"
-      - "!renovate.json"
+
+      # Workflows
+      - ".github/workflows/nix.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/trigger_builds.yml
+++ b/.github/workflows/trigger_builds.yml
@@ -4,39 +4,48 @@ on:
   push:
     branches-ignore:
       - "renovate/**"
-    # NOTE: `!` doesn't work with `paths-ignore` :(
-    # So we a catch-all glob instead
-    # https://github.com/orgs/community/discussions/25369#discussioncomment-3247674
     paths:
-      - "**"
-      - "!.github/**"
+      # File types
+      - "**.cpp"
+      - "**.h"
+      - "**.java"
+
+      # Directories
+      - "buildconfig/"
+      - "cmake/"
+      - "launcher/"
+      - "libraries/"
+      - "program_info/"
+      - "tests/"
+
+      # Files
+      - "CMakeLists.txt"
+      - "COPYING.md"
+
+      # Workflows
       - ".github/workflows/build.yml"
       - ".github/workflows/trigger_builds.yml"
-      - "!flatpak/"
-      - "!nix/"
-      - "!scripts/"
-
-      - "!.git*"
-      - "!.envrc"
-      - "!**.md"
-      - "COPYING.md"
-      - "!renovate.json"
   pull_request:
-    # See above
     paths:
-      - "**"
-      - "!.github/**"
+      # File types
+      - "**.cpp"
+      - "**.h"
+
+      # Directories
+      - "buildconfig/"
+      - "cmake/"
+      - "launcher/"
+      - "libraries/"
+      - "program_info/"
+      - "tests/"
+
+      # Files
+      - "CMakeLists.txt"
+      - "COPYING.md"
+
+      # Workflows
       - ".github/workflows/build.yml"
       - ".github/workflows/trigger_builds.yml"
-      - "!flatpak/"
-      - "!nix/"
-      - "!scripts/"
-
-      - "!.git*"
-      - "!.envrc"
-      - "!**.md"
-      - "COPYING.md"
-      - "!renovate.json"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This avoids the previously applied paths-ignore exception workaround,
and makes runs as strict as (reasonably) possible. Only directories
known to affect builds will trigger builds, as well as any `.cpp` or
`.h` files to account for any new folders created - though these should
still be added to the workflow later

Signed-off-by: Seth Flynn <getchoo@tuta.io>
