### PR TITLE
fix: task typo in flame export task

### DIFF
--- a/launcher/modplatform/flame/FlamePackExportTask.cpp
+++ b/launcher/modplatform/flame/FlamePackExportTask.cpp
@@ -325,7 +325,7 @@ void FlamePackExportTask::getProjectsInfo()
         buildZip();
     });
     connect(projTask.get(), &Task::failed, this, &FlamePackExportTask::emitFailed);
-    connect(task.get(), &Task::aborted, this, &FlamePackExportTask::emitAborted);
+    connect(projTask.get(), &Task::aborted, this, &FlamePackExportTask::emitAborted);
     task.reset(projTask);
     task->start();
 }


### PR DESCRIPTION
parent PR: #3712