### PR TITLE
Replace deprecated unique_qobject_ptr::swap with unique_ptr

### DIFF
--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -61,7 +61,7 @@ ModPage::ModPage(ModDownloadDialog* dialog, BaseInstance& instance) : ResourcePa
     connect(m_ui->resourceFilterButton, &QPushButton::clicked, this, &ModPage::filterMods);
 }
 
-void ModPage::setFilterWidget(unique_qobject_ptr<ModFilterWidget>& widget)
+void ModPage::setFilterWidget(std::unique_ptr<ModFilterWidget>& widget)
 {
     if (m_filter_widget)
         disconnect(m_filter_widget.get(), nullptr, nullptr, nullptr);

--- a/launcher/ui/pages/modplatform/ModPage.h
+++ b/launcher/ui/pages/modplatform/ModPage.h
@@ -51,11 +51,11 @@ class ModPage : public ResourcePage {
 
     void addResourceToPage(ModPlatform::IndexedPack::Ptr, ModPlatform::IndexedVersion&, std::shared_ptr<ResourceFolderModel>) override;
 
-    virtual unique_qobject_ptr<ModFilterWidget> createFilterWidget() = 0;
+    virtual std::unique_ptr<ModFilterWidget> createFilterWidget() = 0;
 
     [[nodiscard]] bool supportsFiltering() const override { return true; };
     auto getFilter() const -> const std::shared_ptr<ModFilterWidget::Filter> { return m_filter; }
-    void setFilterWidget(unique_qobject_ptr<ModFilterWidget>&);
+    void setFilterWidget(std::unique_ptr<ModFilterWidget>&);
 
    protected:
     ModPage(ModDownloadDialog* dialog, BaseInstance& instance);
@@ -67,7 +67,7 @@ class ModPage : public ResourcePage {
     void triggerSearch() override;
 
    protected:
-    unique_qobject_ptr<ModFilterWidget> m_filter_widget;
+    std::unique_ptr<ModFilterWidget> m_filter_widget;
     std::shared_ptr<ModFilterWidget::Filter> m_filter;
 };
 

--- a/launcher/ui/pages/modplatform/flame/FlamePage.h
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.h
@@ -100,6 +100,6 @@ class FlamePage : public QWidget, public ModpackProviderBasePage {
     // Used to do instant searching with a delay to cache quick changes
     QTimer m_search_timer;
 
-    unique_qobject_ptr<ModFilterWidget> m_filterWidget;
+    std::unique_ptr<ModFilterWidget> m_filterWidget;
     Task::Ptr m_categoriesTask;
 };

--- a/launcher/ui/pages/modplatform/flame/FlameResourcePages.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameResourcePages.cpp
@@ -207,7 +207,7 @@ auto FlameShaderPackPage::shouldDisplay() const -> bool
     return true;
 }
 
-unique_qobject_ptr<ModFilterWidget> FlameModPage::createFilterWidget()
+std::unique_ptr<ModFilterWidget> FlameModPage::createFilterWidget()
 {
     return ModFilterWidget::create(&static_cast<MinecraftInstance&>(m_baseInstance), false, this);
 }

--- a/launcher/ui/pages/modplatform/flame/FlameResourcePages.h
+++ b/launcher/ui/pages/modplatform/flame/FlameResourcePages.h
@@ -96,7 +96,7 @@ class FlameModPage : public ModPage {
     [[nodiscard]] inline auto helpPage() const -> QString override { return "Mod-platform"; }
 
     void openUrl(const QUrl& url) override;
-    unique_qobject_ptr<ModFilterWidget> createFilterWidget() override;
+    std::unique_ptr<ModFilterWidget> createFilterWidget() override;
 
    protected:
     virtual void prepareProviderCategories() override;

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.h
@@ -103,6 +103,6 @@ class ModrinthPage : public QWidget, public ModpackProviderBasePage {
     // Used to do instant searching with a delay to cache quick changes
     QTimer m_search_timer;
 
-    unique_qobject_ptr<ModFilterWidget> m_filterWidget;
+    std::unique_ptr<ModFilterWidget> m_filterWidget;
     Task::Ptr m_categoriesTask;
 };

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.cpp
@@ -142,7 +142,7 @@ auto ModrinthShaderPackPage::shouldDisplay() const -> bool
     return true;
 }
 
-unique_qobject_ptr<ModFilterWidget> ModrinthModPage::createFilterWidget()
+std::unique_ptr<ModFilterWidget> ModrinthModPage::createFilterWidget()
 {
     return ModFilterWidget::create(&static_cast<MinecraftInstance&>(m_baseInstance), true, this);
 }

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.h
@@ -94,7 +94,7 @@ class ModrinthModPage : public ModPage {
 
     [[nodiscard]] inline auto helpPage() const -> QString override { return "Mod-platform"; }
 
-    unique_qobject_ptr<ModFilterWidget> createFilterWidget() override;
+    std::unique_ptr<ModFilterWidget> createFilterWidget() override;
 
    protected:
     virtual void prepareProviderCategories() override;

--- a/launcher/ui/widgets/ModFilterWidget.cpp
+++ b/launcher/ui/widgets/ModFilterWidget.cpp
@@ -49,9 +49,9 @@
 #include "Application.h"
 #include "minecraft/PackProfile.h"
 
-unique_qobject_ptr<ModFilterWidget> ModFilterWidget::create(MinecraftInstance* instance, bool extended, QWidget* parent)
+std::unique_ptr<ModFilterWidget> ModFilterWidget::create(MinecraftInstance* instance, bool extended, QWidget* parent)
 {
-    return unique_qobject_ptr<ModFilterWidget>(new ModFilterWidget(instance, extended, parent));
+    return std::unique_ptr<ModFilterWidget>(new ModFilterWidget(instance, extended, parent));
 }
 
 class VersionBasicModel : public QIdentityProxyModel {

--- a/launcher/ui/widgets/ModFilterWidget.h
+++ b/launcher/ui/widgets/ModFilterWidget.h
@@ -83,7 +83,7 @@ class ModFilterWidget : public QTabWidget {
         }
     };
 
-    static unique_qobject_ptr<ModFilterWidget> create(MinecraftInstance* instance, bool extended, QWidget* parent = nullptr);
+    static std::unique_ptr<ModFilterWidget> create(MinecraftInstance* instance, bool extended, QWidget* parent = nullptr);
     virtual ~ModFilterWidget();
 
     auto getFilter() -> std::shared_ptr<Filter>;


### PR DESCRIPTION
ScopedPointer::swap is [deprecated](https://doc.qt.io/qt-6/qscopedpointer-obsolete.html#swap) since Qt 6.2
Might as well replace with std::unique_ptr, it still works all fine !
(Also removes some compiler warnings)