### PR TITLE
Add support for vcpkg

### DIFF
--- a/.github/actions/setup-dependencies/windows/action.yml
+++ b/.github/actions/setup-dependencies/windows/action.yml
@@ -25,6 +25,31 @@ runs:
         arch: ${{ inputs.vcvars-arch }}
         vsversion: 2022
 
+    - name: Setup vcpkg cache (MSVC)
+      if: ${{ inputs.msystem == '' && inputs.build-type == 'Debug' }}
+      shell: pwsh
+      env:
+        USERNAME: ${{ github.repository_owner }}
+        FEED_URL: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
+      run: |
+        .$(vcpkg fetch nuget) `
+          sources add `
+          -Source "$env:FEED_URL" `
+          -StorePasswordInClearText `
+          -Name GitHubPackages `
+          -UserName "$env:USERNAME" `
+          -Password "$env:GITHUB_TOKEN"
+        .$(vcpkg fetch nuget) `
+          setapikey "$env:GITHUB_TOKEN" `
+          -Source "$env:FEED_URL"
+        Write-Output "VCPKG_BINARY_SOURCES=clear;nuget,$env:FEED_URL,readwrite" >> "$GITHUB_ENV"
+
+    - name: Setup vcpkg environment (MSVC)
+      if: ${{ inputs.msystem == '' }}
+      shell: bash
+      run: |
+        echo "CMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" >> "$GITHUB_ENV"
+
     - name: Setup MSYS2 (MinGW)
       if: ${{ inputs.msystem != '' }}
       uses: msys2/setup-msys2@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,10 @@ jobs:
   build:
     name: Build (${{ matrix.artifact-name }})
 
+    permissions:
+      # Required for vcpkg binary cache
+      packages: write
+
     strategy:
       fail-fast: false
       matrix:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,6 +348,14 @@ endif()
 if(NOT Launcher_FORCE_BUNDLED_LIBS)
     # Find toml++
     find_package(tomlplusplus 3.2.0 QUIET)
+    # Fallback to pkg-config (if available) if CMake files aren't found
+    if(NOT tomlplusplus_FOUND)
+        find_package(PkgConfig)
+        if(PkgConfig_FOUND)
+            pkg_check_modules(tomlplusplus IMPORTED_TARGET tomlplusplus>=3.2.0)
+        endif()
+    endif()
+
 
     # Find cmark
     find_package(cmark QUIET)

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -1309,12 +1309,16 @@ target_link_libraries(Launcher_logic
     Launcher_murmur2
     nbt++
     ${ZLIB_LIBRARIES}
-    tomlplusplus::tomlplusplus
     qdcss
     BuildConfig
     Qt${QT_VERSION_MAJOR}::Widgets
     qrcodegenerator
 )
+if(TARGET PkgConfig::tomlplusplus)
+    target_link_libraries(Launcher_logic PkgConfig::tomlplusplus)
+else()
+    target_link_libraries(Launcher_logic tomlplusplus::tomlplusplus)
+endif()
 
 if (UNIX AND NOT CYGWIN AND NOT APPLE)
     target_link_libraries(Launcher_logic

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,14 @@
+{
+  "default-registry": {
+    "kind": "git",
+    "baseline": "0c4cf19224a049cf82f4521e29e39f7bd680440c",
+    "repository": "https://github.com/microsoft/vcpkg"
+  },
+  "registries": [
+    {
+      "kind": "artifact",
+      "location": "https://github.com/microsoft/vcpkg-ce-catalog/archive/refs/heads/main.zip",
+      "name": "microsoft"
+    }
+  ]
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "dependencies": [
+    "bzip2",
+    "cmark",
+    { "name": "ecm", "host": true },
+    { "name": "pkgconf", "host": true },
+    "tomlplusplus",
+    "zlib"
+  ]
+}


### PR DESCRIPTION
Helps bring MSVC (and maybe macOS?) to parity with other platforms we build for, as well as decrease CI time by not recompiling libraries on every run. This is hopefully one step closer to us not vendoring so much :p

stacked on #3741
