### PR TITLE
feat: add setting to disable mod icons

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -771,6 +771,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         m_settings->registerSetting("ModMetadataDisabled", false);
         m_settings->registerSetting("ModDependenciesDisabled", false);
         m_settings->registerSetting("SkipModpackUpdatePrompt", false);
+        m_settings->registerSetting("ModIconsDisabled", false);
 
         // Minecraft offline player name
         m_settings->registerSetting("LastOfflinePlayerName", "");

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -67,7 +67,9 @@ ModFolderModel::ModFolderModel(const QDir& dir, BaseInstance* instance, bool is_
                               QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive,
                               QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive };
     m_columnsHideable = { false, true, false, true, true, true, true, true, true, true, true };
-    m_columnsHiddenByDefault = { false, false, false, false, false, false, false, true, true, true, true };
+    m_columnsHiddenByDefault = {
+        false, APPLICATION->settings()->get("ModIconsDisabled").toBool(), false, false, false, false, false, true, true, true, true
+    };
 }
 
 QVariant ModFolderModel::data(const QModelIndex& index, int role) const
@@ -134,7 +136,7 @@ QVariant ModFolderModel::data(const QModelIndex& index, int role) const
         case Qt::DecorationRole: {
             if (column == NameColumn && (at(row).isSymLinkUnder(instDirPath()) || at(row).isMoreThanOneHardLink()))
                 return APPLICATION->getThemedIcon("status-yellow");
-            if (column == ImageColumn) {
+            if (!APPLICATION->settings()->get("ModIconsDisabled").toBool() && column == ImageColumn) {
                 return at(row).icon({ 32, 32 }, Qt::AspectRatioMode::KeepAspectRatioByExpanding);
             }
             return {};

--- a/launcher/ui/pages/global/LauncherPage.cpp
+++ b/launcher/ui/pages/global/LauncherPage.cpp
@@ -276,6 +276,7 @@ void LauncherPage::applySettings()
     s->set("ModMetadataDisabled", ui->metadataDisableBtn->isChecked());
     s->set("ModDependenciesDisabled", ui->dependenciesDisableBtn->isChecked());
     s->set("SkipModpackUpdatePrompt", ui->skipModpackUpdatePromptBtn->isChecked());
+    s->set("ModIconsDisabled", ui->disableModsIcons->isChecked());
 }
 void LauncherPage::loadSettings()
 {
@@ -350,6 +351,7 @@ void LauncherPage::loadSettings()
     ui->metadataWarningLabel->setHidden(!ui->metadataDisableBtn->isChecked());
     ui->dependenciesDisableBtn->setChecked(s->get("ModDependenciesDisabled").toBool());
     ui->skipModpackUpdatePromptBtn->setChecked(s->get("SkipModpackUpdatePrompt").toBool());
+    ui->disableModsIcons->setChecked(s->get("ModIconsDisabled").toBool());
 }
 
 void LauncherPage::refreshFontPreview()

--- a/launcher/ui/pages/global/LauncherPage.ui
+++ b/launcher/ui/pages/global/LauncherPage.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>511</width>
+    <width>625</width>
     <height>726</height>
    </rect>
   </property>
@@ -58,8 +58,8 @@
            <rect>
             <x>0</x>
             <y>0</y>
-            <width>473</width>
-            <height>770</height>
+            <width>591</width>
+            <height>907</height>
            </rect>
           </property>
           <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -132,7 +132,6 @@
                 </property>
                </widget>
               </item>
-
               <item row="1" column="1">
                <widget class="QLabel" name="labelRenamingBehavior">
                 <property name="text">
@@ -159,7 +158,6 @@
                 </item>
                </widget>
               </item>
-
               <item row="2" column="0">
                <widget class="QLabel" name="labelModsDir">
                 <property name="text">
@@ -180,7 +178,6 @@
                 </property>
                </widget>
               </item>
-
               <item row="3" column="0">
                <widget class="QLabel" name="labelIconsDir">
                 <property name="text">
@@ -201,7 +198,6 @@
                 </property>
                </widget>
               </item>
-
               <item row="4" column="0">
                <widget class="QLabel" name="labelJavaDir">
                 <property name="text">
@@ -222,7 +218,6 @@
                 </property>
                </widget>
               </item>
-
               <item row="5" column="0">
                <widget class="QLabel" name="labelSkinsDir">
                 <property name="text">
@@ -243,7 +238,6 @@
                 </property>
                </widget>
               </item>
-
               <item row="6" column="0">
                <widget class="QLabel" name="labelDownloadsDir">
                 <property name="text">
@@ -264,7 +258,6 @@
                 </property>
                </widget>
               </item>
-
               <item row="7" column="1" colspan="3">
                <layout class="QHBoxLayout" name="downloadModsCheckLayout">
                 <item>
@@ -335,6 +328,16 @@
                 </property>
                 <property name="text">
                  <string>Skip modpack update prompt</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QCheckBox" name="disableModsIcons">
+                <property name="toolTip">
+                 <string>Disable mods icons column and parsing.</string>
+                </property>
+                <property name="text">
+                 <string>Disable mods icons</string>
                 </property>
                </widget>
               </item>
@@ -703,6 +706,7 @@
   <tabstop>metadataDisableBtn</tabstop>
   <tabstop>dependenciesDisableBtn</tabstop>
   <tabstop>skipModpackUpdatePromptBtn</tabstop>
+  <tabstop>disableModsIcons</tabstop>
   <tabstop>numberOfConcurrentTasksSpinBox</tabstop>
   <tabstop>numberOfConcurrentDownloadsSpinBox</tabstop>
   <tabstop>numberOfManualRetriesSpinBox</tabstop>

--- a/launcher/ui/pages/instance/ModFolderPage.cpp
+++ b/launcher/ui/pages/instance/ModFolderPage.cpp
@@ -90,7 +90,7 @@ ModFolderPage::ModFolderPage(BaseInstance* inst, std::shared_ptr<ModFolderModel>
     auto depsDisabled = APPLICATION->settings()->getSetting("ModDependenciesDisabled");
     ui->actionVerifyItemDependencies->setVisible(!depsDisabled->get().toBool());
     connect(depsDisabled.get(), &Setting::SettingChanged, this,
-            [this](const Setting& setting, const QVariant& value) { ui->actionVerifyItemDependencies->setVisible(!value.toBool()); });
+            [this](const Setting&, const QVariant& value) { ui->actionVerifyItemDependencies->setVisible(!value.toBool()); });
 
     updateMenu->addAction(ui->actionResetItemMetadata);
     connect(ui->actionResetItemMetadata, &QAction::triggered, this, &ModFolderPage::deleteModMetadata);
@@ -106,6 +106,10 @@ ModFolderPage::ModFolderPage(BaseInstance* inst, std::shared_ptr<ModFolderModel>
     ui->actionExportMetadata->setToolTip(tr("Export mod's metadata to text."));
     connect(ui->actionExportMetadata, &QAction::triggered, this, &ModFolderPage::exportModMetadata);
     ui->actionsToolbar->insertActionAfter(ui->actionViewHomepage, ui->actionExportMetadata);
+
+    if (APPLICATION->settings()->get("ModIconsDisabled").toBool()) {
+        ui->treeView->setColumnHidden(1, true);
+    }
 }
 
 bool ModFolderPage::shouldDisplay() const


### PR DESCRIPTION
I know there is an issue somewhere that says the user wants a way to disable this column because it is slow without needing to go on each instance. I can't find it now(link it if you find it)