### PR TITLE
Replace deprecated unique_qobject_ptr::swap with unique_ptr

### DIFF
--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -61,7 +61,7 @@ ModPage::ModPage(ModDownloadDialog* dialog, BaseInstance& instance) : ResourcePa
     connect(m_ui->resourceFilterButton, &QPushButton::clicked, this, &ModPage::filterMods);
 }
 
-void ModPage::setFilterWidget(unique_qobject_ptr<ModFilterWidget>& widget)
+void ModPage::setFilterWidget(std::unique_ptr<ModFilterWidget>& widget)
 {
     if (m_filter_widget)
         disconnect(m_filter_widget.get(), nullptr, nullptr, nullptr);

--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -61,24 +61,22 @@ ModPage::ModPage(ModDownloadDialog* dialog, BaseInstance& instance) : ResourcePa
     connect(m_ui->resourceFilterButton, &QPushButton::clicked, this, &ModPage::filterMods);
 }
 
-void ModPage::setFilterWidget(ModFilterWidget* widget)
+void ModPage::setFilterWidget(unique_qobject_ptr<ModFilterWidget>& widget)
 {
     if (m_filter_widget)
-        disconnect(m_filter_widget, nullptr, nullptr, nullptr);
+        disconnect(m_filter_widget.get(), nullptr, nullptr, nullptr);
 
-    auto old = m_ui->splitter->replaceWidget(0, widget);
+    auto old = m_ui->splitter->replaceWidget(0, widget.get());
     // because we replaced the widget we also need to delete it
     if (old) {
-        old->deleteLater();
+        delete old;
     }
 
-    m_filter_widget = widget;
-    if (m_filter_widget) {
-        m_filter_widget->deleteLater();
-    }
+    m_filter_widget.swap(widget);
+
     m_filter = m_filter_widget->getFilter();
 
-    connect(m_filter_widget, &ModFilterWidget::filterChanged, this, &ModPage::triggerSearch);
+    connect(m_filter_widget.get(), &ModFilterWidget::filterChanged, this, &ModPage::triggerSearch);
     prepareProviderCategories();
 }
 

--- a/launcher/ui/pages/modplatform/ModPage.h
+++ b/launcher/ui/pages/modplatform/ModPage.h
@@ -51,11 +51,11 @@ class ModPage : public ResourcePage {
 
     void addResourceToPage(ModPlatform::IndexedPack::Ptr, ModPlatform::IndexedVersion&, std::shared_ptr<ResourceFolderModel>) override;
 
-    virtual ModFilterWidget* createFilterWidget() = 0;
+    virtual unique_qobject_ptr<ModFilterWidget> createFilterWidget() = 0;
 
     [[nodiscard]] bool supportsFiltering() const override { return true; };
     auto getFilter() const -> const std::shared_ptr<ModFilterWidget::Filter> { return m_filter; }
-    void setFilterWidget(ModFilterWidget*);
+    void setFilterWidget(unique_qobject_ptr<ModFilterWidget>&);
 
    protected:
     ModPage(ModDownloadDialog* dialog, BaseInstance& instance);
@@ -67,7 +67,7 @@ class ModPage : public ResourcePage {
     void triggerSearch() override;
 
    protected:
-    ModFilterWidget* m_filter_widget = nullptr;
+    unique_qobject_ptr<ModFilterWidget> m_filter_widget;
     std::shared_ptr<ModFilterWidget::Filter> m_filter;
 };
 

--- a/launcher/ui/pages/modplatform/ModPage.h
+++ b/launcher/ui/pages/modplatform/ModPage.h
@@ -51,11 +51,11 @@ class ModPage : public ResourcePage {
 
     void addResourceToPage(ModPlatform::IndexedPack::Ptr, ModPlatform::IndexedVersion&, std::shared_ptr<ResourceFolderModel>) override;
 
-    virtual unique_qobject_ptr<ModFilterWidget> createFilterWidget() = 0;
+    virtual std::unique_ptr<ModFilterWidget> createFilterWidget() = 0;
 
     [[nodiscard]] bool supportsFiltering() const override { return true; };
     auto getFilter() const -> const std::shared_ptr<ModFilterWidget::Filter> { return m_filter; }
-    void setFilterWidget(unique_qobject_ptr<ModFilterWidget>&);
+    void setFilterWidget(std::unique_ptr<ModFilterWidget>&);
 
    protected:
     ModPage(ModDownloadDialog* dialog, BaseInstance& instance);
@@ -67,7 +67,7 @@ class ModPage : public ResourcePage {
     void triggerSearch() override;
 
    protected:
-    unique_qobject_ptr<ModFilterWidget> m_filter_widget;
+    std::unique_ptr<ModFilterWidget> m_filter_widget;
     std::shared_ptr<ModFilterWidget::Filter> m_filter;
 };
 

--- a/launcher/ui/pages/modplatform/flame/FlamePage.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.cpp
@@ -341,7 +341,7 @@ void FlamePage::setSearchTerm(QString term)
 
 void FlamePage::createFilterWidget()
 {
-    auto widget = ModFilterWidget::create(nullptr, false, this);
+    auto widget = ModFilterWidget::create(nullptr, false);
     m_filterWidget.swap(widget);
     auto old = ui->splitter->replaceWidget(0, m_filterWidget.get());
     // because we replaced the widget we also need to delete it

--- a/launcher/ui/pages/modplatform/flame/FlamePage.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.cpp
@@ -341,20 +341,17 @@ void FlamePage::setSearchTerm(QString term)
 
 void FlamePage::createFilterWidget()
 {
-    auto widget = new ModFilterWidget(nullptr, false, this);
-    if (m_filterWidget) {
-        m_filterWidget->deleteLater();
-    }
-    m_filterWidget = (widget);
-    auto old = ui->splitter->replaceWidget(0, m_filterWidget);
+    auto widget = ModFilterWidget::create(nullptr, false, this);
+    m_filterWidget.swap(widget);
+    auto old = ui->splitter->replaceWidget(0, m_filterWidget.get());
     // because we replaced the widget we also need to delete it
     if (old) {
-        old->deleteLater();
+        delete old;
     }
 
     connect(ui->filterButton, &QPushButton::clicked, this, [this] { m_filterWidget->setHidden(!m_filterWidget->isHidden()); });
 
-    connect(m_filterWidget, &ModFilterWidget::filterChanged, this, &FlamePage::triggerSearch);
+    connect(m_filterWidget.get(), &ModFilterWidget::filterChanged, this, &FlamePage::triggerSearch);
     auto response = std::make_shared<QByteArray>();
     m_categoriesTask = FlameAPI::getCategories(response, ModPlatform::ResourceType::MODPACK);
     QObject::connect(m_categoriesTask.get(), &Task::succeeded, [this, response]() {

--- a/launcher/ui/pages/modplatform/flame/FlamePage.h
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.h
@@ -100,6 +100,6 @@ class FlamePage : public QWidget, public ModpackProviderBasePage {
     // Used to do instant searching with a delay to cache quick changes
     QTimer m_search_timer;
 
-    unique_qobject_ptr<ModFilterWidget> m_filterWidget;
+    std::unique_ptr<ModFilterWidget> m_filterWidget;
     Task::Ptr m_categoriesTask;
 };

--- a/launcher/ui/pages/modplatform/flame/FlamePage.h
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.h
@@ -100,6 +100,6 @@ class FlamePage : public QWidget, public ModpackProviderBasePage {
     // Used to do instant searching with a delay to cache quick changes
     QTimer m_search_timer;
 
-    ModFilterWidget* m_filterWidget;
+    unique_qobject_ptr<ModFilterWidget> m_filterWidget;
     Task::Ptr m_categoriesTask;
 };

--- a/launcher/ui/pages/modplatform/flame/FlameResourcePages.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameResourcePages.cpp
@@ -207,9 +207,9 @@ auto FlameShaderPackPage::shouldDisplay() const -> bool
     return true;
 }
 
-unique_qobject_ptr<ModFilterWidget> FlameModPage::createFilterWidget()
+std::unique_ptr<ModFilterWidget> FlameModPage::createFilterWidget()
 {
-    return ModFilterWidget::create(&static_cast<MinecraftInstance&>(m_baseInstance), false, this);
+    return ModFilterWidget::create(&static_cast<MinecraftInstance&>(m_baseInstance), false);
 }
 
 void FlameModPage::prepareProviderCategories()

--- a/launcher/ui/pages/modplatform/flame/FlameResourcePages.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameResourcePages.cpp
@@ -207,9 +207,9 @@ auto FlameShaderPackPage::shouldDisplay() const -> bool
     return true;
 }
 
-ModFilterWidget* FlameModPage::createFilterWidget()
+unique_qobject_ptr<ModFilterWidget> FlameModPage::createFilterWidget()
 {
-    return new ModFilterWidget(&static_cast<MinecraftInstance&>(m_baseInstance), false, this);
+    return ModFilterWidget::create(&static_cast<MinecraftInstance&>(m_baseInstance), false, this);
 }
 
 void FlameModPage::prepareProviderCategories()

--- a/launcher/ui/pages/modplatform/flame/FlameResourcePages.h
+++ b/launcher/ui/pages/modplatform/flame/FlameResourcePages.h
@@ -96,7 +96,7 @@ class FlameModPage : public ModPage {
     [[nodiscard]] inline auto helpPage() const -> QString override { return "Mod-platform"; }
 
     void openUrl(const QUrl& url) override;
-    unique_qobject_ptr<ModFilterWidget> createFilterWidget() override;
+    std::unique_ptr<ModFilterWidget> createFilterWidget() override;
 
    protected:
     virtual void prepareProviderCategories() override;

--- a/launcher/ui/pages/modplatform/flame/FlameResourcePages.h
+++ b/launcher/ui/pages/modplatform/flame/FlameResourcePages.h
@@ -96,7 +96,7 @@ class FlameModPage : public ModPage {
     [[nodiscard]] inline auto helpPage() const -> QString override { return "Mod-platform"; }
 
     void openUrl(const QUrl& url) override;
-    ModFilterWidget* createFilterWidget() override;
+    unique_qobject_ptr<ModFilterWidget> createFilterWidget() override;
 
    protected:
     virtual void prepareProviderCategories() override;

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
@@ -391,19 +391,17 @@ QString ModrinthPage::getSerachTerm() const
 
 void ModrinthPage::createFilterWidget()
 {
-    auto widget = new ModFilterWidget(nullptr, true, this);
-    if (m_filterWidget)
-        m_filterWidget->deleteLater();
-    m_filterWidget = widget;
-    auto old = ui->splitter->replaceWidget(0, m_filterWidget);
+    auto widget = ModFilterWidget::create(nullptr, true, this);
+    m_filterWidget.swap(widget);
+    auto old = ui->splitter->replaceWidget(0, m_filterWidget.get());
     // because we replaced the widget we also need to delete it
     if (old) {
-        old->deleteLater();
+        delete old;
     }
 
     connect(ui->filterButton, &QPushButton::clicked, this, [this] { m_filterWidget->setHidden(!m_filterWidget->isHidden()); });
 
-    connect(m_filterWidget, &ModFilterWidget::filterChanged, this, &ModrinthPage::triggerSearch);
+    connect(m_filterWidget.get(), &ModFilterWidget::filterChanged, this, &ModrinthPage::triggerSearch);
     auto response = std::make_shared<QByteArray>();
     m_categoriesTask = ModrinthAPI::getModCategories(response);
     QObject::connect(m_categoriesTask.get(), &Task::succeeded, [this, response]() {

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
@@ -391,7 +391,7 @@ QString ModrinthPage::getSerachTerm() const
 
 void ModrinthPage::createFilterWidget()
 {
-    auto widget = ModFilterWidget::create(nullptr, true, this);
+    auto widget = ModFilterWidget::create(nullptr, true);
     m_filterWidget.swap(widget);
     auto old = ui->splitter->replaceWidget(0, m_filterWidget.get());
     // because we replaced the widget we also need to delete it

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.h
@@ -103,6 +103,6 @@ class ModrinthPage : public QWidget, public ModpackProviderBasePage {
     // Used to do instant searching with a delay to cache quick changes
     QTimer m_search_timer;
 
-    unique_qobject_ptr<ModFilterWidget> m_filterWidget;
+    std::unique_ptr<ModFilterWidget> m_filterWidget;
     Task::Ptr m_categoriesTask;
 };

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.h
@@ -103,6 +103,6 @@ class ModrinthPage : public QWidget, public ModpackProviderBasePage {
     // Used to do instant searching with a delay to cache quick changes
     QTimer m_search_timer;
 
-    ModFilterWidget* m_filterWidget;
+    unique_qobject_ptr<ModFilterWidget> m_filterWidget;
     Task::Ptr m_categoriesTask;
 };

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.cpp
@@ -142,9 +142,9 @@ auto ModrinthShaderPackPage::shouldDisplay() const -> bool
     return true;
 }
 
-ModFilterWidget* ModrinthModPage::createFilterWidget()
+unique_qobject_ptr<ModFilterWidget> ModrinthModPage::createFilterWidget()
 {
-    return new ModFilterWidget(&static_cast<MinecraftInstance&>(m_baseInstance), true, this);
+    return ModFilterWidget::create(&static_cast<MinecraftInstance&>(m_baseInstance), true, this);
 }
 
 void ModrinthModPage::prepareProviderCategories()

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.cpp
@@ -150,11 +150,11 @@ std::unique_ptr<ModFilterWidget> ModrinthModPage::createFilterWidget()
 void ModrinthModPage::prepareProviderCategories()
 {
     auto response = std::make_shared<QByteArray>();
-    auto task = ModrinthAPI::getModCategories(response);
-    QObject::connect(task.get(), &Task::succeeded, [this, response]() {
+    m_categoriesTask = ModrinthAPI::getModCategories(response);
+    QObject::connect(m_categoriesTask.get(), &Task::succeeded, [this, response]() {
         auto categories = ModrinthAPI::loadModCategories(response);
         m_filter_widget->setCategories(categories);
     });
-    task->start();
+    m_categoriesTask->start();
 };
 }  // namespace ResourceDownload

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.cpp
@@ -142,9 +142,9 @@ auto ModrinthShaderPackPage::shouldDisplay() const -> bool
     return true;
 }
 
-unique_qobject_ptr<ModFilterWidget> ModrinthModPage::createFilterWidget()
+std::unique_ptr<ModFilterWidget> ModrinthModPage::createFilterWidget()
 {
-    return ModFilterWidget::create(&static_cast<MinecraftInstance&>(m_baseInstance), true, this);
+    return ModFilterWidget::create(&static_cast<MinecraftInstance&>(m_baseInstance), true);
 }
 
 void ModrinthModPage::prepareProviderCategories()

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.h
@@ -94,7 +94,7 @@ class ModrinthModPage : public ModPage {
 
     [[nodiscard]] inline auto helpPage() const -> QString override { return "Mod-platform"; }
 
-    ModFilterWidget* createFilterWidget() override;
+    unique_qobject_ptr<ModFilterWidget> createFilterWidget() override;
 
    protected:
     virtual void prepareProviderCategories() override;

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.h
@@ -94,7 +94,7 @@ class ModrinthModPage : public ModPage {
 
     [[nodiscard]] inline auto helpPage() const -> QString override { return "Mod-platform"; }
 
-    unique_qobject_ptr<ModFilterWidget> createFilterWidget() override;
+    std::unique_ptr<ModFilterWidget> createFilterWidget() override;
 
    protected:
     virtual void prepareProviderCategories() override;

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.h
@@ -98,6 +98,7 @@ class ModrinthModPage : public ModPage {
 
    protected:
     virtual void prepareProviderCategories() override;
+    Task::Ptr m_categoriesTask;
 };
 
 class ModrinthResourcePackPage : public ResourcePackResourcePage {

--- a/launcher/ui/widgets/ModFilterWidget.cpp
+++ b/launcher/ui/widgets/ModFilterWidget.cpp
@@ -49,9 +49,9 @@
 #include "Application.h"
 #include "minecraft/PackProfile.h"
 
-unique_qobject_ptr<ModFilterWidget> ModFilterWidget::create(MinecraftInstance* instance, bool extended, QWidget* parent)
+std::unique_ptr<ModFilterWidget> ModFilterWidget::create(MinecraftInstance* instance, bool extended)
 {
-    return unique_qobject_ptr<ModFilterWidget>(new ModFilterWidget(instance, extended, parent));
+    return std::unique_ptr<ModFilterWidget>(new ModFilterWidget(instance, extended));
 }
 
 class VersionBasicModel : public QIdentityProxyModel {
@@ -107,8 +107,8 @@ class AllVersionProxyModel : public QSortFilterProxyModel {
     }
 };
 
-ModFilterWidget::ModFilterWidget(MinecraftInstance* instance, bool extended, QWidget* parent)
-    : QTabWidget(parent), ui(new Ui::ModFilterWidget), m_instance(instance), m_filter(new Filter())
+ModFilterWidget::ModFilterWidget(MinecraftInstance* instance, bool extended)
+    : QTabWidget(), ui(new Ui::ModFilterWidget), m_instance(instance), m_filter(new Filter())
 {
     ui->setupUi(this);
 

--- a/launcher/ui/widgets/ModFilterWidget.cpp
+++ b/launcher/ui/widgets/ModFilterWidget.cpp
@@ -49,6 +49,11 @@
 #include "Application.h"
 #include "minecraft/PackProfile.h"
 
+unique_qobject_ptr<ModFilterWidget> ModFilterWidget::create(MinecraftInstance* instance, bool extended, QWidget* parent)
+{
+    return unique_qobject_ptr<ModFilterWidget>(new ModFilterWidget(instance, extended, parent));
+}
+
 class VersionBasicModel : public QIdentityProxyModel {
     Q_OBJECT
 

--- a/launcher/ui/widgets/ModFilterWidget.h
+++ b/launcher/ui/widgets/ModFilterWidget.h
@@ -83,7 +83,7 @@ class ModFilterWidget : public QTabWidget {
         }
     };
 
-    static unique_qobject_ptr<ModFilterWidget> create(MinecraftInstance* instance, bool extended, QWidget* parent = nullptr);
+    static std::unique_ptr<ModFilterWidget> create(MinecraftInstance* instance, bool extended);
     virtual ~ModFilterWidget();
 
     auto getFilter() -> std::shared_ptr<Filter>;
@@ -96,7 +96,7 @@ class ModFilterWidget : public QTabWidget {
     void setCategories(const QList<ModPlatform::Category>&);
 
    private:
-    ModFilterWidget(MinecraftInstance* instance, bool extendedSupport, QWidget* parent = nullptr);
+    ModFilterWidget(MinecraftInstance* instance, bool extendedSupport);
 
     void loadVersionList();
     void prepareBasicFilter();

--- a/launcher/ui/widgets/ModFilterWidget.h
+++ b/launcher/ui/widgets/ModFilterWidget.h
@@ -83,7 +83,7 @@ class ModFilterWidget : public QTabWidget {
         }
     };
 
-    ModFilterWidget(MinecraftInstance* instance, bool extendedSupport, QWidget* parent = nullptr);
+    static unique_qobject_ptr<ModFilterWidget> create(MinecraftInstance* instance, bool extended, QWidget* parent = nullptr);
     virtual ~ModFilterWidget();
 
     auto getFilter() -> std::shared_ptr<Filter>;
@@ -96,6 +96,8 @@ class ModFilterWidget : public QTabWidget {
     void setCategories(const QList<ModPlatform::Category>&);
 
    private:
+    ModFilterWidget(MinecraftInstance* instance, bool extendedSupport, QWidget* parent = nullptr);
+
     void loadVersionList();
     void prepareBasicFilter();
 


### PR DESCRIPTION
reverts https://github.com/PrismLauncher/PrismLauncher/pull/3655
and implements: https://github.com/PrismLauncher/PrismLauncher/pull/3739
@timoreo22 I wanted to use your commit, but the branch was deleted already
The only change from your PR is that I removed the widget parent from both the constructor and the function that creates it.
Sorry for the confusion.