### PR TITLE
Make column visibility global

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -1662,8 +1662,8 @@ MainWindow* Application::showMainWindow(bool minimized)
         m_mainWindow->activateWindow();
     } else {
         m_mainWindow = new MainWindow();
-        m_mainWindow->restoreState(QByteArray::fromBase64(APPLICATION->settings()->get("MainWindowState").toByteArray()));
-        m_mainWindow->restoreGeometry(QByteArray::fromBase64(APPLICATION->settings()->get("MainWindowGeometry").toByteArray()));
+        m_mainWindow->restoreState(QByteArray::fromBase64(APPLICATION->settings()->get("MainWindowState").toString().toUtf8()));
+        m_mainWindow->restoreGeometry(QByteArray::fromBase64(APPLICATION->settings()->get("MainWindowGeometry").toString().toUtf8()));
 
         if (minimized) {
             m_mainWindow->showMinimized();

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -816,7 +816,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         m_settings->registerSetting("TPDownloadGeometry", "");
         m_settings->registerSetting("ShaderDownloadGeometry", "");
 
-        m_settings->registerSetting("UI/FolderResourceColumnVisibility", QVariantMap{});
+        m_settings->registerSetting("UI/FolderResourceColumnVisibility", "{}");
 
         // HACK: This code feels so stupid is there a less stupid way of doing this?
         {
@@ -855,7 +855,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         m_settings->registerSetting("CloseAfterLaunch", false);
         m_settings->registerSetting("QuitAfterGameStop", false);
 
-        m_settings->registerSetting("Env", QVariant(QMap<QString, QVariant>()));
+        m_settings->registerSetting("Env", "{}");
 
         // Custom Microsoft Authentication Client ID
         m_settings->registerSetting("MSAClientIDOverride", "");

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -816,6 +816,8 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         m_settings->registerSetting("TPDownloadGeometry", "");
         m_settings->registerSetting("ShaderDownloadGeometry", "");
 
+        m_settings->registerSetting("UI/FolderResourceColumnVisibility", QVariantMap{});
+
         // HACK: This code feels so stupid is there a less stupid way of doing this?
         {
             m_settings->registerSetting("PastebinURL", "");

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -816,8 +816,6 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         m_settings->registerSetting("TPDownloadGeometry", "");
         m_settings->registerSetting("ShaderDownloadGeometry", "");
 
-        m_settings->registerSetting("UI/FolderResourceColumnVisibility", "{}");
-
         // HACK: This code feels so stupid is there a less stupid way of doing this?
         {
             m_settings->registerSetting("PastebinURL", "");

--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -44,6 +44,7 @@
 #include <QJsonObject>
 
 #include "Application.h"
+#include "Json.h"
 #include "settings/INISettingsObject.h"
 #include "settings/OverrideSetting.h"
 #include "settings/Setting.h"
@@ -202,25 +203,25 @@ bool BaseInstance::shouldStopOnConsoleOverflow() const
 
 QStringList BaseInstance::getLinkedInstances() const
 {
-    return m_settings->get("linkedInstances").toStringList();
+    auto setting = m_settings->get("linkedInstances").toString();
+    return Json::toStringList(setting);
 }
 
 void BaseInstance::setLinkedInstances(const QStringList& list)
 {
-    auto linkedInstances = m_settings->get("linkedInstances").toStringList();
-    m_settings->set("linkedInstances", list);
+    m_settings->set("linkedInstances", Json::fromStringList(list));
 }
 
 void BaseInstance::addLinkedInstanceId(const QString& id)
 {
-    auto linkedInstances = m_settings->get("linkedInstances").toStringList();
+    auto linkedInstances = getLinkedInstances();
     linkedInstances.append(id);
     setLinkedInstances(linkedInstances);
 }
 
 bool BaseInstance::removeLinkedInstanceId(const QString& id)
 {
-    auto linkedInstances = m_settings->get("linkedInstances").toStringList();
+    auto linkedInstances = getLinkedInstances();
     int numRemoved = linkedInstances.removeAll(id);
     setLinkedInstances(linkedInstances);
     return numRemoved > 0;
@@ -228,7 +229,7 @@ bool BaseInstance::removeLinkedInstanceId(const QString& id)
 
 bool BaseInstance::isLinkedToInstanceId(const QString& id) const
 {
-    auto linkedInstances = m_settings->get("linkedInstances").toStringList();
+    auto linkedInstances = getLinkedInstances();
     return linkedInstances.contains(id);
 }
 

--- a/launcher/Json.cpp
+++ b/launcher/Json.cpp
@@ -304,4 +304,23 @@ QString fromStringList(const QStringList& list)
     return QString::fromUtf8(doc.toJson(QJsonDocument::Compact));
 }
 
+QVariantMap toMap(const QString& jsonString)
+{
+    QJsonParseError parseError;
+    QJsonDocument doc = QJsonDocument::fromJson(jsonString.toUtf8(), &parseError);
+
+    if (parseError.error != QJsonParseError::NoError || !doc.isObject())
+        return {};
+
+    QJsonObject obj = doc.object();
+    return obj.toVariantMap();
+}
+
+QString fromMap(const QVariantMap& map)
+{
+    QJsonObject obj = QJsonObject::fromVariantMap(map);
+    QJsonDocument doc(obj);
+    return QString::fromUtf8(doc.toJson(QJsonDocument::Compact));
+}
+
 }  // namespace Json

--- a/launcher/Json.h
+++ b/launcher/Json.h
@@ -282,5 +282,8 @@ JSON_HELPERFUNCTIONS(Variant, QVariant)
 QStringList toStringList(const QString& jsonString);
 QString fromStringList(const QStringList& list);
 
+QVariantMap toMap(const QString& jsonString);
+QString fromMap(const QVariantMap& map);
+
 }  // namespace Json
 using JSONValidationError = Json::JsonException;

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -38,6 +38,7 @@
 #include "MinecraftInstance.h"
 #include "Application.h"
 #include "BuildConfig.h"
+#include "Json.h"
 #include "QObjectPtr.h"
 #include "minecraft/launch/AutoInstallJava.h"
 #include "minecraft/launch/CreateGameFolders.h"
@@ -232,7 +233,7 @@ void MinecraftInstance::loadSpecificSettings()
         m_settings->registerOverride(global_settings->getSetting("Env"), envSetting);
 
         m_settings->registerSetting("UI/ColumnsOverride", false);
-        m_settings->registerSetting("UI/FolderResourceColumnVisibility", QVariantMap{});
+        m_settings->registerSetting("UI/FolderResourceColumnVisibility", "{}");
 
         m_settings->set("InstanceType", "OneSix");
     }
@@ -623,7 +624,8 @@ QProcessEnvironment MinecraftInstance::createEnvironment()
     }
     // custom env
 
-    auto insertEnv = [&env](QMap<QString, QVariant> envMap) {
+    auto insertEnv = [&env](QString value) {
+        auto envMap = Json::toMap(value);
         if (envMap.isEmpty())
             return;
 
@@ -634,9 +636,9 @@ QProcessEnvironment MinecraftInstance::createEnvironment()
     bool overrideEnv = settings()->get("OverrideEnv").toBool();
 
     if (!overrideEnv)
-        insertEnv(APPLICATION->settings()->get("Env").toMap());
+        insertEnv(APPLICATION->settings()->get("Env").toString());
     else
-        insertEnv(settings()->get("Env").toMap());
+        insertEnv(settings()->get("Env").toString());
     return env;
 }
 

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -231,6 +231,9 @@ void MinecraftInstance::loadSpecificSettings()
         auto envSetting = m_settings->registerSetting("OverrideEnv", false);
         m_settings->registerOverride(global_settings->getSetting("Env"), envSetting);
 
+        m_settings->registerSetting("UI/ColumnsOverride", false);
+        m_settings->registerSetting("UI/FolderResourceColumnVisibility", QVariantMap{});
+
         m_settings->set("InstanceType", "OneSix");
     }
 

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -232,9 +232,6 @@ void MinecraftInstance::loadSpecificSettings()
         auto envSetting = m_settings->registerSetting("OverrideEnv", false);
         m_settings->registerOverride(global_settings->getSetting("Env"), envSetting);
 
-        m_settings->registerSetting("UI/ColumnsOverride", false);
-        m_settings->registerSetting("UI/FolderResourceColumnVisibility", "{}");
-
         m_settings->set("InstanceType", "OneSix");
     }
 

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -67,7 +67,6 @@ ModFolderModel::ModFolderModel(const QDir& dir, BaseInstance* instance, bool is_
                               QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive,
                               QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive };
     m_columnsHideable = { false, true, false, true, true, true, true, true, true, true, true };
-    m_columnsHiddenByDefault = { false, false, false, false, false, false, false, true, true, true, true };
 }
 
 QVariant ModFolderModel::data(const QModelIndex& index, int role) const

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -597,14 +597,14 @@ void ResourceFolderModel::saveColumns(QTreeView* tree)
     if (!settings->get("UI/ColumnsOverride").toBool()) {
         settings = APPLICATION->settings();
     }
-    auto visibility = settings->get("UI/FolderResourceColumnVisibility").toMap();
+    auto visibility = Json::toMap(settings->get("UI/FolderResourceColumnVisibility").toString());
     for (auto i = 0; i < m_column_names.size(); ++i) {
         if (m_columnsHideable[i]) {
             auto name = m_column_names[i];
             visibility[name] = !tree->isColumnHidden(i);
         }
     }
-    settings->set("UI/FolderResourceColumnVisibility", visibility);
+    settings->set("UI/FolderResourceColumnVisibility", Json::fromMap(visibility));
 }
 
 void ResourceFolderModel::loadColumns(QTreeView* tree)
@@ -615,7 +615,7 @@ void ResourceFolderModel::loadColumns(QTreeView* tree)
     tree->header()->restoreState(QByteArray::fromBase64(setting->get().toString().toUtf8()));
 
     auto setVisible = [this, tree](QVariant value) {
-        auto visibility = value.toMap();
+        auto visibility = Json::toMap(value.toString());
         for (auto i = 0; i < m_column_names.size(); ++i) {
             if (m_columnsHideable[i]) {
                 auto name = m_column_names[i];
@@ -630,13 +630,13 @@ void ResourceFolderModel::loadColumns(QTreeView* tree)
         settings = APPLICATION->settings();
     }
     auto visibility = settings->getSetting("UI/FolderResourceColumnVisibility");
-    setVisible(visibility->get().toMap());
+    setVisible(visibility->get());
 
     // allways connect the signal in case the setting is toggled on and off
     auto gSetting = APPLICATION->settings()->getOrRegisterSetting("UI/FolderResourceColumnVisibility");
     connect(gSetting.get(), &Setting::SettingChanged, tree, [this, setVisible](const Setting&, QVariant value) {
         if (!m_instance->settings()->get("UI/ColumnsOverride").toBool()) {
-            setVisible(value.toMap());
+            setVisible(value);
         }
     });
 }

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -1,5 +1,4 @@
 #include "ResourceFolderModel.h"
-#include <qvariant.h>
 #include <QMessageBox>
 
 #include <QCoreApplication>

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -657,7 +657,7 @@ QMenu* ResourceFolderModel::createHeaderContextMenu(QTreeView* tree)
     auto menu = new QMenu(tree);
 
     {  // action to decide if the visibility is per instance or not
-        auto act = new QAction(tr("Overide Columns Visibility"), menu);
+        auto act = new QAction(tr("Override Columns Visibility"), menu);
         auto const overrideSettingName = QString("UI/%1_Page/ColumnsOverride").arg(id());
 
         act->setCheckable(true);

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -590,7 +590,7 @@ void ResourceFolderModel::saveColumns(QTreeView* tree)
     auto const settingName = QString("UI/%1_Page/Columns").arg(id());
     auto setting = m_instance->settings()->getSetting(settingName);
 
-    setting->set(tree->header()->saveState().toBase64());
+    setting->set(QString::fromUtf8(tree->header()->saveState().toBase64()));
 
     // neither passthrough nor override settings works for this usecase as I need to only set the global when the gate is false
     auto settings = m_instance->settings();
@@ -611,8 +611,8 @@ void ResourceFolderModel::loadColumns(QTreeView* tree)
 {
     auto const settingName = QString("UI/%1_Page/Columns").arg(id());
 
-    auto setting = m_instance->settings()->getOrRegisterSetting(settingName, QByteArray{});
-    tree->header()->restoreState(QByteArray::fromBase64(setting->get().toByteArray()));
+    auto setting = m_instance->settings()->getOrRegisterSetting(settingName, "");
+    tree->header()->restoreState(QByteArray::fromBase64(setting->get().toString().toUtf8()));
 
     auto setVisible = [this, tree](QVariant value) {
         auto visibility = value.toMap();

--- a/launcher/minecraft/mod/ResourceFolderModel.h
+++ b/launcher/minecraft/mod/ResourceFolderModel.h
@@ -243,7 +243,6 @@ class ResourceFolderModel : public QAbstractListModel {
     QList<QHeaderView::ResizeMode> m_column_resize_modes = { QHeaderView::Interactive, QHeaderView::Stretch, QHeaderView::Interactive,
                                                              QHeaderView::Interactive, QHeaderView::Interactive };
     QList<bool> m_columnsHideable = { false, false, true, true, true };
-    QList<bool> m_columnsHiddenByDefault = { false, false, false, false, true };
 
     QDir m_dir;
     BaseInstance* m_instance;

--- a/launcher/minecraft/mod/TexturePackFolderModel.cpp
+++ b/launcher/minecraft/mod/TexturePackFolderModel.cpp
@@ -51,7 +51,6 @@ TexturePackFolderModel::TexturePackFolderModel(const QDir& dir, BaseInstance* in
     m_column_resize_modes = { QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Stretch,
                               QHeaderView::Interactive, QHeaderView::Interactive, QHeaderView::Interactive };
     m_columnsHideable = { false, true, false, true, true, true };
-    m_columnsHiddenByDefault = { false, false, false, false, false, true };
 }
 
 Task* TexturePackFolderModel::createParseTask(Resource& resource)

--- a/launcher/settings/INIFile.cpp
+++ b/launcher/settings/INIFile.cpp
@@ -44,6 +44,7 @@
 #include <QTextStream>
 
 #include <QSettings>
+#include "Json.h"
 
 INIFile::INIFile() {}
 
@@ -151,15 +152,21 @@ bool parseOldFileFormat(QIODevice& device, QSettings::SettingsMap& map)
 
 QVariant migrateQByteArrayToBase64(QString key, QVariant value)
 {
-    if (key.startsWith("WideBarVisibility_") || (key.startsWith("UI/") && key.endsWith("_Page/Columns"))) {
-        return QString::fromUtf8(value.toByteArray().toBase64());
-    }
     static const QStringList otherByteArrays = { "MainWindowState",       "MainWindowGeometry", "ConsoleWindowState",
                                                  "ConsoleWindowGeometry", "PagedGeometry",      "NewInstanceGeometry",
                                                  "ModDownloadGeometry",   "RPDownloadGeometry", "TPDownloadGeometry",
                                                  "ShaderDownloadGeometry" };
+    if (key.startsWith("WideBarVisibility_") || (key.startsWith("UI/") && key.endsWith("_Page/Columns"))) {
+        return QString::fromUtf8(value.toByteArray().toBase64());
+    }
     if (otherByteArrays.contains(key)) {
         return QString::fromUtf8(value.toByteArray());
+    }
+    if (key == "linkedInstances") {
+        return Json::fromStringList(value.toStringList());
+    }
+    if (key == "Env") {
+        return Json::fromMap(value.toMap());
     }
     return value;
 }

--- a/launcher/settings/INIFile.cpp
+++ b/launcher/settings/INIFile.cpp
@@ -152,7 +152,14 @@ bool parseOldFileFormat(QIODevice& device, QSettings::SettingsMap& map)
 QVariant migrateQByteArrayToBase64(QString key, QVariant value)
 {
     if (key.startsWith("WideBarVisibility_") || (key.startsWith("UI/") && key.endsWith("_Page/Columns"))) {
-        return value.toByteArray().toBase64();
+        return QString::fromUtf8(value.toByteArray().toBase64());
+    }
+    static const QStringList otherByteArrays = { "MainWindowState",       "MainWindowGeometry", "ConsoleWindowState",
+                                                 "ConsoleWindowGeometry", "PagedGeometry",      "NewInstanceGeometry",
+                                                 "ModDownloadGeometry",   "RPDownloadGeometry", "TPDownloadGeometry",
+                                                 "ShaderDownloadGeometry" };
+    if (otherByteArrays.contains(key)) {
+        return QString::fromUtf8(value.toByteArray());
     }
     return value;
 }

--- a/launcher/settings/INIFile.cpp
+++ b/launcher/settings/INIFile.cpp
@@ -50,7 +50,7 @@ INIFile::INIFile() {}
 bool INIFile::saveFile(QString fileName)
 {
     if (!contains("ConfigVersion"))
-        insert("ConfigVersion", "1.2");
+        insert("ConfigVersion", "1.3");
     QSettings _settings_obj{ fileName, QSettings::Format::IniFormat };
     _settings_obj.setFallbacksEnabled(false);
     _settings_obj.clear();
@@ -149,6 +149,14 @@ bool parseOldFileFormat(QIODevice& device, QSettings::SettingsMap& map)
     return true;
 }
 
+QVariant migrateQByteArrayToBase64(QString key, QVariant value)
+{
+    if (key.startsWith("WideBarVisibility_") || (key.startsWith("UI/") && key.endsWith("_Page/Columns"))) {
+        return value.toByteArray().toBase64();
+    }
+    return value;
+}
+
 bool INIFile::loadFile(QString fileName)
 {
     QSettings _settings_obj{ fileName, QSettings::Format::IniFormat };
@@ -168,22 +176,34 @@ bool INIFile::loadFile(QString fileName)
         QSettings::SettingsMap map;
         parseOldFileFormat(file, map);
         file.close();
-        for (auto&& key : map.keys())
-            insert(key, map.value(key));
-        insert("ConfigVersion", "1.2");
+        for (auto&& key : map.keys()) {
+            auto value = migrateQByteArrayToBase64(key, map.value(key));
+            insert(key, value);
+        }
+        insert("ConfigVersion", "1.3");
     } else if (_settings_obj.value("ConfigVersion").toString() == "1.1") {
         for (auto&& key : _settings_obj.allKeys()) {
-            if (auto valueStr = _settings_obj.value(key).toString();
+            auto value = migrateQByteArrayToBase64(key, _settings_obj.value(key));
+            if (auto valueStr = value.toString();
                 (valueStr.contains(QChar(';')) || valueStr.contains(QChar('=')) || valueStr.contains(QChar(','))) &&
                 valueStr.endsWith("\"") && valueStr.startsWith("\"")) {
                 insert(key, unquote(valueStr));
-            } else
-                insert(key, _settings_obj.value(key));
+            } else {
+                insert(key, value);
+            }
         }
-        insert("ConfigVersion", "1.2");
-    } else
-        for (auto&& key : _settings_obj.allKeys())
+        insert("ConfigVersion", "1.3");
+    } else if (_settings_obj.value("ConfigVersion").toString() == "1.2") {
+        for (auto&& key : _settings_obj.allKeys()) {
+            auto value = migrateQByteArrayToBase64(key, _settings_obj.value(key));
+            insert(key, value);
+        }
+        insert("ConfigVersion", "1.3");
+    } else {
+        for (auto&& key : _settings_obj.allKeys()) {
             insert(key, _settings_obj.value(key));
+        }
+    }
     return true;
 }
 

--- a/launcher/ui/InstanceWindow.cpp
+++ b/launcher/ui/InstanceWindow.cpp
@@ -116,9 +116,9 @@ InstanceWindow::InstanceWindow(InstancePtr instance, QWidget* parent) : QMainWin
 
     // restore window state
     {
-        auto base64State = APPLICATION->settings()->get("ConsoleWindowState").toByteArray();
+        auto base64State = APPLICATION->settings()->get("ConsoleWindowState").toString().toUtf8();
         restoreState(QByteArray::fromBase64(base64State));
-        auto base64Geometry = APPLICATION->settings()->get("ConsoleWindowGeometry").toByteArray();
+        auto base64Geometry = APPLICATION->settings()->get("ConsoleWindowGeometry").toString().toUtf8();
         restoreGeometry(QByteArray::fromBase64(base64Geometry));
     }
 
@@ -190,8 +190,8 @@ void InstanceWindow::closeEvent(QCloseEvent* event)
         return;
     }
 
-    APPLICATION->settings()->set("ConsoleWindowState", saveState().toBase64());
-    APPLICATION->settings()->set("ConsoleWindowGeometry", saveGeometry().toBase64());
+    APPLICATION->settings()->set("ConsoleWindowState", QString::fromUtf8(saveState().toBase64()));
+    APPLICATION->settings()->set("ConsoleWindowGeometry", QString::fromUtf8(saveGeometry().toBase64()));
     emit isClosing();
     event->accept();
 }

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -181,7 +181,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWi
         auto const setting_name = QString("WideBarVisibility_%1").arg(ui->instanceToolBar->objectName());
         instanceToolbarSetting = APPLICATION->settings()->getOrRegisterSetting(setting_name);
 
-        ui->instanceToolBar->setVisibilityState(instanceToolbarSetting->get().toByteArray());
+        ui->instanceToolBar->setVisibilityState(QByteArray::fromBase64(instanceToolbarSetting->get().toByteArray()));
 
         ui->instanceToolBar->addContextMenuAction(ui->newsToolBar->toggleViewAction());
         ui->instanceToolBar->addContextMenuAction(ui->instanceToolBar->toggleViewAction());
@@ -1493,7 +1493,7 @@ void MainWindow::closeEvent(QCloseEvent* event)
     // Save the window state and geometry.
     APPLICATION->settings()->set("MainWindowState", saveState().toBase64());
     APPLICATION->settings()->set("MainWindowGeometry", saveGeometry().toBase64());
-    instanceToolbarSetting->set(ui->instanceToolBar->getVisibilityState());
+    instanceToolbarSetting->set(ui->instanceToolBar->getVisibilityState().toBase64());
     event->accept();
     emit isClosing();
 }

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -181,7 +181,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWi
         auto const setting_name = QString("WideBarVisibility_%1").arg(ui->instanceToolBar->objectName());
         instanceToolbarSetting = APPLICATION->settings()->getOrRegisterSetting(setting_name);
 
-        ui->instanceToolBar->setVisibilityState(QByteArray::fromBase64(instanceToolbarSetting->get().toByteArray()));
+        ui->instanceToolBar->setVisibilityState(QByteArray::fromBase64(instanceToolbarSetting->get().toString().toUtf8()));
 
         ui->instanceToolBar->addContextMenuAction(ui->newsToolBar->toggleViewAction());
         ui->instanceToolBar->addContextMenuAction(ui->instanceToolBar->toggleViewAction());
@@ -1296,7 +1296,7 @@ void MainWindow::globalSettingsClosed()
     updateStatusCenter();
     // This needs to be done to prevent UI elements disappearing in the event the config is changed
     // but Prism Launcher exits abnormally, causing the window state to never be saved:
-    APPLICATION->settings()->set("MainWindowState", saveState().toBase64());
+    APPLICATION->settings()->set("MainWindowState", QString::fromUtf8(saveState().toBase64()));
     update();
 }
 
@@ -1491,9 +1491,9 @@ void MainWindow::on_actionViewSelectedInstFolder_triggered()
 void MainWindow::closeEvent(QCloseEvent* event)
 {
     // Save the window state and geometry.
-    APPLICATION->settings()->set("MainWindowState", saveState().toBase64());
-    APPLICATION->settings()->set("MainWindowGeometry", saveGeometry().toBase64());
-    instanceToolbarSetting->set(ui->instanceToolBar->getVisibilityState().toBase64());
+    APPLICATION->settings()->set("MainWindowState", QString::fromUtf8(saveState().toBase64()));
+    APPLICATION->settings()->set("MainWindowGeometry", QString::fromUtf8(saveGeometry().toBase64()));
+    instanceToolbarSetting->set(QString::fromUtf8(ui->instanceToolBar->getVisibilityState().toBase64()));
     event->accept();
     emit isClosing();
 }

--- a/launcher/ui/dialogs/NewInstanceDialog.cpp
+++ b/launcher/ui/dialogs/NewInstanceDialog.cpp
@@ -134,7 +134,7 @@ NewInstanceDialog::NewInstanceDialog(const QString& initialGroup,
     updateDialogState();
 
     if (APPLICATION->settings()->get("NewInstanceGeometry").isValid()) {
-        restoreGeometry(QByteArray::fromBase64(APPLICATION->settings()->get("NewInstanceGeometry").toByteArray()));
+        restoreGeometry(QByteArray::fromBase64(APPLICATION->settings()->get("NewInstanceGeometry").toString().toUtf8()));
     } else {
         auto screen = parent->screen();
         auto geometry = screen->availableSize();
@@ -146,7 +146,7 @@ NewInstanceDialog::NewInstanceDialog(const QString& initialGroup,
 
 void NewInstanceDialog::reject()
 {
-    APPLICATION->settings()->set("NewInstanceGeometry", saveGeometry().toBase64());
+    APPLICATION->settings()->set("NewInstanceGeometry", QString::fromUtf8(saveGeometry().toBase64()));
 
     // This is just so that the pages get the close() call and can react to it, if needed.
     m_container->prepareToClose();
@@ -156,7 +156,7 @@ void NewInstanceDialog::reject()
 
 void NewInstanceDialog::accept()
 {
-    APPLICATION->settings()->set("NewInstanceGeometry", saveGeometry().toBase64());
+    APPLICATION->settings()->set("NewInstanceGeometry", QString::fromUtf8(saveGeometry().toBase64()));
     importIconNow();
 
     // This is just so that the pages get the close() call and can react to it, if needed.
@@ -316,7 +316,7 @@ void NewInstanceDialog::importIconNow()
         InstIconKey = importIconName.mid(0, importIconName.lastIndexOf('.'));
         importIcon = false;
     }
-    APPLICATION->settings()->set("NewInstanceGeometry", saveGeometry().toBase64());
+    APPLICATION->settings()->set("NewInstanceGeometry", QString::fromUtf8(saveGeometry().toBase64()));
 }
 
 void NewInstanceDialog::selectedPageChanged(BasePage* previous, BasePage* selected)

--- a/launcher/ui/dialogs/ResourceDownloadDialog.cpp
+++ b/launcher/ui/dialogs/ResourceDownloadDialog.cpp
@@ -84,7 +84,7 @@ ResourceDownloadDialog::ResourceDownloadDialog(QWidget* parent, const std::share
 void ResourceDownloadDialog::accept()
 {
     if (!geometrySaveKey().isEmpty())
-        APPLICATION->settings()->set(geometrySaveKey(), saveGeometry().toBase64());
+        APPLICATION->settings()->set(geometrySaveKey(), QString::fromUtf8(saveGeometry().toBase64()));
 
     QDialog::accept();
 }
@@ -105,7 +105,7 @@ void ResourceDownloadDialog::reject()
     }
 
     if (!geometrySaveKey().isEmpty())
-        APPLICATION->settings()->set(geometrySaveKey(), saveGeometry().toBase64());
+        APPLICATION->settings()->set(geometrySaveKey(), QString::fromUtf8(saveGeometry().toBase64()));
 
     QDialog::reject();
 }
@@ -275,7 +275,7 @@ ModDownloadDialog::ModDownloadDialog(QWidget* parent, const std::shared_ptr<ModF
     connectButtons();
 
     if (!geometrySaveKey().isEmpty())
-        restoreGeometry(QByteArray::fromBase64(APPLICATION->settings()->get(geometrySaveKey()).toByteArray()));
+        restoreGeometry(QByteArray::fromBase64(APPLICATION->settings()->get(geometrySaveKey()).toString().toUtf8()));
 }
 
 QList<BasePage*> ModDownloadDialog::getPages()
@@ -318,7 +318,7 @@ ResourcePackDownloadDialog::ResourcePackDownloadDialog(QWidget* parent,
     connectButtons();
 
     if (!geometrySaveKey().isEmpty())
-        restoreGeometry(QByteArray::fromBase64(APPLICATION->settings()->get(geometrySaveKey()).toByteArray()));
+        restoreGeometry(QByteArray::fromBase64(APPLICATION->settings()->get(geometrySaveKey()).toString().toUtf8()));
 }
 
 QList<BasePage*> ResourcePackDownloadDialog::getPages()
@@ -343,7 +343,7 @@ TexturePackDownloadDialog::TexturePackDownloadDialog(QWidget* parent,
     connectButtons();
 
     if (!geometrySaveKey().isEmpty())
-        restoreGeometry(QByteArray::fromBase64(APPLICATION->settings()->get(geometrySaveKey()).toByteArray()));
+        restoreGeometry(QByteArray::fromBase64(APPLICATION->settings()->get(geometrySaveKey()).toString().toUtf8()));
 }
 
 QList<BasePage*> TexturePackDownloadDialog::getPages()
@@ -368,7 +368,7 @@ ShaderPackDownloadDialog::ShaderPackDownloadDialog(QWidget* parent,
     connectButtons();
 
     if (!geometrySaveKey().isEmpty())
-        restoreGeometry(QByteArray::fromBase64(APPLICATION->settings()->get(geometrySaveKey()).toByteArray()));
+        restoreGeometry(QByteArray::fromBase64(APPLICATION->settings()->get(geometrySaveKey()).toString().toUtf8()));
 }
 
 QList<BasePage*> ShaderPackDownloadDialog::getPages()

--- a/launcher/ui/pagedialog/PageDialog.cpp
+++ b/launcher/ui/pagedialog/PageDialog.cpp
@@ -53,7 +53,7 @@ PageDialog::PageDialog(BasePageProvider* pageProvider, QString defaultId, QWidge
     connect(buttons->button(QDialogButtonBox::Cancel), &QPushButton::clicked, this, &PageDialog::reject);
     connect(buttons->button(QDialogButtonBox::Help), &QPushButton::clicked, m_container, &PageContainer::help);
 
-    restoreGeometry(QByteArray::fromBase64(APPLICATION->settings()->get("PagedGeometry").toByteArray()));
+    restoreGeometry(QByteArray::fromBase64(APPLICATION->settings()->get("PagedGeometry").toString().toUtf8()));
 }
 
 void PageDialog::accept()
@@ -75,7 +75,7 @@ bool PageDialog::handleClose()
         return false;
 
     qDebug() << "Paged dialog close approved";
-    APPLICATION->settings()->set("PagedGeometry", saveGeometry().toBase64());
+    APPLICATION->settings()->set("PagedGeometry", QString::fromUtf8(saveGeometry().toBase64()));
     qDebug() << "Paged dialog geometry saved";
 
     emit applied();

--- a/launcher/ui/pages/instance/ExternalResourcesPage.cpp
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.cpp
@@ -148,14 +148,14 @@ void ExternalResourcesPage::openedImpl()
     auto const setting_name = QString("WideBarVisibility_%1").arg(id());
     m_wide_bar_setting = APPLICATION->settings()->getOrRegisterSetting(setting_name);
 
-    ui->actionsToolbar->setVisibilityState(m_wide_bar_setting->get().toByteArray());
+    ui->actionsToolbar->setVisibilityState(QByteArray::fromBase64(m_wide_bar_setting->get().toByteArray()));
 }
 
 void ExternalResourcesPage::closedImpl()
 {
     m_model->stopWatching();
 
-    m_wide_bar_setting->set(ui->actionsToolbar->getVisibilityState());
+    m_wide_bar_setting->set(ui->actionsToolbar->getVisibilityState().toBase64());
 }
 
 void ExternalResourcesPage::retranslate()

--- a/launcher/ui/pages/instance/ExternalResourcesPage.cpp
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.cpp
@@ -148,14 +148,14 @@ void ExternalResourcesPage::openedImpl()
     auto const setting_name = QString("WideBarVisibility_%1").arg(id());
     m_wide_bar_setting = APPLICATION->settings()->getOrRegisterSetting(setting_name);
 
-    ui->actionsToolbar->setVisibilityState(QByteArray::fromBase64(m_wide_bar_setting->get().toByteArray()));
+    ui->actionsToolbar->setVisibilityState(QByteArray::fromBase64(m_wide_bar_setting->get().toString().toUtf8()));
 }
 
 void ExternalResourcesPage::closedImpl()
 {
     m_model->stopWatching();
 
-    m_wide_bar_setting->set(ui->actionsToolbar->getVisibilityState().toBase64());
+    m_wide_bar_setting->set(QString::fromUtf8(ui->actionsToolbar->getVisibilityState().toBase64()));
 }
 
 void ExternalResourcesPage::retranslate()

--- a/launcher/ui/pages/instance/ScreenshotsPage.cpp
+++ b/launcher/ui/pages/instance/ScreenshotsPage.cpp
@@ -562,12 +562,12 @@ void ScreenshotsPage::openedImpl()
     auto const setting_name = QString("WideBarVisibility_%1").arg(id());
     m_wide_bar_setting = APPLICATION->settings()->getOrRegisterSetting(setting_name);
 
-    ui->toolBar->setVisibilityState(m_wide_bar_setting->get().toByteArray());
+    ui->toolBar->setVisibilityState(QByteArray::fromBase64(m_wide_bar_setting->get().toByteArray()));
 }
 
 void ScreenshotsPage::closedImpl()
 {
-    m_wide_bar_setting->set(ui->toolBar->getVisibilityState());
+    m_wide_bar_setting->set(ui->toolBar->getVisibilityState().toBase64());
 }
 
 #include "ScreenshotsPage.moc"

--- a/launcher/ui/pages/instance/ScreenshotsPage.cpp
+++ b/launcher/ui/pages/instance/ScreenshotsPage.cpp
@@ -562,12 +562,12 @@ void ScreenshotsPage::openedImpl()
     auto const setting_name = QString("WideBarVisibility_%1").arg(id());
     m_wide_bar_setting = APPLICATION->settings()->getOrRegisterSetting(setting_name);
 
-    ui->toolBar->setVisibilityState(QByteArray::fromBase64(m_wide_bar_setting->get().toByteArray()));
+    ui->toolBar->setVisibilityState(QByteArray::fromBase64(m_wide_bar_setting->get().toString().toUtf8()));
 }
 
 void ScreenshotsPage::closedImpl()
 {
-    m_wide_bar_setting->set(ui->toolBar->getVisibilityState().toBase64());
+    m_wide_bar_setting->set(QString::fromUtf8(ui->toolBar->getVisibilityState().toBase64()));
 }
 
 #include "ScreenshotsPage.moc"

--- a/launcher/ui/pages/instance/ServersPage.cpp
+++ b/launcher/ui/pages/instance/ServersPage.cpp
@@ -705,7 +705,7 @@ void ServersPage::openedImpl()
     auto const setting_name = QString("WideBarVisibility_%1").arg(id());
     m_wide_bar_setting = APPLICATION->settings()->getOrRegisterSetting(setting_name);
 
-    ui->toolBar->setVisibilityState(QByteArray::fromBase64(m_wide_bar_setting->get().toByteArray()));
+    ui->toolBar->setVisibilityState(QByteArray::fromBase64(m_wide_bar_setting->get().toString().toUtf8()));
 
     // ping servers
     m_model->queryServersStatus();
@@ -715,7 +715,7 @@ void ServersPage::closedImpl()
 {
     m_model->unobserve();
 
-    m_wide_bar_setting->set(ui->toolBar->getVisibilityState().toBase64());
+    m_wide_bar_setting->set(QString::fromUtf8(ui->toolBar->getVisibilityState().toBase64()));
 }
 
 void ServersPage::on_actionAdd_triggered()

--- a/launcher/ui/pages/instance/ServersPage.cpp
+++ b/launcher/ui/pages/instance/ServersPage.cpp
@@ -705,7 +705,7 @@ void ServersPage::openedImpl()
     auto const setting_name = QString("WideBarVisibility_%1").arg(id());
     m_wide_bar_setting = APPLICATION->settings()->getOrRegisterSetting(setting_name);
 
-    ui->toolBar->setVisibilityState(m_wide_bar_setting->get().toByteArray());
+    ui->toolBar->setVisibilityState(QByteArray::fromBase64(m_wide_bar_setting->get().toByteArray()));
 
     // ping servers
     m_model->queryServersStatus();
@@ -715,7 +715,7 @@ void ServersPage::closedImpl()
 {
     m_model->unobserve();
 
-    m_wide_bar_setting->set(ui->toolBar->getVisibilityState());
+    m_wide_bar_setting->set(ui->toolBar->getVisibilityState().toBase64());
 }
 
 void ServersPage::on_actionAdd_triggered()

--- a/launcher/ui/pages/instance/VersionPage.cpp
+++ b/launcher/ui/pages/instance/VersionPage.cpp
@@ -126,11 +126,11 @@ void VersionPage::openedImpl()
     auto const setting_name = QString("WideBarVisibility_%1").arg(id());
     m_wide_bar_setting = APPLICATION->settings()->getOrRegisterSetting(setting_name);
 
-    ui->toolBar->setVisibilityState(QByteArray::fromBase64(m_wide_bar_setting->get().toByteArray()));
+    ui->toolBar->setVisibilityState(QByteArray::fromBase64(m_wide_bar_setting->get().toString().toUtf8()));
 }
 void VersionPage::closedImpl()
 {
-    m_wide_bar_setting->set(ui->toolBar->getVisibilityState().toBase64());
+    m_wide_bar_setting->set(QString::fromUtf8(ui->toolBar->getVisibilityState().toBase64()));
 }
 
 QMenu* VersionPage::createPopupMenu()

--- a/launcher/ui/pages/instance/VersionPage.cpp
+++ b/launcher/ui/pages/instance/VersionPage.cpp
@@ -126,11 +126,11 @@ void VersionPage::openedImpl()
     auto const setting_name = QString("WideBarVisibility_%1").arg(id());
     m_wide_bar_setting = APPLICATION->settings()->getOrRegisterSetting(setting_name);
 
-    ui->toolBar->setVisibilityState(m_wide_bar_setting->get().toByteArray());
+    ui->toolBar->setVisibilityState(QByteArray::fromBase64(m_wide_bar_setting->get().toByteArray()));
 }
 void VersionPage::closedImpl()
 {
-    m_wide_bar_setting->set(ui->toolBar->getVisibilityState());
+    m_wide_bar_setting->set(ui->toolBar->getVisibilityState().toBase64());
 }
 
 QMenu* VersionPage::createPopupMenu()

--- a/launcher/ui/pages/instance/WorldListPage.cpp
+++ b/launcher/ui/pages/instance/WorldListPage.cpp
@@ -121,14 +121,14 @@ void WorldListPage::openedImpl()
     auto const setting_name = QString("WideBarVisibility_%1").arg(id());
     m_wide_bar_setting = APPLICATION->settings()->getOrRegisterSetting(setting_name);
 
-    ui->toolBar->setVisibilityState(QByteArray::fromBase64(m_wide_bar_setting->get().toByteArray()));
+    ui->toolBar->setVisibilityState(QByteArray::fromBase64(m_wide_bar_setting->get().toString().toUtf8()));
 }
 
 void WorldListPage::closedImpl()
 {
     m_worlds->stopWatching();
 
-    m_wide_bar_setting->set(ui->toolBar->getVisibilityState().toBase64());
+    m_wide_bar_setting->set(QString::fromUtf8(ui->toolBar->getVisibilityState().toBase64()));
 }
 
 WorldListPage::~WorldListPage()

--- a/launcher/ui/pages/instance/WorldListPage.cpp
+++ b/launcher/ui/pages/instance/WorldListPage.cpp
@@ -121,14 +121,14 @@ void WorldListPage::openedImpl()
     auto const setting_name = QString("WideBarVisibility_%1").arg(id());
     m_wide_bar_setting = APPLICATION->settings()->getOrRegisterSetting(setting_name);
 
-    ui->toolBar->setVisibilityState(m_wide_bar_setting->get().toByteArray());
+    ui->toolBar->setVisibilityState(QByteArray::fromBase64(m_wide_bar_setting->get().toByteArray()));
 }
 
 void WorldListPage::closedImpl()
 {
     m_worlds->stopWatching();
 
-    m_wide_bar_setting->set(ui->toolBar->getVisibilityState());
+    m_wide_bar_setting->set(ui->toolBar->getVisibilityState().toBase64());
 }
 
 WorldListPage::~WorldListPage()

--- a/launcher/ui/widgets/MinecraftSettingsWidget.cpp
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.cpp
@@ -180,7 +180,7 @@ void MinecraftSettingsWidget::loadSettings()
 
     // Environment variables
     m_ui->environmentVariables->initialize(m_instance != nullptr, m_instance == nullptr || settings->get("OverrideEnv").toBool(),
-                                           settings->get("Env").toMap());
+                                           Json::toMap(settings->get("Env").toString()));
 
     // Legacy Tweaks
     m_ui->legacySettingsGroupBox->setChecked(m_instance == nullptr || settings->get("OverrideLegacySettings").toBool());
@@ -342,7 +342,7 @@ void MinecraftSettingsWidget::saveSettings()
             settings->set("OverrideEnv", env);
 
         if (env)
-            settings->set("Env", m_ui->environmentVariables->value());
+            settings->set("Env", Json::fromMap(m_ui->environmentVariables->value()));
         else
             settings->reset("Env");
 

--- a/tests/INIFile_test.cpp
+++ b/tests/INIFile_test.cpp
@@ -110,7 +110,7 @@ Wrapperommand=)";
         f2.loadFile(fileName);
         QCOMPARE(f2.get("PreLaunchCommand", "NOT SET").toString(), "\"$INST_JAVA\" -jar packwiz-installer-bootstrap.jar link");
         QCOMPARE(f2.get("Wrapperommand", "NOT SET").toString(), "\"$INST_JAVA\" -jar packwiz-installer-bootstrap.jar link =");
-        QCOMPARE(f2.get("ConfigVersion", "NOT SET").toString(), "1.2");
+        QCOMPARE(f2.get("ConfigVersion", "NOT SET").toString(), "1.3");
 #if defined(Q_OS_WIN)
         FS::deletePath(fileName);
 #endif
@@ -151,7 +151,7 @@ Wrapperommand=)";
         f2.loadFile(fileName);
         for (auto key : settings.allKeys())
             QCOMPARE(f2.get(key, "NOT SET").toString(), settings.value(key).toString());
-        QCOMPARE(f2.get("ConfigVersion", "NOT SET").toString(), "1.2");
+        QCOMPARE(f2.get("ConfigVersion", "NOT SET").toString(), "1.3");
 #if defined(Q_OS_WIN)
         FS::deletePath(fileName);
 #endif
@@ -185,7 +185,7 @@ PreLaunchCommand=)";
         INIFile f1;
         f1.loadFile(fileName);
         QCOMPARE(f1.get("PreLaunchCommand", "NOT SET").toString(), "env mesa=true");
-        QCOMPARE(f1.get("ConfigVersion", "NOT SET").toString(), "1.2");
+        QCOMPARE(f1.get("ConfigVersion", "NOT SET").toString(), "1.3");
 #if defined(Q_OS_WIN)
         FS::deletePath(fileName);
 #endif


### PR DESCRIPTION
@TheKodeToad I put these settings in the Minecraft  Settings Page. If you do not like it, can you suggest a different place?

Also, this will disable saving the column's hidden state per instance(but can be added as a similar setting page if needed).

fixes #1804
fixes #3787
fixes #3474 (by the base64 encoding of the column state)
related to #1808