### PR TITLE
Delete associated shortcuts when deleting instance

### DIFF
--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -427,7 +427,19 @@ QList<ShortcutData> BaseInstance::shortcuts() const
     QList<ShortcutData> results;
     for (const auto& elem : document.array()) {
         auto dict = elem.toObject();
-        results.append({ dict["name"].toString(), dict["filePath"].toString(), static_cast<ShortcutTarget>(dict["target"].toInt()) });
+        if (!dict.contains("name") || !dict.contains("filePath") || !dict.contains("target"))
+            return {};
+        int value = dict["target"].toInt(-1);
+        if (!dict["name"].isString() || !dict["filePath"].isString() || value < 0 || value >= 3)
+            return {};
+
+        QString shortcutName = dict["name"].toString();
+        QString filePath = dict["filePath"].toString();
+        if (!QDir(filePath).exists()) {
+            qWarning() << "Shortcut" << shortcutName << "for instance" << name() << "have non-existent path" << filePath;
+            continue;
+        }
+        results.append({ shortcutName, filePath, static_cast<ShortcutTarget>(value) });
     }
     return results;
 }

--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -69,7 +69,7 @@ BaseInstance::BaseInstance(SettingsObjectPtr globalSettings, SettingsObjectPtr s
     m_settings->registerSetting("lastTimePlayed", 0);
 
     m_settings->registerSetting("linkedInstances", "[]");
-    m_settings->registerSetting("shortcuts", QVariant::fromValue(QByteArray{}));
+    m_settings->registerSetting("shortcuts", QString());
 
     // Game time override
     auto gameTimeOverride = m_settings->registerSetting("OverrideGameTime", false);
@@ -417,12 +417,12 @@ void BaseInstance::setShortcuts(const QList<ShortcutData>& shortcuts)
 
     QJsonDocument document;
     document.setArray(array);
-    m_settings->set("shortcuts", QVariant::fromValue(document.toJson(QJsonDocument::Compact)));
+    m_settings->set("shortcuts", QString::fromUtf8(document.toJson(QJsonDocument::Compact)));
 }
 
 QList<ShortcutData> BaseInstance::shortcuts() const
 {
-    auto data = m_settings->get("shortcuts").value<QByteArray>();
+    auto data = m_settings->get("shortcuts").toString().toUtf8();
     auto document = QJsonDocument::fromJson(data);
     QList<ShortcutData> results;
     for (const auto& elem : document.array()) {

--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -398,6 +398,17 @@ bool BaseInstance::syncInstanceDirName(const QString& newRoot) const
     return oldRoot == newRoot || QFile::rename(oldRoot, newRoot);
 }
 
+void BaseInstance::registerShortcut(const ShortcutData& data)
+{
+    m_shortcuts.append(data);
+    qDebug() << "Registering shortcut for instance" << id() << "with name" << data.name << "and path" << data.filePath;
+}
+
+QList<ShortcutData>& BaseInstance::getShortcuts()
+{
+    return m_shortcuts;
+}
+
 QString BaseInstance::name() const
 {
     return m_settings->get("name").toString();

--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -69,6 +69,7 @@ BaseInstance::BaseInstance(SettingsObjectPtr globalSettings, SettingsObjectPtr s
     m_settings->registerSetting("lastTimePlayed", 0);
 
     m_settings->registerSetting("linkedInstances", "[]");
+    m_settings->registerSetting("shortcuts", QVariant::fromValue(QList<ShortcutData>{}));
 
     // Game time override
     auto gameTimeOverride = m_settings->registerSetting("OverrideGameTime", false);
@@ -400,13 +401,21 @@ bool BaseInstance::syncInstanceDirName(const QString& newRoot) const
 
 void BaseInstance::registerShortcut(const ShortcutData& data)
 {
-    m_shortcuts.append(data);
+    auto currentShortcuts = shortcuts();
+    currentShortcuts.append(data);
     qDebug() << "Registering shortcut for instance" << id() << "with name" << data.name << "and path" << data.filePath;
+    setShortcuts(currentShortcuts);
 }
 
-QList<ShortcutData>& BaseInstance::getShortcuts()
+void BaseInstance::setShortcuts(const QList<ShortcutData>& shortcuts)
 {
-    return m_shortcuts;
+    // FIXME: if no change, do not set. setting involves saving a file.
+    m_settings->set("shortcuts", QVariant::fromValue(shortcuts));
+}
+
+QList<ShortcutData> BaseInstance::shortcuts() const
+{
+    return m_settings->get("shortcuts").value<QList<ShortcutData>>();
 }
 
 QString BaseInstance::name() const

--- a/launcher/BaseInstance.h
+++ b/launcher/BaseInstance.h
@@ -76,17 +76,6 @@ struct ShortcutData {
     QString name;
     QString filePath;
     ShortcutTarget target = ShortcutTarget::Other;
-
-    friend QDataStream& operator<<(QDataStream& out, const ShortcutData& data)
-    {
-        out << data.name << data.filePath << data.target;
-        return out;
-    }
-    friend QDataStream& operator>>(QDataStream& in, ShortcutData& data)
-    {
-        in >> data.name >> data.filePath >> data.target;
-        return in;
-    }
 };
 
 /*!
@@ -339,6 +328,5 @@ class BaseInstance : public QObject, public std::enable_shared_from_this<BaseIns
 };
 
 Q_DECLARE_METATYPE(shared_qobject_ptr<BaseInstance>)
-Q_DECLARE_METATYPE(ShortcutData)
 // Q_DECLARE_METATYPE(BaseInstance::InstanceFlag)
 // Q_DECLARE_OPERATORS_FOR_FLAGS(BaseInstance::InstanceFlags)

--- a/launcher/BaseInstance.h
+++ b/launcher/BaseInstance.h
@@ -39,6 +39,7 @@
 #include <cassert>
 
 #include <QDateTime>
+#include <QList>
 #include <QMenu>
 #include <QObject>
 #include <QProcess>
@@ -65,6 +66,16 @@ class BaseInstance;
 
 // pointer for lazy people
 using InstancePtr = std::shared_ptr<BaseInstance>;
+
+/// Shortcut saving target representations
+enum class ShortcutTarget { Desktop, Applications, Other };
+
+/// Shortcut data representation
+struct ShortcutData {
+    QString name;
+    QString filePath;
+    ShortcutTarget target;
+};
 
 /*!
  * \brief Base class for instances.
@@ -128,6 +139,10 @@ class BaseInstance : public QObject, public std::enable_shared_from_this<BaseIns
 
     /// Sync name and rename instance dir accordingly; returns true if successful
     bool syncInstanceDirName(const QString& newRoot) const;
+
+    /// Register a created shortcut
+    void registerShortcut(const ShortcutData& data);
+    QList<ShortcutData>& getShortcuts();
 
     /// Value used for instance window titles
     QString windowTitle() const;
@@ -308,6 +323,8 @@ class BaseInstance : public QObject, public std::enable_shared_from_this<BaseIns
 
     SettingsObjectWeakPtr m_global_settings;
     bool m_specific_settings_loaded = false;
+
+    QList<ShortcutData> m_shortcuts;
 };
 
 Q_DECLARE_METATYPE(shared_qobject_ptr<BaseInstance>)

--- a/launcher/BaseInstance.h
+++ b/launcher/BaseInstance.h
@@ -38,6 +38,7 @@
 #pragma once
 #include <cassert>
 
+#include <QDataStream>
 #include <QDateTime>
 #include <QList>
 #include <QMenu>
@@ -74,7 +75,18 @@ enum class ShortcutTarget { Desktop, Applications, Other };
 struct ShortcutData {
     QString name;
     QString filePath;
-    ShortcutTarget target;
+    ShortcutTarget target = ShortcutTarget::Other;
+
+    friend QDataStream& operator<<(QDataStream& out, const ShortcutData& data)
+    {
+        out << data.name << data.filePath << data.target;
+        return out;
+    }
+    friend QDataStream& operator>>(QDataStream& in, ShortcutData& data)
+    {
+        in >> data.name >> data.filePath >> data.target;
+        return in;
+    }
 };
 
 /*!
@@ -142,7 +154,8 @@ class BaseInstance : public QObject, public std::enable_shared_from_this<BaseIns
 
     /// Register a created shortcut
     void registerShortcut(const ShortcutData& data);
-    QList<ShortcutData>& getShortcuts();
+    QList<ShortcutData> shortcuts() const;
+    void setShortcuts(const QList<ShortcutData>& shortcuts);
 
     /// Value used for instance window titles
     QString windowTitle() const;
@@ -323,10 +336,9 @@ class BaseInstance : public QObject, public std::enable_shared_from_this<BaseIns
 
     SettingsObjectWeakPtr m_global_settings;
     bool m_specific_settings_loaded = false;
-
-    QList<ShortcutData> m_shortcuts;
 };
 
 Q_DECLARE_METATYPE(shared_qobject_ptr<BaseInstance>)
+Q_DECLARE_METATYPE(ShortcutData)
 // Q_DECLARE_METATYPE(BaseInstance::InstanceFlag)
 // Q_DECLARE_OPERATORS_FOR_FLAGS(BaseInstance::InstanceFlags)

--- a/launcher/FileSystem.cpp
+++ b/launcher/FileSystem.cpp
@@ -905,19 +905,19 @@ QString createShortcut(QString destination, QString target, QStringList args, QS
     }
     if (!ensureFilePathExists(destination)) {
         qWarning() << "Destination path can't be created!";
-        return "";
+        return QString();
     }
 #if defined(Q_OS_MACOS)
     QDir application = destination + ".app/";
 
     if (application.exists()) {
         qWarning() << "Application already exists!";
-        return "";
+        return QString();
     }
 
     if (!application.mkpath(".")) {
         qWarning() << "Couldn't create application";
-        return "";
+        return QString();
     }
 
     QDir content = application.path() + "/Contents/";
@@ -927,7 +927,7 @@ QString createShortcut(QString destination, QString target, QStringList args, QS
 
     if (!(content.mkpath(".") && resources.mkpath(".") && binaryDir.mkpath("."))) {
         qWarning() << "Couldn't create directories within application";
-        return "";
+        return QString();
     }
     info.open(QIODevice::WriteOnly | QIODevice::Text);
 
@@ -1008,26 +1008,26 @@ QString createShortcut(QString destination, QString target, QStringList args, QS
 
     if (!targetInfo.exists()) {
         qWarning() << "Target file does not exist!";
-        return "";
+        return QString();
     }
 
     target = targetInfo.absoluteFilePath();
 
     if (target.length() >= MAX_PATH) {
         qWarning() << "Target file path is too long!";
-        return "";
+        return QString();
     }
 
     if (!icon.isEmpty() && icon.length() >= MAX_PATH) {
         qWarning() << "Icon path is too long!";
-        return "";
+        return QString();
     }
 
     destination += ".lnk";
 
     if (destination.length() >= MAX_PATH) {
         qWarning() << "Destination path is too long!";
-        return "";
+        return QString();
     }
 
     QString argStr;
@@ -1046,7 +1046,7 @@ QString createShortcut(QString destination, QString target, QStringList args, QS
 
     if (argStr.length() >= MAX_PATH) {
         qWarning() << "Arguments string is too long!";
-        return "";
+        return QString();
     }
 
     HRESULT hres;
@@ -1055,7 +1055,7 @@ QString createShortcut(QString destination, QString target, QStringList args, QS
     hres = CoInitialize(nullptr);
     if (FAILED(hres)) {
         qWarning() << "Failed to initialize COM!";
-        return "";
+        return QString();
     }
 
     WCHAR wsz[MAX_PATH];
@@ -1111,10 +1111,10 @@ QString createShortcut(QString destination, QString target, QStringList args, QS
 
     if (SUCCEEDED(hres))
         return destination;
-    return "";
+    return QString();
 #else
     qWarning("Desktop Shortcuts not supported on your platform!");
-    return "";
+    return QString();
 #endif
 }
 

--- a/launcher/FileSystem.cpp
+++ b/launcher/FileSystem.cpp
@@ -898,26 +898,26 @@ QString getApplicationsDir()
 }
 
 // Cross-platform Shortcut creation
-bool createShortcut(QString destination, QString target, QStringList args, QString name, QString icon)
+QString createShortcut(QString destination, QString target, QStringList args, QString name, QString icon)
 {
     if (destination.isEmpty()) {
         destination = PathCombine(getDesktopDir(), RemoveInvalidFilenameChars(name));
     }
     if (!ensureFilePathExists(destination)) {
         qWarning() << "Destination path can't be created!";
-        return false;
+        return "";
     }
 #if defined(Q_OS_MACOS)
     QDir application = destination + ".app/";
 
     if (application.exists()) {
         qWarning() << "Application already exists!";
-        return false;
+        return "";
     }
 
     if (!application.mkpath(".")) {
         qWarning() << "Couldn't create application";
-        return false;
+        return "";
     }
 
     QDir content = application.path() + "/Contents/";
@@ -927,7 +927,7 @@ bool createShortcut(QString destination, QString target, QStringList args, QStri
 
     if (!(content.mkpath(".") && resources.mkpath(".") && binaryDir.mkpath("."))) {
         qWarning() << "Couldn't create directories within application";
-        return false;
+        return "";
     }
     info.open(QIODevice::WriteOnly | QIODevice::Text);
 
@@ -976,7 +976,7 @@ bool createShortcut(QString destination, QString target, QStringList args, QStri
                   "</dict>\n"
                   "</plist>";
 
-    return true;
+    return application.path();
 #elif defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD) || defined(Q_OS_OPENBSD)
     if (!destination.endsWith(".desktop"))  // in case of isFlatpak destination is already populated
         destination += ".desktop";
@@ -1002,32 +1002,32 @@ bool createShortcut(QString destination, QString target, QStringList args, QStri
 
     f.setPermissions(f.permissions() | QFileDevice::ExeOwner | QFileDevice::ExeGroup | QFileDevice::ExeOther);
 
-    return true;
+    return destination;
 #elif defined(Q_OS_WIN)
     QFileInfo targetInfo(target);
 
     if (!targetInfo.exists()) {
         qWarning() << "Target file does not exist!";
-        return false;
+        return "";
     }
 
     target = targetInfo.absoluteFilePath();
 
     if (target.length() >= MAX_PATH) {
         qWarning() << "Target file path is too long!";
-        return false;
+        return "";
     }
 
     if (!icon.isEmpty() && icon.length() >= MAX_PATH) {
         qWarning() << "Icon path is too long!";
-        return false;
+        return "";
     }
 
     destination += ".lnk";
 
     if (destination.length() >= MAX_PATH) {
         qWarning() << "Destination path is too long!";
-        return false;
+        return "";
     }
 
     QString argStr;
@@ -1046,7 +1046,7 @@ bool createShortcut(QString destination, QString target, QStringList args, QStri
 
     if (argStr.length() >= MAX_PATH) {
         qWarning() << "Arguments string is too long!";
-        return false;
+        return "";
     }
 
     HRESULT hres;
@@ -1055,7 +1055,7 @@ bool createShortcut(QString destination, QString target, QStringList args, QStri
     hres = CoInitialize(nullptr);
     if (FAILED(hres)) {
         qWarning() << "Failed to initialize COM!";
-        return false;
+        return "";
     }
 
     WCHAR wsz[MAX_PATH];
@@ -1109,10 +1109,12 @@ bool createShortcut(QString destination, QString target, QStringList args, QStri
     // go away COM, nobody likes you
     CoUninitialize();
 
-    return SUCCEEDED(hres);
+    if (SUCCEEDED(hres))
+        return destination;
+    return "";
 #else
     qWarning("Desktop Shortcuts not supported on your platform!");
-    return false;
+    return "";
 #endif
 }
 

--- a/launcher/FileSystem.h
+++ b/launcher/FileSystem.h
@@ -362,8 +362,9 @@ bool overrideFolder(QString overwritten_path, QString override_path);
 
 /**
  * Creates a shortcut to the specified target file at the specified destination path.
+ * Returns empty string if creation failed; otherwise returns the path to the created shortcut.
  */
-bool createShortcut(QString destination, QString target, QStringList args, QString name, QString icon);
+QString createShortcut(QString destination, QString target, QStringList args, QString name, QString icon);
 
 enum class FilesystemType {
     FAT,

--- a/launcher/FileSystem.h
+++ b/launcher/FileSystem.h
@@ -362,7 +362,7 @@ bool overrideFolder(QString overwritten_path, QString override_path);
 
 /**
  * Creates a shortcut to the specified target file at the specified destination path.
- * Returns empty string if creation failed; otherwise returns the path to the created shortcut.
+ * Returns null QString if creation failed; otherwise returns the path to the created shortcut.
  */
 QString createShortcut(QString destination, QString target, QStringList args, QString name, QString icon);
 

--- a/launcher/InstanceList.cpp
+++ b/launcher/InstanceList.cpp
@@ -686,18 +686,7 @@ InstancePtr InstanceList::loadInstance(const InstanceId& id)
     }
     qDebug() << "Loaded instance" << inst->name() << "from" << inst->instanceRoot();
 
-    // Fixup the shortcuts by pruning all non-existing links
     auto shortcut = inst->shortcuts();
-    for (auto it = shortcut.begin(); it != shortcut.end();) {
-        const auto& [name, filePath, target] = *it;
-        if (!QDir(filePath).exists()) {
-            qWarning() << "Shortcut" << name << "have non-existent path" << filePath;
-            it = shortcut.erase(it);
-            continue;
-        }
-        ++it;
-    }
-    inst->setShortcuts(shortcut);
     if (!shortcut.isEmpty())
         qDebug() << "Loaded" << shortcut.size() << "shortcut(s) for instance" << inst->name();
 

--- a/launcher/InstanceList.cpp
+++ b/launcher/InstanceList.cpp
@@ -670,7 +670,6 @@ InstancePtr InstanceList::loadInstance(const InstanceId& id)
     }
 
     auto instanceRoot = FS::PathCombine(m_instDir, id);
-    qRegisterMetaType<QList<ShortcutData>>("QList<ShortcutData>");
     auto instanceSettings = std::make_shared<INISettingsObject>(FS::PathCombine(instanceRoot, "instance.cfg"));
     InstancePtr inst;
 

--- a/launcher/InstanceList.h
+++ b/launcher/InstanceList.h
@@ -56,11 +56,17 @@ enum class InstCreateError { NoCreateError = 0, NoSuchVersion, UnknownCreateErro
 
 enum class GroupsState { NotLoaded, Steady, Dirty };
 
+struct TrashShortcutItem {
+    ShortcutData data;
+    QString trashPath;
+};
+
 struct TrashHistoryItem {
     QString id;
     QString path;
     QString trashPath;
     QString groupName;
+    QList<TrashShortcutItem> shortcuts;
 };
 
 class InstanceList : public QAbstractListModel {
@@ -111,8 +117,8 @@ class InstanceList : public QAbstractListModel {
     void deleteGroup(const GroupId& name);
     void renameGroup(const GroupId& src, const GroupId& dst);
     bool trashInstance(const InstanceId& id);
-    bool trashedSomething();
-    void undoTrashInstance();
+    bool trashedSomething() const;
+    bool undoTrashInstance();
     void deleteInstance(const InstanceId& id);
 
     // Wrap an instance creation task in some more task machinery and make it ready to be used

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -1040,6 +1040,10 @@ QString MinecraftInstance::getStatusbarDescription()
                     .arg(Time::prettifyDuration(totalTimePlayed(), APPLICATION->settings()->get("ShowGameTimeWithoutDays").toBool())));
         }
     }
+    auto currentShortcuts = shortcuts();
+    if (!currentShortcuts.isEmpty()) {
+        description.append(tr(", %n shortcut(s) registered", "", currentShortcuts.size()));
+    }
     if (hasCrashed()) {
         description.append(tr(", has crashed."));
     }

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -1040,10 +1040,6 @@ QString MinecraftInstance::getStatusbarDescription()
                     .arg(Time::prettifyDuration(totalTimePlayed(), APPLICATION->settings()->get("ShowGameTimeWithoutDays").toBool())));
         }
     }
-    auto currentShortcuts = shortcuts();
-    if (!currentShortcuts.isEmpty()) {
-        description.append(tr(", %n shortcut(s) registered", "", currentShortcuts.size()));
-    }
     if (hasCrashed()) {
         description.append(tr(", has crashed."));
     }

--- a/launcher/minecraft/ShortcutUtils.h
+++ b/launcher/minecraft/ShortcutUtils.h
@@ -38,6 +38,7 @@
 #pragma once
 #include "Application.h"
 
+#include <QList>
 #include <QMessageBox>
 
 namespace ShortcutUtils {
@@ -49,18 +50,19 @@ struct Shortcut {
     QWidget* parent = nullptr;
     QStringList extraArgs = {};
     QString iconKey = "";
+    ShortcutTarget target;
 };
 
 /// Create an instance shortcut on the specified file path
-void createInstanceShortcut(const Shortcut& shortcut, const QString& filePath);
+bool createInstanceShortcut(const Shortcut& shortcut, const QString& filePath);
 
 /// Create an instance shortcut on the desktop
-void createInstanceShortcutOnDesktop(const Shortcut& shortcut);
+bool createInstanceShortcutOnDesktop(const Shortcut& shortcut);
 
 /// Create an instance shortcut in the Applications directory
-void createInstanceShortcutInApplications(const Shortcut& shortcut);
+bool createInstanceShortcutInApplications(const Shortcut& shortcut);
 
 /// Create an instance shortcut in other directories
-void createInstanceShortcutInOther(const Shortcut& shortcut);
+bool createInstanceShortcutInOther(const Shortcut& shortcut);
 
 }  // namespace ShortcutUtils

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -1207,7 +1207,10 @@ void MainWindow::renameGroup(QString group)
 
 void MainWindow::undoTrashInstance()
 {
-    APPLICATION->instances()->undoTrashInstance();
+    if (!APPLICATION->instances()->undoTrashInstance())
+        QMessageBox::warning(
+            this, tr("Failed to undo trashing instance"),
+            tr("Some instances and shortcuts could not be restored.\nPlease check your trashbin to manually restore them."));
     ui->actionUndoTrashInstance->setEnabled(APPLICATION->instances()->trashedSomething());
 }
 
@@ -1407,7 +1410,7 @@ void MainWindow::on_actionDeleteInstance_triggered()
     auto id = m_selectedInstance->id();
 
     auto response = CustomMessageBox::selectable(this, tr("Confirm Deletion"),
-                                                 tr("You are about to delete \"%1\".\n"
+                                                 tr("You are about to delete \"%1\" and all of its shortcut(s).\n"
                                                     "This may be permanent and will completely delete the instance.\n\n"
                                                     "Are you sure?")
                                                      .arg(m_selectedInstance->name()),

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -1409,11 +1409,15 @@ void MainWindow::on_actionDeleteInstance_triggered()
     }
     auto id = m_selectedInstance->id();
 
+    QString shortcutStr;
+    auto shortcuts = m_selectedInstance->shortcuts();
+    if (!shortcuts.isEmpty())
+        shortcutStr = tr(" and its %n registered shortcut(s)", "", shortcuts.size());
     auto response = CustomMessageBox::selectable(this, tr("Confirm Deletion"),
-                                                 tr("You are about to delete \"%1\" and all of its shortcut(s).\n"
+                                                 tr("You are about to delete \"%1\"%2.\n"
                                                     "This may be permanent and will completely delete the instance.\n\n"
                                                     "Are you sure?")
-                                                     .arg(m_selectedInstance->name()),
+                                                     .arg(m_selectedInstance->name(), shortcutStr),
                                                  QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No, QMessageBox::No)
                         ->exec();
 

--- a/launcher/ui/dialogs/CreateShortcutDialog.cpp
+++ b/launcher/ui/dialogs/CreateShortcutDialog.cpp
@@ -83,12 +83,12 @@ CreateShortcutDialog::CreateShortcutDialog(InstancePtr instance, QWidget* parent
         QString applicationDir = FS::getApplicationsDir();
 
         if (!desktopDir.isEmpty())
-            ui->saveTargetSelectionBox->addItem(tr("Desktop"), QVariant::fromValue(SaveTarget::Desktop));
+            ui->saveTargetSelectionBox->addItem(tr("Desktop"), QVariant::fromValue(ShortcutTarget::Desktop));
 
         if (!applicationDir.isEmpty())
-            ui->saveTargetSelectionBox->addItem(tr("Applications"), QVariant::fromValue(SaveTarget::Applications));
+            ui->saveTargetSelectionBox->addItem(tr("Applications"), QVariant::fromValue(ShortcutTarget::Applications));
     }
-    ui->saveTargetSelectionBox->addItem(tr("Other..."), QVariant::fromValue(SaveTarget::Other));
+    ui->saveTargetSelectionBox->addItem(tr("Other..."), QVariant::fromValue(ShortcutTarget::Other));
 
     // Populate worlds
     if (m_QuickJoinSupported) {
@@ -206,17 +206,17 @@ void CreateShortcutDialog::createShortcut()
         }
     }
 
-    auto target = ui->saveTargetSelectionBox->currentData().value<SaveTarget>();
+    auto target = ui->saveTargetSelectionBox->currentData().value<ShortcutTarget>();
     auto name = ui->instNameTextBox->text();
     if (name.isEmpty())
         name = ui->instNameTextBox->placeholderText();
     if (ui->overrideAccountCheckbox->isChecked())
         extraArgs.append({ "--profile", ui->accountSelectionBox->currentData().toString() });
 
-    ShortcutUtils::Shortcut args{ m_instance.get(), name, targetString, this, extraArgs, InstIconKey };
-    if (target == SaveTarget::Desktop)
+    ShortcutUtils::Shortcut args{ m_instance.get(), name, targetString, this, extraArgs, InstIconKey, target };
+    if (target == ShortcutTarget::Desktop)
         ShortcutUtils::createInstanceShortcutOnDesktop(args);
-    else if (target == SaveTarget::Applications)
+    else if (target == ShortcutTarget::Applications)
         ShortcutUtils::createInstanceShortcutInApplications(args);
     else
         ShortcutUtils::createInstanceShortcutInOther(args);

--- a/launcher/ui/dialogs/CreateShortcutDialog.h
+++ b/launcher/ui/dialogs/CreateShortcutDialog.h
@@ -54,9 +54,6 @@ class CreateShortcutDialog : public QDialog {
     InstancePtr m_instance;
     bool m_QuickJoinSupported = false;
 
-    // Index representations
-    enum class SaveTarget { Desktop, Applications, Other };
-
     // Functions
     void stateChanged();
 };

--- a/launcher/ui/dialogs/CreateShortcutDialog.ui
+++ b/launcher/ui/dialogs/CreateShortcutDialog.ui
@@ -195,6 +195,20 @@
     </widget>
    </item>
    <item>
+    <widget class="QLabel" name="noteLabel">
+     <property name="text">
+      <string>Note: If a shortcut is moved after creation, it won't be deleted when deleting the instance.</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QLabel" name="noteLabel2">
+     <property name="text">
+      <string>You'll need to delete them manually if that is the case.</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Orientation::Horizontal</enum>


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->

Implement the other half of #3767: delete the instance's shortcuts when deleting the instance itself.
The deletion dialogue mentioned in https://github.com/PrismLauncher/PrismLauncher/pull/2966#issuecomment-2509813997 is not implemented for now, as I don't think there is a huge demand for looking at all shortcuts for an instance and select some for deletion. If there is demand for that, I can implement this too.

Strategies:
- Try trashing the shortcuts first; if trashing is not successful, directly try to delete them
- Register shortcut for an instance on creation; modified `FS::createShortcut` to return the shortcut location (which may have `.app`/`.lnk` appended) instead of bool.
- Store shortcut list for an instance in the settings object, and restore them on loading appropriately (remove the link if the shortcut path does not exist)

Known issues:
- If the shortcut itself is deleted, and another unrelated folder is renamed to be the same name as the shortcut, it will be associated as a shortcut on reload/launch instead, which may cause unrelated folder to be trashed/deleted. However, we cannot do anything about that.
  - Technically one can imagine validating the shortcut by looking into the bash script and extract the parameter; however that is too hard for Windows I think.

Fixes #3148.