### PR TITLE
Remove reference to deprecated Q_OS_OSX macro

### DIFF
--- a/launcher/NullInstance.h
+++ b/launcher/NullInstance.h
@@ -70,7 +70,7 @@ class NullInstance : public BaseInstance {
         return out;
     }
     QString modsRoot() const override { return QString(); }
-    void updateRuntimeContext()
+    void updateRuntimeContext() override
     {
         // NOOP
     }

--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -501,7 +501,7 @@ QString JavaUtils::getJavaCheckPath()
 QStringList getMinecraftJavaBundle()
 {
     QStringList processpaths;
-#if defined(Q_OS_OSX)
+#if defined(Q_OS_MACOS)
     processpaths << FS::PathCombine(QDir::homePath(), FS::PathCombine("Library", "Application Support", "minecraft", "runtime"));
 #elif defined(Q_OS_WIN32)
 

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -104,7 +104,7 @@
 
 #define IBUS "@im=ibus"
 
-static bool switcherooSetupGPU(QProcessEnvironment& env)
+[[maybe_unused]] static bool switcherooSetupGPU(QProcessEnvironment& env)
 {
 #ifdef WITH_QTDBUS
     if (!QDBusConnection::systemBus().isConnected())

--- a/launcher/tools/MCEditTool.cpp
+++ b/launcher/tools/MCEditTool.cpp
@@ -45,7 +45,7 @@ bool MCEditTool::check(const QString& toolPath, QString& error)
 
 QString MCEditTool::getProgramPath()
 {
-#ifdef Q_OS_OSX
+#ifdef Q_OS_MACOS
     return path();
 #else
     const QString mceditPath = path();

--- a/launcher/ui/pages/global/ExternalToolsPage.cpp
+++ b/launcher/ui/pages/global/ExternalToolsPage.cpp
@@ -156,7 +156,7 @@ void ExternalToolsPage::on_mceditPathBtn_clicked()
     QString raw_dir = ui->mceditPathEdit->text();
     QString error;
     do {
-#ifdef Q_OS_OSX
+#ifdef Q_OS_MACOS
         raw_dir = QFileDialog::getOpenFileName(this, tr("MCEdit Application"), raw_dir);
 #else
         raw_dir = QFileDialog::getExistingDirectory(this, tr("MCEdit Folder"), raw_dir);

--- a/launcher/ui/pages/instance/ServerPingTask.cpp
+++ b/launcher/ui/pages/instance/ServerPingTask.cpp
@@ -16,7 +16,7 @@ void ServerPingTask::executeTask()
 
     // Resolve the actual IP and port for the server
     McResolver* resolver = new McResolver(nullptr, m_domain, m_port);
-    QObject::connect(resolver, &McResolver::succeeded, this, [this, resolver](QString ip, int port) {
+    QObject::connect(resolver, &McResolver::succeeded, this, [this](QString ip, int port) {
         qDebug() << "Resolved Address for" << m_domain << ": " << ip << ":" << port;
 
         // Now that we have the IP and port, query the server
@@ -30,7 +30,7 @@ void ServerPingTask::executeTask()
         QObject::connect(client, &McClient::failed, this, [this](QString error) { emitFailed(error); });
 
         // Delete McClient object when done
-        QObject::connect(client, &McClient::finished, this, [this, client]() { client->deleteLater(); });
+        QObject::connect(client, &McClient::finished, this, [client]() { client->deleteLater(); });
         client->getStatusData();
     });
     QObject::connect(resolver, &McResolver::failed, this, [this](QString error) { emitFailed(error); });

--- a/launcher/ui/pages/modplatform/import_ftb/ListModel.cpp
+++ b/launcher/ui/pages/modplatform/import_ftb/ListModel.cpp
@@ -36,7 +36,7 @@ namespace FTBImportAPP {
 QString getFTBRoot()
 {
     QString partialPath = QDir::homePath();
-#if defined(Q_OS_OSX)
+#if defined(Q_OS_MACOS)
     partialPath = FS::PathCombine(partialPath, "Library/Application Support");
 #endif
     return FS::PathCombine(partialPath, ".ftba");

--- a/launcher/updater/MacSparkleUpdater.mm
+++ b/launcher/updater/MacSparkleUpdater.mm
@@ -166,7 +166,7 @@ void MacSparkleUpdater::setAllowedChannels(const QSet<QString>& channels) {
     QString channelsConfig = "";
     // Convert QSet<QString> -> NSSet<NSString>
     NSMutableSet<NSString*>* nsChannels = [NSMutableSet setWithCapacity:channels.count()];
-    for (const QString channel : channels) {
+    for (const QString& channel : channels) {
         [nsChannels addObject:channel.toNSString()];
         channelsConfig += channel + " ";
     }


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
`Q_OS_OSX` is [deprecated](https://doc.qt.io/qt-6/qtsystemdetection.html#Q_OS_OSX) and not recommended for use; therefore, this PR tries to rename all of its usage to `Q_OS_MACOS`, which should have identical effects.

Also, fixed several small things causing warnings when building under macOS + Clang:
- Missing `override` on a function (warned by Clang since all other members in the same class have override)
- An unused local function since its usage is wrapped in an `#if` that is not triggered under macOS
- Some unnecessary captures
- `for (const QString`... probably a missing `&`?

Unfortunately, Clang 19+ decided to [add a warning](https://reviews.llvm.org/D111459) when you try to pass no argument for `...` in macros (which is only officially supported after C++20), which caused all `qCCritical` etc. to warn. Besides this, there should now be no other warnings when building the project under macOS + Clang 20.