### PR TITLE
fix: warning with different signedness

### DIFF
--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -426,7 +426,7 @@ bool FlameCreationTask::createInstance()
         const uint64_t sysMiB = Sys::getSystemRam() / Sys::mebibyte;
         const uint64_t max = sysMiB * 0.9;
 
-        if (recommendedRAM > max) {
+        if (static_cast<uint64_t>(recommendedRAM) > max) {
             logWarning(tr("The recommended memory of the modpack exceeds 90% of your system RAM—reducing it from %1 MiB to %2 MiB!")
                            .arg(recommendedRAM)
                            .arg(max));


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
