### PR TITLE
More intuitive version changing for modpacks

### DIFF
--- a/launcher/modplatform/flame/FlamePackIndex.cpp
+++ b/launcher/modplatform/flame/FlamePackIndex.cpp
@@ -140,3 +140,11 @@ void Flame::loadIndexedPackVersions(Flame::IndexedPack& pack, QJsonArray& arr)
     pack.versions = unsortedVersions;
     pack.versionsLoaded = true;
 }
+
+auto Flame::getVersionDisplayString(const IndexedVersion& version) -> QString
+{
+    auto release_type = version.version_type.isValid() ? QString(" [%1]").arg(version.version_type.toString()) : "";
+    auto mcVersion =
+        !version.mcVersion.isEmpty() && !version.version.contains(version.mcVersion) ? QObject::tr(" for %1").arg(version.mcVersion) : "";
+    return QString("%1%2%3").arg(version.version, mcVersion, release_type);
+}

--- a/launcher/modplatform/flame/FlamePackIndex.h
+++ b/launcher/modplatform/flame/FlamePackIndex.h
@@ -47,6 +47,8 @@ struct IndexedPack {
 void loadIndexedPack(IndexedPack& m, QJsonObject& obj);
 void loadIndexedInfo(IndexedPack&, QJsonObject&);
 void loadIndexedPackVersions(IndexedPack& m, QJsonArray& arr);
+
+auto getVersionDisplayString(const IndexedVersion&) -> QString;
 }  // namespace Flame
 
 Q_DECLARE_METATYPE(Flame::IndexedPack)

--- a/launcher/modplatform/modrinth/ModrinthPackManifest.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackManifest.cpp
@@ -183,4 +183,14 @@ auto loadIndexedVersion(QJsonObject& obj) -> ModpackVersion
     return file;
 }
 
+auto getVersionDisplayString(const ModpackVersion& version) -> QString
+{
+    auto release_type = version.version_type.isValid() ? QString(" [%1]").arg(version.version_type.toString()) : "";
+    auto mcVersion = !version.gameVersion.isEmpty() && !version.name.contains(version.gameVersion)
+                         ? QObject::tr(" for %1").arg(version.gameVersion)
+                         : "";
+    auto versionStr = !version.name.contains(version.version) ? version.version : "";
+    return QString("%1%2 — %3%4").arg(version.name, mcVersion, versionStr, release_type);
+}
+
 }  // namespace Modrinth

--- a/launcher/modplatform/modrinth/ModrinthPackManifest.h
+++ b/launcher/modplatform/modrinth/ModrinthPackManifest.h
@@ -120,6 +120,8 @@ auto loadIndexedVersion(QJsonObject&) -> ModpackVersion;
 
 auto validateDownloadUrl(QUrl) -> bool;
 
+auto getVersionDisplayString(const ModpackVersion&) -> QString;
+
 }  // namespace Modrinth
 
 Q_DECLARE_METATYPE(Modrinth::Modpack)

--- a/launcher/ui/pages/instance/ManagedPackPage.cpp
+++ b/launcher/ui/pages/instance/ManagedPackPage.cpp
@@ -292,11 +292,8 @@ void ModrinthManagedPackPage::parseManagedPack()
         ui->versionsComboBox->clear();
         ui->versionsComboBox->blockSignals(false);
 
-        for (auto version : m_pack.versions) {
-            QString name = version.version;
-
-            if (!version.name.contains(version.version))
-                name = QString("%1 — %2").arg(version.name, version.version);
+        for (const auto& version : m_pack.versions) {
+            QString name = Modrinth::getVersionDisplayString(version);
 
             // NOTE: the id from version isn't the same id in the modpack format spec...
             // e.g. HexMC's 4.4.0 has versionId 4.0.0 in the modpack index..............
@@ -489,8 +486,8 @@ void FlameManagedPackPage::parseManagedPack()
         ui->versionsComboBox->clear();
         ui->versionsComboBox->blockSignals(false);
 
-        for (auto version : m_pack.versions) {
-            QString name = version.version;
+        for (const auto& version : m_pack.versions) {
+            QString name = Flame::getVersionDisplayString(version);
 
             if (version.fileId == m_inst->getManagedPackVersionID().toInt())
                 name = tr("%1 (Current)").arg(name);

--- a/launcher/ui/pages/modplatform/flame/FlamePage.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.cpp
@@ -206,13 +206,8 @@ void FlamePage::onSelectionChanged(QModelIndex curr, [[maybe_unused]] QModelInde
         else
             ++it;
 #endif
-            for (auto version : current.versions) {
-                auto release_type = version.version_type.isValid() ? QString(" [%1]").arg(version.version_type.toString()) : "";
-                auto mcVersion = !version.mcVersion.isEmpty() && !version.version.contains(version.mcVersion)
-                                     ? QString(" for %1").arg(version.mcVersion)
-                                     : "";
-                ui->versionSelectionBox->addItem(QString("%1%2%3").arg(version.version, mcVersion, release_type),
-                                                 QVariant(version.downloadUrl));
+            for (const auto& version : current.versions) {
+                ui->versionSelectionBox->addItem(Flame::getVersionDisplayString(version), QVariant(version.downloadUrl));
             }
 
             QVariant current_updated;

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
@@ -244,14 +244,8 @@ void ModrinthPage::onSelectionChanged(QModelIndex curr, [[maybe_unused]] QModelI
         else
             ++it;
 #endif
-            for (auto version : current.versions) {
-                auto release_type = version.version_type.isValid() ? QString(" [%1]").arg(version.version_type.toString()) : "";
-                auto mcVersion = !version.gameVersion.isEmpty() && !version.name.contains(version.gameVersion)
-                                     ? QString(" for %1").arg(version.gameVersion)
-                                     : "";
-                auto versionStr = !version.name.contains(version.version) ? version.version : "";
-                ui->versionSelectionBox->addItem(QString("%1%2 — %3%4").arg(version.name, mcVersion, versionStr, release_type),
-                                                 QVariant(version.id));
+            for (const auto& version : current.versions) {
+                ui->versionSelectionBox->addItem(Modrinth::getVersionDisplayString(version), QVariant(version.id));
             }
 
             QVariant current_updated;


### PR DESCRIPTION
fixes #4205

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
Currently, the change version screen for modpacks only shows a version number, which makes it hard to decipher which Minecraft version each version number is for, as well as the release status (alpha, beta, ...) for each version. Apparently the new instance page have a more comprehensive version string scheme, so this PR proposes to use the same version string for both scenario.
![combined](https://github.com/user-attachments/assets/491d5c85-e9da-4d2c-b807-4f28d0b745a0)