### PR TITLE
Auth abort fixes

### DIFF
--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -299,16 +299,10 @@ void LaunchController::login()
                 progDialog.setSkipButton(true, tr("Abort"));
 
                 auto task = accountToCheck->currentTask();
-
-                bool aborted = false;
-                auto abortListener = connect(task.get(), &Task::aborted, [&aborted] { aborted = true; });
-
                 progDialog.execWithTask(task.get());
 
-                disconnect(abortListener);
-
                 // don't retry if aborted
-                if (aborted)
+                if (task->getState() == Task::State::AbortedByUser)
                     tryagain = false;
 
                 continue;

--- a/launcher/minecraft/auth/MinecraftAccount.cpp
+++ b/launcher/minecraft/auth/MinecraftAccount.cpp
@@ -181,8 +181,10 @@ void MinecraftAccount::authFailed(QString reason)
             data.validity_ = Validity::None;
             emit changed();
         } break;
+        case AccountTaskState::STATE_WORKING: {
+            data.accountState = AccountState::Unchecked;
+        } break;
         case AccountTaskState::STATE_CREATED:
-        case AccountTaskState::STATE_WORKING:
         case AccountTaskState::STATE_SUCCEEDED: {
             // Not reachable here, as they are not failures.
         }


### PR DESCRIPTION
- Changed Play Offline button to say Abort... because that's what it actually does
- Avoid retrying if abort was explicitly used
- Reset the account to Unchecked on abort so it actually ends up being refreshed on launch (fixes the infamous infinite retry where it doesn't actually retry)

Does not entirely fix #3311 - the infinite hang is a qt bug (it seems) which is only fixed in a pretty new version :/