### PR TITLE
feat: game options

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -254,6 +254,8 @@ set(MINECRAFT_SOURCES
 
     minecraft/gameoptions/GameOptions.h
     minecraft/gameoptions/GameOptions.cpp
+    minecraft/gameoptions/GameOptionsSchema.h
+    minecraft/gameoptions/GameOptionsSchema.cpp
 
     minecraft/update/AssetUpdateTask.h
     minecraft/update/AssetUpdateTask.cpp

--- a/launcher/InstancePageProvider.h
+++ b/launcher/InstancePageProvider.h
@@ -4,6 +4,7 @@
 #include "minecraft/MinecraftInstance.h"
 #include "ui/pages/BasePage.h"
 #include "ui/pages/BasePageProvider.h"
+#include "ui/pages/instance/GameOptionsPage.h"
 #include "ui/pages/instance/InstanceSettingsPage.h"
 #include "ui/pages/instance/LogPage.h"
 #include "ui/pages/instance/ManagedPackPage.h"
@@ -43,7 +44,7 @@ class InstancePageProvider : protected QObject, public BasePageProvider {
         values.append(new NotesPage(onesix.get()));
         values.append(new WorldListPage(onesix, onesix->worldList()));
         values.append(new ServersPage(onesix));
-        // values.append(new GameOptionsPage(onesix.get()));
+        values.append(new GameOptionsPage(onesix.get()));
         values.append(new ScreenshotsPage(FS::PathCombine(onesix->gameRoot(), "screenshots")));
         values.append(new InstanceSettingsPage(onesix));
         values.append(new OtherLogsPage("logs", tr("Other logs"), "Other-Logs", inst));

--- a/launcher/minecraft/gameoptions/GameOptions.cpp
+++ b/launcher/minecraft/gameoptions/GameOptions.cpp
@@ -1,12 +1,30 @@
 #include "GameOptions.h"
 #include <QDebug>
+#include <QFile>
 #include <QSaveFile>
-#include "FileSystem.h"
+#include "minecraft/gameoptions/GameOptionsSchema.h"
 
 namespace {
-bool load(const QString& path, std::vector<GameOptionItem>& contents, int& version)
+void upsertGameOption(std::vector<GameOption>& contents, const QString& key, const QString& value)
+{
+    for (auto& option : contents) {
+        if (option.key == key) {
+            QVariant converted = QVariant(value);
+            if (!converted.convert(option.value.metaType())) {
+                qWarning() << "Failed to convert" << value << "to type" << option.value.typeName();
+            }
+            option.value = converted;
+            return;
+        }
+    }
+    contents.emplace_back(GameOption{ key, value });  // Insert new
+}
+bool load(const QString& path, std::vector<GameOption>& contents, int& version)
 {
     contents.clear();
+    for (auto v : globalDelegateMap) {
+        contents.emplace_back(v);
+    }
     QFile file(path);
     if (!file.open(QFile::ReadOnly)) {
         qWarning() << "Failed to read options file.";
@@ -29,12 +47,12 @@ bool load(const QString& path, std::vector<GameOptionItem>& contents, int& versi
             version = value.toInt();
             continue;
         }
-        contents.emplace_back(GameOptionItem{ key, value });
+        upsertGameOption(contents, key, value);
     }
     qDebug() << "Loaded" << path << "with version:" << version;
     return true;
 }
-bool save(const QString& path, std::vector<GameOptionItem>& mapping, int version)
+bool save(const QString& path, std::vector<GameOption>& mapping, int version)
 {
     QSaveFile out(path);
     if (!out.open(QIODevice::WriteOnly)) {
@@ -48,7 +66,7 @@ bool save(const QString& path, std::vector<GameOptionItem>& mapping, int version
     while (iter != mapping.end()) {
         out.write(iter->key.toUtf8());
         out.write(":");
-        out.write(iter->value.toUtf8());
+        out.write(iter->value.toString().toUtf8());
         out.write("\n");
         iter++;
     }
@@ -71,6 +89,8 @@ QVariant GameOptions::headerData(int section, Qt::Orientation orientation, int r
             return tr("Key");
         case 1:
             return tr("Value");
+        case 2:
+            return tr("Description");
         default:
             return QVariant();
     }
@@ -87,12 +107,33 @@ QVariant GameOptions::data(const QModelIndex& index, int role) const
     if (row < 0 || row >= int(contents.size()))
         return QVariant();
 
-    if (role == Qt::DisplayRole) {
-        if (column == 0)
-            return contents[row].key;
-        return contents[row].value;
+    if (role == Qt::UserRole + 1) {
+        switch (column) {
+            case 0:
+                return contents[row].min;
+            case 1:
+                return contents[row].max;
+            case 2:
+                return contents[row].values;
+            default:
+                return QVariant();
+        }
     }
-    return QVariant();
+
+    if (role != Qt::DisplayRole && role != Qt::EditRole) {
+        return QVariant();
+    }
+
+    switch (column) {
+        case 0:
+            return contents[row].key;
+        case 1:
+            return contents[row].value;
+        case 2:
+            return contents[row].description;
+        default:
+            return QVariant();
+    }
 }
 
 int GameOptions::rowCount(const QModelIndex&) const
@@ -102,7 +143,7 @@ int GameOptions::rowCount(const QModelIndex&) const
 
 int GameOptions::columnCount(const QModelIndex&) const
 {
-    return 2;
+    return 3;
 }
 
 bool GameOptions::isLoaded() const
@@ -121,4 +162,19 @@ bool GameOptions::reload()
 bool GameOptions::save()
 {
     return ::save(path, contents, version);
+}
+
+bool GameOptions::setData(const QModelIndex& index, const QVariant& value, int role)
+{
+    if (role != Qt::EditRole)
+        return false;
+
+    if (index.column() == 1) {
+        contents[index.row()].value = value.toString();
+
+        emit dataChanged(index, index, { Qt::EditRole });
+        return true;
+    }
+
+    return false;
 }

--- a/launcher/minecraft/gameoptions/GameOptions.h
+++ b/launcher/minecraft/gameoptions/GameOptions.h
@@ -2,7 +2,7 @@
 
 #include <QAbstractListModel>
 #include <QString>
-#include <map>
+#include "minecraft/gameoptions/GameOptionsSchema.h"
 
 struct GameOptionItem {
     QString key;
@@ -20,12 +20,14 @@ class GameOptions : public QAbstractListModel {
     QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
     QVariant headerData(int section, Qt::Orientation orientation, int role) const override;
 
+    bool setData(const QModelIndex& index, const QVariant& value, int role) override;
+
     bool isLoaded() const;
     bool reload();
     bool save();
 
    private:
-    std::vector<GameOptionItem> contents;
+    std::vector<GameOption> contents;
     bool loaded = false;
     QString path;
     int version = 0;

--- a/launcher/minecraft/gameoptions/GameOptionsSchema.cpp
+++ b/launcher/minecraft/gameoptions/GameOptionsSchema.cpp
@@ -1,0 +1,38 @@
+#include "GameOptionsSchema.h"
+#include <QPair>
+#include <QVariantList>
+
+QVariantList makeOptions(QList<QPair<QString, QVariant>> data)
+{
+    QVariantList opt;
+    for (auto v : data)
+        opt << QVariant::fromValue((QVariantList({ v.first, v.second })));
+    return opt;
+}
+const std::vector<GameOption> globalDelegateMap = {
+    { "ao", true, QObject::tr("Smooth lighting") },
+    { "biomeBlendRadius", 2, QObject::tr("Radius for which biome blending should happen"), 0, 7 },
+    { "enableVsync", true, QObject::tr("Whether v-sync (vertical synchronization) is enabled") },
+    { "entityDistanceScaling", 1.0, QObject::tr("The maximum distance from the player that entities render"), 0.5, 5.0 },
+    { "entityShadows", true, QObject::tr("Whether to display entity shadows ") },
+    { "forceUnicodeFont", false, QObject::tr("Whether Unicode font should be used") },
+    { "japaneseGlyphVariants", false,
+      QObject::tr("Uses Japanese variants of CJK (Chinese, Japanese, and Korean) characters in the default font") },
+    { "fov", 0.0,
+      QObject::tr("How large the field of view is (floating-point). The in-game value is counted in degrees, however, the options.txt "
+                  "isn't. The value is converted into degrees with the following formula: degrees = 40 * value + 70"),
+      -1, 1 },
+    { "fovEffectScale", 1.0,
+      QObject::tr(" 	FOV Effects (how much the field of view changes when sprinting, having Speed or Slowness etc.)"), 0.0, 1.0 },
+    { "darknessEffectScale", 1.0, QObject::tr("Darkness Pulsing (how much the Darkness effect pulses)"), 0.0, 1.0 },
+    { "glintSpeed", 0.5, QObject::tr("The speed of visual glint on enchanted items "), 0.0, 1.0 },
+    { "glintStrength", 0.75, QObject::tr("The strength of visual glint on enchanted items"), 0.0, 1.0 },
+    {
+        "prioritizeChunkUpdates",
+        0,
+        QObject::tr("Chunk section update strategy"),
+        0,
+        2,
+        makeOptions({ { "Threaded", 0 }, { "Semi Blocking", 1 }, { "Fully Blocking", 2 } }),
+    },
+};

--- a/launcher/minecraft/gameoptions/GameOptionsSchema.h
+++ b/launcher/minecraft/gameoptions/GameOptionsSchema.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <QVariant>
+#include <vector>
+
+struct GameOption {
+    QString key;
+    QVariant value;
+    QString description;
+    QVariant min;
+    QVariant max;
+    QVariantList values;
+};
+
+extern const std::vector<GameOption> globalDelegateMap;

--- a/launcher/ui/pages/instance/GameOptionsPage.cpp
+++ b/launcher/ui/pages/instance/GameOptionsPage.cpp
@@ -34,9 +34,93 @@
  */
 
 #include "GameOptionsPage.h"
+#include <QCheckBox>
+#include <QComboBox>
+#include <QHash>
+#include <QLineEdit>
+#include <QSpinBox>
 #include "minecraft/MinecraftInstance.h"
 #include "minecraft/gameoptions/GameOptions.h"
 #include "ui_GameOptionsPage.h"
+
+void setupWidgetsForView(QTreeView* view, QAbstractItemModel* model)
+{
+    for (int row = 0; row < model->rowCount(); ++row) {
+        QModelIndex typeIndex = model->index(row, 0);
+        QModelIndex valueIndex = model->index(row, 1);
+        QString key = model->data(typeIndex).toString();
+        auto value = model->data(valueIndex);
+        auto min = model->data(model->index(row, 0), Qt::UserRole + 1);
+        auto max = model->data(model->index(row, 1), Qt::UserRole + 1);
+        auto values = model->data(model->index(row, 2), Qt::UserRole + 1);
+
+        if (values.isValid() && !values.isNull() && values.canConvert<QVariantList>()) {
+            auto items = values.value<QVariantList>();
+            if (!items.isEmpty()) {
+                QComboBox* combo = new QComboBox(view);
+                int curIdx = 0;
+                int i = 0;
+                for (auto v : items) {
+                    auto data = v.value<QVariantList>();
+                    combo->addItem(data.at(0).toString(), data.at(1));
+                    if (data.at(1) == value) {
+                        curIdx = i;
+                    }
+                    i++;
+                }
+                combo->setCurrentIndex(curIdx);
+                QObject::connect(combo, &QComboBox::currentIndexChanged, view,
+                                 [model, valueIndex, combo](int index) { model->setData(valueIndex, combo->itemData(index)); });
+                view->setIndexWidget(valueIndex, combo);
+                continue;
+            }
+        }
+        if (min.isValid() && max.isValid()) {
+            if (min.typeId() == QMetaType::Int) {
+                QSpinBox* sb = new QSpinBox(view);
+                if (min != max)
+                    sb->setRange(min.toInt(), max.toInt());
+                auto val = value.toInt();
+                sb->setValue(val);
+                QObject::connect(sb, qOverload<int>(&QSpinBox::valueChanged),
+                                 [model, valueIndex](int v) { model->setData(valueIndex, v, Qt::EditRole); });
+                view->setIndexWidget(valueIndex, sb);
+                continue;
+            } else if (min.typeId() == QMetaType::Float || min.typeId() == QMetaType::Double) {
+                QDoubleSpinBox* dsb = new QDoubleSpinBox(view);
+                if (min != max)
+                    dsb->setRange(min.toDouble(), max.toDouble());
+                dsb->setDecimals(2);
+                auto val = value.toDouble();
+                dsb->setValue(val);
+                QObject::connect(dsb, qOverload<double>(&QDoubleSpinBox::valueChanged),
+                                 [model, valueIndex](double v) { model->setData(valueIndex, v, Qt::EditRole); });
+                view->setIndexWidget(valueIndex, dsb);
+                continue;
+            }
+        }
+        if (value.typeId() == QMetaType::Bool) {
+            QCheckBox* cb = new QCheckBox(view);
+            cb->setAutoFillBackground(true);
+            cb->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+
+            bool val = model->data(valueIndex, Qt::EditRole).toBool();
+            cb->setChecked(val);
+            QObject::connect(cb, &QCheckBox::toggled,
+                             [model, valueIndex](bool checked) { model->setData(valueIndex, checked, Qt::EditRole); });
+            view->setIndexWidget(valueIndex, cb);
+            continue;
+        }
+
+        // fallback: simple line edit widget
+        QWidget* editor = new QLineEdit(view);
+        QLineEdit* le = qobject_cast<QLineEdit*>(editor);
+        le->setText(model->data(valueIndex).toString());
+        QObject::connect(le, &QLineEdit::textChanged, [model, valueIndex](const QString& newText) { model->setData(valueIndex, newText); });
+        view->setIndexWidget(valueIndex, editor);
+        continue;
+    }
+}
 
 GameOptionsPage::GameOptionsPage(MinecraftInstance* inst, QWidget* parent) : QWidget(parent), ui(new Ui::GameOptionsPage)
 {
@@ -44,6 +128,7 @@ GameOptionsPage::GameOptionsPage(MinecraftInstance* inst, QWidget* parent) : QWi
     ui->tabWidget->tabBar()->hide();
     m_model = inst->gameOptionsModel();
     ui->optionsView->setModel(m_model.get());
+    setupWidgetsForView(ui->optionsView, m_model.get());
     auto head = ui->optionsView->header();
     if (head->count()) {
         head->setSectionResizeMode(0, QHeaderView::ResizeToContents);
@@ -55,7 +140,7 @@ GameOptionsPage::GameOptionsPage(MinecraftInstance* inst, QWidget* parent) : QWi
 
 GameOptionsPage::~GameOptionsPage()
 {
-    // m_model->save();
+    m_model->save();
 }
 
 void GameOptionsPage::openedImpl()


### PR DESCRIPTION
@TayouVR, before going further to complete all the possible options found at minecraft.wiki/w/Options.txt
Could you please take a look and see what's missing? 
Values that this PR focuses on:
- true/false
- int with range
- float with range
- multiple options
- string as fallback

The key codes can be handled in a separate one on a later date.

Stuff that I plan to add before making this ready to review:
A reset to default button can be added (it should be pretty easy as either an action or an actual column)
But I think it's better to add both the default and the range/possible values as separate columns(making it similar to the table from the website)

And maybe if this is received well, have a way to globally manage them and share them between instances(maybe in a separate PR)