### PR TITLE
Support Omniarchive's asset indexes and version data that omits `mainClass`

### DIFF
--- a/launcher/minecraft/AssetsUtils.cpp
+++ b/launcher/minecraft/AssetsUtils.cpp
@@ -160,6 +160,8 @@ bool loadAssetsIndexJson(const QString& assetsId, const QString& path, AssetsInd
                 object.hash = value.toString();
             } else if (key == "size") {
                 object.size = value.toLongLong();
+            } else if (key == "url") {
+                object.customUrl = value.toString();
             }
         }
 
@@ -298,6 +300,9 @@ QString AssetObject::getLocalPath()
 
 QUrl AssetObject::getUrl()
 {
+    if (customUrl != nullptr && !customUrl.isEmpty()) {
+        return QUrl(customUrl);
+    }
     return BuildConfig.RESOURCE_BASE + getRelPath();
 }
 

--- a/launcher/minecraft/AssetsUtils.h
+++ b/launcher/minecraft/AssetsUtils.h
@@ -28,6 +28,7 @@ struct AssetObject {
 
     QString hash;
     qint64 size;
+    QString customUrl;
 };
 
 struct AssetsIndex {

--- a/libraries/launcher/legacy/org/prismlauncher/legacy/LegacyLauncher.java
+++ b/libraries/launcher/legacy/org/prismlauncher/legacy/LegacyLauncher.java
@@ -96,7 +96,13 @@ final class LegacyLauncher extends AbstractLauncher {
 
     @Override
     public void launch() throws Throwable {
-        Class<?> main = ClassLoader.getSystemClassLoader().loadClass(mainClassName);
+        Class<?> main;
+        try {
+            main = ClassLoader.getSystemClassLoader().loadClass(mainClassName);
+        } catch (ClassNotFoundException e) {
+            main = findClientClass(ClassLoader.getSystemClassLoader().loadClass(appletClass));
+        }
+
         Field gameDirField = findMinecraftGameDirField(main);
 
         if (gameDirField != null) {
@@ -128,6 +134,16 @@ final class LegacyLauncher extends AbstractLauncher {
 
         MethodHandle appletConstructor = MethodHandles.lookup().findConstructor(appletClass, MethodType.methodType(void.class));
         return (Applet) appletConstructor.invoke();
+    }
+
+    private static Class<?> findClientClass(Class<?> appletClass) {
+        for (Field field : appletClass.getDeclaredFields()) {
+            if (Runnable.class.isAssignableFrom(field.getType())) {
+                return field.getType();
+            }
+        }
+
+        throw new RuntimeException("Failed to find client class in applet class " + appletClass.getName());
     }
 
     private static Field findMinecraftGameDirField(Class<?> clazz) {

--- a/libraries/launcher/legacy/org/prismlauncher/legacy/LegacyLauncher.java
+++ b/libraries/launcher/legacy/org/prismlauncher/legacy/LegacyLauncher.java
@@ -96,11 +96,12 @@ final class LegacyLauncher extends AbstractLauncher {
 
     @Override
     public void launch() throws Throwable {
+        Class<?> applet = ClassLoader.getSystemClassLoader().loadClass(appletClass);
         Class<?> main;
         try {
             main = ClassLoader.getSystemClassLoader().loadClass(mainClassName);
         } catch (ClassNotFoundException e) {
-            main = findClientClass(ClassLoader.getSystemClassLoader().loadClass(appletClass));
+            main = findClientClass(applet);
         }
 
         Field gameDirField = findMinecraftGameDirField(main);
@@ -114,7 +115,7 @@ final class LegacyLauncher extends AbstractLauncher {
             System.setProperty("minecraft.applet.TargetDirectory", gameDir);
 
             try {
-                LegacyFrame window = new LegacyFrame(title, createAppletClass(appletClass));
+                LegacyFrame window = new LegacyFrame(title, createAppletInstance(applet));
 
                 window.start(user, session, width, height, maximize, serverAddress, serverPort, gameArgs.contains("--demo"));
                 return;
@@ -129,10 +130,8 @@ final class LegacyLauncher extends AbstractLauncher {
         method.invokeExact(gameArgs.toArray(new String[0]));
     }
 
-    private static Applet createAppletClass(String clazz) throws Throwable {
-        Class<?> appletClass = ClassLoader.getSystemClassLoader().loadClass(clazz);
-
-        MethodHandle appletConstructor = MethodHandles.lookup().findConstructor(appletClass, MethodType.methodType(void.class));
+    private static Applet createAppletInstance(Class<?> clazz) throws Throwable {
+        MethodHandle appletConstructor = MethodHandles.lookup().findConstructor(clazz, MethodType.methodType(void.class));
         return (Applet) appletConstructor.invoke();
     }
 

--- a/libraries/launcher/legacy/org/prismlauncher/legacy/LegacyLauncher.java
+++ b/libraries/launcher/legacy/org/prismlauncher/legacy/LegacyLauncher.java
@@ -99,8 +99,11 @@ final class LegacyLauncher extends AbstractLauncher {
         Class<?> applet = ClassLoader.getSystemClassLoader().loadClass(appletClass);
         Class<?> main;
         try {
+            // Try the main class given by parameters
             main = ClassLoader.getSystemClassLoader().loadClass(mainClassName);
         } catch (ClassNotFoundException e) {
+            // If it failed (net.minecraft.client.Minecraft was typically obfuscated when the Applet existed),
+            // detect from the Applet. Required for meta sources that strip or omit the main class, such as OmniArchive.
             main = findClientClass(applet);
         }
 


### PR DESCRIPTION
This brings support for the current outputs of [metabolism](https://github.com/PrismLauncher/metabolism) as well as Omniarchive asset indexes referencing files not present on piston-data.

The main class locating code is based off code @TheKodeToad shared with me