### PR TITLE
Build for Windows on ARM with MSVC natively

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -107,11 +107,10 @@ jobs:
             # TODO(@getchoo): This is the default in setup-dependencies/windows. Why isn't it working?!?!
             vcvars-arch: amd64
 
-          - os: windows-2022
+          - os: windows-11-arm
             artifact-name: Windows-MSVC-arm64
-            base-cmake-preset: windows_msvc_arm64_cross
-            vcvars-arch: amd64_arm64
-            qt-architecture: win64_msvc2022_arm64_cross_compiled
+            base-cmake-preset: windows_msvc
+            vcvars-arch: arm64
 
           - os: macos-14
             artifact-name: macOS


### PR DESCRIPTION
Similar to https://github.com/PrismLauncher/PrismLauncher/pull/3724, and again, what it says on the tin. This is nice for avoiding some of the not-so-fun parts of cross compiling

~~stacked previously on #3304 (for the cmake artifact name commit)~~

~~Blocked on an [upstream Qt bug](https://bugreports.qt.io/browse/QTBUG-136551). The new WoA binary builds just..don't ship with QtOGL. Yay :/~~ Fixed!

stacked on #4300