### PR TITLE
Cleanup CI trigger events

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,9 @@ name: Build
 
 on:
   push:
-    branches-ignore:
-      - "renovate/**"
+    branches:
+      - "develop"
+      - "release-*"
     paths:
       # File types
       - "**.cpp"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,6 +2,9 @@ name: "CodeQL Code Scanning"
 
 on:
   push:
+    branches:
+      - "develop"
+      - "release-*"
     paths:
       # File types
       - "**.cpp"

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -2,6 +2,9 @@ name: Flatpak
 
 on:
   push:
+    branches:
+      - "develop"
+      - "release-*"
     # We don't do anything with these artifacts on releases. They go to Flathub
     tags-ignore:
       - "*"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -2,6 +2,9 @@ name: Nix
 
 on:
   push:
+    branches:
+      - "develop"
+      - "release-*"
     tags:
       - "*"
     paths:


### PR DESCRIPTION
Right now the Nix and Flatpak workflow don't actually run on pushes to a branch because I only specified tag fields...oops

This also prevents PRs from in-tree branches basically running CI twice :)
