### PR TITLE
Improve the message when component metadata fails to download

### DIFF
--- a/launcher/minecraft/ComponentUpdateTask.cpp
+++ b/launcher/minecraft/ComponentUpdateTask.cpp
@@ -748,7 +748,6 @@ void ComponentUpdateTask::remoteLoadFailed(size_t taskIndex, const QString& msg)
     d->remoteLoadSuccessful = false;
     taskSlot.succeeded = false;
     taskSlot.finished = true;
-    taskSlot.error = msg;
     d->remoteTasksInProgress--;
     checkIfAllFinished();
 }
@@ -769,7 +768,9 @@ void ComponentUpdateTask::checkIfAllFinished()
         QStringList allErrorsList;
         for (auto& item : d->remoteLoadStatusList) {
             if (!item.succeeded) {
-                allErrorsList.append(item.error);
+                const ComponentPtr component = d->m_profile->getComponent(item.PackProfileIndex);
+                allErrorsList.append(tr("Could not download metadata for %1 %2. Please change the version or try again later.")
+                                         .arg(component->getName(), component->m_version));
             }
         }
         auto allErrors = allErrorsList.join("\n");

--- a/launcher/minecraft/ComponentUpdateTask_p.h
+++ b/launcher/minecraft/ComponentUpdateTask_p.h
@@ -15,7 +15,6 @@ struct RemoteLoadStatus {
     size_t PackProfileIndex = 0;
     bool finished = false;
     bool succeeded = false;
-    QString error;
     Task::Ptr task;
 };
 


### PR DESCRIPTION
```
Could not download metadata for Minecraft 1.12.3. Please change the version or try again later.
Could not download metadata for Forge 15.23.5.2860. Please change the version or try again later.
```