### PR TITLE
fix: icon import with dot in name

### DIFF
--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -263,9 +263,9 @@ void InstanceImportTask::extractFinished()
     }
 }
 
-bool installIcon(QString root, QString instIcon)
+bool installIcon(QString root, QString instIconKey)
 {
-    auto importIconPath = IconUtils::findBestIconIn(root, instIcon);
+    auto importIconPath = IconUtils::findBestIconIn(root, instIconKey);
     if (importIconPath.isNull() || !QFile::exists(importIconPath))
         importIconPath = IconUtils::findBestIconIn(root, "icon.png");
     if (importIconPath.isNull() || !QFile::exists(importIconPath))
@@ -273,10 +273,10 @@ bool installIcon(QString root, QString instIcon)
     if (!importIconPath.isNull() && QFile::exists(importIconPath)) {
         // import icon
         auto iconList = APPLICATION->icons();
-        if (iconList->iconFileExists(instIcon)) {
-            iconList->deleteIcon(instIcon);
+        if (iconList->iconFileExists(instIconKey)) {
+            iconList->deleteIcon(instIconKey);
         }
-        iconList->installIcon(importIconPath, instIcon);
+        iconList->installIcon(importIconPath, instIconKey + ".png");
         return true;
     }
     return false;

--- a/launcher/icons/IconList.cpp
+++ b/launcher/icons/IconList.cpp
@@ -55,7 +55,7 @@ IconList::IconList(const QStringList& builtinPaths, const QString& path, QObject
         QDir instanceIcons(builtinPath);
         auto fileInfoList = instanceIcons.entryInfoList(QDir::Files, QDir::Name);
         for (const auto& fileInfo : fileInfoList) {
-            builtinNames.insert(fileInfo.baseName());
+            builtinNames.insert(fileInfo.completeBaseName());
         }
     }
     for (const auto& builtinName : builtinNames) {
@@ -127,10 +127,11 @@ QStringList IconList::getIconFilePaths() const
 QString formatName(const QDir& iconsDir, const QFileInfo& iconFile)
 {
     if (iconFile.dir() == iconsDir)
-        return iconFile.baseName();
+        return iconFile.completeBaseName();
 
     constexpr auto delimiter = " » ";
-    QString relativePathWithoutExtension = iconsDir.relativeFilePath(iconFile.dir().path()) + QDir::separator() + iconFile.baseName();
+    QString relativePathWithoutExtension =
+        iconsDir.relativeFilePath(iconFile.dir().path()) + QDir::separator() + iconFile.completeBaseName();
     return relativePathWithoutExtension.replace(QDir::separator(), delimiter);
 }
 


### PR DESCRIPTION
https://discord.com/channels/1031648380885147709/1031823065937629267/1387408363138060299


Prepare a MRPack whose name contains a dot `a.a.a` that includes a icon.png 
With this change, the icon should be correctly imported 