### PR TITLE
Correct Corruption in CustomCommands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ on:
       - "**.cpp"
       - "**.h"
       - "**.java"
+      - "**.ui"
 
       # Directories
       - "buildconfig/"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -10,6 +10,7 @@ on:
       - "**.cpp"
       - "**.h"
       - "**.java"
+      - "**.ui"
 
       # Directories
       - "buildconfig/"

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -13,6 +13,7 @@ on:
       - "**.cpp"
       - "**.h"
       - "**.java"
+      - "**.ui"
 
       # Build files
       - "flatpak/"

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -12,6 +12,7 @@ on:
       - "**.cpp"
       - "**.h"
       - "**.java"
+      - "**.ui"
 
       # Build files
       - "**.nix"

--- a/launcher/ui/widgets/CustomCommands.ui
+++ b/launcher/ui/widgets/CustomCommands.ui
@@ -86,7 +86,7 @@
          <string>P&amp;ost-exit Command</string>
         </property>
         <property name="buddy">
-         <cstring>labelPostExitCmd</cstring>
+         <cstring>postExitCmdTextBox</cstring>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Fixes a regression from https://github.com/PrismLauncher/PrismLauncher/pull/3534

Making a QLabel a buddy of itself causes a double free and crashing on
deconstruction in some cases (like MSVC)

And yes, it took me a whole 2 minutes to come up with this PR title