### PR TITLE
Update to Qt 6.9

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -21,7 +21,7 @@ inputs:
   qt-version:
     description: Version of Qt to use
     required: true
-    default: 6.8.1
+    default: 6.9.1
 
 outputs:
   build-type:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)  # minimum version required by QuaZip
+cmake_minimum_required(VERSION 3.22)  # minimum version required by Qt
 
 project(Launcher)
 


### PR DESCRIPTION
Parent PR: #4599
Qt 6.8 went EOL in April. This series will last until October, and hopefully land some fixes necessary for https://github.com/PrismLauncher/PrismLauncher/pull/3872 soon

## TODO

Test on:

- [x] Windows (MSVC)
- [x] Linux
- [x] macOS

https://doc.qt.io/qt-6/whatsnew69.html

![image](https://github.com/user-attachments/assets/95f0c5bb-9e9b-4d9e-a934-7fb6810fa0d2)