### PR TITLE
Don't bundle Qt with the Linux Portable build

### DIFF
--- a/.github/actions/package/linux/action.yml
+++ b/.github/actions/package/linux/action.yml
@@ -111,17 +111,8 @@ runs:
 
         INSTALL_PORTABLE_DIR: install-portable
       run: |
-        cmake --preset "$CMAKE_PRESET" -DCMAKE_INSTALL_PREFIX=${{ env.INSTALL_PORTABLE_DIR }} -DINSTALL_BUNDLE=full
-        cmake --install ${{ env.BUILD_DIR }}
-        cmake --install ${{ env.BUILD_DIR }} --component portable
-
-        mkdir  ${{ env.INSTALL_PORTABLE_DIR }}/lib
-        cp /lib/"$DEB_HOST_MULTIARCH"/libbz2.so.1.0 ${{ env.INSTALL_PORTABLE_DIR }}/lib
-        cp /usr/lib/"$DEB_HOST_MULTIARCH"/libgobject-2.0.so.0 ${{ env.INSTALL_PORTABLE_DIR }}/lib
-        cp /usr/lib/"$DEB_HOST_MULTIARCH"/libcrypto.so.* ${{ env.INSTALL_PORTABLE_DIR }}/lib
-        cp /usr/lib/"$DEB_HOST_MULTIARCH"/libssl.so.* ${{ env.INSTALL_PORTABLE_DIR }}/lib
-        cp /usr/lib/"$DEB_HOST_MULTIARCH"/libffi.so.*.* ${{ env.INSTALL_PORTABLE_DIR }}/lib
-        mv ${{ env.INSTALL_PORTABLE_DIR }}/bin/*.so* ${{ env.INSTALL_PORTABLE_DIR }}/lib
+        cmake --install ${{ env.BUILD_DIR }} --prefix ${{ env.INSTALL_PORTABLE_DIR }}
+        cmake --install ${{ env.BUILD_DIR }} --prefix ${{ env.INSTALL_PORTABLE_DIR }} --component portable
 
         for l in $(find ${{ env.INSTALL_PORTABLE_DIR }} -type f); do l=${l#$(pwd)/}; l=${l#${{ env.INSTALL_PORTABLE_DIR }}/}; l=${l#./}; echo $l; done > ${{ env.INSTALL_PORTABLE_DIR }}/manifest.txt
         cd ${{ env.INSTALL_PORTABLE_DIR }}


### PR DESCRIPTION
This was mainly implemented to work around an ABI incompatibility in
Arch Linux, which is no longer a major issue as they have an official
binary package for us now. Many ABI incompatibility issues still remain
(as not every distribution is, or similar to, Ubuntu) which this doesn't
even begin to scratch the surface of fixing, and isn't a very supported
use case in Linux-land outside of our mostly self-rolled `fixup_bundle`

Users who experience ABI incompatibilities with our binaries would be
*much* better served using Flatpak or AppImage, as they can guarntee^*
compatibility with any host system through a complete bundle; packagers
who experience ABI incompatibilities should probably build the launcher
against their own distribution, like Arch and many others do

This would also make #3741 a little easier lol