### PR TITLE
Reduce usage of [[nodiscard]] attributes 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributions Guidelines
 
-## Code formatting
+## Code style
 
 All files are formatted with `clang-format` using the configuration in `.clang-format`. Ensure it is run on changed files before committing!
 
@@ -15,6 +15,11 @@ Please also follow the project's conventions for C++:
 - Global functions and non-`const` global variables should be formatted as `camelCase` without a prefix: `globalData`.
 - `const` global variables, macros, and enum constants should be formatted as `SCREAMING_SNAKE_CASE`: `LIGHT_GRAY`.
 - Avoid inventing acronyms or abbreviations especially for a name of multiple words - like `tp` for `texturePack`.
+- Avoid using `[[nodiscard]]` unless ignoring the return value is likely to cause a bug in cases such as:
+  - A function allocates memory or another resource and the caller needs to clean it up.
+  - A function has side effects and an error status is returned.
+  - A function is likely be mistaken for having side effects.
+- A plain getter is unlikely to cause confusion and adding `[[nodiscard]]` can create clutter and inconsistency.
 
 Most of these rules are included in the `.clang-tidy` file, so you can run `clang-tidy` to check for any violations.
 

--- a/launcher/InstanceCopyPrefs.h
+++ b/launcher/InstanceCopyPrefs.h
@@ -8,23 +8,23 @@
 
 struct InstanceCopyPrefs {
    public:
-    [[nodiscard]] bool allTrue() const;
-    [[nodiscard]] QString getSelectedFiltersAsRegex() const;
-    [[nodiscard]] QString getSelectedFiltersAsRegex(const QStringList& additionalFilters) const;
+    bool allTrue() const;
+    QString getSelectedFiltersAsRegex() const;
+    QString getSelectedFiltersAsRegex(const QStringList& additionalFilters) const;
     // Getters
-    [[nodiscard]] bool isCopySavesEnabled() const;
-    [[nodiscard]] bool isKeepPlaytimeEnabled() const;
-    [[nodiscard]] bool isCopyGameOptionsEnabled() const;
-    [[nodiscard]] bool isCopyResourcePacksEnabled() const;
-    [[nodiscard]] bool isCopyShaderPacksEnabled() const;
-    [[nodiscard]] bool isCopyServersEnabled() const;
-    [[nodiscard]] bool isCopyModsEnabled() const;
-    [[nodiscard]] bool isCopyScreenshotsEnabled() const;
-    [[nodiscard]] bool isUseSymLinksEnabled() const;
-    [[nodiscard]] bool isLinkRecursivelyEnabled() const;
-    [[nodiscard]] bool isUseHardLinksEnabled() const;
-    [[nodiscard]] bool isDontLinkSavesEnabled() const;
-    [[nodiscard]] bool isUseCloneEnabled() const;
+    bool isCopySavesEnabled() const;
+    bool isKeepPlaytimeEnabled() const;
+    bool isCopyGameOptionsEnabled() const;
+    bool isCopyResourcePacksEnabled() const;
+    bool isCopyShaderPacksEnabled() const;
+    bool isCopyServersEnabled() const;
+    bool isCopyModsEnabled() const;
+    bool isCopyScreenshotsEnabled() const;
+    bool isUseSymLinksEnabled() const;
+    bool isLinkRecursivelyEnabled() const;
+    bool isUseHardLinksEnabled() const;
+    bool isDontLinkSavesEnabled() const;
+    bool isUseCloneEnabled() const;
     // Setters
     void enableCopySaves(bool b);
     void enableKeepPlaytime(bool b);

--- a/launcher/InstanceTask.h
+++ b/launcher/InstanceTask.h
@@ -14,10 +14,10 @@ struct InstanceName {
     InstanceName() = default;
     InstanceName(QString name, QString version) : m_original_name(std::move(name)), m_original_version(std::move(version)) {}
 
-    [[nodiscard]] QString modifiedName() const;
-    [[nodiscard]] QString originalName() const;
-    [[nodiscard]] QString name() const;
-    [[nodiscard]] QString version() const;
+    QString modifiedName() const;
+    QString originalName() const;
+    QString name() const;
+    QString version() const;
 
     void setName(QString name) { m_modified_name = name; }
     void setName(InstanceName& other);
@@ -44,12 +44,12 @@ class InstanceTask : public Task, public InstanceName {
     void setGroup(const QString& group) { m_instGroup = group; }
     QString group() const { return m_instGroup; }
 
-    [[nodiscard]] bool shouldConfirmUpdate() const { return m_confirm_update; }
+    bool shouldConfirmUpdate() const { return m_confirm_update; }
     void setConfirmUpdate(bool confirm) { m_confirm_update = confirm; }
 
     bool shouldOverride() const { return m_override_existing; }
 
-    [[nodiscard]] QString originalInstanceID() const { return m_original_instance_id; };
+    QString originalInstanceID() const { return m_original_instance_id; };
 
    protected:
     void setOverride(bool override, QString instance_id_to_override = {})

--- a/launcher/Version.h
+++ b/launcher/Version.h
@@ -96,8 +96,8 @@ class Version {
 
         QString m_fullString;
 
-        [[nodiscard]] inline bool isAppendix() const { return m_stringPart.startsWith('+'); }
-        [[nodiscard]] inline bool isPreRelease() const { return m_stringPart.startsWith('-') && m_stringPart.length() > 1; }
+        inline bool isAppendix() const { return m_stringPart.startsWith('+'); }
+        inline bool isPreRelease() const { return m_stringPart.startsWith('-') && m_stringPart.length() > 1; }
 
         inline bool operator==(const Section& other) const
         {

--- a/launcher/java/JavaInstallList.h
+++ b/launcher/java/JavaInstallList.h
@@ -35,7 +35,7 @@ class JavaInstallList : public BaseVersionList {
    public:
     explicit JavaInstallList(QObject* parent = 0, bool onlyManagedVersions = false);
 
-    [[nodiscard]] Task::Ptr getLoadTask() override;
+    Task::Ptr getLoadTask() override;
     bool isLoaded() override;
     const BaseVersion::Ptr at(int i) const override;
     int count() const override;

--- a/launcher/java/download/ArchiveDownloadTask.h
+++ b/launcher/java/download/ArchiveDownloadTask.h
@@ -28,7 +28,7 @@ class ArchiveDownloadTask : public Task {
     ArchiveDownloadTask(QUrl url, QString final_path, QString checksumType = "", QString checksumHash = "");
     virtual ~ArchiveDownloadTask() = default;
 
-    [[nodiscard]] bool canAbort() const override { return true; }
+    bool canAbort() const override { return true; }
     void executeTask() override;
     virtual bool abort() override;
 

--- a/launcher/java/download/ManifestDownloadTask.h
+++ b/launcher/java/download/ManifestDownloadTask.h
@@ -29,7 +29,7 @@ class ManifestDownloadTask : public Task {
     ManifestDownloadTask(QUrl url, QString final_path, QString checksumType = "", QString checksumHash = "");
     virtual ~ManifestDownloadTask() = default;
 
-    [[nodiscard]] bool canAbort() const override { return true; }
+    bool canAbort() const override { return true; }
     void executeTask() override;
     virtual bool abort() override;
 

--- a/launcher/meta/Version.h
+++ b/launcher/meta/Version.h
@@ -60,7 +60,7 @@ class Version : public QObject, public BaseVersion, public BaseEntity {
 
     QString localFilename() const override;
 
-    [[nodiscard]] ::Version toComparableVersion() const;
+    ::Version toComparableVersion() const;
 
    public:  // for usage by format parsers only
     void setType(const QString& type);

--- a/launcher/meta/VersionList.h
+++ b/launcher/meta/VersionList.h
@@ -37,7 +37,7 @@ class VersionList : public BaseVersionList, public BaseEntity {
     enum Roles { UidRole = Qt::UserRole + 100, TimeRole, RequiresRole, VersionPtrRole };
 
     bool isLoaded() override;
-    [[nodiscard]] Task::Ptr getLoadTask() override;
+    Task::Ptr getLoadTask() override;
     const BaseVersion::Ptr at(int i) const override;
     int count() const override;
     void sortVersions() override;

--- a/launcher/minecraft/MinecraftInstance.h
+++ b/launcher/minecraft/MinecraftInstance.h
@@ -104,7 +104,7 @@ class MinecraftInstance : public BaseInstance {
     QString getLocalLibraryPath() const;
 
     /** Returns whether the instance, with its version, has support for demo mode. */
-    [[nodiscard]] bool supportsDemo() const;
+    bool supportsDemo() const;
 
     void updateRuntimeContext() override;
 

--- a/launcher/minecraft/World.h
+++ b/launcher/minecraft/World.h
@@ -59,7 +59,7 @@ class World {
     // WEAK compare operator - used for replacing worlds
     bool operator==(const World& other) const;
 
-    [[nodiscard]] auto isSymLink() const -> bool { return m_containerFile.isSymLink(); }
+    auto isSymLink() const -> bool { return m_containerFile.isSymLink(); }
 
     /**
      * @brief Take a instance path, checks if the file pointed to by the resource is a symlink or under a symlink in that instance
@@ -68,9 +68,9 @@ class World {
      * @return true
      * @return false
      */
-    [[nodiscard]] bool isSymLinkUnder(const QString& instPath) const;
+    bool isSymLinkUnder(const QString& instPath) const;
 
-    [[nodiscard]] bool isMoreThanOneHardLink() const;
+    bool isMoreThanOneHardLink() const;
 
     QString canonicalFilePath() const { return m_containerFile.canonicalFilePath(); }
 

--- a/launcher/minecraft/auth/MinecraftAccount.h
+++ b/launcher/minecraft/auth/MinecraftAccount.h
@@ -114,7 +114,7 @@ class MinecraftAccount : public QObject, public Usable {
 
     bool isActive() const;
 
-    [[nodiscard]] AccountType accountType() const noexcept { return data.type; }
+    AccountType accountType() const noexcept { return data.type; }
 
     bool ownsMinecraft() const { return data.type != AccountType::Offline && data.minecraftEntitlement.ownsMinecraft; }
 

--- a/launcher/minecraft/mod/DataPack.h
+++ b/launcher/minecraft/mod/DataPack.h
@@ -40,15 +40,15 @@ class DataPack : public Resource {
     DataPack(QFileInfo file_info) : Resource(file_info) {}
 
     /** Gets the numerical ID of the pack format. */
-    [[nodiscard]] int packFormat() const { return m_pack_format; }
+    int packFormat() const { return m_pack_format; }
     /** Gets, respectively, the lower and upper versions supported by the set pack format. */
-    [[nodiscard]] virtual std::pair<Version, Version> compatibleVersions() const;
+    virtual std::pair<Version, Version> compatibleVersions() const;
 
     /** Gets the description of the data pack. */
-    [[nodiscard]] QString description() const { return m_description; }
+    QString description() const { return m_description; }
 
     /** Gets the image of the data pack, converted to a QPixmap for drawing, and scaled to size. */
-    [[nodiscard]] QPixmap image(QSize size, Qt::AspectRatioMode mode = Qt::AspectRatioMode::IgnoreAspectRatio) const;
+    QPixmap image(QSize size, Qt::AspectRatioMode mode = Qt::AspectRatioMode::IgnoreAspectRatio) const;
 
     /** Thread-safe. */
     void setPackFormat(int new_format_id);

--- a/launcher/minecraft/mod/DataPackFolderModel.h
+++ b/launcher/minecraft/mod/DataPackFolderModel.h
@@ -50,10 +50,10 @@ class DataPackFolderModel : public ResourceFolderModel {
 
     virtual QString id() const override { return "datapacks"; }
 
-    [[nodiscard]] QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
 
-    [[nodiscard]] QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
-    [[nodiscard]] int columnCount(const QModelIndex& parent) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+    int columnCount(const QModelIndex& parent) const override;
 
     [[nodiscard]] Resource* createResource(const QFileInfo& file) override;
     [[nodiscard]] Task* createParseTask(Resource&) override;

--- a/launcher/minecraft/mod/Mod.h
+++ b/launcher/minecraft/mod/Mod.h
@@ -76,7 +76,7 @@ class Mod : public Resource {
     /** Get the intneral path to the mod's icon file*/
     QString iconPath() const { return m_local_details.icon_file; }
     /** Gets the icon of the mod, converted to a QPixmap for drawing, and scaled to size. */
-    [[nodiscard]] QPixmap icon(QSize size, Qt::AspectRatioMode mode = Qt::AspectRatioMode::IgnoreAspectRatio) const;
+    QPixmap icon(QSize size, Qt::AspectRatioMode mode = Qt::AspectRatioMode::IgnoreAspectRatio) const;
     /** Thread-safe. */
     QPixmap setIcon(QImage new_image) const;
 

--- a/launcher/minecraft/mod/Resource.h
+++ b/launcher/minecraft/mod/Resource.h
@@ -83,23 +83,23 @@ class Resource : public QObject {
     void setFile(QFileInfo file_info);
     void parseFile();
 
-    [[nodiscard]] auto fileinfo() const -> QFileInfo { return m_file_info; }
-    [[nodiscard]] auto dateTimeChanged() const -> QDateTime { return m_changed_date_time; }
-    [[nodiscard]] auto internal_id() const -> QString { return m_internal_id; }
-    [[nodiscard]] auto type() const -> ResourceType { return m_type; }
-    [[nodiscard]] bool enabled() const { return m_enabled; }
-    [[nodiscard]] auto getOriginalFileName() const -> QString;
-    [[nodiscard]] QString sizeStr() const { return m_size_str; }
-    [[nodiscard]] qint64 sizeInfo() const { return m_size_info; }
+    auto fileinfo() const -> QFileInfo { return m_file_info; }
+    auto dateTimeChanged() const -> QDateTime { return m_changed_date_time; }
+    auto internal_id() const -> QString { return m_internal_id; }
+    auto type() const -> ResourceType { return m_type; }
+    bool enabled() const { return m_enabled; }
+    auto getOriginalFileName() const -> QString;
+    QString sizeStr() const { return m_size_str; }
+    qint64 sizeInfo() const { return m_size_info; }
 
-    [[nodiscard]] virtual auto name() const -> QString;
-    [[nodiscard]] virtual bool valid() const { return m_type != ResourceType::UNKNOWN; }
+    virtual auto name() const -> QString;
+    virtual bool valid() const { return m_type != ResourceType::UNKNOWN; }
 
-    [[nodiscard]] auto status() const -> ResourceStatus { return m_status; };
-    [[nodiscard]] auto metadata() -> std::shared_ptr<Metadata::ModStruct> { return m_metadata; }
-    [[nodiscard]] auto metadata() const -> std::shared_ptr<const Metadata::ModStruct> { return m_metadata; }
-    [[nodiscard]] auto provider() const -> QString;
-    [[nodiscard]] virtual auto homepage() const -> QString;
+    auto status() const -> ResourceStatus { return m_status; };
+    auto metadata() -> std::shared_ptr<Metadata::ModStruct> { return m_metadata; }
+    auto metadata() const -> std::shared_ptr<const Metadata::ModStruct> { return m_metadata; }
+    auto provider() const -> QString;
+    virtual auto homepage() const -> QString;
 
     void setStatus(ResourceStatus status) { m_status = status; }
     void setMetadata(std::shared_ptr<Metadata::ModStruct>&& metadata);
@@ -110,12 +110,12 @@ class Resource : public QObject {
      *  = 0: 'this' is equal to 'other'
      *  < 0: 'this' comes before 'other'
      */
-    [[nodiscard]] virtual int compare(Resource const& other, SortType type = SortType::NAME) const;
+    virtual int compare(Resource const& other, SortType type = SortType::NAME) const;
 
     /** Returns whether the given filter should filter out 'this' (false),
      *  or if such filter includes the Resource (true).
      */
-    [[nodiscard]] virtual bool applyFilter(QRegularExpression filter) const;
+    virtual bool applyFilter(QRegularExpression filter) const;
 
     /** Changes the enabled property, according to 'action'.
      *
@@ -123,10 +123,10 @@ class Resource : public QObject {
      */
     bool enable(EnableAction action);
 
-    [[nodiscard]] auto shouldResolve() const -> bool { return !m_is_resolving && !m_is_resolved; }
-    [[nodiscard]] auto isResolving() const -> bool { return m_is_resolving; }
-    [[nodiscard]] auto isResolved() const -> bool { return m_is_resolved; }
-    [[nodiscard]] auto resolutionTicket() const -> int { return m_resolution_ticket; }
+    auto shouldResolve() const -> bool { return !m_is_resolving && !m_is_resolved; }
+    auto isResolving() const -> bool { return m_is_resolving; }
+    auto isResolved() const -> bool { return m_is_resolved; }
+    auto resolutionTicket() const -> int { return m_resolution_ticket; }
 
     void setResolving(bool resolving, int resolutionTicket)
     {
@@ -139,7 +139,7 @@ class Resource : public QObject {
     // Delete the metadata only.
     auto destroyMetadata(const QDir& index_dir) -> void;
 
-    [[nodiscard]] auto isSymLink() const -> bool { return m_file_info.isSymLink(); }
+    auto isSymLink() const -> bool { return m_file_info.isSymLink(); }
 
     /**
      * @brief Take a instance path, checks if the file pointed to by the resource is a symlink or under a symlink in that instance
@@ -148,11 +148,11 @@ class Resource : public QObject {
      * @return true
      * @return false
      */
-    [[nodiscard]] bool isSymLinkUnder(const QString& instPath) const;
+    bool isSymLinkUnder(const QString& instPath) const;
 
-    [[nodiscard]] bool isMoreThanOneHardLink() const;
+    bool isMoreThanOneHardLink() const;
 
-    [[nodiscard]] auto mod_id() const -> QString { return m_mod_id; }
+    auto mod_id() const -> QString { return m_mod_id; }
     void setModId(const QString& modId) { m_mod_id = modId; }
 
    protected:

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -709,7 +709,7 @@ SortType ResourceFolderModel::columnToSortKey(size_t column) const
 }
 
 /* Standard Proxy Model for createFilterProxyModel */
-[[nodiscard]] bool ResourceFolderModel::ProxyModel::filterAcceptsRow(int source_row,
+bool ResourceFolderModel::ProxyModel::filterAcceptsRow(int source_row,
                                                                      [[maybe_unused]] const QModelIndex& source_parent) const
 {
     auto* model = qobject_cast<ResourceFolderModel*>(sourceModel());
@@ -721,7 +721,7 @@ SortType ResourceFolderModel::columnToSortKey(size_t column) const
     return resource.applyFilter(filterRegularExpression());
 }
 
-[[nodiscard]] bool ResourceFolderModel::ProxyModel::lessThan(const QModelIndex& source_left, const QModelIndex& source_right) const
+bool ResourceFolderModel::ProxyModel::lessThan(const QModelIndex& source_left, const QModelIndex& source_right) const
 {
     auto* model = qobject_cast<ResourceFolderModel*>(sourceModel());
     if (!model || !source_left.isValid() || !source_right.isValid() || source_left.column() != source_right.column()) {

--- a/launcher/minecraft/mod/ResourceFolderModel.h
+++ b/launcher/minecraft/mod/ResourceFolderModel.h
@@ -21,11 +21,11 @@ class QSortFilterProxyModel;
 
 /* A macro to define useful functions to handle Resource* -> T* more easily on derived classes */
 #define RESOURCE_HELPERS(T)                                         \
-    [[nodiscard]] T& at(int index)                                  \
+    T& at(int index)                                  \
     {                                                               \
         return *static_cast<T*>(m_resources[index].get());          \
     }                                                               \
-    [[nodiscard]] const T& at(int index) const                      \
+    const T& at(int index) const                      \
     {                                                               \
         return *static_cast<const T*>(m_resources.at(index).get()); \
     }                                                               \
@@ -115,24 +115,24 @@ class ResourceFolderModel : public QAbstractListModel {
     /** Creates a new parse task, if needed, for 'res' and start it.*/
     virtual void resolveResource(Resource::Ptr res);
 
-    [[nodiscard]] qsizetype size() const { return m_resources.size(); }
+    qsizetype size() const { return m_resources.size(); }
     [[nodiscard]] bool empty() const { return size() == 0; }
 
-    [[nodiscard]] Resource& at(int index) { return *m_resources[index].get(); }
-    [[nodiscard]] const Resource& at(int index) const { return *m_resources.at(index).get(); }
+    Resource& at(int index) { return *m_resources[index].get(); }
+    const Resource& at(int index) const { return *m_resources.at(index).get(); }
     QList<Resource*> selectedResources(const QModelIndexList& indexes);
     QList<Resource*> allResources();
 
-    [[nodiscard]] Resource::Ptr find(QString id);
+    Resource::Ptr find(QString id);
 
-    [[nodiscard]] QDir const& dir() const { return m_dir; }
+    QDir const& dir() const { return m_dir; }
 
     /** Checks whether there's any parse tasks being done.
      *
      *  Since they can be quite expensive, and are usually done in a separate thread, if we were to destroy the model while having
      *  such tasks would introduce an undefined behavior, most likely resulting in a crash.
      */
-    [[nodiscard]] bool hasPendingParseTasks() const;
+    bool hasPendingParseTasks() const;
 
     /* Qt behavior */
 
@@ -141,22 +141,22 @@ class ResourceFolderModel : public QAbstractListModel {
 
     QStringList columnNames(bool translated = true) const { return translated ? m_column_names_translated : m_column_names; }
 
-    [[nodiscard]] int rowCount(const QModelIndex& parent = {}) const override { return parent.isValid() ? 0 : static_cast<int>(size()); }
-    [[nodiscard]] int columnCount(const QModelIndex& parent = {}) const override { return parent.isValid() ? 0 : NUM_COLUMNS; }
+    int rowCount(const QModelIndex& parent = {}) const override { return parent.isValid() ? 0 : static_cast<int>(size()); }
+    int columnCount(const QModelIndex& parent = {}) const override { return parent.isValid() ? 0 : NUM_COLUMNS; }
 
-    [[nodiscard]] Qt::DropActions supportedDropActions() const override;
+    Qt::DropActions supportedDropActions() const override;
 
     /// flags, mostly to support drag&drop
-    [[nodiscard]] Qt::ItemFlags flags(const QModelIndex& index) const override;
-    [[nodiscard]] QStringList mimeTypes() const override;
-    bool dropMimeData(const QMimeData* data, Qt::DropAction action, int row, int column, const QModelIndex& parent) override;
+    Qt::ItemFlags flags(const QModelIndex& index) const override;
+    QStringList mimeTypes() const override;
+    [[nodiscard]] bool dropMimeData(const QMimeData* data, Qt::DropAction action, int row, int column, const QModelIndex& parent) override;
 
     [[nodiscard]] bool validateIndex(const QModelIndex& index) const;
 
-    [[nodiscard]] QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
     bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole) override;
 
-    [[nodiscard]] QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
 
     void setupHeaderAction(QAction* act, int column);
     void saveColumns(QTreeView* tree);
@@ -169,16 +169,16 @@ class ResourceFolderModel : public QAbstractListModel {
      */
     QSortFilterProxyModel* createFilterProxyModel(QObject* parent = nullptr);
 
-    [[nodiscard]] SortType columnToSortKey(size_t column) const;
-    [[nodiscard]] QList<QHeaderView::ResizeMode> columnResizeModes() const { return m_column_resize_modes; }
+    SortType columnToSortKey(size_t column) const;
+    QList<QHeaderView::ResizeMode> columnResizeModes() const { return m_column_resize_modes; }
 
     class ProxyModel : public QSortFilterProxyModel {
        public:
         explicit ProxyModel(QObject* parent = nullptr) : QSortFilterProxyModel(parent) {}
 
        protected:
-        [[nodiscard]] bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const override;
-        [[nodiscard]] bool lessThan(const QModelIndex& source_left, const QModelIndex& source_right) const override;
+        bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const override;
+        bool lessThan(const QModelIndex& source_left, const QModelIndex& source_right) const override;
     };
 
     QString instDirPath() const;

--- a/launcher/minecraft/mod/ResourcePack.h
+++ b/launcher/minecraft/mod/ResourcePack.h
@@ -22,7 +22,7 @@ class ResourcePack : public DataPack {
     ResourcePack(QFileInfo file_info) : DataPack(file_info) {}
 
     /** Gets, respectively, the lower and upper versions supported by the set pack format. */
-    [[nodiscard]] std::pair<Version, Version> compatibleVersions() const override;
+    std::pair<Version, Version> compatibleVersions() const override;
 
     QString directory() override { return "/assets"; }
 };

--- a/launcher/minecraft/mod/ResourcePackFolderModel.h
+++ b/launcher/minecraft/mod/ResourcePackFolderModel.h
@@ -13,10 +13,10 @@ class ResourcePackFolderModel : public ResourceFolderModel {
 
     QString id() const override { return "resourcepacks"; }
 
-    [[nodiscard]] QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
 
-    [[nodiscard]] QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
-    [[nodiscard]] int columnCount(const QModelIndex& parent) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+    int columnCount(const QModelIndex& parent) const override;
 
     [[nodiscard]] Resource* createResource(const QFileInfo& file) override { return new ResourcePack(file); }
     [[nodiscard]] Task* createParseTask(Resource&) override;

--- a/launcher/minecraft/mod/ShaderPack.h
+++ b/launcher/minecraft/mod/ShaderPack.h
@@ -45,7 +45,7 @@ class ShaderPack : public Resource {
    public:
     using Ptr = shared_qobject_ptr<Resource>;
 
-    [[nodiscard]] ShaderPackFormat packFormat() const { return m_pack_format; }
+    ShaderPackFormat packFormat() const { return m_pack_format; }
 
     ShaderPack(QObject* parent = nullptr) : Resource(parent) {}
     ShaderPack(QFileInfo file_info) : Resource(file_info) {}

--- a/launcher/minecraft/mod/TexturePack.h
+++ b/launcher/minecraft/mod/TexturePack.h
@@ -37,10 +37,10 @@ class TexturePack : public Resource {
     TexturePack(QFileInfo file_info) : Resource(file_info) {}
 
     /** Gets the description of the texture pack. */
-    [[nodiscard]] QString description() const { return m_description; }
+    QString description() const { return m_description; }
 
     /** Gets the image of the texture pack, converted to a QPixmap for drawing, and scaled to size. */
-    [[nodiscard]] QPixmap image(QSize size, Qt::AspectRatioMode mode = Qt::AspectRatioMode::IgnoreAspectRatio) const;
+    QPixmap image(QSize size, Qt::AspectRatioMode mode = Qt::AspectRatioMode::IgnoreAspectRatio) const;
 
     /** Thread-safe. */
     void setDescription(QString new_description);

--- a/launcher/minecraft/mod/TexturePackFolderModel.h
+++ b/launcher/minecraft/mod/TexturePackFolderModel.h
@@ -50,10 +50,10 @@ class TexturePackFolderModel : public ResourceFolderModel {
 
     virtual QString id() const override { return "texturepacks"; }
 
-    [[nodiscard]] QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
 
-    [[nodiscard]] QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
-    [[nodiscard]] int columnCount(const QModelIndex& parent) const override;
+    QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
+    int columnCount(const QModelIndex& parent) const override;
 
     [[nodiscard]] Resource* createResource(const QFileInfo& file) override { return new TexturePack(file); }
     [[nodiscard]] Task* createParseTask(Resource&) override;

--- a/launcher/minecraft/mod/WorldSave.h
+++ b/launcher/minecraft/mod/WorldSave.h
@@ -38,9 +38,9 @@ class WorldSave : public Resource {
     WorldSave(QFileInfo file_info) : Resource(file_info) {}
 
     /** Gets the format of the save. */
-    [[nodiscard]] WorldSaveFormat saveFormat() const { return m_save_format; }
+    WorldSaveFormat saveFormat() const { return m_save_format; }
     /** Gets the name of the save dir (first found in multi mode). */
-    [[nodiscard]] QString saveDirName() const { return m_save_dir_name; }
+    QString saveDirName() const { return m_save_dir_name; }
 
     /** Thread-safe. */
     void setSaveFormat(WorldSaveFormat new_save_format);

--- a/launcher/minecraft/mod/tasks/LocalDataPackParseTask.h
+++ b/launcher/minecraft/mod/tasks/LocalDataPackParseTask.h
@@ -61,7 +61,7 @@ class LocalDataPackParseTask : public Task {
 
     void executeTask() override;
 
-    [[nodiscard]] int token() const { return m_token; }
+    int token() const { return m_token; }
 
    private:
     int m_token;

--- a/launcher/minecraft/mod/tasks/LocalModParseTask.h
+++ b/launcher/minecraft/mod/tasks/LocalModParseTask.h
@@ -39,13 +39,13 @@ class LocalModParseTask : public Task {
     using ResultPtr = std::shared_ptr<Result>;
     ResultPtr result() const { return m_result; }
 
-    [[nodiscard]] bool canAbort() const override { return true; }
+    bool canAbort() const override { return true; }
     bool abort() override;
 
     LocalModParseTask(int token, ResourceType type, const QFileInfo& modFile);
     void executeTask() override;
 
-    [[nodiscard]] int token() const { return m_token; }
+    int token() const { return m_token; }
 
    private:
     int m_token;

--- a/launcher/minecraft/mod/tasks/LocalShaderPackParseTask.h
+++ b/launcher/minecraft/mod/tasks/LocalShaderPackParseTask.h
@@ -46,12 +46,12 @@ class LocalShaderPackParseTask : public Task {
    public:
     LocalShaderPackParseTask(int token, ShaderPack& sp);
 
-    [[nodiscard]] bool canAbort() const override { return true; }
+    bool canAbort() const override { return true; }
     bool abort() override;
 
     void executeTask() override;
 
-    [[nodiscard]] int token() const { return m_token; }
+    int token() const { return m_token; }
 
    private:
     int m_token;

--- a/launcher/minecraft/mod/tasks/LocalTexturePackParseTask.h
+++ b/launcher/minecraft/mod/tasks/LocalTexturePackParseTask.h
@@ -50,12 +50,12 @@ class LocalTexturePackParseTask : public Task {
    public:
     LocalTexturePackParseTask(int token, TexturePack& rp);
 
-    [[nodiscard]] bool canAbort() const override { return true; }
+    bool canAbort() const override { return true; }
     bool abort() override;
 
     void executeTask() override;
 
-    [[nodiscard]] int token() const { return m_token; }
+    int token() const { return m_token; }
 
    private:
     int m_token;

--- a/launcher/minecraft/mod/tasks/LocalWorldSaveParseTask.h
+++ b/launcher/minecraft/mod/tasks/LocalWorldSaveParseTask.h
@@ -46,12 +46,12 @@ class LocalWorldSaveParseTask : public Task {
    public:
     LocalWorldSaveParseTask(int token, WorldSave& save);
 
-    [[nodiscard]] bool canAbort() const override { return true; }
+    bool canAbort() const override { return true; }
     bool abort() override;
 
     void executeTask() override;
 
-    [[nodiscard]] int token() const { return m_token; }
+    int token() const { return m_token; }
 
    private:
     int m_token;

--- a/launcher/minecraft/mod/tasks/ResourceFolderLoadTask.h
+++ b/launcher/minecraft/mod/tasks/ResourceFolderLoadTask.h
@@ -60,7 +60,7 @@ class ResourceFolderLoadTask : public Task {
                            bool clean_orphan,
                            std::function<Resource*(const QFileInfo&)> create_function);
 
-    [[nodiscard]] bool canAbort() const override { return true; }
+    bool canAbort() const override { return true; }
     bool abort() override
     {
         m_aborted.store(true);

--- a/launcher/modplatform/ModIndex.h
+++ b/launcher/modplatform/ModIndex.h
@@ -155,14 +155,14 @@ struct IndexedPack {
     ExtraPackData extraData;
 
     // For internal use, not provided by APIs
-    [[nodiscard]] bool isVersionSelected(int index) const
+    bool isVersionSelected(int index) const
     {
         if (!versionsLoaded)
             return false;
 
         return versions.at(index).is_currently_selected;
     }
-    [[nodiscard]] bool isAnyVersionSelected() const
+    bool isAnyVersionSelected() const
     {
         if (!versionsLoaded)
             return false;

--- a/launcher/modplatform/ResourceAPI.h
+++ b/launcher/modplatform/ResourceAPI.h
@@ -128,7 +128,7 @@ class ResourceAPI {
 
    public:
     /** Gets a list of available sorting methods for this API. */
-    [[nodiscard]] virtual auto getSortingMethods() const -> QList<SortingMethod> = 0;
+    virtual auto getSortingMethods() const -> QList<SortingMethod> = 0;
 
    public slots:
     [[nodiscard]] virtual Task::Ptr searchProjects(SearchArgs&&, SearchCallbacks&&) const
@@ -136,40 +136,40 @@ class ResourceAPI {
         qWarning() << "TODO: ResourceAPI::searchProjects";
         return nullptr;
     }
-    [[nodiscard]] virtual Task::Ptr getProject([[maybe_unused]] QString addonId,
+    virtual Task::Ptr getProject([[maybe_unused]] QString addonId,
                                                [[maybe_unused]] std::shared_ptr<QByteArray> response) const
     {
         qWarning() << "TODO: ResourceAPI::getProject";
         return nullptr;
     }
-    [[nodiscard]] virtual Task::Ptr getProjects([[maybe_unused]] QStringList addonIds,
+    virtual Task::Ptr getProjects([[maybe_unused]] QStringList addonIds,
                                                 [[maybe_unused]] std::shared_ptr<QByteArray> response) const
     {
         qWarning() << "TODO: ResourceAPI::getProjects";
         return nullptr;
     }
 
-    [[nodiscard]] virtual Task::Ptr getProjectInfo(ProjectInfoArgs&&, ProjectInfoCallbacks&&) const
+    virtual Task::Ptr getProjectInfo(ProjectInfoArgs&&, ProjectInfoCallbacks&&) const
     {
         qWarning() << "TODO: ResourceAPI::getProjectInfo";
         return nullptr;
     }
-    [[nodiscard]] virtual Task::Ptr getProjectVersions(VersionSearchArgs&&, VersionSearchCallbacks&&) const
+    virtual Task::Ptr getProjectVersions(VersionSearchArgs&&, VersionSearchCallbacks&&) const
     {
         qWarning() << "TODO: ResourceAPI::getProjectVersions";
         return nullptr;
     }
 
-    [[nodiscard]] virtual Task::Ptr getDependencyVersion(DependencySearchArgs&&, DependencySearchCallbacks&&) const
+    virtual Task::Ptr getDependencyVersion(DependencySearchArgs&&, DependencySearchCallbacks&&) const
     {
         qWarning() << "TODO";
         return nullptr;
     }
 
    protected:
-    [[nodiscard]] inline QString debugName() const { return "External resource API"; }
+    inline QString debugName() const { return "External resource API"; }
 
-    [[nodiscard]] inline QString mapMCVersionToModrinth(Version v) const
+    inline QString mapMCVersionToModrinth(Version v) const
     {
         static const QString preString = " Pre-Release ";
         auto verStr = v.toString();
@@ -181,7 +181,7 @@ class ResourceAPI {
         return verStr;
     }
 
-    [[nodiscard]] inline QString getGameVersionsString(std::list<Version> mcVersions) const
+    inline QString getGameVersionsString(std::list<Version> mcVersions) const
     {
         QString s;
         for (auto& ver : mcVersions) {

--- a/launcher/modplatform/flame/FlameAPI.h
+++ b/launcher/modplatform/flame/FlameAPI.h
@@ -29,7 +29,7 @@ class FlameAPI : public NetworkResourceAPI {
     static Task::Ptr getModCategories(std::shared_ptr<QByteArray> response);
     static QList<ModPlatform::Category> loadModCategories(std::shared_ptr<QByteArray> response);
 
-    [[nodiscard]] QList<ResourceAPI::SortingMethod> getSortingMethods() const override;
+    QList<ResourceAPI::SortingMethod> getSortingMethods() const override;
 
     static inline bool validateModLoaders(ModPlatform::ModLoaderTypes loaders)
     {
@@ -90,7 +90,7 @@ class FlameAPI : public NetworkResourceAPI {
     static const QString getModLoaderFilters(ModPlatform::ModLoaderTypes types) { return "[" + getModLoaderStrings(types).join(',') + "]"; }
 
    public:
-    [[nodiscard]] std::optional<QString> getSearchURL(SearchArgs const& args) const override
+    std::optional<QString> getSearchURL(SearchArgs const& args) const override
     {
         QStringList get_arguments;
         get_arguments.append(QString("classId=%1").arg(getClassId(args.type)));
@@ -116,7 +116,7 @@ class FlameAPI : public NetworkResourceAPI {
         return BuildConfig.FLAME_BASE_URL + "/mods/search?gameId=432&" + get_arguments.join('&');
     }
 
-    [[nodiscard]] std::optional<QString> getVersionsURL(VersionSearchArgs const& args) const override
+    std::optional<QString> getVersionsURL(VersionSearchArgs const& args) const override
     {
         auto addonId = args.pack.addonId.toString();
         QString url = QString(BuildConfig.FLAME_BASE_URL + "/mods/%1/files?pageSize=10000").arg(addonId);
@@ -133,11 +133,11 @@ class FlameAPI : public NetworkResourceAPI {
     }
 
    private:
-    [[nodiscard]] std::optional<QString> getInfoURL(QString const& id) const override
+    std::optional<QString> getInfoURL(QString const& id) const override
     {
         return QString(BuildConfig.FLAME_BASE_URL + "/mods/%1").arg(id);
     }
-    [[nodiscard]] std::optional<QString> getDependencyURL(DependencySearchArgs const& args) const override
+    std::optional<QString> getDependencyURL(DependencySearchArgs const& args) const override
     {
         auto addonId = args.dependency.addonId.toString();
         auto url =

--- a/launcher/modplatform/helpers/NetworkResourceAPI.h
+++ b/launcher/modplatform/helpers/NetworkResourceAPI.h
@@ -18,8 +18,8 @@ class NetworkResourceAPI : public ResourceAPI {
     Task::Ptr getDependencyVersion(DependencySearchArgs&&, DependencySearchCallbacks&&) const override;
 
    protected:
-    [[nodiscard]] virtual auto getSearchURL(SearchArgs const& args) const -> std::optional<QString> = 0;
-    [[nodiscard]] virtual auto getInfoURL(QString const& id) const -> std::optional<QString> = 0;
-    [[nodiscard]] virtual auto getVersionsURL(VersionSearchArgs const& args) const -> std::optional<QString> = 0;
-    [[nodiscard]] virtual auto getDependencyURL(DependencySearchArgs const& args) const -> std::optional<QString> = 0;
+    virtual auto getSearchURL(SearchArgs const& args) const -> std::optional<QString> = 0;
+    virtual auto getInfoURL(QString const& id) const -> std::optional<QString> = 0;
+    virtual auto getVersionsURL(VersionSearchArgs const& args) const -> std::optional<QString> = 0;
+    virtual auto getDependencyURL(DependencySearchArgs const& args) const -> std::optional<QString> = 0;
 };

--- a/launcher/modplatform/modrinth/ModrinthAPI.h
+++ b/launcher/modplatform/modrinth/ModrinthAPI.h
@@ -35,7 +35,7 @@ class ModrinthAPI : public NetworkResourceAPI {
     static QList<ModPlatform::Category> loadModCategories(std::shared_ptr<QByteArray> response);
 
    public:
-    [[nodiscard]] auto getSortingMethods() const -> QList<ResourceAPI::SortingMethod> override;
+    auto getSortingMethods() const -> QList<ResourceAPI::SortingMethod> override;
 
     inline auto getAuthorURL(const QString& name) const -> QString { return "https://modrinth.com/user/" + name; };
 
@@ -83,7 +83,7 @@ class ModrinthAPI : public NetworkResourceAPI {
         return {};
     }
 
-    [[nodiscard]] static inline QString mapMCVersionFromModrinth(QString v)
+    static inline QString mapMCVersionFromModrinth(QString v)
     {
         static const QString preString = " Pre-Release ";
         bool pre = false;
@@ -99,7 +99,7 @@ class ModrinthAPI : public NetworkResourceAPI {
     }
 
    private:
-    [[nodiscard]] static QString resourceTypeParameter(ModPlatform::ResourceType type)
+    static QString resourceTypeParameter(ModPlatform::ResourceType type)
     {
         switch (type) {
             case ModPlatform::ResourceType::MOD:
@@ -120,7 +120,7 @@ class ModrinthAPI : public NetworkResourceAPI {
         return "";
     }
 
-    [[nodiscard]] QString createFacets(SearchArgs const& args) const
+    QString createFacets(SearchArgs const& args) const
     {
         QStringList facets_list;
 
@@ -144,7 +144,7 @@ class ModrinthAPI : public NetworkResourceAPI {
     }
 
    public:
-    [[nodiscard]] inline auto getSearchURL(SearchArgs const& args) const -> std::optional<QString> override
+    inline auto getSearchURL(SearchArgs const& args) const -> std::optional<QString> override
     {
         if (args.loaders.has_value() && args.loaders.value() != 0) {
             if (!validateModLoaders(args.loaders.value())) {
@@ -203,7 +203,7 @@ class ModrinthAPI : public NetworkResourceAPI {
                           ModPlatform::DataPack);
     }
 
-    [[nodiscard]] std::optional<QString> getDependencyURL(DependencySearchArgs const& args) const override
+    std::optional<QString> getDependencyURL(DependencySearchArgs const& args) const override
     {
         return args.dependency.version.length() != 0 ? QString("%1/version/%2").arg(BuildConfig.MODRINTH_PROD_URL, args.dependency.version)
                                                      : QString("%1/project/%2/version?game_versions=[\"%3\"]&loaders=[\"%4\"]")

--- a/launcher/net/HttpMetaCache.h
+++ b/launcher/net/HttpMetaCache.h
@@ -66,7 +66,7 @@ class MetaEntry {
 
     /* Whether the entry expires after some time (false) or not (true). */
     void makeEternal(bool eternal) { m_is_eternal = eternal; }
-    [[nodiscard]] bool isEternal() const { return m_is_eternal; }
+    bool isEternal() const { return m_is_eternal; }
 
     auto getCurrentAge() -> qint64 { return m_current_age; }
     void setCurrentAge(qint64 age) { m_current_age = age; }

--- a/launcher/tasks/ConcurrentTask.h
+++ b/launcher/tasks/ConcurrentTask.h
@@ -88,7 +88,7 @@ class ConcurrentTask : public Task {
 
    protected:
     // NOTE: This is not thread-safe.
-    [[nodiscard]] unsigned int totalSize() const { return static_cast<unsigned int>(m_queue.size() + m_doing.size() + m_done.size()); }
+    unsigned int totalSize() const { return static_cast<unsigned int>(m_queue.size() + m_doing.size() + m_done.size()); }
 
     virtual void updateState();
 

--- a/launcher/ui/dialogs/ResourceDownloadDialog.h
+++ b/launcher/ui/dialogs/ResourceDownloadDialog.h
@@ -57,7 +57,7 @@ class ResourceDownloadDialog : public QDialog, public BasePageProvider {
     void connectButtons();
 
     //: String that gets appended to the download dialog title ("Download " + resourcesString())
-    [[nodiscard]] virtual QString resourcesString() const { return tr("resources"); }
+    virtual QString resourcesString() const { return tr("resources"); }
 
     QString dialogTitle() override { return tr("Download %1").arg(resourcesString()); };
 
@@ -68,7 +68,7 @@ class ResourceDownloadDialog : public QDialog, public BasePageProvider {
     void removeResource(const QString&);
 
     const QList<DownloadTaskPtr> getTasks();
-    [[nodiscard]] const std::shared_ptr<ResourceFolderModel> getBaseModel() const { return m_base_model; }
+    const std::shared_ptr<ResourceFolderModel> getBaseModel() const { return m_base_model; }
 
     void setResourceMetadata(const std::shared_ptr<Metadata::ModStruct>& meta);
 
@@ -82,10 +82,10 @@ class ResourceDownloadDialog : public QDialog, public BasePageProvider {
     virtual void confirm();
 
    protected:
-    [[nodiscard]] virtual QString geometrySaveKey() const { return ""; }
+    virtual QString geometrySaveKey() const { return ""; }
     void setButtonStatus();
 
-    [[nodiscard]] virtual GetModDependenciesTask::Ptr getModDependenciesTask() { return nullptr; }
+    virtual GetModDependenciesTask::Ptr getModDependenciesTask() { return nullptr; }
 
    protected:
     const std::shared_ptr<ResourceFolderModel> m_base_model;
@@ -104,8 +104,8 @@ class ModDownloadDialog final : public ResourceDownloadDialog {
     ~ModDownloadDialog() override = default;
 
     //: String that gets appended to the mod download dialog title ("Download " + resourcesString())
-    [[nodiscard]] QString resourcesString() const override { return tr("mods"); }
-    [[nodiscard]] QString geometrySaveKey() const override { return "ModDownloadGeometry"; }
+    QString resourcesString() const override { return tr("mods"); }
+    QString geometrySaveKey() const override { return "ModDownloadGeometry"; }
 
     QList<BasePage*> getPages() override;
     GetModDependenciesTask::Ptr getModDependenciesTask() override;
@@ -124,8 +124,8 @@ class ResourcePackDownloadDialog final : public ResourceDownloadDialog {
     ~ResourcePackDownloadDialog() override = default;
 
     //: String that gets appended to the resource pack download dialog title ("Download " + resourcesString())
-    [[nodiscard]] QString resourcesString() const override { return tr("resource packs"); }
-    [[nodiscard]] QString geometrySaveKey() const override { return "RPDownloadGeometry"; }
+    QString resourcesString() const override { return tr("resource packs"); }
+    QString geometrySaveKey() const override { return "RPDownloadGeometry"; }
 
     QList<BasePage*> getPages() override;
 
@@ -143,8 +143,8 @@ class TexturePackDownloadDialog final : public ResourceDownloadDialog {
     ~TexturePackDownloadDialog() override = default;
 
     //: String that gets appended to the texture pack download dialog title ("Download " + resourcesString())
-    [[nodiscard]] QString resourcesString() const override { return tr("texture packs"); }
-    [[nodiscard]] QString geometrySaveKey() const override { return "TPDownloadGeometry"; }
+    QString resourcesString() const override { return tr("texture packs"); }
+    QString geometrySaveKey() const override { return "TPDownloadGeometry"; }
 
     QList<BasePage*> getPages() override;
 
@@ -160,8 +160,8 @@ class ShaderPackDownloadDialog final : public ResourceDownloadDialog {
     ~ShaderPackDownloadDialog() override = default;
 
     //: String that gets appended to the shader pack download dialog title ("Download " + resourcesString())
-    [[nodiscard]] QString resourcesString() const override { return tr("shader packs"); }
-    [[nodiscard]] QString geometrySaveKey() const override { return "ShaderDownloadGeometry"; }
+    QString resourcesString() const override { return tr("shader packs"); }
+    QString geometrySaveKey() const override { return "ShaderDownloadGeometry"; }
 
     QList<BasePage*> getPages() override;
 
@@ -177,8 +177,8 @@ class DataPackDownloadDialog final : public ResourceDownloadDialog {
     ~DataPackDownloadDialog() override = default;
 
     //: String that gets appended to the data pack download dialog title ("Download " + resourcesString())
-    [[nodiscard]] QString resourcesString() const override { return tr("data packs"); }
-    [[nodiscard]] QString geometrySaveKey() const override { return "DataPackDownloadGeometry"; }
+    QString resourcesString() const override { return tr("data packs"); }
+    QString geometrySaveKey() const override { return "DataPackDownloadGeometry"; }
 
     QList<BasePage*> getPages() override;
 

--- a/launcher/ui/pages/instance/ManagedPackPage.h
+++ b/launcher/ui/pages/instance/ManagedPackPage.h
@@ -37,11 +37,11 @@ class ManagedPackPage : public QWidget, public BasePage {
     static ManagedPackPage* createPage(BaseInstance* inst, QString type, QWidget* parent = nullptr);
     ~ManagedPackPage() override;
 
-    [[nodiscard]] QString displayName() const override;
-    [[nodiscard]] QIcon icon() const override;
-    [[nodiscard]] QString helpPage() const override;
-    [[nodiscard]] QString id() const override { return "managed_pack"; }
-    [[nodiscard]] bool shouldDisplay() const override;
+    QString displayName() const override;
+    QIcon icon() const override;
+    QString helpPage() const override;
+    QString id() const override { return "managed_pack"; }
+    bool shouldDisplay() const override;
 
     void openedImpl() override;
 
@@ -55,7 +55,7 @@ class ManagedPackPage : public QWidget, public BasePage {
     /** URL of the managed pack.
      *  Not the version-specific one.
      */
-    [[nodiscard]] virtual QString url() const { return {}; };
+    virtual QString url() const { return {}; };
 
     void setInstanceWindow(InstanceWindow* window) { m_instance_window = window; }
 
@@ -109,7 +109,7 @@ class GenericManagedPackPage final : public ManagedPackPage {
     ~GenericManagedPackPage() override = default;
 
     // TODO: We may want to show this page with some useful info at some point.
-    [[nodiscard]] bool shouldDisplay() const override { return false; };
+    bool shouldDisplay() const override { return false; };
 };
 
 class ModrinthManagedPackPage final : public ManagedPackPage {
@@ -120,8 +120,8 @@ class ModrinthManagedPackPage final : public ManagedPackPage {
     ~ModrinthManagedPackPage() override = default;
 
     void parseManagedPack() override;
-    [[nodiscard]] QString url() const override;
-    [[nodiscard]] QString helpPage() const override { return "modrinth-managed-pack"; }
+    QString url() const override;
+    QString helpPage() const override { return "modrinth-managed-pack"; }
 
    public slots:
     void suggestVersion() override;
@@ -144,8 +144,8 @@ class FlameManagedPackPage final : public ManagedPackPage {
     ~FlameManagedPackPage() override = default;
 
     void parseManagedPack() override;
-    [[nodiscard]] QString url() const override;
-    [[nodiscard]] QString helpPage() const override { return "curseforge-managed-pack"; }
+    QString url() const override;
+    QString helpPage() const override { return "curseforge-managed-pack"; }
 
    public slots:
     void suggestVersion() override;

--- a/launcher/ui/pages/modplatform/DataPackPage.h
+++ b/launcher/ui/pages/modplatform/DataPackPage.h
@@ -34,13 +34,13 @@ class DataPackResourcePage : public ResourcePage {
     }
 
     //: The plural version of 'data pack'
-    [[nodiscard]] inline QString resourcesString() const override { return tr("data packs"); }
+    inline QString resourcesString() const override { return tr("data packs"); }
     //: The singular version of 'data packs'
-    [[nodiscard]] inline QString resourceString() const override { return tr("data pack"); }
+    inline QString resourceString() const override { return tr("data pack"); }
 
-    [[nodiscard]] bool supportsFiltering() const override { return false; };
+    bool supportsFiltering() const override { return false; };
 
-    [[nodiscard]] QMap<QString, QString> urlHandlers() const override;
+    QMap<QString, QString> urlHandlers() const override;
 
    protected:
     DataPackResourcePage(DataPackDownloadDialog* dialog, BaseInstance& instance);

--- a/launcher/ui/pages/modplatform/ModPage.h
+++ b/launcher/ui/pages/modplatform/ModPage.h
@@ -43,17 +43,17 @@ class ModPage : public ResourcePage {
     }
 
     //: The plural version of 'mod'
-    [[nodiscard]] inline QString resourcesString() const override { return tr("mods"); }
+    inline QString resourcesString() const override { return tr("mods"); }
     //: The singular version of 'mods'
-    [[nodiscard]] inline QString resourceString() const override { return tr("mod"); }
+    inline QString resourceString() const override { return tr("mod"); }
 
-    [[nodiscard]] QMap<QString, QString> urlHandlers() const override;
+    QMap<QString, QString> urlHandlers() const override;
 
     void addResourceToPage(ModPlatform::IndexedPack::Ptr, ModPlatform::IndexedVersion&, std::shared_ptr<ResourceFolderModel>) override;
 
     virtual std::unique_ptr<ModFilterWidget> createFilterWidget() = 0;
 
-    [[nodiscard]] bool supportsFiltering() const override { return true; };
+    bool supportsFiltering() const override { return true; };
     auto getFilter() const -> const std::shared_ptr<ModFilterWidget::Filter> { return m_filter; }
     void setFilterWidget(std::unique_ptr<ModFilterWidget>&);
 

--- a/launcher/ui/pages/modplatform/ModpackProviderBasePage.h
+++ b/launcher/ui/pages/modplatform/ModpackProviderBasePage.h
@@ -25,5 +25,5 @@ class ModpackProviderBasePage : public BasePage {
     /** Programatically set the term in the search bar. */
     virtual void setSearchTerm(QString) = 0;
     /** Get the current term in the search bar. */
-    [[nodiscard]] virtual QString getSerachTerm() const = 0;
+    virtual QString getSerachTerm() const = 0;
 };

--- a/launcher/ui/pages/modplatform/ResourceModel.h
+++ b/launcher/ui/pages/modplatform/ResourceModel.h
@@ -36,25 +36,25 @@ class ResourceModel : public QAbstractListModel {
     ResourceModel(ResourceAPI* api);
     ~ResourceModel() override;
 
-    [[nodiscard]] auto data(const QModelIndex&, int role) const -> QVariant override;
-    [[nodiscard]] auto roleNames() const -> QHash<int, QByteArray> override;
+    auto data(const QModelIndex&, int role) const -> QVariant override;
+    auto roleNames() const -> QHash<int, QByteArray> override;
     bool setData(const QModelIndex& index, const QVariant& value, int role) override;
 
-    [[nodiscard]] virtual auto debugName() const -> QString;
-    [[nodiscard]] virtual auto metaEntryBase() const -> QString = 0;
+    virtual auto debugName() const -> QString;
+    virtual auto metaEntryBase() const -> QString = 0;
 
-    [[nodiscard]] inline int rowCount(const QModelIndex& parent) const override
+    inline int rowCount(const QModelIndex& parent) const override
     {
         return parent.isValid() ? 0 : static_cast<int>(m_packs.size());
     }
-    [[nodiscard]] inline int columnCount(const QModelIndex& parent) const override { return parent.isValid() ? 0 : 1; }
-    [[nodiscard]] inline auto flags(const QModelIndex& index) const -> Qt::ItemFlags override { return QAbstractListModel::flags(index); }
+    inline int columnCount(const QModelIndex& parent) const override { return parent.isValid() ? 0 : 1; }
+    inline auto flags(const QModelIndex& index) const -> Qt::ItemFlags override { return QAbstractListModel::flags(index); }
 
-    [[nodiscard]] bool hasActiveSearchJob() const { return m_current_search_job && m_current_search_job->isRunning(); }
-    [[nodiscard]] bool hasActiveInfoJob() const { return m_current_info_job.isRunning(); }
-    [[nodiscard]] Task::Ptr activeSearchJob() { return hasActiveSearchJob() ? m_current_search_job : nullptr; }
+    bool hasActiveSearchJob() const { return m_current_search_job && m_current_search_job->isRunning(); }
+    bool hasActiveInfoJob() const { return m_current_info_job.isRunning(); }
+    Task::Ptr activeSearchJob() { return hasActiveSearchJob() ? m_current_search_job : nullptr; }
 
-    [[nodiscard]] auto getSortingMethods() const { return m_api->getSortingMethods(); }
+    auto getSortingMethods() const { return m_api->getSortingMethods(); }
 
     virtual QVariant getInstalledPackVersion(ModPlatform::IndexedPack::Ptr) const { return {}; }
     /** Whether the version is opted out or not. Currently only makes sense in CF. */
@@ -69,7 +69,6 @@ class ResourceModel : public QAbstractListModel {
 
    public slots:
     void fetchMore(const QModelIndex& parent) override;
-    // NOTE: Can't use [[nodiscard]] here because of https://bugreports.qt.io/browse/QTBUG-58628 on Qt 5.12
     inline bool canFetchMore(const QModelIndex& parent) const override
     {
         return parent.isValid() ? false : m_search_state == SearchState::CanFetchMore;
@@ -113,14 +112,14 @@ class ResourceModel : public QAbstractListModel {
     void runSearchJob(Task::Ptr);
     void runInfoJob(Task::Ptr);
 
-    [[nodiscard]] auto getCurrentSortingMethodByIndex() const -> std::optional<ResourceAPI::SortingMethod>;
+    auto getCurrentSortingMethodByIndex() const -> std::optional<ResourceAPI::SortingMethod>;
 
     /** Converts a JSON document to a common array format.
      *
      *  This is needed so that different providers, with different JSON structures, can be parsed
      *  uniformally. You NEED to re-implement this if you intend on using the default callbacks.
      */
-    [[nodiscard]] virtual auto documentToArray(QJsonDocument&) const -> QJsonArray;
+    virtual auto documentToArray(QJsonDocument&) const -> QJsonArray;
 
     /** Functions to load data into a pack.
      *

--- a/launcher/ui/pages/modplatform/ResourcePackPage.h
+++ b/launcher/ui/pages/modplatform/ResourcePackPage.h
@@ -33,15 +33,15 @@ class ResourcePackResourcePage : public ResourcePage {
     }
 
     //: The plural version of 'resource pack'
-    [[nodiscard]] inline QString resourcesString() const override { return tr("resource packs"); }
+    inline QString resourcesString() const override { return tr("resource packs"); }
     //: The singular version of 'resource packs'
-    [[nodiscard]] inline QString resourceString() const override { return tr("resource pack"); }
+    inline QString resourceString() const override { return tr("resource pack"); }
 
-    [[nodiscard]] bool supportsFiltering() const override { return false; };
+    bool supportsFiltering() const override { return false; };
 
-    [[nodiscard]] QMap<QString, QString> urlHandlers() const override;
+    QMap<QString, QString> urlHandlers() const override;
 
-    [[nodiscard]] inline auto helpPage() const -> QString override { return "resourcepack-platform"; }
+    inline auto helpPage() const -> QString override { return "resourcepack-platform"; }
 
    protected:
     ResourcePackResourcePage(ResourceDownloadDialog* dialog, BaseInstance& instance);

--- a/launcher/ui/pages/modplatform/ResourcePage.h
+++ b/launcher/ui/pages/modplatform/ResourcePage.h
@@ -33,37 +33,37 @@ class ResourcePage : public QWidget, public BasePage {
     ~ResourcePage() override;
 
     /* Affects what the user sees */
-    [[nodiscard]] auto displayName() const -> QString override = 0;
-    [[nodiscard]] auto icon() const -> QIcon override = 0;
-    [[nodiscard]] auto id() const -> QString override = 0;
-    [[nodiscard]] auto helpPage() const -> QString override = 0;
-    [[nodiscard]] bool shouldDisplay() const override = 0;
+    auto displayName() const -> QString override = 0;
+    auto icon() const -> QIcon override = 0;
+    auto id() const -> QString override = 0;
+    auto helpPage() const -> QString override = 0;
+    bool shouldDisplay() const override = 0;
 
     /* Used internally */
-    [[nodiscard]] virtual auto metaEntryBase() const -> QString = 0;
-    [[nodiscard]] virtual auto debugName() const -> QString = 0;
+    virtual auto metaEntryBase() const -> QString = 0;
+    virtual auto debugName() const -> QString = 0;
 
     //: The plural version of 'resource'
-    [[nodiscard]] virtual inline QString resourcesString() const { return tr("resources"); }
+    virtual inline QString resourcesString() const { return tr("resources"); }
     //: The singular version of 'resources'
-    [[nodiscard]] virtual inline QString resourceString() const { return tr("resource"); }
+    virtual inline QString resourceString() const { return tr("resource"); }
 
     /* Features this resource's page supports */
-    [[nodiscard]] virtual bool supportsFiltering() const = 0;
+    virtual bool supportsFiltering() const = 0;
 
     void retranslate() override;
     void openedImpl() override;
     auto eventFilter(QObject* watched, QEvent* event) -> bool override;
 
     /** Get the current term in the search bar. */
-    [[nodiscard]] auto getSearchTerm() const -> QString;
+    auto getSearchTerm() const -> QString;
     /** Programatically set the term in the search bar. */
     void setSearchTerm(QString);
 
-    [[nodiscard]] bool setCurrentPack(ModPlatform::IndexedPack::Ptr);
-    [[nodiscard]] auto getCurrentPack() const -> ModPlatform::IndexedPack::Ptr;
-    [[nodiscard]] auto getDialog() const -> const ResourceDownloadDialog* { return m_parentDialog; }
-    [[nodiscard]] auto getModel() const -> ResourceModel* { return m_model; }
+    bool setCurrentPack(ModPlatform::IndexedPack::Ptr);
+    auto getCurrentPack() const -> ModPlatform::IndexedPack::Ptr;
+    auto getDialog() const -> const ResourceDownloadDialog* { return m_parentDialog; }
+    auto getModel() const -> ResourceModel* { return m_model; }
 
    protected:
     ResourcePage(ResourceDownloadDialog* parent, BaseInstance&);
@@ -94,8 +94,6 @@ class ResourcePage : public QWidget, public BasePage {
     void onVersionSelectionChanged(int index);
     void onResourceSelected();
     void onResourceToggle(const QModelIndex& index);
-
-    // NOTE: Can't use [[nodiscard]] here because of https://bugreports.qt.io/browse/QTBUG-58628 on Qt 5.12
 
     /** Associates regex expressions to pages in the order they're given in the map. */
     virtual QMap<QString, QString> urlHandlers() const = 0;

--- a/launcher/ui/pages/modplatform/ShaderPackPage.h
+++ b/launcher/ui/pages/modplatform/ShaderPackPage.h
@@ -33,17 +33,17 @@ class ShaderPackResourcePage : public ResourcePage {
     }
 
     //: The plural version of 'shader pack'
-    [[nodiscard]] inline QString resourcesString() const override { return tr("shader packs"); }
+    inline QString resourcesString() const override { return tr("shader packs"); }
     //: The singular version of 'shader packs'
-    [[nodiscard]] inline QString resourceString() const override { return tr("shader pack"); }
+    inline QString resourceString() const override { return tr("shader pack"); }
 
-    [[nodiscard]] bool supportsFiltering() const override { return false; };
+    bool supportsFiltering() const override { return false; };
 
     void addResourceToPage(ModPlatform::IndexedPack::Ptr, ModPlatform::IndexedVersion&, std::shared_ptr<ResourceFolderModel>) override;
 
-    [[nodiscard]] QMap<QString, QString> urlHandlers() const override;
+    QMap<QString, QString> urlHandlers() const override;
 
-    [[nodiscard]] inline auto helpPage() const -> QString override { return "shaderpack-platform"; }
+    inline auto helpPage() const -> QString override { return "shaderpack-platform"; }
 
    protected:
     ShaderPackResourcePage(ShaderPackDownloadDialog* dialog, BaseInstance& instance);

--- a/launcher/ui/pages/modplatform/TexturePackModel.h
+++ b/launcher/ui/pages/modplatform/TexturePackModel.h
@@ -15,7 +15,7 @@ class TexturePackResourceModel : public ResourcePackResourceModel {
    public:
     TexturePackResourceModel(BaseInstance const& inst, ResourceAPI* api);
 
-    [[nodiscard]] inline ::Version maximumTexturePackVersion() const { return { "1.6" }; }
+    inline ::Version maximumTexturePackVersion() const { return { "1.6" }; }
 
     ResourceAPI::SearchArgs createSearchArguments() override;
     ResourceAPI::VersionSearchArgs createVersionsArguments(const QModelIndex&) override;

--- a/launcher/ui/pages/modplatform/TexturePackPage.h
+++ b/launcher/ui/pages/modplatform/TexturePackPage.h
@@ -35,9 +35,9 @@ class TexturePackResourcePage : public ResourcePackResourcePage {
     }
 
     //: The plural version of 'texture pack'
-    [[nodiscard]] inline QString resourcesString() const override { return tr("texture packs"); }
+    inline QString resourcesString() const override { return tr("texture packs"); }
     //: The singular version of 'texture packs'
-    [[nodiscard]] inline QString resourceString() const override { return tr("texture pack"); }
+    inline QString resourceString() const override { return tr("texture pack"); }
 
    protected:
     TexturePackResourcePage(TexturePackDownloadDialog* dialog, BaseInstance& instance) : ResourcePackResourcePage(dialog, instance) {}

--- a/launcher/ui/pages/modplatform/atlauncher/AtlPage.h
+++ b/launcher/ui/pages/modplatform/atlauncher/AtlPage.h
@@ -68,7 +68,7 @@ class AtlPage : public QWidget, public ModpackProviderBasePage {
     /** Programatically set the term in the search bar. */
     virtual void setSearchTerm(QString) override;
     /** Get the current term in the search bar. */
-    [[nodiscard]] virtual QString getSerachTerm() const override;
+    virtual QString getSerachTerm() const override;
 
    private:
     void suggestCurrent();

--- a/launcher/ui/pages/modplatform/flame/FlameModel.h
+++ b/launcher/ui/pages/modplatform/flame/FlameModel.h
@@ -41,8 +41,8 @@ class ListModel : public QAbstractListModel {
     void getLogo(const QString& logo, const QString& logoUrl, LogoCallback callback);
     void searchWithTerm(const QString& term, int sort, std::shared_ptr<ModFilterWidget::Filter> filter, bool filterChanged);
 
-    [[nodiscard]] bool hasActiveSearchJob() const { return jobPtr && jobPtr->isRunning(); }
-    [[nodiscard]] Task::Ptr activeSearchJob() { return hasActiveSearchJob() ? jobPtr : nullptr; }
+    bool hasActiveSearchJob() const { return jobPtr && jobPtr->isRunning(); }
+    Task::Ptr activeSearchJob() { return hasActiveSearchJob() ? jobPtr : nullptr; }
 
    private slots:
     void performPaginatedSearch();

--- a/launcher/ui/pages/modplatform/flame/FlamePage.h
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.h
@@ -76,7 +76,7 @@ class FlamePage : public QWidget, public ModpackProviderBasePage {
     /** Programatically set the term in the search bar. */
     virtual void setSearchTerm(QString) override;
     /** Get the current term in the search bar. */
-    [[nodiscard]] virtual QString getSerachTerm() const override;
+    virtual QString getSerachTerm() const override;
 
    private:
     void suggestCurrent();

--- a/launcher/ui/pages/modplatform/flame/FlameResourceModels.h
+++ b/launcher/ui/pages/modplatform/flame/FlameResourceModels.h
@@ -20,8 +20,8 @@ class FlameModModel : public ModModel {
     bool optedOut(const ModPlatform::IndexedVersion& ver) const override;
 
    private:
-    [[nodiscard]] QString debugName() const override { return Flame::debugName() + " (Model)"; }
-    [[nodiscard]] QString metaEntryBase() const override { return Flame::metaEntryBase(); }
+    QString debugName() const override { return Flame::debugName() + " (Model)"; }
+    QString metaEntryBase() const override { return Flame::metaEntryBase(); }
 
     void loadIndexedPack(ModPlatform::IndexedPack& m, QJsonObject& obj) override;
     void loadExtraPackInfo(ModPlatform::IndexedPack& m, QJsonObject& obj) override;
@@ -41,8 +41,8 @@ class FlameResourcePackModel : public ResourcePackResourceModel {
     bool optedOut(const ModPlatform::IndexedVersion& ver) const override;
 
    private:
-    [[nodiscard]] QString debugName() const override { return Flame::debugName() + " (Model)"; }
-    [[nodiscard]] QString metaEntryBase() const override { return Flame::metaEntryBase(); }
+    QString debugName() const override { return Flame::debugName() + " (Model)"; }
+    QString metaEntryBase() const override { return Flame::metaEntryBase(); }
 
     void loadIndexedPack(ModPlatform::IndexedPack& m, QJsonObject& obj) override;
     void loadExtraPackInfo(ModPlatform::IndexedPack& m, QJsonObject& obj) override;
@@ -61,8 +61,8 @@ class FlameTexturePackModel : public TexturePackResourceModel {
     bool optedOut(const ModPlatform::IndexedVersion& ver) const override;
 
    private:
-    [[nodiscard]] QString debugName() const override { return Flame::debugName() + " (Model)"; }
-    [[nodiscard]] QString metaEntryBase() const override { return Flame::metaEntryBase(); }
+    QString debugName() const override { return Flame::debugName() + " (Model)"; }
+    QString metaEntryBase() const override { return Flame::metaEntryBase(); }
 
     void loadIndexedPack(ModPlatform::IndexedPack& m, QJsonObject& obj) override;
     void loadExtraPackInfo(ModPlatform::IndexedPack& m, QJsonObject& obj) override;
@@ -84,8 +84,8 @@ class FlameShaderPackModel : public ShaderPackResourceModel {
     bool optedOut(const ModPlatform::IndexedVersion& ver) const override;
 
    private:
-    [[nodiscard]] QString debugName() const override { return Flame::debugName() + " (Model)"; }
-    [[nodiscard]] QString metaEntryBase() const override { return Flame::metaEntryBase(); }
+    QString debugName() const override { return Flame::debugName() + " (Model)"; }
+    QString metaEntryBase() const override { return Flame::metaEntryBase(); }
 
     void loadIndexedPack(ModPlatform::IndexedPack& m, QJsonObject& obj) override;
     void loadExtraPackInfo(ModPlatform::IndexedPack& m, QJsonObject& obj) override;
@@ -103,8 +103,8 @@ class FlameDataPackModel : public DataPackResourceModel {
     bool optedOut(const ModPlatform::IndexedVersion& ver) const override;
 
    private:
-    [[nodiscard]] QString debugName() const override { return Flame::debugName() + " (Model)"; }
-    [[nodiscard]] QString metaEntryBase() const override { return Flame::metaEntryBase(); }
+    QString debugName() const override { return Flame::debugName() + " (Model)"; }
+    QString metaEntryBase() const override { return Flame::metaEntryBase(); }
 
     void loadIndexedPack(ModPlatform::IndexedPack& m, QJsonObject& obj) override;
     void loadExtraPackInfo(ModPlatform::IndexedPack& m, QJsonObject& obj) override;

--- a/launcher/ui/pages/modplatform/flame/FlameResourcePages.h
+++ b/launcher/ui/pages/modplatform/flame/FlameResourcePages.h
@@ -86,15 +86,15 @@ class FlameModPage : public ModPage {
     FlameModPage(ModDownloadDialog* dialog, BaseInstance& instance);
     ~FlameModPage() override = default;
 
-    [[nodiscard]] bool shouldDisplay() const override;
+    bool shouldDisplay() const override;
 
-    [[nodiscard]] inline auto displayName() const -> QString override { return Flame::displayName(); }
-    [[nodiscard]] inline auto icon() const -> QIcon override { return Flame::icon(); }
-    [[nodiscard]] inline auto id() const -> QString override { return Flame::id(); }
-    [[nodiscard]] inline auto debugName() const -> QString override { return Flame::debugName(); }
-    [[nodiscard]] inline auto metaEntryBase() const -> QString override { return Flame::metaEntryBase(); }
+    inline auto displayName() const -> QString override { return Flame::displayName(); }
+    inline auto icon() const -> QIcon override { return Flame::icon(); }
+    inline auto id() const -> QString override { return Flame::id(); }
+    inline auto debugName() const -> QString override { return Flame::debugName(); }
+    inline auto metaEntryBase() const -> QString override { return Flame::metaEntryBase(); }
 
-    [[nodiscard]] inline auto helpPage() const -> QString override { return "Mod-platform"; }
+    inline auto helpPage() const -> QString override { return "Mod-platform"; }
 
     void openUrl(const QUrl& url) override;
     std::unique_ptr<ModFilterWidget> createFilterWidget() override;
@@ -118,15 +118,15 @@ class FlameResourcePackPage : public ResourcePackResourcePage {
     FlameResourcePackPage(ResourcePackDownloadDialog* dialog, BaseInstance& instance);
     ~FlameResourcePackPage() override = default;
 
-    [[nodiscard]] bool shouldDisplay() const override;
+    bool shouldDisplay() const override;
 
-    [[nodiscard]] inline auto displayName() const -> QString override { return Flame::displayName(); }
-    [[nodiscard]] inline auto icon() const -> QIcon override { return Flame::icon(); }
-    [[nodiscard]] inline auto id() const -> QString override { return Flame::id(); }
-    [[nodiscard]] inline auto debugName() const -> QString override { return Flame::debugName(); }
-    [[nodiscard]] inline auto metaEntryBase() const -> QString override { return Flame::metaEntryBase(); }
+    inline auto displayName() const -> QString override { return Flame::displayName(); }
+    inline auto icon() const -> QIcon override { return Flame::icon(); }
+    inline auto id() const -> QString override { return Flame::id(); }
+    inline auto debugName() const -> QString override { return Flame::debugName(); }
+    inline auto metaEntryBase() const -> QString override { return Flame::metaEntryBase(); }
 
-    [[nodiscard]] inline auto helpPage() const -> QString override { return ""; }
+    inline auto helpPage() const -> QString override { return ""; }
 
     void openUrl(const QUrl& url) override;
 };
@@ -143,15 +143,15 @@ class FlameTexturePackPage : public TexturePackResourcePage {
     FlameTexturePackPage(TexturePackDownloadDialog* dialog, BaseInstance& instance);
     ~FlameTexturePackPage() override = default;
 
-    [[nodiscard]] bool shouldDisplay() const override;
+    bool shouldDisplay() const override;
 
-    [[nodiscard]] inline auto displayName() const -> QString override { return Flame::displayName(); }
-    [[nodiscard]] inline auto icon() const -> QIcon override { return Flame::icon(); }
-    [[nodiscard]] inline auto id() const -> QString override { return Flame::id(); }
-    [[nodiscard]] inline auto debugName() const -> QString override { return Flame::debugName(); }
-    [[nodiscard]] inline auto metaEntryBase() const -> QString override { return Flame::metaEntryBase(); }
+    inline auto displayName() const -> QString override { return Flame::displayName(); }
+    inline auto icon() const -> QIcon override { return Flame::icon(); }
+    inline auto id() const -> QString override { return Flame::id(); }
+    inline auto debugName() const -> QString override { return Flame::debugName(); }
+    inline auto metaEntryBase() const -> QString override { return Flame::metaEntryBase(); }
 
-    [[nodiscard]] inline auto helpPage() const -> QString override { return ""; }
+    inline auto helpPage() const -> QString override { return ""; }
 
     void openUrl(const QUrl& url) override;
 };
@@ -168,15 +168,15 @@ class FlameShaderPackPage : public ShaderPackResourcePage {
     FlameShaderPackPage(ShaderPackDownloadDialog* dialog, BaseInstance& instance);
     ~FlameShaderPackPage() override = default;
 
-    [[nodiscard]] bool shouldDisplay() const override;
+    bool shouldDisplay() const override;
 
-    [[nodiscard]] inline auto displayName() const -> QString override { return Flame::displayName(); }
-    [[nodiscard]] inline auto icon() const -> QIcon override { return Flame::icon(); }
-    [[nodiscard]] inline auto id() const -> QString override { return Flame::id(); }
-    [[nodiscard]] inline auto debugName() const -> QString override { return Flame::debugName(); }
-    [[nodiscard]] inline auto metaEntryBase() const -> QString override { return Flame::metaEntryBase(); }
+    inline auto displayName() const -> QString override { return Flame::displayName(); }
+    inline auto icon() const -> QIcon override { return Flame::icon(); }
+    inline auto id() const -> QString override { return Flame::id(); }
+    inline auto debugName() const -> QString override { return Flame::debugName(); }
+    inline auto metaEntryBase() const -> QString override { return Flame::metaEntryBase(); }
 
-    [[nodiscard]] inline auto helpPage() const -> QString override { return ""; }
+    inline auto helpPage() const -> QString override { return ""; }
 
     void openUrl(const QUrl& url) override;
 };
@@ -195,15 +195,15 @@ class FlameDataPackPage : public DataPackResourcePage {
     FlameDataPackPage(DataPackDownloadDialog* dialog, BaseInstance& instance);
     ~FlameDataPackPage() override = default;
 
-    [[nodiscard]] bool shouldDisplay() const override;
+    bool shouldDisplay() const override;
 
-    [[nodiscard]] inline auto displayName() const -> QString override { return Flame::displayName(); }
-    [[nodiscard]] inline auto icon() const -> QIcon override { return Flame::icon(); }
-    [[nodiscard]] inline auto id() const -> QString override { return Flame::id(); }
-    [[nodiscard]] inline auto debugName() const -> QString override { return Flame::debugName(); }
-    [[nodiscard]] inline auto metaEntryBase() const -> QString override { return Flame::metaEntryBase(); }
+    inline auto displayName() const -> QString override { return Flame::displayName(); }
+    inline auto icon() const -> QIcon override { return Flame::icon(); }
+    inline auto id() const -> QString override { return Flame::id(); }
+    inline auto debugName() const -> QString override { return Flame::debugName(); }
+    inline auto metaEntryBase() const -> QString override { return Flame::metaEntryBase(); }
 
-    [[nodiscard]] inline auto helpPage() const -> QString override { return ""; }
+    inline auto helpPage() const -> QString override { return ""; }
 
     void openUrl(const QUrl& url) override;
 };

--- a/launcher/ui/pages/modplatform/import_ftb/ImportFTBPage.h
+++ b/launcher/ui/pages/modplatform/import_ftb/ImportFTBPage.h
@@ -52,7 +52,7 @@ class ImportFTBPage : public QWidget, public ModpackProviderBasePage {
     /** Programatically set the term in the search bar. */
     virtual void setSearchTerm(QString) override;
     /** Get the current term in the search bar. */
-    [[nodiscard]] virtual QString getSerachTerm() const override;
+    virtual QString getSerachTerm() const override;
 
    private:
     void suggestCurrent();

--- a/launcher/ui/pages/modplatform/legacy_ftb/Page.h
+++ b/launcher/ui/pages/modplatform/legacy_ftb/Page.h
@@ -74,7 +74,7 @@ class Page : public QWidget, public ModpackProviderBasePage {
     /** Programatically set the term in the search bar. */
     virtual void setSearchTerm(QString) override;
     /** Get the current term in the search bar. */
-    [[nodiscard]] virtual QString getSerachTerm() const override;
+    virtual QString getSerachTerm() const override;
 
    private:
     void suggestCurrent();

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModel.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModel.h
@@ -73,8 +73,8 @@ class ModpackListModel : public QAbstractListModel {
     void refresh();
     void searchWithTerm(const QString& term, int sort, std::shared_ptr<ModFilterWidget::Filter> filter, bool filterChanged);
 
-    [[nodiscard]] bool hasActiveSearchJob() const { return jobPtr && jobPtr->isRunning(); }
-    [[nodiscard]] Task::Ptr activeSearchJob() { return hasActiveSearchJob() ? jobPtr : nullptr; }
+    bool hasActiveSearchJob() const { return jobPtr && jobPtr->isRunning(); }
+    Task::Ptr activeSearchJob() { return hasActiveSearchJob() ? jobPtr : nullptr; }
 
     void getLogo(const QString& logo, const QString& logoUrl, LogoCallback callback);
 

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.h
@@ -82,7 +82,7 @@ class ModrinthPage : public QWidget, public ModpackProviderBasePage {
     /** Programatically set the term in the search bar. */
     virtual void setSearchTerm(QString) override;
     /** Get the current term in the search bar. */
-    [[nodiscard]] virtual QString getSerachTerm() const override;
+    virtual QString getSerachTerm() const override;
 
    private slots:
     void onSelectionChanged(QModelIndex first, QModelIndex second);

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthResourceModels.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthResourceModels.h
@@ -35,8 +35,8 @@ class ModrinthModModel : public ModModel {
     ~ModrinthModModel() override = default;
 
    private:
-    [[nodiscard]] QString debugName() const override { return Modrinth::debugName() + " (Model)"; }
-    [[nodiscard]] QString metaEntryBase() const override { return Modrinth::metaEntryBase(); }
+    QString debugName() const override { return Modrinth::debugName() + " (Model)"; }
+    QString metaEntryBase() const override { return Modrinth::metaEntryBase(); }
 
     void loadIndexedPack(ModPlatform::IndexedPack& m, QJsonObject& obj) override;
     void loadExtraPackInfo(ModPlatform::IndexedPack& m, QJsonObject& obj) override;
@@ -54,8 +54,8 @@ class ModrinthResourcePackModel : public ResourcePackResourceModel {
     ~ModrinthResourcePackModel() override = default;
 
    private:
-    [[nodiscard]] QString debugName() const override { return Modrinth::debugName() + " (Model)"; }
-    [[nodiscard]] QString metaEntryBase() const override { return Modrinth::metaEntryBase(); }
+    QString debugName() const override { return Modrinth::debugName() + " (Model)"; }
+    QString metaEntryBase() const override { return Modrinth::metaEntryBase(); }
 
     void loadIndexedPack(ModPlatform::IndexedPack& m, QJsonObject& obj) override;
     void loadExtraPackInfo(ModPlatform::IndexedPack& m, QJsonObject& obj) override;
@@ -72,8 +72,8 @@ class ModrinthTexturePackModel : public TexturePackResourceModel {
     ~ModrinthTexturePackModel() override = default;
 
    private:
-    [[nodiscard]] QString debugName() const override { return Modrinth::debugName() + " (Model)"; }
-    [[nodiscard]] QString metaEntryBase() const override { return Modrinth::metaEntryBase(); }
+    QString debugName() const override { return Modrinth::debugName() + " (Model)"; }
+    QString metaEntryBase() const override { return Modrinth::metaEntryBase(); }
 
     void loadIndexedPack(ModPlatform::IndexedPack& m, QJsonObject& obj) override;
     void loadExtraPackInfo(ModPlatform::IndexedPack& m, QJsonObject& obj) override;
@@ -90,8 +90,8 @@ class ModrinthShaderPackModel : public ShaderPackResourceModel {
     ~ModrinthShaderPackModel() override = default;
 
    private:
-    [[nodiscard]] QString debugName() const override { return Modrinth::debugName() + " (Model)"; }
-    [[nodiscard]] QString metaEntryBase() const override { return Modrinth::metaEntryBase(); }
+    QString debugName() const override { return Modrinth::debugName() + " (Model)"; }
+    QString metaEntryBase() const override { return Modrinth::metaEntryBase(); }
 
     void loadIndexedPack(ModPlatform::IndexedPack& m, QJsonObject& obj) override;
     void loadExtraPackInfo(ModPlatform::IndexedPack& m, QJsonObject& obj) override;
@@ -108,8 +108,8 @@ class ModrinthDataPackModel : public DataPackResourceModel {
     ~ModrinthDataPackModel() override = default;
 
    private:
-    [[nodiscard]] QString debugName() const override { return Modrinth::debugName() + " (Model)"; }
-    [[nodiscard]] QString metaEntryBase() const override { return Modrinth::metaEntryBase(); }
+    QString debugName() const override { return Modrinth::debugName() + " (Model)"; }
+    QString metaEntryBase() const override { return Modrinth::metaEntryBase(); }
 
     void loadIndexedPack(ModPlatform::IndexedPack& m, QJsonObject& obj) override;
     void loadExtraPackInfo(ModPlatform::IndexedPack& m, QJsonObject& obj) override;

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.h
@@ -85,15 +85,15 @@ class ModrinthModPage : public ModPage {
     ModrinthModPage(ModDownloadDialog* dialog, BaseInstance& instance);
     ~ModrinthModPage() override = default;
 
-    [[nodiscard]] bool shouldDisplay() const override;
+    bool shouldDisplay() const override;
 
-    [[nodiscard]] inline auto displayName() const -> QString override { return Modrinth::displayName(); }
-    [[nodiscard]] inline auto icon() const -> QIcon override { return Modrinth::icon(); }
-    [[nodiscard]] inline auto id() const -> QString override { return Modrinth::id(); }
-    [[nodiscard]] inline auto debugName() const -> QString override { return Modrinth::debugName(); }
-    [[nodiscard]] inline auto metaEntryBase() const -> QString override { return Modrinth::metaEntryBase(); }
+    inline auto displayName() const -> QString override { return Modrinth::displayName(); }
+    inline auto icon() const -> QIcon override { return Modrinth::icon(); }
+    inline auto id() const -> QString override { return Modrinth::id(); }
+    inline auto debugName() const -> QString override { return Modrinth::debugName(); }
+    inline auto metaEntryBase() const -> QString override { return Modrinth::metaEntryBase(); }
 
-    [[nodiscard]] inline auto helpPage() const -> QString override { return "Mod-platform"; }
+    inline auto helpPage() const -> QString override { return "Mod-platform"; }
 
     std::unique_ptr<ModFilterWidget> createFilterWidget() override;
 
@@ -114,15 +114,15 @@ class ModrinthResourcePackPage : public ResourcePackResourcePage {
     ModrinthResourcePackPage(ResourcePackDownloadDialog* dialog, BaseInstance& instance);
     ~ModrinthResourcePackPage() override = default;
 
-    [[nodiscard]] bool shouldDisplay() const override;
+    bool shouldDisplay() const override;
 
-    [[nodiscard]] inline auto displayName() const -> QString override { return Modrinth::displayName(); }
-    [[nodiscard]] inline auto icon() const -> QIcon override { return Modrinth::icon(); }
-    [[nodiscard]] inline auto id() const -> QString override { return Modrinth::id(); }
-    [[nodiscard]] inline auto debugName() const -> QString override { return Modrinth::debugName(); }
-    [[nodiscard]] inline auto metaEntryBase() const -> QString override { return Modrinth::metaEntryBase(); }
+    inline auto displayName() const -> QString override { return Modrinth::displayName(); }
+    inline auto icon() const -> QIcon override { return Modrinth::icon(); }
+    inline auto id() const -> QString override { return Modrinth::id(); }
+    inline auto debugName() const -> QString override { return Modrinth::debugName(); }
+    inline auto metaEntryBase() const -> QString override { return Modrinth::metaEntryBase(); }
 
-    [[nodiscard]] inline auto helpPage() const -> QString override { return ""; }
+    inline auto helpPage() const -> QString override { return ""; }
 };
 
 class ModrinthTexturePackPage : public TexturePackResourcePage {
@@ -137,15 +137,15 @@ class ModrinthTexturePackPage : public TexturePackResourcePage {
     ModrinthTexturePackPage(TexturePackDownloadDialog* dialog, BaseInstance& instance);
     ~ModrinthTexturePackPage() override = default;
 
-    [[nodiscard]] bool shouldDisplay() const override;
+    bool shouldDisplay() const override;
 
-    [[nodiscard]] inline auto displayName() const -> QString override { return Modrinth::displayName(); }
-    [[nodiscard]] inline auto icon() const -> QIcon override { return Modrinth::icon(); }
-    [[nodiscard]] inline auto id() const -> QString override { return Modrinth::id(); }
-    [[nodiscard]] inline auto debugName() const -> QString override { return Modrinth::debugName(); }
-    [[nodiscard]] inline auto metaEntryBase() const -> QString override { return Modrinth::metaEntryBase(); }
+    inline auto displayName() const -> QString override { return Modrinth::displayName(); }
+    inline auto icon() const -> QIcon override { return Modrinth::icon(); }
+    inline auto id() const -> QString override { return Modrinth::id(); }
+    inline auto debugName() const -> QString override { return Modrinth::debugName(); }
+    inline auto metaEntryBase() const -> QString override { return Modrinth::metaEntryBase(); }
 
-    [[nodiscard]] inline auto helpPage() const -> QString override { return ""; }
+    inline auto helpPage() const -> QString override { return ""; }
 };
 
 class ModrinthShaderPackPage : public ShaderPackResourcePage {
@@ -160,15 +160,15 @@ class ModrinthShaderPackPage : public ShaderPackResourcePage {
     ModrinthShaderPackPage(ShaderPackDownloadDialog* dialog, BaseInstance& instance);
     ~ModrinthShaderPackPage() override = default;
 
-    [[nodiscard]] bool shouldDisplay() const override;
+    bool shouldDisplay() const override;
 
-    [[nodiscard]] inline auto displayName() const -> QString override { return Modrinth::displayName(); }
-    [[nodiscard]] inline auto icon() const -> QIcon override { return Modrinth::icon(); }
-    [[nodiscard]] inline auto id() const -> QString override { return Modrinth::id(); }
-    [[nodiscard]] inline auto debugName() const -> QString override { return Modrinth::debugName(); }
-    [[nodiscard]] inline auto metaEntryBase() const -> QString override { return Modrinth::metaEntryBase(); }
+    inline auto displayName() const -> QString override { return Modrinth::displayName(); }
+    inline auto icon() const -> QIcon override { return Modrinth::icon(); }
+    inline auto id() const -> QString override { return Modrinth::id(); }
+    inline auto debugName() const -> QString override { return Modrinth::debugName(); }
+    inline auto metaEntryBase() const -> QString override { return Modrinth::metaEntryBase(); }
 
-    [[nodiscard]] inline auto helpPage() const -> QString override { return ""; }
+    inline auto helpPage() const -> QString override { return ""; }
 };
 
 class ModrinthDataPackPage : public DataPackResourcePage {
@@ -183,15 +183,15 @@ class ModrinthDataPackPage : public DataPackResourcePage {
     ModrinthDataPackPage(DataPackDownloadDialog* dialog, BaseInstance& instance);
     ~ModrinthDataPackPage() override = default;
 
-    [[nodiscard]] bool shouldDisplay() const override;
+    bool shouldDisplay() const override;
 
-    [[nodiscard]] inline auto displayName() const -> QString override { return Modrinth::displayName(); }
-    [[nodiscard]] inline auto icon() const -> QIcon override { return Modrinth::icon(); }
-    [[nodiscard]] inline auto id() const -> QString override { return Modrinth::id(); }
-    [[nodiscard]] inline auto debugName() const -> QString override { return Modrinth::debugName(); }
-    [[nodiscard]] inline auto metaEntryBase() const -> QString override { return Modrinth::metaEntryBase(); }
+    inline auto displayName() const -> QString override { return Modrinth::displayName(); }
+    inline auto icon() const -> QIcon override { return Modrinth::icon(); }
+    inline auto id() const -> QString override { return Modrinth::id(); }
+    inline auto debugName() const -> QString override { return Modrinth::debugName(); }
+    inline auto metaEntryBase() const -> QString override { return Modrinth::metaEntryBase(); }
 
-    [[nodiscard]] inline auto helpPage() const -> QString override { return ""; }
+    inline auto helpPage() const -> QString override { return ""; }
 };
 
 }  // namespace ResourceDownload

--- a/launcher/ui/pages/modplatform/technic/TechnicModel.h
+++ b/launcher/ui/pages/modplatform/technic/TechnicModel.h
@@ -58,8 +58,8 @@ class ListModel : public QAbstractListModel {
     void getLogo(const QString& logo, const QString& logoUrl, LogoCallback callback);
     void searchWithTerm(const QString& term);
 
-    [[nodiscard]] bool hasActiveSearchJob() const { return jobPtr && jobPtr->isRunning(); }
-    [[nodiscard]] Task::Ptr activeSearchJob() { return hasActiveSearchJob() ? jobPtr : nullptr; }
+    bool hasActiveSearchJob() const { return jobPtr && jobPtr->isRunning(); }
+    Task::Ptr activeSearchJob() { return hasActiveSearchJob() ? jobPtr : nullptr; }
 
    private slots:
     void searchRequestFinished();

--- a/launcher/ui/pages/modplatform/technic/TechnicPage.h
+++ b/launcher/ui/pages/modplatform/technic/TechnicPage.h
@@ -74,7 +74,7 @@ class TechnicPage : public QWidget, public ModpackProviderBasePage {
     /** Programatically set the term in the search bar. */
     virtual void setSearchTerm(QString) override;
     /** Get the current term in the search bar. */
-    [[nodiscard]] virtual QString getSerachTerm() const override;
+    virtual QString getSerachTerm() const override;
 
    private:
     void suggestCurrent();

--- a/launcher/ui/widgets/WideBar.cpp
+++ b/launcher/ui/widgets/WideBar.cpp
@@ -250,7 +250,7 @@ void WideBar::addContextMenuAction(QAction* action)
     m_context_menu_actions.append(action);
 }
 
-[[nodiscard]] QByteArray WideBar::getVisibilityState() const
+QByteArray WideBar::getVisibilityState() const
 {
     QByteArray state;
 

--- a/launcher/ui/widgets/WideBar.h
+++ b/launcher/ui/widgets/WideBar.h
@@ -35,7 +35,7 @@ class WideBar : public QToolBar {
     // Ideally we would use a QBitArray for this, but it doesn't support string conversion,
     // so using it in settings is very messy.
 
-    [[nodiscard]] QByteArray getVisibilityState() const;
+    QByteArray getVisibilityState() const;
     void setVisibilityState(QByteArray&&);
 
     void removeAction(QAction* action);
@@ -50,8 +50,8 @@ class WideBar : public QToolBar {
     auto getMatching(QAction* act) -> QList<BarEntry>::iterator;
 
     /** Used to distinguish between versions of the WideBar with different actions */
-    [[nodiscard]] QByteArray getHash() const;
-    [[nodiscard]] bool checkHash(QByteArray const&) const;
+    QByteArray getHash() const;
+    bool checkHash(QByteArray const&) const;
 
    private:
     QList<BarEntry> m_entries;

--- a/tests/DummyResourceAPI.h
+++ b/tests/DummyResourceAPI.h
@@ -32,9 +32,9 @@ class DummyResourceAPI : public ResourceAPI {
     }
 
     DummyResourceAPI() : ResourceAPI() {}
-    [[nodiscard]] auto getSortingMethods() const -> QList<SortingMethod> override { return {}; }
+    auto getSortingMethods() const -> QList<SortingMethod> override { return {}; }
 
-    [[nodiscard]] Task::Ptr searchProjects(SearchArgs&&, SearchCallbacks&& callbacks) const override
+    Task::Ptr searchProjects(SearchArgs&&, SearchCallbacks&& callbacks) const override
     {
         auto task = makeShared<SearchTask>();
         QObject::connect(task.get(), &Task::succeeded, [callbacks] {

--- a/tests/ResourceModel_test.cpp
+++ b/tests/ResourceModel_test.cpp
@@ -40,7 +40,7 @@ class DummyResourceModel : public ResourceModel {
     DummyResourceModel() : ResourceModel(new DummyResourceAPI) {}
     ~DummyResourceModel() {}
 
-    [[nodiscard]] auto metaEntryBase() const -> QString override { return ""; }
+    auto metaEntryBase() const -> QString override { return ""; }
 
     ResourceAPI::SearchArgs createSearchArguments() override { return {}; }
     ResourceAPI::VersionSearchArgs createVersionsArguments(const QModelIndex&) override { return {}; }


### PR DESCRIPTION
In my opinion, most of the time [[nodiscard]] doesn't achieve much. In the case of a simple getter, such as `int age() const { return m_age; }`, the harmlessness and unlikeliness of somebody accidentally using it without using the return value does not feel like it justifies the added verbosity and inconsistency.