### PR TITLE
Use `libqrencode` for MSA QR codes

### DIFF
--- a/.github/actions/setup-dependencies/linux/action.yml
+++ b/.github/actions/setup-dependencies/linux/action.yml
@@ -11,6 +11,7 @@ runs:
         sudo apt-get -y install \
           dpkg-dev \
           ninja-build extra-cmake-modules scdoc \
+          libqrencode-dev \
           appstream libxcb-cursor-dev
 
     - name: Setup AppImage tooling

--- a/.github/actions/setup-dependencies/windows/action.yml
+++ b/.github/actions/setup-dependencies/windows/action.yml
@@ -79,6 +79,7 @@ runs:
           qt6-5compat:p
           qt6-networkauth:p
           cmark:p
+          qrencode:p
           tomlplusplus:p
           quazip-qt6:p
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -19,6 +19,3 @@
 [submodule "flatpak/shared-modules"]
 	path = flatpak/shared-modules
 	url = https://github.com/flathub/shared-modules.git
-[submodule "libraries/qrcodegenerator"]
-	path = libraries/qrcodegenerator
-	url = https://github.com/nayuki/QR-Code-generator

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -345,12 +345,24 @@ if(Launcher_QT_VERSION_MAJOR EQUAL 6)
     set(QT_LIBEXECS_DIR ${QT${QT_VERSION_MAJOR}_INSTALL_PREFIX}/${QT${QT_VERSION_MAJOR}_INSTALL_LIBEXECS})
 endif()
 
+# Find libqrencode
+## NOTE(@getchoo): Never use pkg-config with MSVC since the vcpkg port makes our install bundle fail to find the dll
+if(MSVC)
+    find_path(LIBQRENCODE_INCLUDE_DIR qrencode.h REQUIRED)
+    find_library(LIBQRENCODE_LIBRARY_RELEASE qrencode REQUIRED)
+    find_library(LIBQRENCODE_LIBRARY_DEBUG qrencoded)
+    set(LIBQRENCODE_LIBRARIES optimized ${LIBQRENCODE_LIBRARY_RELEASE} debug ${LIBQRENCODE_LIBRARY_DEBUG})
+else()
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(libqrencode REQUIRED IMPORTED_TARGET libqrencode)
+endif()
+
 if(NOT Launcher_FORCE_BUNDLED_LIBS)
     # Find toml++
     find_package(tomlplusplus 3.2.0 QUIET)
     # Fallback to pkg-config (if available) if CMake files aren't found
     if(NOT tomlplusplus_FOUND)
-        find_package(PkgConfig)
+        find_package(PkgConfig QUIET)
         if(PkgConfig_FOUND)
             pkg_check_modules(tomlplusplus IMPORTED_TARGET tomlplusplus>=3.2.0)
         endif()
@@ -359,9 +371,6 @@ if(NOT Launcher_FORCE_BUNDLED_LIBS)
 
     # Find cmark
     find_package(cmark QUIET)
-
-    # Find qrcodegencpp-cmake
-    find_package(qrcodegencpp QUIET)
 endif()
 
 include(ECMQtDeclareLoggingCategory)
@@ -522,18 +531,6 @@ if(NOT cmark_FOUND)
     set(BUILD_TESTING ${ORIGINAL_BUILD_TESTING})
 else()
     message(STATUS "Using system cmark")
-endif()
-if(NOT qrcodegencpp_FOUND)
-    set(QRCODE_SOURCES
-        libraries/qrcodegenerator/cpp/qrcodegen.cpp
-        libraries/qrcodegenerator/cpp/qrcodegen.hpp
-    )
-    add_library(qrcodegenerator STATIC ${QRCODE_SOURCES})
-    target_include_directories(qrcodegenerator PUBLIC "libraries/qrcodegenerator/cpp/" )
-    generate_export_header(qrcodegenerator)
-else()
-    add_library(qrcodegenerator ALIAS qrcodegencpp::qrcodegencpp)
-    message(STATUS "Using system qrcodegencpp-cmake")
 endif()
 add_subdirectory(libraries/gamemode)
 add_subdirectory(libraries/murmur2) # Hash for usage with the CurseForge API

--- a/COPYING.md
+++ b/COPYING.md
@@ -404,14 +404,23 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this library. If not, see <http://www.gnu.org/licenses/>.
 
-## QR-Code-generator (`libraries/qrcodegenerator`)
+## libqrencode (`fukuchi/libqrencode`)
 
-    Copyright © 2024 Project Nayuki. (MIT License)
-    https://www.nayuki.io/page/qr-code-generator-library
+    Copyright (C) 2020 libqrencode Authors
 
-    Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-        - The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-        - The Software is provided "as is", without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose and noninfringement. In no event shall the authors or copyright holders be liable for any claim, damages or other liability, whether in an action of contract, tort or otherwise, arising from, out of or in connection with the Software or the use or other dealings in the Software.
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 ## vcpkg (`cmake/vcpkg-ports`)
 

--- a/flake.lock
+++ b/flake.lock
@@ -32,27 +32,10 @@
         "type": "github"
       }
     },
-    "qrcodegenerator": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1737616857,
-        "narHash": "sha256-6SugPt0lp1Gz7nV23FLmsmpfzgFItkSw7jpGftsDPWc=",
-        "owner": "nayuki",
-        "repo": "QR-Code-generator",
-        "rev": "2c9044de6b049ca25cb3cd1649ed7e27aa055138",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nayuki",
-        "repo": "QR-Code-generator",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
         "libnbtplusplus": "libnbtplusplus",
-        "nixpkgs": "nixpkgs",
-        "qrcodegenerator": "qrcodegenerator"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -15,11 +15,6 @@
       url = "github:PrismLauncher/libnbtplusplus";
       flake = false;
     };
-
-    qrcodegenerator = {
-      url = "github:nayuki/QR-Code-generator";
-      flake = false;
-    };
   };
 
   outputs =
@@ -27,7 +22,6 @@
       self,
       nixpkgs,
       libnbtplusplus,
-      qrcodegenerator,
     }:
 
     let
@@ -175,7 +169,6 @@
         prismlauncher-unwrapped = prev.callPackage ./nix/unwrapped.nix {
           inherit
             libnbtplusplus
-            qrcodegenerator
             self
             ;
         };

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -1297,8 +1297,15 @@ target_link_libraries(Launcher_logic
     qdcss
     BuildConfig
     Qt${QT_VERSION_MAJOR}::Widgets
-    qrcodegenerator
 )
+
+if(TARGET PkgConfig::libqrencode)
+    target_link_libraries(Launcher_logic PkgConfig::libqrencode)
+else()
+    target_include_directories(Launcher_logic PRIVATE ${LIBQRENCODE_INCLUDE_DIR})
+    target_link_libraries(Launcher_logic ${LIBQRENCODE_LIBRARIES})
+endif()
+
 if(TARGET PkgConfig::tomlplusplus)
     target_link_libraries(Launcher_logic PkgConfig::tomlplusplus)
 else()

--- a/nix/unwrapped.nix
+++ b/nix/unwrapped.nix
@@ -9,8 +9,8 @@
   jdk17,
   kdePackages,
   libnbtplusplus,
-  qrcodegenerator,
   ninja,
+  qrencode,
   self,
   stripJavaArchivesHook,
   tomlplusplus,
@@ -63,9 +63,6 @@ stdenv.mkDerivation {
   postUnpack = ''
     rm -rf source/libraries/libnbtplusplus
     ln -s ${libnbtplusplus} source/libraries/libnbtplusplus
-
-    rm -rf source/libraries/qrcodegenerator
-    ln -s ${qrcodegenerator} source/libraries/qrcodegenerator
   '';
 
   nativeBuildInputs = [
@@ -81,6 +78,7 @@ stdenv.mkDerivation {
     kdePackages.qtbase
     kdePackages.qtnetworkauth
     kdePackages.quazip
+    qrencode
     tomlplusplus
     zlib
   ]

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "0c4cf19224a049cf82f4521e29e39f7bd680440c",
+    "baseline": "1fddddc280dfed63956e15ef74f4321bc6a219c9",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,9 +2,18 @@
   "dependencies": [
     "bzip2",
     "cmark",
-    { "name": "ecm", "host": true },
-    "libqrencode",
-    { "name": "pkgconf", "host": true },
+    {
+      "name": "ecm",
+      "host": true
+    },
+    {
+      "name": "libqrencode",
+      "default-features": false
+    },
+    {
+      "name": "pkgconf",
+      "host": true
+    },
     "tomlplusplus",
     "zlib"
   ]

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -3,6 +3,7 @@
     "bzip2",
     "cmark",
     { "name": "ecm", "host": true },
+    "libqrencode",
     { "name": "pkgconf", "host": true },
     "tomlplusplus",
     "zlib"


### PR DESCRIPTION
Follow up on https://github.com/PrismLauncher/PrismLauncher/pull/3257

`qrcodegen` isn't available in most repositories, package discovery
scripts for it are maintained in a different repository, and they are
bugged for Windows at least. This basically forces us into vendoring it,
which isn't cool; libqrencode seems like viable alternative used by many
more apps

Signed-off-by: Seth Flynn <getchoo@tuta.io>

blocked on #3977