### PR TITLE
Add "Babric" and "BTA (Babric)" filters as shown on Modrinth

### DIFF
--- a/launcher/modplatform/ModIndex.cpp
+++ b/launcher/modplatform/ModIndex.cpp
@@ -31,7 +31,7 @@ static const QMap<QString, IndexedVersionType::VersionType> s_indexed_version_ty
     { "alpha", IndexedVersionType::VersionType::Alpha }
 };
 
-static const QList<ModLoaderType> loaderList = { NeoForge, Forge, Cauldron, LiteLoader, Quilt, Fabric };
+static const QList<ModLoaderType> loaderList = { NeoForge, Forge, Cauldron, LiteLoader, Quilt, Fabric, Babric, BTA };
 
 QList<ModLoaderType> modLoaderTypesToList(ModLoaderTypes flags)
 {
@@ -129,6 +129,10 @@ auto getModLoaderAsString(ModLoaderType type) -> const QString
             return "quilt";
         case DataPack:
             return "datapack";
+        case Babric:
+            return "babric";
+        case BTA:
+            return "bta-babric";
         default:
             break;
     }
@@ -149,6 +153,10 @@ auto getModLoaderFromString(QString type) -> ModLoaderType
         return Fabric;
     if (type == "quilt")
         return Quilt;
+    if (type == "babric")
+        return Babric;
+    if (type == "bta-babric")
+        return BTA;
     return {};
 }
 

--- a/launcher/modplatform/ModIndex.h
+++ b/launcher/modplatform/ModIndex.h
@@ -36,7 +36,9 @@ enum ModLoaderType {
     LiteLoader = 1 << 3,
     Fabric = 1 << 4,
     Quilt = 1 << 5,
-    DataPack = 1 << 6
+    DataPack = 1 << 6,
+    Babric = 1 << 7,
+    BTA = 1 << 8
 };
 Q_DECLARE_FLAGS(ModLoaderTypes, ModLoaderType)
 QList<ModLoaderType> modLoaderTypesToList(ModLoaderTypes flags);

--- a/launcher/modplatform/flame/FlameAPI.h
+++ b/launcher/modplatform/flame/FlameAPI.h
@@ -71,6 +71,8 @@ class FlameAPI : public NetworkResourceAPI {
             case ModPlatform::NeoForge:
                 return 6;
             case ModPlatform::DataPack:
+            case ModPlatform::Babric:
+            case ModPlatform::BTA:
                 break;  // not supported
         }
         return 0;

--- a/launcher/modplatform/import_ftb/PackInstallTask.cpp
+++ b/launcher/modplatform/import_ftb/PackInstallTask.cpp
@@ -91,6 +91,10 @@ void PackInstallTask::copySettings()
                 break;
             case ModPlatform::DataPack:
                 break;
+            case ModPlatform::Babric:
+                break;
+            case ModPlatform::BTA:
+                break;
         }
     components->saveNow();
 

--- a/launcher/modplatform/modrinth/ModrinthAPI.h
+++ b/launcher/modplatform/modrinth/ModrinthAPI.h
@@ -43,7 +43,7 @@ class ModrinthAPI : public NetworkResourceAPI {
     {
         QStringList l;
         for (auto loader : { ModPlatform::NeoForge, ModPlatform::Forge, ModPlatform::Fabric, ModPlatform::Quilt, ModPlatform::LiteLoader,
-                             ModPlatform::DataPack }) {
+                             ModPlatform::DataPack, ModPlatform::Babric, ModPlatform::BTA }) {
             if (types & loader) {
                 l << getModLoaderAsString(loader);
             }
@@ -202,7 +202,7 @@ class ModrinthAPI : public NetworkResourceAPI {
     static inline auto validateModLoaders(ModPlatform::ModLoaderTypes loaders) -> bool
     {
         return loaders & (ModPlatform::NeoForge | ModPlatform::Forge | ModPlatform::Fabric | ModPlatform::Quilt | ModPlatform::LiteLoader |
-                          ModPlatform::DataPack);
+                          ModPlatform::DataPack | ModPlatform::Babric | ModPlatform::BTA);
     }
 
     [[nodiscard]] std::optional<QString> getDependencyURL(DependencySearchArgs const& args) const override

--- a/launcher/ui/widgets/ModFilterWidget.cpp
+++ b/launcher/ui/widgets/ModFilterWidget.cpp
@@ -149,10 +149,16 @@ ModFilterWidget::ModFilterWidget(MinecraftInstance* instance, bool extended)
     connect(ui->forge, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
     connect(ui->fabric, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
     connect(ui->quilt, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
-    if (extended)
-        connect(ui->liteLoader, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
-    else
-        ui->liteLoader->setVisible(false);
+    connect(ui->liteLoader, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
+    connect(ui->babric, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
+    connect(ui->btaBabric, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
+    
+    connect(ui->showMoreButton, &QPushButton::clicked, this, &ModFilterWidget::onShowMoreClicked);
+    
+    if (!extended) {
+        ui->showMoreButton->setVisible(false);
+        ui->extendedModLoadersWidget->setVisible(false);
+    }
 
     if (extended) {
         connect(ui->clientSide, &QCheckBox::stateChanged, this, &ModFilterWidget::onSideFilterChanged);
@@ -279,6 +285,10 @@ void ModFilterWidget::onLoadersFilterChanged()
         loaders |= ModPlatform::Quilt;
     if (ui->liteLoader->isChecked())
         loaders |= ModPlatform::LiteLoader;
+    if (ui->babric->isChecked())
+        loaders |= ModPlatform::Babric;
+    if (ui->btaBabric->isChecked())
+        loaders |= ModPlatform::BTA;
     m_filter_changed = loaders != m_filter->loaders;
     m_filter->loaders = loaders;
     if (m_filter_changed)
@@ -379,6 +389,12 @@ void ModFilterWidget::onReleaseFilterChanged()
     m_filter->releases = releases;
     if (m_filter_changed)
         emit filterChanged();
+}
+
+void ModFilterWidget::onShowMoreClicked()
+{
+    ui->extendedModLoadersWidget->setVisible(true);
+    ui->showMoreButton->setVisible(false);
 }
 
 #include "ModFilterWidget.moc"

--- a/launcher/ui/widgets/ModFilterWidget.h
+++ b/launcher/ui/widgets/ModFilterWidget.h
@@ -110,6 +110,7 @@ class ModFilterWidget : public QTabWidget {
     void onShowAllVersionsChanged();
     void onOpenSourceFilterChanged();
     void onReleaseFilterChanged();
+    void onShowMoreClicked();
 
    private:
     Ui::ModFilterWidget* ui;

--- a/launcher/ui/widgets/ModFilterWidget.ui
+++ b/launcher/ui/widgets/ModFilterWidget.ui
@@ -122,10 +122,52 @@
            </widget>
           </item>
           <item>
-           <widget class="QCheckBox" name="liteLoader">
+           <widget class="QPushButton" name="showMoreButton">
             <property name="text">
-             <string>LiteLoader</string>
+             <string>Show More</string>
             </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QWidget" name="extendedModLoadersWidget" native="true">
+            <property name="visible">
+             <bool>false</bool>
+            </property>
+            <layout class="QVBoxLayout" name="extendedModLoadersLayout">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QCheckBox" name="liteLoader">
+               <property name="text">
+                <string>LiteLoader</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="babric">
+               <property name="text">
+                <string>Babric</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="btaBabric">
+               <property name="text">
+                <string>BTA (Babric)</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
           </item>
          </layout>


### PR DESCRIPTION
Add "Babric" and "Babric (BTA)" as shown on Modrinth. Add "Show More" button to allow for space efficiency and readiness to add all other Modrinth modloader types.

Appearance in PrismLauncher:
<img width="977" height="677" alt="image" src="https://github.com/user-attachments/assets/23a7481f-8ab1-4ceb-af26-d8d82e40699d" />
<img width="975" height="676" alt="image" src="https://github.com/user-attachments/assets/3c4c6108-dfdc-4c65-a17a-944d38ec93ce" />

Attempting to match:
<img width="311" height="249" alt="Screenshot_20250710_101145" src="https://github.com/user-attachments/assets/6b4800b8-3490-45be-898c-37cf0e251435" />
<img width="315" height="541" alt="Screenshot_20250710_101200" src="https://github.com/user-attachments/assets/59877d8d-66e1-4f86-917e-5b71bd9338cd" />


I decided not to add other loaders than the ones I am interested in filtering for in my usage, but the Show More button is helpful for if and when these other options that are present on Modrinth are added, because it would take up so much space with all the new modrinth additions.

Additionally, this is my first PR towards PrismLauncher, and I'm not entirely familiar other than the fact that I would like this feature for myself and I can write c++, I would welcome any changes at all that are recommended! Thank you.

Related to #1612 and #3902

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
