### PR TITLE
Apply selected style to NSWindow elements (e.g. title bar) on macOS

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -1178,6 +1178,13 @@ SET(LAUNCHER_SOURCES
     ui/instanceview/VisualGroup.h
 )
 
+if (APPLE)
+    set(LAUNCHER_SOURCES
+        ${LAUNCHER_SOURCES}
+        ui/themes/ThemeManager.mm
+    )
+endif()
+
 if (NOT Apple)
     set(LAUNCHER_SOURCES
     ${LAUNCHER_SOURCES}

--- a/launcher/ui/themes/ThemeManager.cpp
+++ b/launcher/ui/themes/ThemeManager.cpp
@@ -174,6 +174,13 @@ void ThemeManager::initializeWidgets()
     themeDebugLog() << "<> Widget themes initialized.";
 }
 
+#ifndef Q_OS_MACOS
+void ThemeManager::setTitlebarColorOnMac(WId windowId, QColor color)
+{}
+void ThemeManager::setTitlebarColorOfAllWindowsOnMac(QColor color)
+{}
+#endif
+
 QList<IconTheme*> ThemeManager::getValidIconThemes()
 {
     QList<IconTheme*> ret;
@@ -247,6 +254,7 @@ void ThemeManager::setApplicationTheme(const QString& name, bool initial)
         auto& theme = themeIter->second;
         themeDebugLog() << "applying theme" << theme->name();
         theme->apply(initial);
+        setTitlebarColorOfAllWindowsOnMac(qApp->palette().window().color());
 
         m_logColors = theme->logColorScheme();
     } else {

--- a/launcher/ui/themes/ThemeManager.cpp
+++ b/launcher/ui/themes/ThemeManager.cpp
@@ -50,6 +50,11 @@ ThemeManager::ThemeManager()
     initializeCatPacks();
 }
 
+ThemeManager::~ThemeManager()
+{
+    stopSettingNewWindowColorsOnMac();
+}
+
 /// @brief Adds the Theme to the list of themes
 /// @param theme The Theme to add
 /// @return Theme ID
@@ -178,6 +183,8 @@ void ThemeManager::initializeWidgets()
 void ThemeManager::setTitlebarColorOnMac(WId windowId, QColor color)
 {}
 void ThemeManager::setTitlebarColorOfAllWindowsOnMac(QColor color)
+{}
+void ThemeManager::stopSettingNewWindowColorsOnMac()
 {}
 #endif
 

--- a/launcher/ui/themes/ThemeManager.h
+++ b/launcher/ui/themes/ThemeManager.h
@@ -81,6 +81,15 @@ class ThemeManager {
     void initializeIcons();
     void initializeWidgets();
 
+    // On non-Mac systems, this is a no-op.
+    void setTitlebarColorOnMac(WId windowId, QColor color);
+    // This also will set the titlebar color of newly opened windows after this method is called.
+    // On non-Mac systems, this is a no-op.
+    void setTitlebarColorOfAllWindowsOnMac(QColor color);
+#ifdef Q_OS_MACOS
+    NSObject* m_windowTitlebarObserver = nullptr;
+#endif
+
     const QStringList builtinIcons{ "pe_colored", "pe_light", "pe_dark", "pe_blue",    "breeze_light", "breeze_dark",
                                     "OSX",        "iOS",      "flat",    "flat_white", "multimc" };
 };

--- a/launcher/ui/themes/ThemeManager.h
+++ b/launcher/ui/themes/ThemeManager.h
@@ -39,6 +39,7 @@ inline auto themeWarningLog()
 class ThemeManager {
    public:
     ThemeManager();
+    ~ThemeManager();
 
     QList<IconTheme*> getValidIconThemes();
     QList<ITheme*> getValidApplicationThemes();
@@ -86,6 +87,8 @@ class ThemeManager {
     // This also will set the titlebar color of newly opened windows after this method is called.
     // On non-Mac systems, this is a no-op.
     void setTitlebarColorOfAllWindowsOnMac(QColor color);
+    // On non-Mac systems, this is a no-op.
+    void stopSettingNewWindowColorsOnMac();
 #ifdef Q_OS_MACOS
     NSObject* m_windowTitlebarObserver = nullptr;
 #endif

--- a/launcher/ui/themes/ThemeManager.mm
+++ b/launcher/ui/themes/ThemeManager.mm
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2025 Kenneth Chew <79120643+kthchew@users.noreply.github.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "ThemeManager.h"
+
+#include <AppKit/AppKit.h>
+
+void ThemeManager::setTitlebarColorOnMac(WId windowId, QColor color)
+{
+    if (windowId == 0) {
+        return;
+    }
+
+    NSView* view = (NSView*)windowId;
+    NSWindow* window = [view window];
+    window.titlebarAppearsTransparent = YES;
+    window.backgroundColor = [NSColor colorWithRed:color.redF() green:color.greenF() blue:color.blueF() alpha:color.alphaF()];
+
+    // Unfortunately there seems to be no easy way to set the titlebar text color.
+    // The closest we can do without dubious hacks is set the dark/light mode state based on the brightness of the
+    // background color, which should at least make the text readable even if we can't use the theme's text color.
+    // It's a good idea to set this anyway since it also affects some other UI elements like text shadows (PrismLauncher#3825).
+    if (color.lightnessF() < 0.5) {
+        window.appearance = [NSAppearance appearanceNamed:NSAppearanceNameDarkAqua];
+    } else {
+        window.appearance = [NSAppearance appearanceNamed:NSAppearanceNameAqua];
+    }
+}
+
+void ThemeManager::setTitlebarColorOfAllWindowsOnMac(QColor color)
+{
+    NSArray<NSWindow*>* windows = [NSApp windows];
+    for (NSWindow* window : windows) {
+        setTitlebarColorOnMac((WId)window.contentView, color);
+    }
+
+    // We want to change the titlebar color of newly opened windows as well.
+    // There's no notification for when a new window is opened, but we can set the color when a window switches
+    // from occluded to visible, which also fires on open.
+    NSNotificationCenter* center = [NSNotificationCenter defaultCenter];
+    if (m_windowTitlebarObserver) {
+        [center removeObserver:m_windowTitlebarObserver];
+        m_windowTitlebarObserver = nil;
+    }
+    m_windowTitlebarObserver = [center addObserverForName:NSWindowDidChangeOcclusionStateNotification
+                                                   object:nil
+                                                    queue:[NSOperationQueue mainQueue]
+                                               usingBlock:^(NSNotification* notification) {
+                                                   NSWindow* window = notification.object;
+                                                   setTitlebarColorOnMac((WId)window.contentView, color);
+                                               }];
+}

--- a/launcher/ui/themes/ThemeManager.mm
+++ b/launcher/ui/themes/ThemeManager.mm
@@ -53,10 +53,7 @@ void ThemeManager::setTitlebarColorOfAllWindowsOnMac(QColor color)
     // There's no notification for when a new window is opened, but we can set the color when a window switches
     // from occluded to visible, which also fires on open.
     NSNotificationCenter* center = [NSNotificationCenter defaultCenter];
-    if (m_windowTitlebarObserver) {
-        [center removeObserver:m_windowTitlebarObserver];
-        m_windowTitlebarObserver = nil;
-    }
+    stopSettingNewWindowColorsOnMac();
     m_windowTitlebarObserver = [center addObserverForName:NSWindowDidChangeOcclusionStateNotification
                                                    object:nil
                                                     queue:[NSOperationQueue mainQueue]
@@ -64,4 +61,13 @@ void ThemeManager::setTitlebarColorOfAllWindowsOnMac(QColor color)
                                                    NSWindow* window = notification.object;
                                                    setTitlebarColorOnMac((WId)window.contentView, color);
                                                }];
+}
+
+void ThemeManager::stopSettingNewWindowColorsOnMac()
+{
+    if (m_windowTitlebarObserver) {
+        NSNotificationCenter* center = [NSNotificationCenter defaultCenter];
+        [center removeObserver:m_windowTitlebarObserver];
+        m_windowTitlebarObserver = nil;
+    }
 }


### PR DESCRIPTION
Closes #3814
Closes #3825

Qt doesn't apply the proper style to elements such as the title bar or text shadows, so this must be done in native code.

Example screenshots (see linked issues for before screenshots):

<img width="829" height="627" alt="Screenshot 2025-07-16 at 12 37 26 AM" src="https://github.com/user-attachments/assets/3d72c89f-7687-4a35-a691-4875cbdabc5c" />

<img width="1081" height="1026" alt="Screenshot 2025-07-16 at 12 29 51 AM" src="https://github.com/user-attachments/assets/5e635377-d0bd-4595-8586-0d0379b1d2a2" />

<img width="831" height="626" alt="Screenshot 2025-07-16 at 12 37 44 AM" src="https://github.com/user-attachments/assets/42de9edf-813b-4c87-a829-2bacac2681d2" />

<img width="1081" height="1026" alt="Screenshot 2025-07-16 at 12 29 45 AM" src="https://github.com/user-attachments/assets/e306790e-37fb-49ed-97e8-acfddda3ad98" />
