### PR TITLE
fix: use new Mojang API endpoint for Username->UUID resolution

### DIFF
--- a/launcher/ui/dialogs/skins/SkinManageDialog.cpp
+++ b/launcher/ui/dialogs/skins/SkinManageDialog.cpp
@@ -446,7 +446,7 @@ void SkinManageDialog::on_userBtn_clicked()
     auto uuidLoop = makeShared<WaitTask>();
     auto profileLoop = makeShared<WaitTask>();
 
-    auto getUUID = Net::Download::makeByteArray("https://api.mojang.com/users/profiles/minecraft/" + user, uuidOut);
+    auto getUUID = Net::Download::makeByteArray("https://api.minecraftservices.com/minecraft/profile/lookup/name/" + user, uuidOut);
     auto getProfile = Net::Download::makeByteArray(QUrl(), profileOut);
     auto downloadSkin = Net::Download::makeFile(QUrl(), path);
 

--- a/libraries/launcher/legacy/org/prismlauncher/legacy/utils/api/MojangApi.java
+++ b/libraries/launcher/legacy/org/prismlauncher/legacy/utils/api/MojangApi.java
@@ -49,7 +49,7 @@ import java.util.Map;
 @SuppressWarnings("unchecked")
 public final class MojangApi {
     public static String getUuid(String username) throws IOException {
-        try (InputStream in = new URL("https://api.mojang.com/users/profiles/minecraft/" + username).openStream()) {
+        try (InputStream in = new URL("https://api.minecraftservices.com/minecraft/profile/lookup/name/" + username).openStream()) {
             Map<String, Object> map = (Map<String, Object>) JsonParser.parse(in);
             return (String) map.get("id");
         }


### PR DESCRIPTION
As per https://minecraft.wiki/w/Mojang_API#Query_player's_UUID the old endpoint has been deemed unreliable since January 15, 2025