### PR TITLE
Explicitly install Java for Windows in CI

### DIFF
--- a/.github/actions/setup-dependencies/windows/action.yml
+++ b/.github/actions/setup-dependencies/windows/action.yml
@@ -25,6 +25,14 @@ runs:
         arch: ${{ inputs.vcvars-arch }}
         vsversion: 2022
 
+    - name: Setup Java (MSVC)
+      uses: actions/setup-java@v4
+      with:
+        # NOTE(@getchoo): We should probably stay on Zulu.
+        # Temurin doesn't have Java 17 builds for WoA
+        distribution: zulu
+        java-version: 17
+
     - name: Setup vcpkg cache (MSVC)
       if: ${{ inputs.msystem == '' && inputs.build-type == 'Debug' }}
       shell: pwsh


### PR DESCRIPTION
Recently GitHub updated their `windows-11-arm` runners to include Java 21 by default, and dropped versions prior to it - which we need. This fixes that, and avoids any breakage in the future when Java is inevitably updated in the x64 runner image as well
