### PR TITLE
A few tweaks to new ui

### DIFF
--- a/launcher/ui/pages/global/LauncherPage.cpp
+++ b/launcher/ui/pages/global/LauncherPage.cpp
@@ -65,15 +65,6 @@ enum InstSortMode {
     Sort_LastLaunch
 };
 
-enum InstRenamingMode {
-    // Rename metadata only.
-    Rename_Always,
-    // Ask everytime.
-    Rename_Ask,
-    // Rename physical directory too.
-    Rename_Never
-};
-
 LauncherPage::LauncherPage(QWidget* parent) : QWidget(parent), ui(new Ui::LauncherPage)
 {
     ui->setupUi(this);
@@ -242,18 +233,12 @@ void LauncherPage::applySettings()
             break;
     }
 
-    auto renamingMode = (InstRenamingMode)ui->renamingBehaviorComboBox->currentIndex();
-    switch (renamingMode) {
-        case Rename_Always:
-            s->set("InstRenamingMode", "MetadataOnly");
-            break;
-        case Rename_Never:
-            s->set("InstRenamingMode", "PhysicalDir");
-            break;
-        case Rename_Ask:
-        default:
-            s->set("InstRenamingMode", "AskEverytime");
-            break;
+    if (ui->askToRenameDirBtn->isChecked()) {
+        s->set("InstRenamingMode", "AskEverytime");
+    } else if (ui->alwaysRenameDirBtn->isChecked()) {
+        s->set("InstRenamingMode", "PhysicalDir");
+    } else if (ui->neverRenameDirBtn->isChecked()) {
+        s->set("InstRenamingMode", "MetadataOnly");
     }
 
     // Mods
@@ -300,15 +285,9 @@ void LauncherPage::loadSettings()
     }
 
     QString renamingMode = s->get("InstRenamingMode").toString();
-    InstRenamingMode renamingModeEnum;
-    if (renamingMode == "MetadataOnly") {
-        renamingModeEnum = Rename_Always;
-    } else if (renamingMode == "PhysicalDir") {
-        renamingModeEnum = Rename_Never;
-    } else {
-        renamingModeEnum = Rename_Ask;
-    }
-    ui->renamingBehaviorComboBox->setCurrentIndex(renamingModeEnum);
+    ui->askToRenameDirBtn->setChecked(renamingMode == "AskEverytime");
+    ui->alwaysRenameDirBtn->setChecked(renamingMode == "PhysicalDir");
+    ui->neverRenameDirBtn->setChecked(renamingMode == "MetadataOnly");
 
     // Mods
     ui->metadataEnableBtn->setChecked(!s->get("ModMetadataDisabled").toBool());

--- a/launcher/ui/pages/global/LauncherPage.ui
+++ b/launcher/ui/pages/global/LauncherPage.ui
@@ -43,7 +43,7 @@
         <x>0</x>
         <y>0</y>
         <width>746</width>
-        <height>1202</height>
+        <height>1194</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -64,47 +64,23 @@
            </widget>
           </item>
           <item>
-           <widget class="QGroupBox" name="instanceSortBox">
-            <property name="title">
-             <string/>
+           <widget class="QRadioButton" name="sortByNameBtn">
+            <property name="text">
+             <string>By &amp;name</string>
             </property>
-            <property name="flat">
-             <bool>true</bool>
+            <attribute name="buttonGroup">
+             <string notr="true">sortingModeGroup</string>
+            </attribute>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="sortLastLaunchedBtn">
+            <property name="text">
+             <string>&amp;By last launched</string>
             </property>
-            <layout class="QVBoxLayout" name="verticalLayout_3">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QRadioButton" name="sortByNameBtn">
-               <property name="text">
-                <string>By &amp;name</string>
-               </property>
-               <attribute name="buttonGroup">
-                <string notr="true">sortingModeGroup</string>
-               </attribute>
-              </widget>
-             </item>
-             <item>
-              <widget class="QRadioButton" name="sortLastLaunchedBtn">
-               <property name="text">
-                <string>&amp;By last launched</string>
-               </property>
-               <attribute name="buttonGroup">
-                <string notr="true">sortingModeGroup</string>
-               </attribute>
-              </widget>
-             </item>
-            </layout>
+            <attribute name="buttonGroup">
+             <string notr="true">sortingModeGroup</string>
+            </attribute>
            </widget>
           </item>
           <item>
@@ -131,48 +107,33 @@
            </widget>
           </item>
           <item>
-           <widget class="QGroupBox" name="groupBox">
-            <property name="title">
-             <string/>
+           <widget class="QRadioButton" name="askToRenameDirBtn">
+            <property name="text">
+             <string>Ask what to do</string>
             </property>
-            <property name="flat">
-             <bool>true</bool>
+            <attribute name="buttonGroup">
+             <string notr="true">renamingBehaviorGroup</string>
+            </attribute>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="alwaysRenameDirBtn">
+            <property name="text">
+             <string>Always rename the folder</string>
             </property>
-            <layout class="QVBoxLayout" name="verticalLayout_5">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QRadioButton" name="askToRenameDirBtn">
-               <property name="text">
-                <string>Ask what to do</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QRadioButton" name="alwaysRenameDirBtn">
-               <property name="text">
-                <string>Always rename the folder</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QRadioButton" name="neverRenameDirBtn">
-               <property name="text">
-                <string>Never rename the folder</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
+            <attribute name="buttonGroup">
+             <string notr="true">renamingBehaviorGroup</string>
+            </attribute>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="neverRenameDirBtn">
+            <property name="text">
+             <string>Never rename the folder</string>
+            </property>
+            <attribute name="buttonGroup">
+             <string notr="true">renamingBehaviorGroup</string>
+            </attribute>
            </widget>
           </item>
           <item>
@@ -711,5 +672,6 @@
  <connections/>
  <buttongroups>
   <buttongroup name="sortingModeGroup"/>
+  <buttongroup name="renamingBehaviorGroup"/>
  </buttongroups>
 </ui>

--- a/launcher/ui/pages/global/LauncherPage.ui
+++ b/launcher/ui/pages/global/LauncherPage.ui
@@ -32,7 +32,7 @@
    <item>
     <widget class="QScrollArea" name="scrollArea">
      <property name="horizontalScrollBarPolicy">
-      <enum>Qt::ScrollBarAsNeeded</enum>
+      <enum>Qt::ScrollBarPolicy::ScrollBarAsNeeded</enum>
      </property>
      <property name="widgetResizable">
       <bool>true</bool>
@@ -41,9 +41,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-356</y>
-        <width>742</width>
-        <height>1148</height>
+        <y>0</y>
+        <width>746</width>
+        <height>1202</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -64,32 +64,56 @@
            </widget>
           </item>
           <item>
-           <widget class="QRadioButton" name="sortByNameBtn">
-            <property name="text">
-             <string>By &amp;name</string>
+           <widget class="QGroupBox" name="instanceSortBox">
+            <property name="title">
+             <string/>
             </property>
-            <attribute name="buttonGroup">
-             <string notr="true">sortingModeGroup</string>
-            </attribute>
-           </widget>
-          </item>
-          <item>
-           <widget class="QRadioButton" name="sortLastLaunchedBtn">
-            <property name="text">
-             <string>&amp;By last launched</string>
+            <property name="flat">
+             <bool>true</bool>
             </property>
-            <attribute name="buttonGroup">
-             <string notr="true">sortingModeGroup</string>
-            </attribute>
+            <layout class="QVBoxLayout" name="verticalLayout_3">
+             <property name="leftMargin">
+              <number>0</number>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QRadioButton" name="sortByNameBtn">
+               <property name="text">
+                <string>By &amp;name</string>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">sortingModeGroup</string>
+               </attribute>
+              </widget>
+             </item>
+             <item>
+              <widget class="QRadioButton" name="sortLastLaunchedBtn">
+               <property name="text">
+                <string>&amp;By last launched</string>
+               </property>
+               <attribute name="buttonGroup">
+                <string notr="true">sortingModeGroup</string>
+               </attribute>
+              </widget>
+             </item>
+            </layout>
            </widget>
           </item>
           <item>
            <spacer name="verticalSpacer">
             <property name="orientation">
-             <enum>Qt::Vertical</enum>
+             <enum>Qt::Orientation::Vertical</enum>
             </property>
             <property name="sizeType">
-             <enum>QSizePolicy::Fixed</enum>
+             <enum>QSizePolicy::Policy::Fixed</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -107,37 +131,57 @@
            </widget>
           </item>
           <item>
-           <widget class="QComboBox" name="renamingBehaviorComboBox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
+           <widget class="QGroupBox" name="groupBox">
+            <property name="title">
+             <string/>
             </property>
-            <item>
-             <property name="text">
-              <string>Ask what to do with the folder</string>
+            <property name="flat">
+             <bool>true</bool>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_5">
+             <property name="leftMargin">
+              <number>0</number>
              </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Always rename the folder</string>
+             <property name="topMargin">
+              <number>0</number>
              </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Never rename the folder—only the displayed name</string>
+             <property name="rightMargin">
+              <number>0</number>
              </property>
-            </item>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QRadioButton" name="askToRenameDirBtn">
+               <property name="text">
+                <string>Ask what to do</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QRadioButton" name="alwaysRenameDirBtn">
+               <property name="text">
+                <string>Always rename the folder</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QRadioButton" name="neverRenameDirBtn">
+               <property name="text">
+                <string>Never rename the folder</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
            </widget>
           </item>
           <item>
            <spacer name="verticalSpacer_2">
             <property name="orientation">
-             <enum>Qt::Vertical</enum>
+             <enum>Qt::Orientation::Vertical</enum>
             </property>
             <property name="sizeType">
-             <enum>QSizePolicy::Fixed</enum>
+             <enum>QSizePolicy::Policy::Fixed</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -206,7 +250,7 @@
             <item>
              <spacer name="horizontalSpacer">
               <property name="orientation">
-               <enum>Qt::Horizontal</enum>
+               <enum>Qt::Orientation::Horizontal</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
@@ -433,7 +477,7 @@
          </property>
          <layout class="QFormLayout" name="formLayout">
           <property name="labelAlignment">
-           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+           <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
           </property>
           <item row="0" column="0">
            <widget class="QLabel" name="lineLimitLabel">
@@ -602,7 +646,7 @@
           <item row="0" column="2">
            <spacer name="horizontalSpacer_2">
             <property name="orientation">
-             <enum>Qt::Horizontal</enum>
+             <enum>Qt::Orientation::Horizontal</enum>
             </property>
             <property name="sizeHint" stdset="0">
              <size>
@@ -618,7 +662,7 @@
        <item>
         <spacer name="verticalSpacer_FeaturesTab">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
@@ -636,9 +680,6 @@
  </widget>
  <tabstops>
   <tabstop>scrollArea</tabstop>
-  <tabstop>sortByNameBtn</tabstop>
-  <tabstop>sortLastLaunchedBtn</tabstop>
-  <tabstop>renamingBehaviorComboBox</tabstop>
   <tabstop>preferMenuBarCheckBox</tabstop>
   <tabstop>autoUpdateCheckBox</tabstop>
   <tabstop>updateIntervalSpinBox</tabstop>

--- a/launcher/ui/widgets/AppearanceWidget.ui
+++ b/launcher/ui/widgets/AppearanceWidget.ui
@@ -204,53 +204,6 @@
        </spacer>
       </item>
       <item>
-       <widget class="QLabel" name="catFitLabel">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Fit</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QComboBox" name="catFitComboBox">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>77</width>
-          <height>30</height>
-         </size>
-        </property>
-        <property name="currentIndex">
-         <number>0</number>
-        </property>
-        <item>
-         <property name="text">
-          <string>Fit</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Fill</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Stretch</string>
-         </property>
-        </item>
-       </widget>
-      </item>
-      <item>
        <widget class="QLabel" name="catOpacityLabel">
         <property name="text">
          <string>Cat Opacity</string>
@@ -369,6 +322,53 @@
          </size>
         </property>
        </spacer>
+      </item>
+      <item>
+       <widget class="QLabel" name="catFitLabel">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Cat Scaling</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QComboBox" name="catFitComboBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>77</width>
+          <height>30</height>
+         </size>
+        </property>
+        <property name="currentIndex">
+         <number>0</number>
+        </property>
+        <item>
+         <property name="text">
+          <string>Fit</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Fill</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Stretch</string>
+         </property>
+        </item>
+       </widget>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
Parent PR: #3534

Use radio buttons here for consistency (also avoids stealing scroll)
<img width="519" height="284" alt="image" src="https://github.com/user-attachments/assets/6b5bdc99-8962-4f02-bdf5-ec21e9890198" />

Rename Fit to Cat Scaling and fix up spacing
<img width="541" height="216" alt="image" src="https://github.com/user-attachments/assets/7012cf43-91b0-4efd-818e-7bf1c37b1551" />

Diff of LauncherPage.ui might be large as it was saved in a newer version of Qt Designer than before