### PR TITLE
Remove central mods

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -703,7 +703,6 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
 
         // Folders
         m_settings->registerSetting("InstanceDir", "instances");
-        m_settings->registerSetting({ "CentralModsDir", "ModsDir" }, "mods");
         m_settings->registerSetting("IconsDir", "icons");
         m_settings->registerSetting("DownloadsDir", QStandardPaths::writableLocation(QStandardPaths::DownloadLocation));
         m_settings->registerSetting("DownloadsDirWatchRecursive", false);

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -1220,11 +1220,6 @@ void MainWindow::on_actionViewInstanceFolder_triggered()
     DesktopServices::openPath(str);
 }
 
-void MainWindow::on_actionViewCentralModsFolder_triggered()
-{
-    DesktopServices::openPath(APPLICATION->settings()->get("CentralModsDir").toString(), true);
-}
-
 void MainWindow::on_actionViewSkinsFolder_triggered()
 {
     DesktopServices::openPath(APPLICATION->settings()->get("SkinsDir").toString(), true);

--- a/launcher/ui/MainWindow.h
+++ b/launcher/ui/MainWindow.h
@@ -111,7 +111,6 @@ class MainWindow : public QMainWindow {
     void on_actionViewLauncherRootFolder_triggered();
 
     void on_actionViewInstanceFolder_triggered();
-    void on_actionViewCentralModsFolder_triggered();
 
     void on_actionViewIconThemeFolder_triggered();
     void on_actionViewWidgetThemeFolder_triggered();

--- a/launcher/ui/MainWindow.ui
+++ b/launcher/ui/MainWindow.ui
@@ -190,7 +190,6 @@
     <addaction name="actionViewLauncherRootFolder"/>
     <addaction name="separator"/>
     <addaction name="actionViewInstanceFolder"/>
-    <addaction name="actionViewCentralModsFolder"/>
     <addaction name="actionViewSkinsFolder"/>
     <addaction name="actionViewJavaFolder"/>
     <addaction name="separator"/>
@@ -543,17 +542,6 @@
    </property>
    <property name="toolTip">
     <string>Open the launcher's root folder in a file browser.</string>
-   </property>
-  </action>
-  <action name="actionViewCentralModsFolder">
-   <property name="icon">
-    <iconset theme="centralmods"/>
-   </property>
-   <property name="text">
-    <string>&amp;Central Mods</string>
-   </property>
-   <property name="toolTip">
-    <string>Open the central mods folder in a file browser.</string>
    </property>
   </action>
   <action name="actionViewSkinsFolder">

--- a/launcher/ui/dialogs/BlockedModsDialog.cpp
+++ b/launcher/ui/dialogs/BlockedModsDialog.cpp
@@ -189,14 +189,12 @@ void BlockedModsDialog::directoryChanged(QString path)
     scanPath(path, true);
 }
 
-/// @brief add the user downloads folder and the global mods folder to the filesystem watcher
+/// @brief add the user downloads folder to the filesystem watcher
 void BlockedModsDialog::setupWatch()
 {
     const QString downloadsFolder = APPLICATION->settings()->get("DownloadsDir").toString();
-    const QString modsFolder = APPLICATION->settings()->get("CentralModsDir").toString();
     const bool downloadsFolderWatchRecursive = APPLICATION->settings()->get("DownloadsDirWatchRecursive").toBool();
     watchPath(downloadsFolder, downloadsFolderWatchRecursive);
-    watchPath(modsFolder, true);
 }
 
 void BlockedModsDialog::watchPath(QString path, bool watch_recursive)

--- a/launcher/ui/dialogs/BlockedModsDialog.ui
+++ b/launcher/ui/dialogs/BlockedModsDialog.ui
@@ -42,7 +42,7 @@
    <item>
     <widget class="QLabel" name="labelExplain">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Your configured global mods folder and default downloads folder are automatically checked for the downloaded mods and they will be copied to the instance if found.&lt;/p&gt;&lt;p&gt;Optionally, you may drag and drop the downloaded mods onto this dialog or add a folder to watch if you did not download the mods to a default location.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Click 'Open Missing' to open all the download links in the browser. &lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Your configured download folder is automatically checked for the downloaded mods and they will be copied to the instance if found.&lt;/p&gt;&lt;p&gt;Optionally, you may drag and drop the downloaded mods onto this dialog or add a folder to watch if you did not download the mods to a default location.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Click 'Open Missing' to open all the download links in the browser. &lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="wordWrap">
       <bool>true</bool>

--- a/launcher/ui/pages/global/LauncherPage.cpp
+++ b/launcher/ui/pages/global/LauncherPage.cpp
@@ -151,17 +151,6 @@ void LauncherPage::on_iconsDirBrowseBtn_clicked()
     }
 }
 
-void LauncherPage::on_modsDirBrowseBtn_clicked()
-{
-    QString raw_dir = QFileDialog::getExistingDirectory(this, tr("Mods Folder"), ui->modsDirTextBox->text());
-
-    // do not allow current dir - it's dirty. Do not allow dirs that don't exist
-    if (!raw_dir.isEmpty() && QDir(raw_dir).exists()) {
-        QString cooked_dir = FS::NormalizePath(raw_dir);
-        ui->modsDirTextBox->setText(cooked_dir);
-    }
-}
-
 void LauncherPage::on_downloadsDirBrowseBtn_clicked()
 {
     QString raw_dir = QFileDialog::getExistingDirectory(this, tr("Downloads Folder"), ui->downloadsDirTextBox->text());
@@ -222,7 +211,6 @@ void LauncherPage::applySettings()
     // Folders
     // TODO: Offer to move instances to new instance folder.
     s->set("InstanceDir", ui->instDirTextBox->text());
-    s->set("CentralModsDir", ui->modsDirTextBox->text());
     s->set("IconsDir", ui->iconsDirTextBox->text());
     s->set("DownloadsDir", ui->downloadsDirTextBox->text());
     s->set("SkinsDir", ui->skinsDirTextBox->text());
@@ -283,7 +271,6 @@ void LauncherPage::loadSettings()
 
     // Folders
     ui->instDirTextBox->setText(s->get("InstanceDir").toString());
-    ui->modsDirTextBox->setText(s->get("CentralModsDir").toString());
     ui->iconsDirTextBox->setText(s->get("IconsDir").toString());
     ui->downloadsDirTextBox->setText(s->get("DownloadsDir").toString());
     ui->skinsDirTextBox->setText(s->get("SkinsDir").toString());

--- a/launcher/ui/pages/global/LauncherPage.h
+++ b/launcher/ui/pages/global/LauncherPage.h
@@ -70,7 +70,6 @@ class LauncherPage : public QWidget, public BasePage {
 
    private slots:
     void on_instDirBrowseBtn_clicked();
-    void on_modsDirBrowseBtn_clicked();
     void on_iconsDirBrowseBtn_clicked();
     void on_downloadsDirBrowseBtn_clicked();
     void on_javaDirBrowseBtn_clicked();

--- a/launcher/ui/pages/global/LauncherPage.ui
+++ b/launcher/ui/pages/global/LauncherPage.ui
@@ -271,16 +271,6 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="labelModsDir">
-            <property name="text">
-             <string>&amp;Mods:</string>
-            </property>
-            <property name="buddy">
-             <cstring>modsDirTextBox</cstring>
-            </property>
-           </widget>
-          </item>
           <item row="3" column="2">
            <widget class="QPushButton" name="javaDirBrowseBtn">
             <property name="text">
@@ -300,9 +290,6 @@
           </item>
           <item row="5" column="1">
            <widget class="QLineEdit" name="downloadsDirTextBox"/>
-          </item>
-          <item row="1" column="1">
-           <widget class="QLineEdit" name="modsDirTextBox"/>
           </item>
           <item row="0" column="0">
            <widget class="QLabel" name="labelInstDir">
@@ -330,13 +317,6 @@
           </item>
           <item row="0" column="1">
            <widget class="QLineEdit" name="instDirTextBox"/>
-          </item>
-          <item row="1" column="2">
-           <widget class="QPushButton" name="modsDirBrowseBtn">
-            <property name="text">
-             <string>Browse</string>
-            </property>
-           </widget>
           </item>
           <item row="3" column="1">
            <widget class="QLineEdit" name="javaDirTextBox"/>
@@ -644,8 +624,6 @@
   <tabstop>updateIntervalSpinBox</tabstop>
   <tabstop>instDirTextBox</tabstop>
   <tabstop>instDirBrowseBtn</tabstop>
-  <tabstop>modsDirTextBox</tabstop>
-  <tabstop>modsDirBrowseBtn</tabstop>
   <tabstop>iconsDirTextBox</tabstop>
   <tabstop>iconsDirBrowseBtn</tabstop>
   <tabstop>javaDirTextBox</tabstop>

--- a/launcher/ui/pages/instance/ExternalResourcesPage.cpp
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.cpp
@@ -211,7 +211,7 @@ void ExternalResourcesPage::addItem()
 {
     auto list = GuiUtil::BrowseForFiles(
         helpPage(), tr("Select %1", "Select whatever type of files the page contains. Example: 'Loader Mods'").arg(displayName()),
-        m_fileSelectionFilter.arg(displayName()), APPLICATION->settings()->get("CentralModsDir").toString(), this->parentWidget());
+        m_fileSelectionFilter.arg(displayName()), APPLICATION->settings()->get("DownloadsDir").toString(), this->parentWidget());
 
     if (!list.isEmpty()) {
         for (auto filename : list) {

--- a/launcher/ui/pages/instance/VersionPage.cpp
+++ b/launcher/ui/pages/instance/VersionPage.cpp
@@ -300,7 +300,7 @@ void VersionPage::on_actionRemove_triggered()
 void VersionPage::on_actionAdd_to_Minecraft_jar_triggered()
 {
     auto list = GuiUtil::BrowseForFiles("jarmod", tr("Select jar mods"), tr("Minecraft.jar mods") + " (*.zip *.jar)",
-                                        APPLICATION->settings()->get("CentralModsDir").toString(), this->parentWidget());
+                                        APPLICATION->settings()->get("DownloadsDir").toString(), this->parentWidget());
     if (!list.empty()) {
         m_profile->installJarMods(list);
     }
@@ -310,7 +310,7 @@ void VersionPage::on_actionAdd_to_Minecraft_jar_triggered()
 void VersionPage::on_actionReplace_Minecraft_jar_triggered()
 {
     auto jarPath = GuiUtil::BrowseForFile("jar", tr("Select jar"), tr("Minecraft.jar replacement") + " (*.jar)",
-                                          APPLICATION->settings()->get("CentralModsDir").toString(), this->parentWidget());
+                                          APPLICATION->settings()->get("DownloadsDir").toString(), this->parentWidget());
     if (!jarPath.isEmpty()) {
         m_profile->installCustomJar(jarPath);
     }
@@ -320,7 +320,7 @@ void VersionPage::on_actionReplace_Minecraft_jar_triggered()
 void VersionPage::on_actionImport_Components_triggered()
 {
     QStringList list = GuiUtil::BrowseForFiles("component", tr("Select components"), tr("Components") + " (*.json)",
-                                               APPLICATION->settings()->get("CentralModsDir").toString(), this->parentWidget());
+                                               APPLICATION->settings()->get("DownloadsDir").toString(), this->parentWidget());
 
     if (!list.isEmpty()) {
         if (!m_profile->installComponents(list)) {
@@ -335,7 +335,7 @@ void VersionPage::on_actionImport_Components_triggered()
 void VersionPage::on_actionAdd_Agents_triggered()
 {
     QStringList list = GuiUtil::BrowseForFiles("agent", tr("Select agents"), tr("Java agents") + " (*.jar)",
-                                               APPLICATION->settings()->get("CentralModsDir").toString(), this->parentWidget());
+                                               APPLICATION->settings()->get("DownloadsDir").toString(), this->parentWidget());
 
     if (!list.isEmpty())
         m_profile->installAgents(list);


### PR DESCRIPTION
The central mods folder only has one unique purpose - to appear as the initial folder when pressing Add File. This same folder opens for all resource pages.

Coincidentally, some libraries are downloaded to mods/minecraftforge, but changing the central mods directory does not affect this. I haven't touched this behaviour.

Even if this could sometimes be useful I think it'd be better to persist the file picker dialog and blocked mod watched directories instead. 

Similar to central america, the only time I hear people talking about it is when they're confused about it (edit: being bad at geography might just be a me thing...)