### PR TITLE
Simplify Rule class

### DIFF
--- a/launcher/minecraft/Library.cpp
+++ b/launcher/minecraft/Library.cpp
@@ -242,13 +242,13 @@ bool Library::isActive(const RuntimeContext& runtimeContext) const
     if (m_rules.empty()) {
         result = true;
     } else {
-        RuleAction ruleResult = Disallow;
+        Rule::Action ruleResult = Rule::Disallow;
         for (auto rule : m_rules) {
-            RuleAction temp = rule->apply(this, runtimeContext);
-            if (temp != Defer)
+            Rule::Action temp = rule.apply(runtimeContext);
+            if (temp != Rule::Defer)
                 ruleResult = temp;
         }
-        result = result && (ruleResult == Allow);
+        result = result && (ruleResult == Rule::Allow);
     }
     if (isNative()) {
         result = result && !getCompatibleNative(runtimeContext).isNull();

--- a/launcher/minecraft/Library.h
+++ b/launcher/minecraft/Library.h
@@ -129,7 +129,7 @@ class Library {
     void setHint(const QString& hint) { m_hint = hint; }
 
     /// Set the load rules
-    void setRules(QList<std::shared_ptr<Rule>> rules) { m_rules = rules; }
+    void setRules(QList<Rule> rules) { m_rules = rules; }
 
     /// Returns true if the library should be loaded (or extracted, in case of natives)
     bool isActive(const RuntimeContext& runtimeContext) const;
@@ -203,7 +203,7 @@ class Library {
     bool applyRules = false;
 
     /// rules associated with the library
-    QList<std::shared_ptr<Rule>> m_rules;
+    QList<Rule> m_rules;
 
     /// MOJANG: container with Mojang style download info
     MojangLibraryDownloadInfo::Ptr m_mojangDownloads;

--- a/launcher/minecraft/MojangVersionFormat.cpp
+++ b/launcher/minecraft/MojangVersionFormat.cpp
@@ -319,7 +319,11 @@ LibraryPtr MojangVersionFormat::libraryFromJson(ProblemContainer& problems, cons
     }
     if (libObj.contains("rules")) {
         out->applyRules = true;
-        out->m_rules = rulesFromJsonV4(libObj);
+
+        QJsonArray rulesArray = requireArray(libObj.value("rules"));
+        for (auto rule : rulesArray) {
+            out->m_rules.append(Rule::fromJson(requireObject(rule)));
+        }
     }
     if (libObj.contains("downloads")) {
         out->m_mojangDownloads = libDownloadInfoFromJson(libObj);
@@ -355,7 +359,7 @@ QJsonObject MojangVersionFormat::libraryToJson(Library* library)
     if (!library->m_rules.isEmpty()) {
         QJsonArray allRules;
         for (auto& rule : library->m_rules) {
-            QJsonObject ruleObj = rule->toJson();
+            QJsonObject ruleObj = rule.toJson();
             allRules.append(ruleObj);
         }
         libRoot.insert("rules", allRules);

--- a/launcher/minecraft/Rule.cpp
+++ b/launcher/minecraft/Rule.cpp
@@ -44,13 +44,13 @@ Rule Rule::fromJson(const QJsonObject& object)
     Rule result;
 
     if (object["action"] == "allow")
-        result.action = Allow;
+        result.m_action = Allow;
     else if (object["action"] == "disallow")
-        result.action = Disallow;
+        result.m_action = Disallow;
 
     if (auto os = object["os"]; os.isObject()) {
         if (auto name = os["name"].toString(); !name.isNull()) {
-            result.os = OS{
+            result.m_os = OS{
                 name,
                 os["version"].toString(),
             };
@@ -64,20 +64,20 @@ QJsonObject Rule::toJson()
 {
     QJsonObject result;
 
-    if (action == Allow)
+    if (m_action == Allow)
         result["action"] = "allow";
-    else if (action == Disallow)
+    else if (m_action == Disallow)
         result["action"] = "disallow";
 
-    if (os.has_value()) {
-        QJsonObject osResult;
+    if (m_os.has_value()) {
+        QJsonObject os;
 
-        osResult["name"] = os->name;
+        os["name"] = m_os->name;
 
-        if (!os->version.isEmpty())
-            osResult["version"] = os->version;
+        if (!m_os->version.isEmpty())
+            os["version"] = m_os->version;
 
-        result["os"] = osResult;
+        result["os"] = os;
     }
 
     return result;
@@ -85,8 +85,8 @@ QJsonObject Rule::toJson()
 
 Rule::Action Rule::apply(const RuntimeContext& runtimeContext)
 {
-    if (!runtimeContext.classifierMatches(os->name))
+    if (!runtimeContext.classifierMatches(m_os->name))
         return Defer;
 
-    return action;
+    return m_action;
 }

--- a/launcher/minecraft/Rule.h
+++ b/launcher/minecraft/Rule.h
@@ -2,6 +2,7 @@
 /*
  *  Prism Launcher - Minecraft Launcher
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2025 TheKodeToad <TheKodeToad@proton.me>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -38,59 +39,25 @@
 #include <QJsonObject>
 #include <QList>
 #include <QString>
-#include <memory>
 #include "RuntimeContext.h"
 
 class Library;
-class Rule;
 
-enum RuleAction { Allow, Disallow, Defer };
+struct Rule {
+    enum Action { Allow, Disallow, Defer };
 
-QList<std::shared_ptr<Rule>> rulesFromJsonV4(const QJsonObject& objectWithRules);
+    struct OS {
+        QString name;
+        // FIXME: unsupported
+        // retained to avoid information being lost from files
+        QString version;
+    };
 
-class Rule {
-   protected:
-    RuleAction m_result;
-    virtual bool applies(const Library* parent, const RuntimeContext& runtimeContext) = 0;
+    Action action = Defer;
+    std::optional<OS> os;
 
-   public:
-    Rule(RuleAction result) : m_result(result) {}
-    virtual ~Rule() {}
-    virtual QJsonObject toJson() = 0;
-    RuleAction apply(const Library* parent, const RuntimeContext& runtimeContext)
-    {
-        if (applies(parent, runtimeContext))
-            return m_result;
-        else
-            return Defer;
-    }
-};
+    static Rule fromJson(const QJsonObject& json);
+    QJsonObject toJson();
 
-class OsRule : public Rule {
-   private:
-    // the OS
-    QString m_system;
-    // the OS version regexp
-    QString m_version_regexp;
-
-   protected:
-    virtual bool applies(const Library*, const RuntimeContext& runtimeContext) { return runtimeContext.classifierMatches(m_system); }
-    OsRule(RuleAction result, QString system, QString version_regexp) : Rule(result), m_system(system), m_version_regexp(version_regexp) {}
-
-   public:
-    virtual QJsonObject toJson();
-    static std::shared_ptr<OsRule> create(RuleAction result, QString system, QString version_regexp)
-    {
-        return std::shared_ptr<OsRule>(new OsRule(result, system, version_regexp));
-    }
-};
-
-class ImplicitRule : public Rule {
-   protected:
-    virtual bool applies(const Library*, [[maybe_unused]] const RuntimeContext& runtimeContext) { return true; }
-    ImplicitRule(RuleAction result) : Rule(result) {}
-
-   public:
-    virtual QJsonObject toJson();
-    static std::shared_ptr<ImplicitRule> create(RuleAction result) { return std::shared_ptr<ImplicitRule>(new ImplicitRule(result)); }
+    Action apply(const RuntimeContext& runtimeContext);
 };

--- a/launcher/minecraft/Rule.h
+++ b/launcher/minecraft/Rule.h
@@ -43,9 +43,16 @@
 
 class Library;
 
-struct Rule {
+class Rule {
+   public:
     enum Action { Allow, Disallow, Defer };
 
+    static Rule fromJson(const QJsonObject& json);
+    QJsonObject toJson();
+
+    Action apply(const RuntimeContext& runtimeContext);
+
+   private:
     struct OS {
         QString name;
         // FIXME: unsupported
@@ -53,11 +60,6 @@ struct Rule {
         QString version;
     };
 
-    Action action = Defer;
-    std::optional<OS> os;
-
-    static Rule fromJson(const QJsonObject& json);
-    QJsonObject toJson();
-
-    Action apply(const RuntimeContext& runtimeContext);
+    Action m_action = Defer;
+    std::optional<OS> m_os;
 };


### PR DESCRIPTION
It used inheretence for no good reason - it just made things more limited preventing using e.g. a rule with both `os` and `features` in the future

The class still doesn't really do a very good job at handling errors... but that can be solved later