### PR TITLE
Add Ornithe, LegacyFabric and Rift mod loader filters

### DIFF
--- a/launcher/modplatform/ModIndex.cpp
+++ b/launcher/modplatform/ModIndex.cpp
@@ -31,7 +31,7 @@ static const QMap<QString, IndexedVersionType::VersionType> s_indexed_version_ty
     { "alpha", IndexedVersionType::VersionType::Alpha }
 };
 
-static const QList<ModLoaderType> loaderList = { NeoForge, Forge, Cauldron, LiteLoader, Quilt, Fabric, Babric, BTA };
+static const QList<ModLoaderType> loaderList = { NeoForge, Forge, Cauldron, LiteLoader, Quilt, Fabric, Babric, BTA, LegacyFabric, Ornithe };
 
 QList<ModLoaderType> modLoaderTypesToList(ModLoaderTypes flags)
 {
@@ -122,7 +122,7 @@ auto getModLoaderAsString(ModLoaderType type) -> const QString
         case Cauldron:
             return "cauldron";
         case LiteLoader:
-             return "liteloader";
+            return "liteloader";
         case Fabric:
             return "fabric";
         case Quilt:
@@ -133,6 +133,12 @@ auto getModLoaderAsString(ModLoaderType type) -> const QString
             return "babric";
         case BTA:
             return "bta-babric";
+        case LegacyFabric:
+            return "legacy-fabric";
+        case Ornithe:
+            return "ornithe";
+        case Rift:
+            return "rift";
         default:
             break;
     }
@@ -157,6 +163,10 @@ auto getModLoaderFromString(QString type) -> ModLoaderType
         return Babric;
     if (type == "bta-babric")
         return BTA;
+    if (type == "legacy-fabric")
+        return LegacyFabric;
+    if (type == "ornithe")
+        return Ornithe;
     return {};
 }
 

--- a/launcher/modplatform/ModIndex.cpp
+++ b/launcher/modplatform/ModIndex.cpp
@@ -31,7 +31,7 @@ static const QMap<QString, IndexedVersionType::VersionType> s_indexed_version_ty
     { "alpha", IndexedVersionType::VersionType::Alpha }
 };
 
-static const QList<ModLoaderType> loaderList = { NeoForge, Forge, Cauldron, LiteLoader, Quilt, Fabric, Babric, BTA, LegacyFabric, Ornithe };
+static const QList<ModLoaderType> loaderList = { NeoForge, Forge, Cauldron, LiteLoader, Quilt, Fabric, Babric, BTA, LegacyFabric, Ornithe, Rift };
 
 QList<ModLoaderType> modLoaderTypesToList(ModLoaderTypes flags)
 {
@@ -167,6 +167,8 @@ auto getModLoaderFromString(QString type) -> ModLoaderType
         return LegacyFabric;
     if (type == "ornithe")
         return Ornithe;
+    if (type == "rift")
+        return Rift;
     return {};
 }
 

--- a/launcher/modplatform/ModIndex.h
+++ b/launcher/modplatform/ModIndex.h
@@ -38,7 +38,10 @@ enum ModLoaderType {
     Quilt = 1 << 5,
     DataPack = 1 << 6,
     Babric = 1 << 7,
-    BTA = 1 << 8
+    BTA = 1 << 8,
+    LegacyFabric = 1 << 9,
+    Ornithe = 1 << 10,
+    Rift = 1 << 11
 };
 Q_DECLARE_FLAGS(ModLoaderTypes, ModLoaderType)
 QList<ModLoaderType> modLoaderTypesToList(ModLoaderTypes flags);

--- a/launcher/modplatform/flame/FlameAPI.h
+++ b/launcher/modplatform/flame/FlameAPI.h
@@ -73,6 +73,9 @@ class FlameAPI : public NetworkResourceAPI {
             case ModPlatform::DataPack:
             case ModPlatform::Babric:
             case ModPlatform::BTA:
+            case ModPlatform::LegacyFabric:
+            case ModPlatform::Ornithe:
+            case ModPlatform::Rift:
                 break;  // not supported
         }
         return 0;

--- a/launcher/modplatform/import_ftb/PackInstallTask.cpp
+++ b/launcher/modplatform/import_ftb/PackInstallTask.cpp
@@ -95,6 +95,12 @@ void PackInstallTask::copySettings()
                 break;
             case ModPlatform::BTA:
                 break;
+            case ModPlatform::LegacyFabric:
+                break;
+            case ModPlatform::Ornithe:
+                break;
+            case ModPlatform::Rift:
+                break;
         }
     components->saveNow();
 

--- a/launcher/modplatform/modrinth/ModrinthAPI.h
+++ b/launcher/modplatform/modrinth/ModrinthAPI.h
@@ -43,7 +43,7 @@ class ModrinthAPI : public NetworkResourceAPI {
     {
         QStringList l;
         for (auto loader : { ModPlatform::NeoForge, ModPlatform::Forge, ModPlatform::Fabric, ModPlatform::Quilt, ModPlatform::LiteLoader,
-                             ModPlatform::DataPack, ModPlatform::Babric, ModPlatform::BTA }) {
+                             ModPlatform::DataPack, ModPlatform::Babric, ModPlatform::BTA, ModPlatform::LegacyFabric, ModPlatform::Ornithe, ModPlatform::Rift }) {
             if (types & loader) {
                 l << getModLoaderAsString(loader);
             }
@@ -202,7 +202,7 @@ class ModrinthAPI : public NetworkResourceAPI {
     static inline auto validateModLoaders(ModPlatform::ModLoaderTypes loaders) -> bool
     {
         return loaders & (ModPlatform::NeoForge | ModPlatform::Forge | ModPlatform::Fabric | ModPlatform::Quilt | ModPlatform::LiteLoader |
-                          ModPlatform::DataPack | ModPlatform::Babric | ModPlatform::BTA);
+                          ModPlatform::DataPack | ModPlatform::Babric | ModPlatform::BTA | ModPlatform::LegacyFabric | ModPlatform::Ornithe | ModPlatform::Rift);
     }
 
     std::optional<QString> getDependencyURL(DependencySearchArgs const& args) const override

--- a/launcher/ui/widgets/ModFilterWidget.cpp
+++ b/launcher/ui/widgets/ModFilterWidget.cpp
@@ -152,9 +152,12 @@ ModFilterWidget::ModFilterWidget(MinecraftInstance* instance, bool extended)
     connect(ui->liteLoader, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
     connect(ui->babric, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
     connect(ui->btaBabric, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
-    
+    connect(ui->legacyFabric, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
+    connect(ui->ornithe, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
+    connect(ui->rift, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
+
     connect(ui->showMoreButton, &QPushButton::clicked, this, &ModFilterWidget::onShowMoreClicked);
-    
+
     if (!extended) {
         ui->showMoreButton->setVisible(false);
         ui->extendedModLoadersWidget->setVisible(false);
@@ -289,6 +292,12 @@ void ModFilterWidget::onLoadersFilterChanged()
         loaders |= ModPlatform::Babric;
     if (ui->btaBabric->isChecked())
         loaders |= ModPlatform::BTA;
+    if (ui->legacyFabric->isChecked())
+        loaders |= ModPlatform::LegacyFabric;
+    if (ui->ornithe->isChecked())
+        loaders |= ModPlatform::Ornithe;
+    if (ui->rift->isChecked())
+        loaders |= ModPlatform::Rift;
     m_filter_changed = loaders != m_filter->loaders;
     m_filter->loaders = loaders;
     if (m_filter_changed)

--- a/launcher/ui/widgets/ModFilterWidget.ui
+++ b/launcher/ui/widgets/ModFilterWidget.ui
@@ -167,6 +167,27 @@
                </property>
               </widget>
              </item>
+             <item>
+              <widget class="QCheckBox" name="legacyFabric">
+               <property name="text">
+                <string>Legacy Fabric</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="ornithe">
+               <property name="text">
+                <string>Ornithe</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="rift">
+               <property name="text">
+                <string>Rift</string>
+               </property>
+              </widget>
+             </item>
             </layout>
            </widget>
           </item>


### PR DESCRIPTION
Adds three further loader filters to the mod download Dialog.

This PR builds upon https://github.com/PrismLauncher/PrismLauncher/pull/3961 to implement these.

This implements the loaders mentioned in https://github.com/PrismLauncher/PrismLauncher/issues/3902 with the exception of RGML, however it does not fix the underlying issue.