### PR TITLE
Properly refresh modpack search upon changing filters

### DIFF
--- a/launcher/ui/pages/modplatform/flame/FlamePage.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.cpp
@@ -140,8 +140,8 @@ void FlamePage::triggerSearch()
     ui->packView->clearSelection();
     ui->packDescription->clear();
     ui->versionSelectionBox->clear();
-    listModel->searchWithTerm(ui->searchEdit->text(), ui->sortByBox->currentIndex(), m_filterWidget->getFilter(),
-                              m_filterWidget->changed());
+    bool filterChanged = m_filterWidget->changed();
+    listModel->searchWithTerm(ui->searchEdit->text(), ui->sortByBox->currentIndex(), m_filterWidget->getFilter(), filterChanged);
     m_fetch_progress.watch(listModel->activeSearchJob().get());
 }
 

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
@@ -361,7 +361,8 @@ void ModrinthPage::triggerSearch()
     ui->packView->clearSelection();
     ui->packDescription->clear();
     ui->versionSelectionBox->clear();
-    m_model->searchWithTerm(ui->searchEdit->text(), ui->sortByBox->currentIndex(), m_filterWidget->getFilter(), m_filterWidget->changed());
+    bool filterChanged = m_filterWidget->changed();
+    m_model->searchWithTerm(ui->searchEdit->text(), ui->sortByBox->currentIndex(), m_filterWidget->getFilter(), filterChanged);
     m_fetch_progress.watch(m_model->activeSearchJob().get());
 }
 


### PR DESCRIPTION
getFilter() resets changed(), and this causes UB

I thought C++ 17 made this well defined but if the evaluation order was left-to-right this would never have worked