### PR TITLE
Store accounts in system keychain

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "libraries/qrcodegenerator"]
 	path = libraries/qrcodegenerator
 	url = https://github.com/nayuki/QR-Code-generator
+[submodule "libraries/qtkeychain"]
+	path = libraries/qtkeychain
+	url = https://github.com/frankosterfeld/qtkeychain

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -356,12 +356,9 @@ if(NOT Launcher_FORCE_BUNDLED_LIBS)
         endif()
     endif()
 
-
-    # Find cmark
     find_package(cmark QUIET)
-
-    # Find qrcodegencpp-cmake
     find_package(qrcodegencpp QUIET)
+    find_package(Qt6Keychain 0.15.0 QUIET)
 endif()
 
 include(ECMQtDeclareLoggingCategory)
@@ -534,6 +531,14 @@ if(NOT qrcodegencpp_FOUND)
 else()
     add_library(qrcodegenerator ALIAS qrcodegencpp::qrcodegencpp)
     message(STATUS "Using system qrcodegencpp-cmake")
+endif()
+if(NOT Qt6Keychain_FOUND)
+    message(STATUS "Using bundled qtkeychain")
+    set(BUILD_WITH_QT6 1)
+    add_subdirectory(libraries/qtkeychain EXCLUDE_FROM_ALL)
+else()
+    add_library(qtkeychain ALIAS qt6keychain)
+    message(STATUS "Using system qtkeychain")
 endif()
 add_subdirectory(libraries/gamemode)
 add_subdirectory(libraries/murmur2) # Hash for usage with the CurseForge API

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -982,9 +982,8 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
 
     // and accounts
     {
-        m_accounts.reset(new AccountList(this));
+        m_accounts.reset(new AccountList("accounts.json", "accounts", this));
         qInfo() << "Loading accounts...";
-        m_accounts->setListFilePath("accounts.json", true);
         m_accounts->loadList();
         m_accounts->fillQueue();
         qInfo() << "<> Accounts loaded.";

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -903,6 +903,8 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         // Custom Technic Client ID
         m_settings->registerSetting("TechnicClientID", "");
 
+        m_settings->registerSetting("UseKeychain", false);
+
         // Init page provider
         {
             m_globalSettingsProvider = std::make_shared<GenericPageProvider>(tr("Settings"));

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -1322,6 +1322,7 @@ target_link_libraries(Launcher_logic
     BuildConfig
     Qt${QT_VERSION_MAJOR}::Widgets
     qrcodegenerator
+    qtkeychain
 )
 if(TARGET PkgConfig::tomlplusplus)
     target_link_libraries(Launcher_logic PkgConfig::tomlplusplus)

--- a/launcher/minecraft/auth/AccountData.cpp
+++ b/launcher/minecraft/auth/AccountData.cpp
@@ -34,247 +34,266 @@
  */
 
 #include "AccountData.h"
+#include "BuildConfig.h"
+
+#include <qt6keychain/keychain.h>
 #include <QDebug>
+#include <QEventLoop>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QUuid>
 
 namespace {
-void tokenToJSONV3(QJsonObject& parent, const Token& t, const char* tokenName)
+QJsonValue saveTokenV3(const Token& token)
 {
-    if (!t.persistent) {
-        return;
-    }
-    QJsonObject out;
-    if (t.issueInstant.isValid()) {
-        out["iat"] = QJsonValue(t.issueInstant.toMSecsSinceEpoch() / 1000);
-    }
+    if (!token.persistent)
+        return QJsonValue(QJsonValue::Undefined);
 
-    if (t.notAfter.isValid()) {
-        out["exp"] = QJsonValue(t.notAfter.toMSecsSinceEpoch() / 1000);
-    }
+    QJsonObject out;
 
     bool save = false;
-    if (!t.token.isEmpty()) {
-        out["token"] = QJsonValue(t.token);
+
+    if (!token.token.isEmpty()) {
+        out["token"] = QJsonValue(token.token);
         save = true;
     }
-    if (!t.refresh_token.isEmpty()) {
-        out["refresh_token"] = QJsonValue(t.refresh_token);
+
+    if (!token.refresh_token.isEmpty()) {
+        out["refresh_token"] = QJsonValue(token.refresh_token);
         save = true;
     }
-    if (t.extra.size()) {
-        out["extra"] = QJsonObject::fromVariantMap(t.extra);
+
+    if (!token.extra.isEmpty()) {
+        out["extra"] = QJsonObject::fromVariantMap(token.extra);
         save = true;
     }
-    if (save) {
-        parent[tokenName] = out;
-    }
+
+    if (!save)
+        return QJsonValue(QJsonValue::Undefined);
+
+    if (token.issueInstant.isValid())
+        out["iat"] = QJsonValue(token.issueInstant.toSecsSinceEpoch());
+
+    if (token.notAfter.isValid())
+        out["exp"] = QJsonValue(token.notAfter.toSecsSinceEpoch());
+
+    return out;
 }
 
-Token tokenFromJSONV3(const QJsonObject& parent, const char* tokenName)
+Token loadTokenJSONV3(const QJsonObject& obj)
 {
     Token out;
-    auto tokenObject = parent.value(tokenName).toObject();
-    if (tokenObject.isEmpty()) {
+
+    if (obj.isEmpty())
         return out;
-    }
-    auto issueInstant = tokenObject.value("iat");
-    if (issueInstant.isDouble()) {
-        out.issueInstant = QDateTime::fromMSecsSinceEpoch(((int64_t)issueInstant.toDouble()) * 1000);
-    }
 
-    auto notAfter = tokenObject.value("exp");
-    if (notAfter.isDouble()) {
-        out.notAfter = QDateTime::fromMSecsSinceEpoch(((int64_t)notAfter.toDouble()) * 1000);
-    }
+    QJsonValue issueInstant = obj.value("iat");
+    if (issueInstant.isDouble())
+        out.issueInstant = QDateTime::fromSecsSinceEpoch((int64_t)issueInstant.toDouble());
 
-    auto token = tokenObject.value("token");
+    QJsonValue notAfter = obj.value("exp");
+    if (notAfter.isDouble())
+        out.notAfter = QDateTime::fromSecsSinceEpoch((int64_t)notAfter.toDouble());
+
+    QJsonValue token = obj.value("token");
     if (token.isString()) {
         out.token = token.toString();
         out.validity = Validity::Assumed;
     }
 
-    auto refresh_token = tokenObject.value("refresh_token");
-    if (refresh_token.isString()) {
+    QJsonValue refresh_token = obj.value("refresh_token");
+    if (refresh_token.isString())
         out.refresh_token = refresh_token.toString();
-    }
 
-    auto extra = tokenObject.value("extra");
-    if (extra.isObject()) {
+    QJsonValue extra = obj.value("extra");
+    if (extra.isObject())
         out.extra = extra.toObject().toVariantMap();
-    }
+
     return out;
 }
 
-void profileToJSONV3(QJsonObject& parent, MinecraftProfile p, const char* tokenName)
+QJsonValue saveSkinV3(const Skin& skin)
 {
-    if (p.id.isEmpty()) {
-        return;
-    }
     QJsonObject out;
-    out["id"] = QJsonValue(p.id);
-    out["name"] = QJsonValue(p.name);
-    if (!p.currentCape.isEmpty()) {
-        out["cape"] = p.currentCape;
-    }
+    out["id"] = skin.id;
+    out["url"] = skin.url;
+    out["variant"] = skin.variant;
 
-    {
-        QJsonObject skinObj;
-        skinObj["id"] = p.skin.id;
-        skinObj["url"] = p.skin.url;
-        skinObj["variant"] = p.skin.variant;
-        if (p.skin.data.size()) {
-            skinObj["data"] = QString::fromLatin1(p.skin.data.toBase64());
-        }
-        out["skin"] = skinObj;
-    }
+    if (!skin.data.isEmpty())
+        out["data"] = QString::fromLatin1(skin.data.toBase64());
 
-    QJsonArray capesArray;
-    for (auto& cape : p.capes) {
-        QJsonObject capeObj;
-        capeObj["id"] = cape.id;
-        capeObj["url"] = cape.url;
-        capeObj["alias"] = cape.alias;
-        if (cape.data.size()) {
-            capeObj["data"] = QString::fromLatin1(cape.data.toBase64());
-        }
-        capesArray.push_back(capeObj);
-    }
-    out["capes"] = capesArray;
-    parent[tokenName] = out;
+    return out;
 }
 
-MinecraftProfile profileFromJSONV3(const QJsonObject& parent, const char* tokenName)
+Skin loadSkinV3(const QJsonObject& obj)
 {
-    MinecraftProfile out;
-    auto tokenObject = parent.value(tokenName).toObject();
-    if (tokenObject.isEmpty()) {
+    Skin out;
+
+    out.id = obj.value("id").toString();
+    out.url = obj.value("url").toString();
+    out.variant = obj.value("variant").toString();
+
+    QJsonValue data = obj.value("data");
+
+    if (out.id.isNull() || out.url.isNull() || out.variant.isNull()) {
+        qWarning() << "Skin must contain strings id, url, variant";
         return out;
     }
-    {
-        auto idV = tokenObject.value("id");
-        auto nameV = tokenObject.value("name");
-        if (!idV.isString() || !nameV.isString()) {
-            qWarning() << "mandatory profile attributes are missing or of unexpected type";
-            return MinecraftProfile();
-        }
-        out.name = nameV.toString();
-        out.id = idV.toString();
-    }
 
-    {
-        auto skinV = tokenObject.value("skin");
-        if (!skinV.isObject()) {
-            qWarning() << "skin is missing";
-            return MinecraftProfile();
+    if (!data.isUndefined()) {
+        if (!data.isString()) {
+            qWarning() << "Skin data must be a string";
+            return out;
         }
-        auto skinObj = skinV.toObject();
-        auto idV = skinObj.value("id");
-        auto urlV = skinObj.value("url");
-        auto variantV = skinObj.value("variant");
-        if (!idV.isString() || !urlV.isString() || !variantV.isString()) {
-            qWarning() << "mandatory skin attributes are missing or of unexpected type";
-            return MinecraftProfile();
-        }
-        out.skin.id = idV.toString();
-        out.skin.url = urlV.toString();
-        out.skin.url.replace("http://textures.minecraft.net", "https://textures.minecraft.net");
-        out.skin.variant = variantV.toString();
 
-        // data for skin is optional
-        auto dataV = skinObj.value("data");
-        if (dataV.isString()) {
-            // TODO: validate base64
-            out.skin.data = QByteArray::fromBase64(dataV.toString().toLatin1());
-        } else if (!dataV.isUndefined()) {
-            qWarning() << "skin data is something unexpected";
-            return MinecraftProfile();
+        out.data = QByteArray::fromBase64(data.toString().toLatin1());
+
+        if (out.data.isEmpty()) {
+            qWarning() << "Skin data is invalid";
+            return out;
         }
     }
 
-    {
-        auto capesV = tokenObject.value("capes");
-        if (!capesV.isArray()) {
-            qWarning() << "capes is not an array!";
-            return MinecraftProfile();
-        }
-        auto capesArray = capesV.toArray();
-        for (auto capeV : capesArray) {
-            if (!capeV.isObject()) {
-                qWarning() << "cape is not an object!";
-                return MinecraftProfile();
-            }
-            auto capeObj = capeV.toObject();
-            auto idV = capeObj.value("id");
-            auto urlV = capeObj.value("url");
-            auto aliasV = capeObj.value("alias");
-            if (!idV.isString() || !urlV.isString() || !aliasV.isString()) {
-                qWarning() << "mandatory skin attributes are missing or of unexpected type";
-                return MinecraftProfile();
-            }
-            Cape cape;
-            cape.id = idV.toString();
-            cape.url = urlV.toString();
-            cape.url.replace("http://textures.minecraft.net", "https://textures.minecraft.net");
-            cape.alias = aliasV.toString();
+    return out;
+}
 
-            // data for cape is optional.
-            auto dataV = capeObj.value("data");
-            if (dataV.isString()) {
-                // TODO: validate base64
-                cape.data = QByteArray::fromBase64(dataV.toString().toLatin1());
-            } else if (!dataV.isUndefined()) {
-                qWarning() << "cape data is something unexpected";
-                return MinecraftProfile();
-            }
-            out.capes[cape.id] = cape;
+QJsonValue saveCapeV3(const Cape& cape)
+{
+    QJsonObject out;
+    out["id"] = cape.id;
+    out["url"] = cape.url;
+    out["alias"] = cape.alias;
+
+    if (!cape.data.isEmpty())
+        out["data"] = QString::fromLatin1(cape.data.toBase64());
+
+    return out;
+}
+
+Cape loadCapeV3(const QJsonObject& obj)
+{
+    Cape out;
+
+    out.id = obj.value("id").toString();
+    out.url = obj.value("url").toString();
+    out.url.replace("http://textures.minecraft.net", "https://textures.minecraft.net");
+    out.alias = obj.value("alias").toString();
+
+    QJsonValue data = obj.value("data");
+
+    if (out.id.isNull() || out.url.isNull() || out.alias.isNull()) {
+        qWarning() << "Cape must contain strings id, url, alias";
+        return out;
+    }
+
+    if (!data.isUndefined()) {
+        if (!data.isString()) {
+            qWarning() << "Cape data must be a string";
+            return out;
+        }
+
+        out.data = QByteArray::fromBase64(data.toString().toLatin1());
+
+        if (out.data.isEmpty()) {
+            qWarning() << "Cape data is invalid";
+            return out;
         }
     }
-    // current cape
-    {
-        auto capeV = tokenObject.value("cape");
-        if (capeV.isString()) {
-            auto currentCape = capeV.toString();
-            if (out.capes.contains(currentCape)) {
-                out.currentCape = currentCape;
-            }
-        }
+
+    return out;
+}
+
+QJsonValue saveProfileV3(const MinecraftProfile& profile)
+{
+    if (profile.id.isEmpty())
+        return QJsonValue(QJsonValue::Undefined);
+
+    QJsonObject out;
+    out["id"] = QJsonValue(profile.id);
+    out["name"] = QJsonValue(profile.name);
+
+    if (!profile.currentCape.isEmpty())
+        out["cape"] = profile.currentCape;
+
+    out["skin"] = saveSkinV3(profile.skin);
+
+    QJsonArray capesArray;
+    for (const Cape& cape : profile.capes)
+        capesArray.push_back(saveCapeV3(cape));
+
+    out["capes"] = capesArray;
+
+    return out;
+}
+
+MinecraftProfile loadProfileV3(const QJsonObject& obj)
+{
+    MinecraftProfile out;
+
+    if (obj.isEmpty())
+        return out;
+
+    out.id = obj.value("id").toString();
+    out.name = obj.value("name").toString();
+
+    if (out.id.isNull() || out.name.isNull()) {
+        qWarning() << "Profile must contain strings id, name";
+        return MinecraftProfile();
     }
+
+    out.skin = loadSkinV3(obj.value("skin").toObject());
+
+    auto capes = obj.value("capes");
+
+    if (capes.isArray()) {
+        for (QJsonValue capeObj : capes.toArray()) {
+            Cape cape = loadCapeV3(capeObj.toObject());
+            out.capes[cape.id] = std::move(cape);
+        }
+    } else
+        qWarning() << "Profile capes must be an array";
+
+    QString currentCape = obj["cape"].toString();
+    if (!currentCape.isEmpty() || out.capes.contains(currentCape))
+        out.currentCape = currentCape;
+
     out.validity = Validity::Assumed;
     return out;
 }
 
-void entitlementToJSONV3(QJsonObject& parent, MinecraftEntitlement p)
+QJsonValue saveEntitlementV3(MinecraftEntitlement entitlement)
 {
-    if (p.validity == Validity::None) {
-        return;
-    }
+    if (entitlement.validity == Validity::None)
+        return QJsonValue(QJsonValue::Undefined);
+
     QJsonObject out;
-    out["ownsMinecraft"] = QJsonValue(p.ownsMinecraft);
-    out["canPlayMinecraft"] = QJsonValue(p.canPlayMinecraft);
-    parent["entitlement"] = out;
+    out["ownsMinecraft"] = entitlement.ownsMinecraft;
+    out["canPlayMinecraft"] = entitlement.canPlayMinecraft;
+
+    return out;
 }
 
-bool entitlementFromJSONV3(const QJsonObject& parent, MinecraftEntitlement& out)
+MinecraftEntitlement loadEntitlementV3(const QJsonObject& obj)
 {
-    auto entitlementObject = parent.value("entitlement").toObject();
-    if (entitlementObject.isEmpty()) {
-        return false;
+    MinecraftEntitlement out;
+
+    if (obj.isEmpty())
+        return out;
+
+    QJsonValue ownsMinecraft = obj.value("ownsMinecraft");
+    QJsonValue canPlayMinecraft = obj.value("canPlayMinecraft");
+
+    if (!ownsMinecraft.isBool() || !canPlayMinecraft.isBool()) {
+        qWarning() << "Entitlement must contain booleans ownsMinecraft, canPlayMinecraft";
+        return out;
     }
-    {
-        auto ownsMinecraftV = entitlementObject.value("ownsMinecraft");
-        auto canPlayMinecraftV = entitlementObject.value("canPlayMinecraft");
-        if (!ownsMinecraftV.isBool() || !canPlayMinecraftV.isBool()) {
-            qWarning() << "mandatory attributes are missing or of unexpected type";
-            return false;
-        }
-        out.canPlayMinecraft = canPlayMinecraftV.toBool(false);
-        out.ownsMinecraft = ownsMinecraftV.toBool(false);
-        out.validity = Validity::Assumed;
-    }
-    return true;
+
+    out.canPlayMinecraft = canPlayMinecraft.toBool(false);
+    out.ownsMinecraft = ownsMinecraft.toBool(false);
+    out.validity = Validity::Assumed;
+
+    return out;
 }
 
 }  // namespace
@@ -301,25 +320,19 @@ bool AccountData::resumeStateFromV3(QJsonObject data)
         if (clientIDV.isString()) {
             msaClientID = clientIDV.toString();
         }  // leave msaClientID empty if it doesn't exist or isn't a string
-        msaToken = tokenFromJSONV3(data, "msa");
-        userToken = tokenFromJSONV3(data, "utoken");
-        xboxApiToken = tokenFromJSONV3(data, "xrp-main");
-        mojangservicesToken = tokenFromJSONV3(data, "xrp-mc");
+        msaToken = loadTokenJSONV3(data["msa"].toObject());
+        userToken = loadTokenJSONV3(data["utoken"].toObject());
+        xboxApiToken = loadTokenJSONV3(data["xrp-main"].toObject());
+        mojangservicesToken = loadTokenJSONV3(data["xrp-mc"].toObject());
     }
 
-    yggdrasilToken = tokenFromJSONV3(data, "ygg");
+    yggdrasilToken = loadTokenJSONV3(data["ygg"].toObject());
     // versions before 7.2 used "offline" as the offline token
     if (yggdrasilToken.token == "offline")
         yggdrasilToken.token = "0";
 
-    minecraftProfile = profileFromJSONV3(data, "profile");
-    if (!entitlementFromJSONV3(data, minecraftEntitlement)) {
-        if (minecraftProfile.validity != Validity::None) {
-            minecraftEntitlement.canPlayMinecraft = true;
-            minecraftEntitlement.ownsMinecraft = true;
-            minecraftEntitlement.validity = Validity::Assumed;
-        }
-    }
+    minecraftProfile = loadProfileV3(data["profile"].toObject());
+    minecraftEntitlement = loadEntitlementV3(data["entitlement"].toObject());
 
     validity_ = minecraftProfile.validity;
     return true;
@@ -331,17 +344,18 @@ QJsonObject AccountData::saveState() const
     if (type == AccountType::MSA) {
         output["type"] = "MSA";
         output["msa-client-id"] = msaClientID;
-        tokenToJSONV3(output, msaToken, "msa");
-        tokenToJSONV3(output, userToken, "utoken");
-        tokenToJSONV3(output, xboxApiToken, "xrp-main");
-        tokenToJSONV3(output, mojangservicesToken, "xrp-mc");
+        output["msa"] = saveTokenV3(msaToken);
+        output["utoken"] = saveTokenV3(userToken);
+        output["xrp-main"] = saveTokenV3(xboxApiToken);
+        output["xrp-mc"] = saveTokenV3(mojangservicesToken);
     } else if (type == AccountType::Offline) {
         output["type"] = "Offline";
     }
 
-    tokenToJSONV3(output, yggdrasilToken, "ygg");
-    profileToJSONV3(output, minecraftProfile, "profile");
-    entitlementToJSONV3(output, minecraftEntitlement);
+    output["ygg"] = saveTokenV3(yggdrasilToken);
+    output["profile"] = saveProfileV3(minecraftProfile);
+    output["entitlement"] = saveEntitlementV3(minecraftEntitlement);
+
     return output;
 }
 

--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -54,7 +54,8 @@
 
 enum AccountListVersion { MojangMSA = 3 };
 
-AccountList::AccountList(QObject* parent) : QAbstractListModel(parent)
+AccountList::AccountList(QString filePath, QString keychainKey, QObject* parent)
+    : QAbstractListModel(parent), m_filePath(std::move(filePath)), m_keychainKey(std::move(keychainKey))
 {
     m_refreshTimer = new QTimer(this);
     m_refreshTimer->setSingleShot(true);
@@ -240,18 +241,14 @@ void AccountList::accountActivityChanged(bool active)
 
 void AccountList::onListChanged()
 {
-    if (m_autosave)
-        // TODO: Alert the user if this fails.
-        saveList();
-
+    // TODO: Alert the user if this fails.
+    saveList();
     emit listChanged();
 }
 
 void AccountList::onDefaultAccountChanged()
 {
-    if (m_autosave)
-        saveList();
-
+    saveList();
     emit defaultAccountChanged();
 }
 
@@ -410,17 +407,17 @@ bool AccountList::setData(const QModelIndex& idx, const QVariant& value, int rol
 
 bool AccountList::loadList()
 {
-    if (m_listFilePath.isEmpty()) {
+    if (m_filePath.isEmpty()) {
         qCritical() << "Can't load Mojang account list. No file path given and no default set.";
         return false;
     }
 
-    QFile file(m_listFilePath);
+    QFile file(m_filePath);
 
     // Try to open the file and fail if we can't.
     // TODO: We should probably report this error to the user.
     if (!file.open(QIODevice::ReadOnly)) {
-        qCritical() << QString("Failed to read the account list file (%1).").arg(m_listFilePath).toUtf8();
+        qCritical() << QString("Failed to read the account list file (%1).").arg(m_filePath).toUtf8();
         return false;
     }
 
@@ -452,7 +449,7 @@ bool AccountList::loadList()
     if (listVersion == AccountListVersion::MojangMSA)
         return loadV3(root);
 
-    QString newName = "accounts-old.json";
+    QString newName = m_filePath + ".bak";
     qWarning() << "Unknown format version when loading account list. Existing one will be renamed to" << newName;
     // Attempt to rename the old version.
     file.rename(newName);
@@ -489,23 +486,23 @@ bool AccountList::loadV3(QJsonObject& root)
 
 bool AccountList::saveList()
 {
-    if (m_listFilePath.isEmpty()) {
+    if (m_filePath.isEmpty()) {
         qCritical() << "Can't save Mojang account list. No file path given and no default set.";
         return false;
     }
 
     // make sure the parent folder exists
-    if (!FS::ensureFilePathExists(m_listFilePath))
+    if (!FS::ensureFilePathExists(m_filePath))
         return false;
 
     // make sure the file wasn't overwritten with a folder before (fixes a bug)
-    QFileInfo finfo(m_listFilePath);
+    QFileInfo finfo(m_filePath);
     if (finfo.isDir()) {
-        QDir badDir(m_listFilePath);
+        QDir badDir(m_filePath);
         badDir.removeRecursively();
     }
 
-    qDebug() << "Writing account list to" << m_listFilePath;
+    qDebug() << "Writing account list to" << m_filePath;
 
     qDebug() << "Building JSON data structure.";
     // Build the JSON document to write to the list file.
@@ -532,12 +529,12 @@ bool AccountList::saveList()
 
     // Now that we're done building the JSON object, we can write it to the file.
     qDebug() << "Writing account list to file.";
-    QSaveFile file(m_listFilePath);
+    QSaveFile file(m_filePath);
 
     // Try to open the file and fail if we can't.
     // TODO: We should probably report this error to the user.
     if (!file.open(QIODevice::WriteOnly)) {
-        qCritical() << QString("Failed to read the account list file (%1).").arg(m_listFilePath).toUtf8();
+        qCritical() << QString("Failed to read the account list file (%1).").arg(m_filePath).toUtf8();
         return false;
     }
 
@@ -545,18 +542,12 @@ bool AccountList::saveList()
     file.write(doc.toJson());
     file.setPermissions(QFile::ReadOwner | QFile::WriteOwner | QFile::ReadUser | QFile::WriteUser);
     if (file.commit()) {
-        qDebug() << "Saved account list to" << m_listFilePath;
+        qDebug() << "Saved account list to" << m_filePath;
         return true;
     } else {
-        qDebug() << "Failed to save accounts to" << m_listFilePath;
+        qDebug() << "Failed to save accounts to" << m_filePath;
         return false;
     }
-}
-
-void AccountList::setListFilePath(QString path, bool autosave)
-{
-    m_listFilePath = path;
-    m_autosave = autosave;
 }
 
 bool AccountList::anyAccountIsValid()

--- a/launcher/minecraft/auth/AccountList.h
+++ b/launcher/minecraft/auth/AccountList.h
@@ -62,7 +62,7 @@ class AccountList : public QAbstractListModel {
         NUM_COLUMNS
     };
 
-    explicit AccountList(QObject* parent = 0);
+    explicit AccountList(QString filePath, QString keychainKey, QObject* parent = 0);
     virtual ~AccountList() noexcept;
 
     const MinecraftAccountPtr at(int i) const;
@@ -86,15 +86,6 @@ class AccountList : public QAbstractListModel {
     void requestRefresh(QString accountId);
     // queuing a refresh will let it go to the back of the queue (unless it's somewhere inside the queue already)
     void queueRefresh(QString accountId);
-
-    /*!
-     * Sets the path to load/save the list file from/to.
-     * If autosave is true, this list will automatically save to the given path whenever it changes.
-     * THIS FUNCTION DOES NOT LOAD THE LIST. If you set autosave, be sure to call loadList() immediately
-     * after calling this function to ensure an autosaved change doesn't overwrite the list you intended
-     * to load.
-     */
-    void setListFilePath(QString path, bool autosave = false);
 
     bool loadList();
     bool loadV3(QJsonObject& root);
@@ -164,11 +155,6 @@ class AccountList : public QAbstractListModel {
     MinecraftAccountPtr m_defaultAccount;
 
     //! Path to the account list file. Empty string if there isn't one.
-    QString m_listFilePath;
-
-    /*!
-     * If true, the account list will automatically save to the account list path when it changes.
-     * Ignored if m_listFilePath is blank.
-     */
-    bool m_autosave = false;
+    const QString m_filePath;
+    const QString m_keychainKey;
 };

--- a/launcher/ui/pages/global/AccountListPage.cpp
+++ b/launcher/ui/pages/global/AccountListPage.cpp
@@ -89,6 +89,9 @@ AccountListPage::AccountListPage(QWidget* parent) : QMainWindow(parent), ui(new 
         ui->actionAddMicrosoft->setVisible(false);
         ui->actionAddMicrosoft->setToolTip(tr("No Microsoft Authentication client ID was set."));
     }
+
+    ui->checkBoxUseKeychain->setChecked(APPLICATION->settings()->get("UseKeychain").toBool());
+    connect(ui->checkBoxUseKeychain, &QCheckBox::toggled, this, [](bool value) { APPLICATION->settings()->set("UseKeychain", value); });
 }
 
 AccountListPage::~AccountListPage()

--- a/launcher/ui/pages/global/AccountListPage.ui
+++ b/launcher/ui/pages/global/AccountListPage.ui
@@ -25,23 +25,34 @@
      <number>0</number>
     </property>
     <item>
-     <widget class="VersionListView" name="listView">
-      <property name="alternatingRowColors">
-       <bool>true</bool>
-      </property>
-      <property name="rootIsDecorated">
-       <bool>false</bool>
-      </property>
-      <property name="itemsExpandable">
-       <bool>false</bool>
-      </property>
-      <property name="allColumnsShowFocus">
-       <bool>true</bool>
-      </property>
-      <attribute name="headerStretchLastSection">
-       <bool>false</bool>
-      </attribute>
-     </widget>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="VersionListView" name="listView">
+        <property name="alternatingRowColors">
+         <bool>true</bool>
+        </property>
+        <property name="rootIsDecorated">
+         <bool>false</bool>
+        </property>
+        <property name="itemsExpandable">
+         <bool>false</bool>
+        </property>
+        <property name="allColumnsShowFocus">
+         <bool>true</bool>
+        </property>
+        <attribute name="headerStretchLastSection">
+         <bool>false</bool>
+        </attribute>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="checkBoxUseKeychain">
+        <property name="text">
+         <string>Store accounts on system keychain (recommended)</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </item>
    </layout>
   </widget>


### PR DESCRIPTION
Stores the whole account.json in keychain* instead of file lol (fix #4073)

To-do:
- Probably some vcpkg and nix stuff to sort out
- Probably should avoid the infamous QEventLoop
  - Loading happens once on startup (afaik) so not much of an issue there
  - With saving I'm not sure what the best approach is but the ui potentially freezing isn't good...maybe just ensure each save happens after the previous is done

\* That Thing each platform has for storing credentials that only macos calls the keychain