### PR TITLE
Fix resourcepack parsing

### DIFF
--- a/launcher/minecraft/mod/DataPack.h
+++ b/launcher/minecraft/mod/DataPack.h
@@ -64,8 +64,6 @@ class DataPack : public Resource {
     [[nodiscard]] int compare(Resource const& other, SortType type) const override;
     [[nodiscard]] bool applyFilter(QRegularExpression filter) const override;
 
-    virtual QString directory() { return "/data"; }
-
    protected:
     mutable QMutex m_data_lock;
 

--- a/launcher/minecraft/mod/ResourcePack.h
+++ b/launcher/minecraft/mod/ResourcePack.h
@@ -23,6 +23,4 @@ class ResourcePack : public DataPack {
 
     /** Gets, respectively, the lower and upper versions supported by the set pack format. */
     std::pair<Version, Version> compatibleVersions() const override;
-
-    QString directory() override { return "/assets"; }
 };

--- a/launcher/minecraft/mod/tasks/LocalDataPackParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalDataPackParseTask.cpp
@@ -73,11 +73,6 @@ bool processFolder(DataPack* pack, ProcessingLevel level)
         return mcmeta_invalid();  // mcmeta file isn't a valid file
     }
 
-    QFileInfo data_dir_info(FS::PathCombine(pack->fileinfo().filePath(), pack->directory()));
-    if (!data_dir_info.exists() || !data_dir_info.isDir()) {
-        return false;  // data dir does not exists or isn't valid
-    }
-
     if (level == ProcessingLevel::BasicInfoOnly) {
         return true;  // only need basic info already checked
     }
@@ -139,11 +134,6 @@ bool processZIP(DataPack* pack, ProcessingLevel level)
         }
     } else {
         return mcmeta_invalid();  // could not set pack.mcmeta as current file.
-    }
-
-    QuaZipDir zipDir(&zip);
-    if (!zipDir.exists(pack->directory())) {
-        return false;  // data dir does not exists at zip root
     }
 
     if (level == ProcessingLevel::BasicInfoOnly) {

--- a/tests/ResourcePackParse_test.cpp
+++ b/tests/ResourcePackParse_test.cpp
@@ -69,7 +69,7 @@ class ResourcePackParseTest : public QObject {
 
         QVERIFY(pack.packFormat() == 6);
         QVERIFY(pack.description() == "o quartel pegou fogo, policia deu sinal, acode acode acode a bandeira nacional");
-        QVERIFY(valid == false);  // no assets dir
+        QVERIFY(valid == true);  // no assets dir but it is still valid based on https://minecraft.wiki/w/Resource_pack
     }
 };
 


### PR DESCRIPTION
Based on https://minecraft.wiki/w/Resource_pack and https://minecraft.wiki/w/Data_pack the game identifies a pack based on the presence of the `pack.mcmeta` file in the root directory

fixes #4071