### PR TITLE
FindJavaPaths: fix sdkman search, add asdf search

### DIFF
--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -385,6 +385,13 @@ QList<QString> JavaUtils::FindJavaPaths()
     for (const QString& java : sdkmanJavas) {
         javas.append(sdkmanJavaDir.absolutePath() + "/" + java + "/bin/java");
     }
+
+    // javas downloaded by asdf
+    QString asdfDataDir = qEnvironmentVariable("ASDF_DATA_DIR", FS::PathCombine(home, ".asdf"));
+    QDir asdfJavaDir(FS::PathCombine(asdfDataDir, "installs/java"));
+    QStringList asdfJavas = asdfJavaDir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
+    for (const QString& java : asdfJavas) {
+        javas.append(asdfJavaDir.absolutePath() + "/" + java + "/bin/java");
     }
 
     // java in user library folder (like from intellij downloads)
@@ -472,6 +479,9 @@ QList<QString> JavaUtils::FindJavaPaths()
     // javas downloaded by sdkman
     QString sdkmanDir = qEnvironmentVariable("SDKMAN_DIR", FS::PathCombine(home, ".sdkman"));
     scanJavaDirs(FS::PathCombine(sdkmanDir, "candidates/java"));
+    // javas downloaded by asdf
+    QString asdfDataDir = qEnvironmentVariable("ASDF_DATA_DIR", FS::PathCombine(home, ".asdf"));
+    scanJavaDirs(FS::PathCombine(asdfDataDir, "installs/java"));
     // javas downloaded by gradle (toolchains)
     scanJavaDirs(FS::PathCombine(home, ".gradle/jdks"));
 

--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -379,10 +379,12 @@ QList<QString> JavaUtils::FindJavaPaths()
     auto home = qEnvironmentVariable("HOME");
 
     // javas downloaded by sdkman
-    QDir sdkmanDir(FS::PathCombine(home, ".sdkman/candidates/java"));
-    QStringList sdkmanJavas = sdkmanDir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
+    QString sdkmanDir = qEnvironmentVariable("SDKMAN_DIR", FS::PathCombine(home, ".sdkman"));
+    QDir sdkmanJavaDir(FS::PathCombine(sdkmanDir, "candidates/java"));
+    QStringList sdkmanJavas = sdkmanJavaDir.entryList(QDir::Dirs | QDir::NoDotAndDotDot);
     for (const QString& java : sdkmanJavas) {
-        javas.append(sdkmanDir.absolutePath() + "/" + java + "/bin/java");
+        javas.append(sdkmanJavaDir.absolutePath() + "/" + java + "/bin/java");
+    }
     }
 
     // java in user library folder (like from intellij downloads)
@@ -468,7 +470,8 @@ QList<QString> JavaUtils::FindJavaPaths()
     // javas downloaded by IntelliJ
     scanJavaDirs(FS::PathCombine(home, ".jdks"));
     // javas downloaded by sdkman
-    scanJavaDirs(FS::PathCombine(home, ".sdkman/candidates/java"));
+    QString sdkmanDir = qEnvironmentVariable("SDKMAN_DIR", FS::PathCombine(home, ".sdkman"));
+    scanJavaDirs(FS::PathCombine(sdkmanDir, "candidates/java"));
     // javas downloaded by gradle (toolchains)
     scanJavaDirs(FS::PathCombine(home, ".gradle/jdks"));
 


### PR DESCRIPTION
<img width="622" height="689" alt="image" src="https://github.com/user-attachments/assets/ffc06209-c814-4176-89ec-faac38c15055" />

Sources:
https://sdkman.io/install/#install-to-a-custom-location
https://asdf-vm.com/manage/configuration.html#asdf-data-dir
