### PR TITLE
Actions fixes for setup-dependencies/macOS and package/Windows

### DIFF
--- a/.github/actions/package/windows/action.yml
+++ b/.github/actions/package/windows/action.yml
@@ -14,8 +14,7 @@ inputs:
     required: true
   msystem:
     description: MSYS2 subsystem to use
-    required: true
-    default: false
+    required: false
   windows-codesign-cert:
     description: Certificate for signing Windows builds
     required: false

--- a/.github/actions/setup-dependencies/macos/action.yml
+++ b/.github/actions/setup-dependencies/macos/action.yml
@@ -42,7 +42,6 @@ runs:
         echo "VCPKG_BINARY_SOURCES=clear;nuget,$FEED_URL,readwrite" >> "$GITHUB_ENV"
 
     - name: Setup vcpkg environment
-      if: ${{ inputs.build-type == 'Debug' }}
       shell: bash
       run: |
         echo "CMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" >> "$GITHUB_ENV"


### PR DESCRIPTION
`setup-dependencies/macOS`: `vcpkg` was only ran on Debug builds. If trying to build a Release, it would fail due to missing dependencies
`package/Windows`: `default: false` means "the default value is `false`", not "there is no default value"