### PR TITLE
fix: prioritize .ftbapp/version.json in FTB App import

### DIFF
--- a/launcher/modplatform/import_ftb/PackHelpers.cpp
+++ b/launcher/modplatform/import_ftb/PackHelpers.cpp
@@ -79,9 +79,9 @@ Modpack parseDirectory(QString path)
         return {};
     }
 
-    auto versionsFile = QFileInfo(FS::PathCombine(path, "version.json"));
+    auto versionsFile = QFileInfo(FS::PathCombine(path, ".ftbapp", "version.json"));
     if (!versionsFile.exists() || !versionsFile.isFile()) {
-        versionsFile = QFileInfo(FS::PathCombine(path, ".ftbapp", "version.json"));
+        versionsFile = QFileInfo(FS::PathCombine(path, "version.json"));
     }
     if (!versionsFile.exists() || !versionsFile.isFile()) {
         return {};


### PR DESCRIPTION
Newer versions of FTB App create a stub version.json in the instance root with only a comment directing to .ftbapp/version.json. The old logic would find this stub file first and fail to parse it, causing modpacks to not be detected.

This fix checks .ftbapp/version.json first (newer location) before falling back to the root version.json (older location).

Fixes the https://github.com/PrismLauncher/PrismLauncher/issues/1929#issuecomment-2249220081