### PR TITLE
mod versions now list in newest first order

### DIFF
--- a/launcher/minecraft/mod/Mod.cpp
+++ b/launcher/minecraft/mod/Mod.cpp
@@ -186,8 +186,11 @@ auto Mod::side() const -> QString
 
 auto Mod::mcVersions() const -> QString
 {
-    if (metadata())
-        return metadata()->mcVersions.join(", ");
+    if (metadata()){
+        QStringList reversed = metadata()->mcVersions;
+        std::reverse(reversed.begin(), reversed.end());
+        return reversed.join(", ");
+    }
 
     return {};
 }

--- a/launcher/minecraft/mod/Mod.cpp
+++ b/launcher/minecraft/mod/Mod.cpp
@@ -186,11 +186,8 @@ auto Mod::side() const -> QString
 
 auto Mod::mcVersions() const -> QString
 {
-    if (metadata()){
-        QStringList reversed = metadata()->mcVersions;
-        std::reverse(reversed.begin(), reversed.end());
-        return reversed.join(", ");
-    }
+    if (metadata())
+        return metadata()->mcVersions.join(", ");
 
     return {};
 }

--- a/launcher/modplatform/packwiz/Packwiz.cpp
+++ b/launcher/modplatform/packwiz/Packwiz.cpp
@@ -290,7 +290,8 @@ auto V1::getIndexForMod(const QDir& index_dir, QString slug) -> Mod
                     }
                 }
             }
-            mod.mcVersions.sort();
+            std::sort(mod.mcVersions.begin(), mod.mcVersions.end(), versionsSort);
+            std::reverse(mod.mcVersions.begin(), mod.mcVersions.end());
         }
     }
     mod.version_number = table["x-prismlauncher-version-number"].value_or("");
@@ -350,16 +351,12 @@ auto V1::getIndexForMod(const QDir& index_dir, QVariant& mod_id) -> Mod
 // return false if a > b
 bool V1::versionsSort(QString a, QString b)
 {
-    std::string stringA = a.toStdString();
-    std::string stringB = b.toStdString();
-    std::stringstream streamA(stringA);
-    std::stringstream streamB(stringB);
-    std::string bufA;
-    std::string bufB;
-
-    while (getline(streamA, bufA, '.') && getline(streamB, bufB, '.')) {
-        int intA = atoi(bufA.c_str());
-        int intB = atoi(bufB.c_str());
+    QStringList splitA = a.split('.');
+    QStringList splitB = b.split('.');
+    int i = 0;
+    for (i; i < std::min(splitA.size(), splitB.size()); i++) {
+        int intA = splitA[i].toInt();
+        int intB = splitB[i].toInt();
         if (intA == intB) {
             continue;
         } else if (intA > intB) {
@@ -368,12 +365,15 @@ bool V1::versionsSort(QString a, QString b)
             return true;
         }
     }
-    // one is an 1.x instead of 1.x.y so the small length string is the lower version
-    if (stringA.size() > stringB.size()) {
+    if (splitA.size() == splitB.size()) {
+        return ((splitA[i - 1].size() > splitB[i - 1].size()));
+    }
+    if (splitA.size() > splitB.size()) {
         return false;
     } else {
         return true;
     }
+
 }
 
 }  // namespace Packwiz

--- a/launcher/modplatform/packwiz/Packwiz.cpp
+++ b/launcher/modplatform/packwiz/Packwiz.cpp
@@ -115,7 +115,8 @@ auto V1::createModFormat([[maybe_unused]] const QDir& index_dir,
     mod.side = mod_version.side == ModPlatform::Side::NoSide ? mod_pack.side : mod_version.side;
     mod.loaders = mod_version.loaders;
     mod.mcVersions = mod_version.mcVersion;
-    mod.mcVersions.sort();
+    std::sort(mod.mcVersions.begin(), mod.mcVersions.end(), versionsSort)
+    std::reverse(mod.mcVersions.begin(), mod.mcVersions.end())
     mod.releaseType = mod_version.version_type;
 
     mod.version_number = mod_version.version_number;
@@ -344,6 +345,35 @@ auto V1::getIndexForMod(const QDir& index_dir, QVariant& mod_id) -> Mod
     }
 
     return {};
+}
+
+// return false if a > b
+auto versionsSort(QString a, QString b) -> bool
+{
+    std::string stringA = a.toStdString();
+    std::string stringB = b.toStdString();
+    std::stringstream streamA(stringA);
+    std::stringstream streamB(stringB);
+    std::string bufA;
+    std::string bufB;
+
+    while (getline(streamA, bufA, '.') && getline(streamB, bufB, '.')) {
+        int intA = atoi(bufA.c_str());
+        int intB = atoi(bufB.c_str());
+        if (intA == intB) {
+            continue;
+        } else if (intA > intB) {
+            return false;
+        } else {
+            return true;
+        }
+    }
+    // one is an 1.x instead of 1.x.y so the small length string is the lower version
+    if (stringA.size() > stringB.size()) {
+        return false;
+    } else {
+        return true;
+    }
 }
 
 }  // namespace Packwiz

--- a/launcher/modplatform/packwiz/Packwiz.cpp
+++ b/launcher/modplatform/packwiz/Packwiz.cpp
@@ -116,7 +116,6 @@ auto V1::createModFormat([[maybe_unused]] const QDir& index_dir,
     mod.loaders = mod_version.loaders;
     mod.mcVersions = mod_version.mcVersion;
     std::sort(mod.mcVersions.begin(), mod.mcVersions.end(), versionsSort);
-    std::reverse(mod.mcVersions.begin(), mod.mcVersions.end());
     mod.releaseType = mod_version.version_type;
 
     mod.version_number = mod_version.version_number;
@@ -291,7 +290,6 @@ auto V1::getIndexForMod(const QDir& index_dir, QString slug) -> Mod
                 }
             }
             std::sort(mod.mcVersions.begin(), mod.mcVersions.end(), versionsSort);
-            std::reverse(mod.mcVersions.begin(), mod.mcVersions.end());
         }
     }
     mod.version_number = table["x-prismlauncher-version-number"].value_or("");
@@ -359,20 +357,14 @@ bool V1::versionsSort(QString a, QString b)
         int intB = splitB[i].toInt();
         if (intA == intB) {
             continue;
-        } else if (intA > intB) {
-            return false;
         } else {
-            return true;
+            return intA > intB;
         }
     }
     if (splitA.size() == splitB.size()) {
-        return ((splitA[i - 1].size() > splitB[i - 1].size()));
+        return ((splitA[i - 1].size() <= splitB[i - 1].size()));
     }
-    if (splitA.size() > splitB.size()) {
-        return false;
-    } else {
-        return true;
-    }
+    return splitA.size() > splitB.size();
 
 }
 

--- a/launcher/modplatform/packwiz/Packwiz.cpp
+++ b/launcher/modplatform/packwiz/Packwiz.cpp
@@ -115,8 +115,8 @@ auto V1::createModFormat([[maybe_unused]] const QDir& index_dir,
     mod.side = mod_version.side == ModPlatform::Side::NoSide ? mod_pack.side : mod_version.side;
     mod.loaders = mod_version.loaders;
     mod.mcVersions = mod_version.mcVersion;
-    std::sort(mod.mcVersions.begin(), mod.mcVersions.end(), versionsSort)
-    std::reverse(mod.mcVersions.begin(), mod.mcVersions.end())
+    std::sort(mod.mcVersions.begin(), mod.mcVersions.end(), versionsSort);
+    std::reverse(mod.mcVersions.begin(), mod.mcVersions.end());
     mod.releaseType = mod_version.version_type;
 
     mod.version_number = mod_version.version_number;
@@ -348,7 +348,7 @@ auto V1::getIndexForMod(const QDir& index_dir, QVariant& mod_id) -> Mod
 }
 
 // return false if a > b
-auto versionsSort(QString a, QString b) -> bool
+bool V1::versionsSort(QString a, QString b)
 {
     std::string stringA = a.toStdString();
     std::string stringB = b.toStdString();

--- a/launcher/modplatform/packwiz/Packwiz.h
+++ b/launcher/modplatform/packwiz/Packwiz.h
@@ -90,7 +90,7 @@ class V1 {
     static auto getIndexForMod(const QDir& index_dir, QVariant& mod_id) -> Mod;
 
     /* Returns if version a is greater than version b, ie: 1.20.1 > 1.20; 1.20.10 > 1.20.2*/
-    static auto versionsSort(QString a, QString b) -> bool;
+    static bool versionsSort(QString a, QString b);
 };
 
 }  // namespace Packwiz

--- a/launcher/modplatform/packwiz/Packwiz.h
+++ b/launcher/modplatform/packwiz/Packwiz.h
@@ -88,6 +88,9 @@ class V1 {
      * If the mod doesn't have a metadata, it simply returns an empty Mod object.
      * */
     static auto getIndexForMod(const QDir& index_dir, QVariant& mod_id) -> Mod;
+
+    /* Returns if version a is greater than version b, ie: 1.20.1 > 1.20; 1.20.10 > 1.20.2*/
+    static auto versionsSort(QString a, QString b) -> bool;
 };
 
 }  // namespace Packwiz

--- a/launcher/modplatform/packwiz/Packwiz.h
+++ b/launcher/modplatform/packwiz/Packwiz.h
@@ -89,7 +89,7 @@ class V1 {
      * */
     static auto getIndexForMod(const QDir& index_dir, QVariant& mod_id) -> Mod;
 
-    /* Returns if version a is greater than version b, ie: 1.20.1 > 1.20; 1.20.10 > 1.20.2*/
+    /* Returns if version a is less than version b, ie: 1.20 < 1.20.1; 1.20.2 < 1.20.10*/
     static bool versionsSort(QString a, QString b);
 };
 


### PR DESCRIPTION
Closes #4052 

Clicking a _pack_ in _menu_ -> _edit_ -> _mods_. Fixed minecraft version being in ascending order left-to-right (e.g. 1.21.6, 1.21.7, 1.21.8). Now version are shown in descending order (e.g. 1.21.8, 1.21.7, 1.21.6). 

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
