### PR TITLE
Update to Qt 6.10

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -21,7 +21,7 @@ inputs:
   qt-version:
     description: Version of Qt to use
     required: true
-    default: 6.9.1
+    default: 6.10.0
 
 outputs:
   build-type:


### PR DESCRIPTION
https://www.qt.io/blog/qt-6.10-released

**This bumps our minimum macOS requirement to macOS 13!!!!!** (https://doc.qt.io/qt-6/supported-platforms.html#macos)

But otherwise brings us into a currently in-support release of Qt, which will continue to be for the next ~6 months

## Test Checklist

- [ ] Linux
- [ ] macOS
- [x] MSVC (done by me)
