### PR TITLE
Fixed non-debug Windows MSVC builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -487,8 +487,8 @@ if(FORCE_BUNDLED_ZLIB)
         file(RENAME "${CMAKE_CURRENT_SOURCE_DIR}/libraries/zlib/zconf.h.included" "${CMAKE_CURRENT_SOURCE_DIR}/libraries/zlib/zconf.h")
     endif()
 
-    set(ZLIB_INCLUDE_DIR "${CMAKE_CURRENT_BINARY_DIR}/libraries/zlib" "${CMAKE_CURRENT_SOURCE_DIR}/libraries/zlib" CACHE STRING "" FORCE)
-    set_target_properties(zlibstatic PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${ZLIB_INCLUDE_DIR}")
+    set(ZLIB_INCLUDE "${CMAKE_CURRENT_BINARY_DIR}/libraries/zlib" "${CMAKE_CURRENT_SOURCE_DIR}/libraries/zlib" CACHE STRING "" FORCE)
+    set_target_properties(zlibstatic PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${ZLIB_INCLUDE}")
     add_library(ZLIB::ZLIB ALIAS zlibstatic)
     set(ZLIB_LIBRARY ZLIB::ZLIB CACHE STRING "zlib library name")
 
@@ -498,8 +498,7 @@ else()
 endif()
 if (FORCE_BUNDLED_QUAZIP)
     message(STATUS "Using bundled QuaZip")
-    set(BUILD_SHARED_LIBS 0)  # link statically to avoid conflicts.
-    set(QUAZIP_INSTALL 0)
+    set(EMSCRIPTEN 1)  # link statically to avoid conflicts.
     add_subdirectory(libraries/quazip) # zip manipulation library
 else()
     message(STATUS "Using system QuaZip")


### PR DESCRIPTION
QuaZip gave errors on Windows with MSVC, when triggering a Release, caused by:
1. They renamed the ZLIB_INCLUDE_DIR variable to ZLIB_INCLUDE.
2. If EMSCRIPTEN variable is not set, QuaZip ignores you telling it to use static libraries.

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
