### PR TITLE
Check for mouse button before applying skin rotation

### DIFF
--- a/launcher/ui/dialogs/skins/draw/SkinOpenGLWindow.cpp
+++ b/launcher/ui/dialogs/skins/draw/SkinOpenGLWindow.cpp
@@ -75,6 +75,12 @@ void SkinOpenGLWindow::mousePressEvent(QMouseEvent* e)
 
 void SkinOpenGLWindow::mouseMoveEvent(QMouseEvent* event)
 {
+    // Prevents mouse sticking on Wayland compositors
+    if (!(event->buttons() & Qt::MouseButton::LeftButton)) {
+        m_isMousePressed = false;
+        return;
+    }
+
     if (m_isMousePressed) {
         int dx = event->position().x() - m_mousePosition.x();
         int dy = event->position().y() - m_mousePosition.y();


### PR DESCRIPTION
Fixes #4278 

Wayland prevents the SkinOpenGLWindow from receiving mouse events when the cursor leaves said window. This PR adds a check in SkinOpenGLWindow::mouseMoveEvent to ensure that the left mouse button is still pressed, which prevents the undesirable sticking of the 3D skin model's rotation to the cursor after the left mouse button has been released outside of the SkinOpenGLWindow.