### PR TITLE
Implement Reverse Z projection matrix for skin model

### DIFF
--- a/launcher/resources/shaders/shaders.qrc
+++ b/launcher/resources/shaders/shaders.qrc
@@ -1,6 +1,7 @@
 <RCC>
     <qresource prefix="/shaders">
-        <file>vshader.glsl</file>
+        <file>vshader_skin_model.glsl</file>
+        <file>vshader_skin_background.glsl</file>
         <file>fshader.glsl</file>
     </qresource>
 </RCC>

--- a/launcher/resources/shaders/vshader_skin_background.glsl
+++ b/launcher/resources/shaders/vshader_skin_background.glsl
@@ -1,0 +1,11 @@
+
+attribute vec4 a_position;
+attribute vec2 a_texcoord;
+
+varying vec2 v_texcoord;
+
+void main()
+{
+    gl_Position = a_position;
+    v_texcoord = a_texcoord;
+}

--- a/launcher/resources/shaders/vshader_skin_model.glsl
+++ b/launcher/resources/shaders/vshader_skin_model.glsl
@@ -1,6 +1,12 @@
 // Copyright (C) 2024 The Qt Company Ltd.
 // SPDX-License-Identifier: LicenseRef-Qt-Commercial OR BSD-3-Clause
 // https://code.qt.io/cgit/qt/qtbase.git/tree/examples/opengl/cube/vshader.glsl
+
+// Dylan Schooner - 2025
+// Modification: Implemented final Z-NDC re-inversion to compensate 
+// for rigid OpenGL 2.0 context forcing glClearDepth(1.0).
+// This flips the high-precision Reverse Z output to the standard [0, W] range.
+
 #ifdef GL_ES
 // Set default precision to medium
 precision mediump int;
@@ -19,6 +25,11 @@ void main()
 {
     // Calculate vertex position in screen space
     gl_Position = mvp_matrix * model_matrix * a_position;
+
+    // Invert the z component of our Reverse Z matrix back to standard NDC
+    float near_z  = gl_Position.z;
+    float w_c     = gl_Position.w;
+    gl_Position.z = w_c - near_z;
 
     // Pass texture coordinate to fragment shader
     // Value will be automatically interpolated to fragments inside polygon faces

--- a/launcher/ui/dialogs/skins/draw/SkinOpenGLWindow.h
+++ b/launcher/ui/dialogs/skins/draw/SkinOpenGLWindow.h
@@ -61,7 +61,8 @@ class SkinOpenGLWindow : public QOpenGLWindow, protected QOpenGLFunctions {
     void renderBackground();
 
    private:
-    QOpenGLShaderProgram* m_program;
+    QOpenGLShaderProgram* m_modelProgram;
+    QOpenGLShaderProgram* m_backgroundProgram;
     opengl::Scene* m_scene = nullptr;
 
     QMatrix4x4 m_projection;


### PR DESCRIPTION
Fixes #4280 

Some Wayland environments do not play nicely with the 3D skin model; namely, depth buffer precision issues cause aggressive z-fighting, even among geometry that is not co-planar. One approach to combat this is with a [Reverse Z projection matrix](https://iolite-engine.com/blog_posts/reverse_z_cheatsheet). This remaps the space between the near and far clipping planes from [0, 1] to [1, 0]. This enables greater precision in the depth buffer for geometry further from the camera and, more importantly in this case, greatly reduces z-fighting.

This is with the standard QMatrix4x4 perspective matrix:
[depth_buffer_issue.webm](https://github.com/user-attachments/assets/1bdd45f2-f5bc-4cdb-bb97-e379a9cc0fa0)

And here is with the Reverse Z implementation:
[depth_buffer_fix.webm](https://github.com/user-attachments/assets/58ff1bd6-bdf7-4b6b-9c63-8e33614bab4b)
