### PR TITLE
Update to Qt 6.9.3

### DIFF
--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -21,7 +21,7 @@ inputs:
   qt-version:
     description: Version of Qt to use
     required: true
-    default: 6.9.1
+    default: 6.9.3
 
 outputs:
   build-type:


### PR DESCRIPTION
Parent PR: #4599
This brings us up to date with the latest release in the (now EOL) Qt 6.9 series :)

Nothing really interesting/breaking here aside from Windows on ARM fixes from 6.10, as well as a few CVE fixes in qtsvg
