### PR TITLE
Fix Java memory field alignment when warning label is visible

### DIFF
--- a/launcher/ui/widgets/JavaSettingsWidget.ui
+++ b/launcher/ui/widgets/JavaSettingsWidget.ui
@@ -191,13 +191,6 @@
       <bool>false</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="3" column="0">
-       <widget class="QLabel" name="labelMaxMemNotice">
-        <property name="text">
-         <string>Memory Notice</string>
-        </property>
-       </widget>
-      </item>
       <item row="2" column="2">
        <widget class="QLabel" name="label_3">
         <property name="text">
@@ -345,6 +338,13 @@
          </size>
         </property>
        </spacer>
+      </item>
+      <item row="3" column="0" colspan="4">
+       <widget class="QLabel" name="labelMaxMemNotice">
+        <property name="text">
+         <string>Memory Notice</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
Parent PR: #3534

Before (the warning pushed the fields to the right):
<img width="794" height="184" alt="image" src="https://github.com/user-attachments/assets/3e97abcb-d086-4ca7-9b9c-f2f33cf0b59c" />
After:
<img width="800" height="181" alt="image" src="https://github.com/user-attachments/assets/3173c4ca-600b-4f1a-9e46-c1faa1ce468c" />
