### PR TITLE
Fix fractional scaling issues on skin preview

### DIFF
--- a/launcher/ui/dialogs/skins/draw/SkinOpenGLWindow.cpp
+++ b/launcher/ui/dialogs/skins/draw/SkinOpenGLWindow.cpp
@@ -202,6 +202,13 @@ void SkinOpenGLWindow::resizeGL(int w, int h)
 
 void SkinOpenGLWindow::paintGL()
 {
+    // Adjust the viewport to account for fractional scaling
+    qreal dpr = devicePixelRatio();
+    if (dpr != 1.f) {
+        QSize scaledSize = size() * dpr;
+        glViewport(0, 0, scaledSize.width(), scaledSize.height());
+    }
+
     // Clear color and depth buffer
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
@@ -235,6 +242,13 @@ void SkinOpenGLWindow::paintGL()
 
     m_scene->draw(m_modelProgram);
     m_modelProgram->release();
+
+    // Redraw the first frame; this is necessary because the pixel ratio for Wayland fractional scaling is not negotiated properly on the
+    // first frame
+    if (m_isFirstFrame) {
+        m_isFirstFrame = false;
+        update();
+    }
 }
 
 void SkinOpenGLWindow::updateScene(SkinModel* skin)

--- a/launcher/ui/dialogs/skins/draw/SkinOpenGLWindow.h
+++ b/launcher/ui/dialogs/skins/draw/SkinOpenGLWindow.h
@@ -74,6 +74,8 @@ class SkinOpenGLWindow : public QOpenGLWindow, protected QOpenGLFunctions {
     float m_yaw = 90;   // Horizontal rotation angle
     float m_pitch = 0;  // Vertical rotation angle
 
+    bool m_isFirstFrame = true;
+
     opengl::BoxGeometry* m_background = nullptr;
     QOpenGLTexture* m_backgroundTexture = nullptr;
     QColor m_baseColor;


### PR DESCRIPTION
Fixes #4299 

Due to the asynchronous nature of Wayland, the pixel ratio and thus the OpenGL frame buffer size is not configured correctly at the time of the first frame being rendered. This PR corrects this simply by discarding and redrawing the first frame. It also corrects the small inaccuracy in the view port size when using fractional scaling.