### PR TITLE
Override Ctrl+C functionality for ReviewMessageBox items

### DIFF
--- a/launcher/ui/dialogs/ResourceUpdateDialog.cpp
+++ b/launcher/ui/dialogs/ResourceUpdateDialog.cpp
@@ -22,6 +22,8 @@
 #include "modplatform/flame/FlameCheckUpdate.h"
 #include "modplatform/modrinth/ModrinthCheckUpdate.h"
 
+#include <QClipboard>
+#include <QShortcut>
 #include <QTextBrowser>
 #include <QTreeWidgetItem>
 
@@ -437,17 +439,22 @@ void ResourceUpdateDialog::appendResource(CheckUpdateTask::Update const& info, Q
     item_top->setExpanded(true);
 
     auto provider_item = new QTreeWidgetItem(item_top);
-    provider_item->setText(0, tr("Provider: %1").arg(ModPlatform::ProviderCapabilities::readableName(info.provider)));
+    QString provider_name = ModPlatform::ProviderCapabilities::readableName(info.provider);
+    provider_item->setText(0, tr("Provider: %1").arg(provider_name));
+    provider_item->setData(0, Qt::UserRole, provider_name);
 
     auto old_version_item = new QTreeWidgetItem(item_top);
     old_version_item->setText(0, tr("Old version: %1").arg(info.old_version));
+    old_version_item->setData(0, Qt::UserRole, info.old_version);
 
     auto new_version_item = new QTreeWidgetItem(item_top);
     new_version_item->setText(0, tr("New version: %1").arg(info.new_version));
+    new_version_item->setData(0, Qt::UserRole, info.new_version);
 
     if (info.new_version_type.has_value()) {
-        auto new_version_type_itme = new QTreeWidgetItem(item_top);
-        new_version_type_itme->setText(0, tr("New Version Type: %1").arg(info.new_version_type.value().toString()));
+        auto new_version_type_item = new QTreeWidgetItem(item_top);
+        new_version_type_item->setText(0, tr("New Version Type: %1").arg(info.new_version_type.value().toString()));
+        new_version_type_item->setData(0, Qt::UserRole, info.new_version_type.value().toString());
     }
 
     if (!requiredBy.isEmpty()) {
@@ -487,6 +494,26 @@ void ResourceUpdateDialog::appendResource(CheckUpdateTask::Update const& info, Q
     ui->modTreeWidget->setItemWidget(changelog, 0, changelog_area);
 
     ui->modTreeWidget->addTopLevelItem(item_top);
+
+    // Overwrite Ctrl+C functionality to exclude the label when copying text from tree
+    auto shortcut = new QShortcut(QKeySequence::Copy, ui->modTreeWidget);
+    connect(shortcut, &QShortcut::activated, [this]() {
+        auto currentItem = this->ui->modTreeWidget->currentItem();
+        if (!currentItem)
+            return;
+        auto currentColumn = this->ui->modTreeWidget->currentColumn();
+
+        auto data = currentItem->data(currentColumn, Qt::UserRole);
+        QString txt;
+
+        if (data.isValid()) {
+            txt = data.toString();
+        } else {
+            txt = currentItem->text(currentColumn);
+        }
+
+        QApplication::clipboard()->setText(txt);
+    });
 }
 
 auto ResourceUpdateDialog::getTasks() -> const QList<ResourceDownloadTask::Ptr>

--- a/launcher/ui/dialogs/ResourceUpdateDialog.cpp
+++ b/launcher/ui/dialogs/ResourceUpdateDialog.cpp
@@ -482,6 +482,7 @@ void ResourceUpdateDialog::appendResource(CheckUpdateTask::Update const& info, Q
     auto changelog_area = new QTextBrowser();
 
     QString text = info.changelog;
+    changelog->setData(0, Qt::UserRole, text);
     if (info.provider == ModPlatform::ResourceProvider::MODRINTH) {
         text = markdownToHTML(info.changelog.toUtf8());
     }
@@ -494,26 +495,6 @@ void ResourceUpdateDialog::appendResource(CheckUpdateTask::Update const& info, Q
     ui->modTreeWidget->setItemWidget(changelog, 0, changelog_area);
 
     ui->modTreeWidget->addTopLevelItem(item_top);
-
-    // Overwrite Ctrl+C functionality to exclude the label when copying text from tree
-    auto shortcut = new QShortcut(QKeySequence::Copy, ui->modTreeWidget);
-    connect(shortcut, &QShortcut::activated, [this]() {
-        auto currentItem = this->ui->modTreeWidget->currentItem();
-        if (!currentItem)
-            return;
-        auto currentColumn = this->ui->modTreeWidget->currentColumn();
-
-        auto data = currentItem->data(currentColumn, Qt::UserRole);
-        QString txt;
-
-        if (data.isValid()) {
-            txt = data.toString();
-        } else {
-            txt = currentItem->text(currentColumn);
-        }
-
-        QApplication::clipboard()->setText(txt);
-    });
 }
 
 auto ResourceUpdateDialog::getTasks() -> const QList<ResourceDownloadTask::Ptr>

--- a/launcher/ui/dialogs/ReviewMessageBox.cpp
+++ b/launcher/ui/dialogs/ReviewMessageBox.cpp
@@ -23,6 +23,26 @@ ReviewMessageBox::ReviewMessageBox(QWidget* parent, [[maybe_unused]] QString con
 
     ui->buttonBox->button(QDialogButtonBox::Cancel)->setText(tr("Cancel"));
     ui->buttonBox->button(QDialogButtonBox::Ok)->setText(tr("OK"));
+
+    // Overwrite Ctrl+C functionality to exclude the label when copying text from tree
+    auto shortcut = new QShortcut(QKeySequence::Copy, ui->modTreeWidget);
+    connect(shortcut, &QShortcut::activated, [this]() {
+        auto currentItem = this->ui->modTreeWidget->currentItem();
+        if (!currentItem)
+            return;
+        auto currentColumn = this->ui->modTreeWidget->currentColumn();
+
+        auto data = currentItem->data(currentColumn, Qt::UserRole);
+        QString txt;
+
+        if (data.isValid()) {
+            txt = data.toString();
+        } else {
+            txt = currentItem->text(currentColumn);
+        }
+
+        QApplication::clipboard()->setText(txt);
+    });
 }
 
 ReviewMessageBox::~ReviewMessageBox()
@@ -95,26 +115,6 @@ void ReviewMessageBox::appendResource(ResourceInformation&& info)
     itemTop->insertChildren(childIndx++, { versionTypeItem });
 
     ui->modTreeWidget->addTopLevelItem(itemTop);
-
-    // Overwrite Ctrl+C functionality to exclude the label when copying text from tree
-    auto shortcut = new QShortcut(QKeySequence::Copy, ui->modTreeWidget);
-    connect(shortcut, &QShortcut::activated, [this]() {
-        auto currentItem = this->ui->modTreeWidget->currentItem();
-        if (!currentItem)
-            return;
-        auto currentColumn = this->ui->modTreeWidget->currentColumn();
-
-        auto data = currentItem->data(currentColumn, Qt::UserRole);
-        QString txt;
-
-        if (data.isValid()) {
-            txt = data.toString();
-        } else {
-            txt = currentItem->text(currentColumn);
-        }
-
-        QApplication::clipboard()->setText(txt);
-    });
 }
 
 auto ReviewMessageBox::deselectedResources() -> QStringList

--- a/launcher/ui/dialogs/ReviewMessageBox.cpp
+++ b/launcher/ui/dialogs/ReviewMessageBox.cpp
@@ -1,7 +1,9 @@
 #include "ReviewMessageBox.h"
 #include "ui_ReviewMessageBox.h"
 
+#include <QClipboard>
 #include <QPushButton>
+#include <QShortcut>
 
 ReviewMessageBox::ReviewMessageBox(QWidget* parent, [[maybe_unused]] QString const& title, [[maybe_unused]] QString const& icon)
     : QDialog(parent), ui(new Ui::ReviewMessageBox)
@@ -44,6 +46,7 @@ void ReviewMessageBox::appendResource(ResourceInformation&& info)
 
     auto filenameItem = new QTreeWidgetItem(itemTop);
     filenameItem->setText(0, tr("Filename: %1").arg(info.filename));
+    filenameItem->setData(0, Qt::UserRole, info.filename);
 
     auto childIndx = 0;
     itemTop->insertChildren(childIndx++, { filenameItem });
@@ -62,6 +65,7 @@ void ReviewMessageBox::appendResource(ResourceInformation&& info)
 
     auto providerItem = new QTreeWidgetItem(itemTop);
     providerItem->setText(0, tr("Provider: %1").arg(info.provider));
+    providerItem->setData(0, Qt::UserRole, info.provider);
 
     itemTop->insertChildren(childIndx++, { providerItem });
 
@@ -86,9 +90,31 @@ void ReviewMessageBox::appendResource(ResourceInformation&& info)
 
     auto versionTypeItem = new QTreeWidgetItem(itemTop);
     versionTypeItem->setText(0, tr("Version Type: %1").arg(info.version_type));
+    versionTypeItem->setData(0, Qt::UserRole, info.version_type);
+
     itemTop->insertChildren(childIndx++, { versionTypeItem });
 
     ui->modTreeWidget->addTopLevelItem(itemTop);
+
+    // Overwrite Ctrl+C functionality to exclude the label when copying text from tree
+    auto shortcut = new QShortcut(QKeySequence::Copy, ui->modTreeWidget);
+    connect(shortcut, &QShortcut::activated, [this]() {
+        auto currentItem = this->ui->modTreeWidget->currentItem();
+        if (!currentItem)
+            return;
+        auto currentColumn = this->ui->modTreeWidget->currentColumn();
+
+        auto data = currentItem->data(currentColumn, Qt::UserRole);
+        QString txt;
+
+        if (data.isValid()) {
+            txt = data.toString();
+        } else {
+            txt = currentItem->text(currentColumn);
+        }
+
+        QApplication::clipboard()->setText(txt);
+    });
 }
 
 auto ReviewMessageBox::deselectedResources() -> QStringList


### PR DESCRIPTION
Closes #4309 

This changes the behavior of the Ctrl+C shortcut on QTreeWidgetItem instances owned by ReviewMessageBox::modTreeWidget, such that only the relevant information is copied and not the label.

**Example:**
"Filename: mod.jar" -> "mod.jar"
"Provider: modrinth" -> "modrinth"
"Version Type: release" -> "release"