### PR TITLE
Cleanup main.cpp

### DIFF
--- a/launcher/main.cpp
+++ b/launcher/main.cpp
@@ -35,34 +35,8 @@
 
 #include "Application.h"
 
-// #define BREAK_INFINITE_LOOP
-// #define BREAK_EXCEPTION
-// #define BREAK_RETURN
-
-#ifdef BREAK_INFINITE_LOOP
-#include <chrono>
-#include <thread>
-#endif
-
 int main(int argc, char* argv[])
 {
-#ifdef BREAK_INFINITE_LOOP
-    while (true) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(250));
-    }
-#endif
-#ifdef BREAK_EXCEPTION
-    throw 42;
-#endif
-#ifdef BREAK_RETURN
-    return 42;
-#endif
-
-#if QT_VERSION <= QT_VERSION_CHECK(6, 0, 0)
-    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-    QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
-#endif
-
     // initialize Qt
     Application app(argc, argv);
 


### PR DESCRIPTION
Some stuff in this file is redundant
- The debugging macros were probably used for something at some point but I've never had a use for them (let me know if they're useful for you)
- The high dpi scaling stuff is only for ~~Qt 5~~ I guess Qt 6.0.0 and below... but not 6.0.1 and higher
- ~~Q_INIT_RESOURCE is for if you're linking with a static library (I believe MultiMC used to be more modular)~~ Looks like launcher_logic is still a distinct static library. ~~Maybe we can get rid of it because AFAIK the only thing that depends on it is the launcher executable?~~