### PR TITLE
chore: update to latest version of sparkle framework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -405,8 +405,8 @@ if(UNIX AND APPLE)
     set(MACOSX_SPARKLE_UPDATE_PUBLIC_KEY "v55ZWWD6QlPoXGV6VLzOTZxZUggWeE51X8cRQyQh6vA=" CACHE STRING "Public key for Sparkle update feed")
     set(MACOSX_SPARKLE_UPDATE_FEED_URL "https://prismlauncher.org/feed/appcast.xml" CACHE STRING "URL for Sparkle update feed")
 
-    set(MACOSX_SPARKLE_DOWNLOAD_URL "https://github.com/sparkle-project/Sparkle/releases/download/2.6.4/Sparkle-2.6.4.tar.xz" CACHE STRING "URL to Sparkle release archive")
-    set(MACOSX_SPARKLE_SHA256 "50612a06038abc931f16011d7903b8326a362c1074dabccb718404ce8e585f0b" CACHE STRING "SHA256 checksum for Sparkle release archive")
+    set(MACOSX_SPARKLE_DOWNLOAD_URL "https://github.com/sparkle-project/Sparkle/releases/download/2.8.0/Sparkle-2.8.0.tar.xz" CACHE STRING "URL to Sparkle release archive")
+    set(MACOSX_SPARKLE_SHA256 "fd5681ee92bf238aaac2d08214ceaf0cc8976e452d7f882d80bac1e61581f3b1" CACHE STRING "SHA256 checksum for Sparkle release archive")
     set(MACOSX_SPARKLE_DIR "${CMAKE_BINARY_DIR}/frameworks/Sparkle")
 
     if(NOT MACOSX_SPARKLE_UPDATE_PUBLIC_KEY STREQUAL "" AND NOT MACOSX_SPARKLE_UPDATE_FEED_URL STREQUAL "")


### PR DESCRIPTION
this one also introduces a new UI
before:
<img width="732" height="510" alt="old" src="https://github.com/user-attachments/assets/c76d2ab1-e6f7-4167-bc29-45feb54a7ed3" />

after:
<img width="640" height="496" alt="new" src="https://github.com/user-attachments/assets/127a4080-2e48-4aa3-b7b6-49abb540ed9a" />


i don't have a tahoe mac but it should look even better there, from the sparkle framework website:
<img width="1156" height="804" alt="image" src="https://github.com/user-attachments/assets/4fe13ca1-31e3-42b4-b6b6-9f186a8c0211" />
