### PR TITLE
fix curseforge icon not working on newer versions of Qt on macOS

### DIFF
--- a/launcher/resources/multimc/multimc.qrc
+++ b/launcher/resources/multimc/multimc.qrc
@@ -252,7 +252,6 @@
         <file>scalable/discord.svg</file>
 
         <!-- flat instance icons CC BY-SA 4.0, Santiago Cézar -->
-        <file alias="128x128/flame.png">scalable/instances/flame.svg</file>
         <file>scalable/instances/chicken.svg</file>
         <file>scalable/instances/creeper.svg</file>
         <file>scalable/instances/enderpearl.svg</file>


### PR DESCRIPTION
this fixes the flame icon not rendering on macOS with recent versions of Qt

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
