### PR TITLE
Fix DataPackUtils::processMCMeta error

### DIFF
--- a/launcher/minecraft/mod/DataPack.cpp
+++ b/launcher/minecraft/mod/DataPack.cpp
@@ -118,6 +118,13 @@ void DataPack::setImage(QImage new_image) const
     }
 }
 
+void DataPack::setValidMCMeta(bool valid)
+{
+    QMutexLocker locker(&m_data_lock);
+
+    m_has_valid_mcmeta = valid;
+}
+
 QPixmap DataPack::image(QSize size, Qt::AspectRatioMode mode) const
 {
     QPixmap cached_image;

--- a/launcher/minecraft/mod/DataPack.h
+++ b/launcher/minecraft/mod/DataPack.h
@@ -50,6 +50,9 @@ class DataPack : public Resource {
     /** Gets the image of the data pack, converted to a QPixmap for drawing, and scaled to size. */
     QPixmap image(QSize size, Qt::AspectRatioMode mode = Qt::AspectRatioMode::IgnoreAspectRatio) const;
 
+    /** Gets the validity of the pack's pack.mcmeta file */
+    bool validMCMeta() const { return m_has_valid_mcmeta; }
+
     /** Thread-safe. */
     void setPackFormat(int new_format_id);
 
@@ -58,6 +61,9 @@ class DataPack : public Resource {
 
     /** Thread-safe. */
     void setImage(QImage new_image) const;
+
+    /** Thread-safe. */
+    void setValidMCMeta(bool valid);
 
     bool valid() const override;
 
@@ -85,4 +91,6 @@ class DataPack : public Resource {
         QPixmapCache::Key key;
         bool was_ever_used = false;
     } mutable m_pack_image_cache_key;
+
+    bool m_has_valid_mcmeta = true;
 };

--- a/launcher/minecraft/mod/DataPack.h
+++ b/launcher/minecraft/mod/DataPack.h
@@ -50,7 +50,7 @@ class DataPack : public Resource {
     /** Gets the image of the data pack, converted to a QPixmap for drawing, and scaled to size. */
     QPixmap image(QSize size, Qt::AspectRatioMode mode = Qt::AspectRatioMode::IgnoreAspectRatio) const;
 
-    /** Gets the validity of the pack's pack.mcmeta file */
+    /** Gets the validity of the pack's pack.mcmeta file. */
     bool validMCMeta() const { return m_has_valid_mcmeta; }
 
     /** Thread-safe. */

--- a/launcher/minecraft/mod/ResourcePackFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourcePackFolderModel.cpp
@@ -94,6 +94,8 @@ QVariant ResourcePackFolderModel::data(const QModelIndex& index, int role) const
                     return {};
             }
         case Qt::DecorationRole: {
+            if (column == ActiveColumn && !(at(row).validMCMeta()))
+                return QIcon::fromTheme("status-yellow");
             if (column == NameColumn && (at(row).isSymLinkUnder(instDirPath()) || at(row).isMoreThanOneHardLink()))
                 return QIcon::fromTheme("status-yellow");
             if (column == ImageColumn) {
@@ -102,6 +104,9 @@ QVariant ResourcePackFolderModel::data(const QModelIndex& index, int role) const
             return {};
         }
         case Qt::ToolTipRole: {
+            if (column == ActiveColumn && !at(row).validMCMeta()) {
+                return m_resources[row]->internal_id() + tr("\nWarning: This pack has an invalid pack.mcmeta file.");
+            }
             if (column == PackFormatColumn) {
                 //: The string being explained by this is in the format: ID (Lower version - Upper version)
                 return tr("The resource pack format ID, as well as the Minecraft versions it was designed for.");

--- a/launcher/minecraft/mod/tasks/LocalDataPackParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalDataPackParseTask.cpp
@@ -178,18 +178,17 @@ bool processMCMeta(DataPack* pack, QByteArray&& raw_data)
 {
     // This trims the data after the top level pair of braces is closed. Some pack.mcmeta files include credits/other info after
     // the JSON, which the parser collides with.
-    int open_braces = 0;
-    int close_braces = 0;
+    int braces = 0;
     qsizetype valid_bytes = 0;
     for (auto& byte : raw_data) {
-        if (open_braces == close_braces && open_braces != 0)
+        if (valid_bytes > 0 && braces == 0)
             break;
 
         valid_bytes++;
         if (byte == '{')
-            open_braces++;
+            braces++;
         else if (byte == '}')
-            close_braces++;
+            braces--;
     }
     raw_data.resize(valid_bytes);
 

--- a/launcher/minecraft/mod/tasks/LocalDataPackParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalDataPackParseTask.cpp
@@ -176,6 +176,23 @@ bool processZIP(DataPack* pack, ProcessingLevel level)
 // https://minecraft.wiki/w/Tutorials/Creating_a_resource_pack#Formatting_pack.mcmeta
 bool processMCMeta(DataPack* pack, QByteArray&& raw_data)
 {
+    // This trims the data after the top level pair of braces is closed. Some pack.mcmeta files include credits/other info after
+    // the JSON, which the parser collides with.
+    int open_braces = 0;
+    int close_braces = 0;
+    qsizetype valid_bytes = 0;
+    for (auto& byte : raw_data) {
+        if (open_braces == close_braces && open_braces != 0)
+            break;
+
+        valid_bytes++;
+        if (byte == '{')
+            open_braces++;
+        else if (byte == '}')
+            close_braces++;
+    }
+    raw_data.resize(valid_bytes);
+
     try {
         auto json_doc = QJsonDocument::fromJson(raw_data);
         auto pack_obj = Json::requireObject(json_doc.object(), "pack", {});

--- a/launcher/minecraft/mod/tasks/LocalDataPackParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalDataPackParseTask.cpp
@@ -178,17 +178,18 @@ bool processMCMeta(DataPack* pack, QByteArray&& raw_data)
 {
     // This trims the data after the top level pair of braces is closed. Some pack.mcmeta files include credits/other info after
     // the JSON, which the parser collides with.
-    int braces = 0;
+    int open_braces = 0;
+    int close_braces = 0;
     qsizetype valid_bytes = 0;
     for (auto& byte : raw_data) {
-        if (valid_bytes > 0 && braces == 0)
+        if (open_braces == close_braces && open_braces != 0)
             break;
 
         valid_bytes++;
         if (byte == '{')
-            braces++;
+            open_braces++;
         else if (byte == '}')
-            braces--;
+            close_braces++;
     }
     raw_data.resize(valid_bytes);
 

--- a/launcher/minecraft/mod/tasks/LocalDataPackParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalDataPackParseTask.cpp
@@ -51,7 +51,7 @@ bool processFolder(DataPack* pack, ProcessingLevel level)
     Q_ASSERT(pack->type() == ResourceType::FOLDER);
 
     auto mcmeta_invalid = [&pack]() {
-        qWarning() << "Data pack at" << pack->fileinfo().filePath() << "does not have a valid pack.mcmeta";
+        qWarning() << "Data pack at" << pack->fileinfo().filePath() << "does not have a pack.mcmeta";
         return false;  // the mcmeta is not optional
     };
 
@@ -67,7 +67,10 @@ bool processFolder(DataPack* pack, ProcessingLevel level)
 
         mcmeta_file.close();
         if (!mcmeta_result) {
-            return mcmeta_invalid();  // mcmeta invalid
+            qWarning() << "Data pack at" << pack->fileinfo().filePath() << "has a malformed pack.mcmeta";
+            pack->setValidMCMeta(false);
+            pack->setPackFormat(0);
+            pack->setDescription("\u00A7c\u00A7lInvalid pack.mcmeta!");
         }
     } else {
         return mcmeta_invalid();  // mcmeta file isn't a valid file
@@ -113,7 +116,7 @@ bool processZIP(DataPack* pack, ProcessingLevel level)
     QuaZipFile file(&zip);
 
     auto mcmeta_invalid = [&pack]() {
-        qWarning() << "Data pack at" << pack->fileinfo().filePath() << "does not have a valid pack.mcmeta";
+        qWarning() << "Data pack at" << pack->fileinfo().filePath() << "does not have a pack.mcmeta";
         return false;  // the mcmeta is not optional
     };
 
@@ -130,7 +133,10 @@ bool processZIP(DataPack* pack, ProcessingLevel level)
 
         file.close();
         if (!mcmeta_result) {
-            return mcmeta_invalid();  // mcmeta invalid
+            qWarning() << "Data pack at" << pack->fileinfo().filePath() << "has a malformed pack.mcmeta";
+            pack->setValidMCMeta(false);
+            pack->setPackFormat(0);
+            pack->setDescription("\u00A7c\u00A7lInvalid pack.mcmeta!");
         }
     } else {
         return mcmeta_invalid();  // could not set pack.mcmeta as current file.
@@ -176,23 +182,6 @@ bool processZIP(DataPack* pack, ProcessingLevel level)
 // https://minecraft.wiki/w/Tutorials/Creating_a_resource_pack#Formatting_pack.mcmeta
 bool processMCMeta(DataPack* pack, QByteArray&& raw_data)
 {
-    // This trims the data after the top level pair of braces is closed. Some pack.mcmeta files include credits/other info after
-    // the JSON, which the parser collides with.
-    int open_braces = 0;
-    int close_braces = 0;
-    qsizetype valid_bytes = 0;
-    for (auto& byte : raw_data) {
-        if (open_braces == close_braces && open_braces != 0)
-            break;
-
-        valid_bytes++;
-        if (byte == '{')
-            open_braces++;
-        else if (byte == '}')
-            close_braces++;
-    }
-    raw_data.resize(valid_bytes);
-
     try {
         auto json_doc = QJsonDocument::fromJson(raw_data);
         auto pack_obj = Json::requireObject(json_doc.object(), "pack", {});


### PR DESCRIPTION
Fixes #4331 

Occasionally, a resource/ data pack will have malformed JSON data in its pack.mcmeta in the form of credits or other information that the JSON parser collides with. This can be fixed by trimming the raw_data that is passed to processMCMeta before parsing such that only the top level JSON object remains.