### PR TITLE
Display packs regardless of pack.mcmeta validity

### DIFF
--- a/launcher/minecraft/mod/DataPack.cpp
+++ b/launcher/minecraft/mod/DataPack.cpp
@@ -118,6 +118,13 @@ void DataPack::setImage(QImage new_image) const
     }
 }
 
+void DataPack::setValidMCMeta(bool valid)
+{
+    QMutexLocker locker(&m_data_lock);
+
+    m_has_valid_mcmeta = valid;
+}
+
 QPixmap DataPack::image(QSize size, Qt::AspectRatioMode mode) const
 {
     QPixmap cached_image;

--- a/launcher/minecraft/mod/DataPack.h
+++ b/launcher/minecraft/mod/DataPack.h
@@ -50,6 +50,9 @@ class DataPack : public Resource {
     /** Gets the image of the data pack, converted to a QPixmap for drawing, and scaled to size. */
     QPixmap image(QSize size, Qt::AspectRatioMode mode = Qt::AspectRatioMode::IgnoreAspectRatio) const;
 
+    /** Gets the validity of the pack's pack.mcmeta file */
+    bool validMCMeta() const { return m_has_valid_mcmeta; }
+
     /** Thread-safe. */
     void setPackFormat(int new_format_id);
 
@@ -58,6 +61,9 @@ class DataPack : public Resource {
 
     /** Thread-safe. */
     void setImage(QImage new_image) const;
+
+    /** Thread-safe. */
+    void setValidMCMeta(bool valid);
 
     bool valid() const override;
 
@@ -85,4 +91,6 @@ class DataPack : public Resource {
         QPixmapCache::Key key;
         bool was_ever_used = false;
     } mutable m_pack_image_cache_key;
+
+    bool m_has_valid_mcmeta = true;
 };

--- a/launcher/minecraft/mod/ResourcePackFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourcePackFolderModel.cpp
@@ -94,35 +94,35 @@ QVariant ResourcePackFolderModel::data(const QModelIndex& index, int role) const
                     return {};
             }
         case Qt::DecorationRole: {
-            if (column == ActiveColumn && !(at(row).validMCMeta()))
+            if (column == NameColumn &&
+                (at(row).isSymLinkUnder(instDirPath()) || at(row).isMoreThanOneHardLink() || !at(row).validMCMeta())) {
                 return QIcon::fromTheme("status-yellow");
-            if (column == NameColumn && (at(row).isSymLinkUnder(instDirPath()) || at(row).isMoreThanOneHardLink()))
-                return QIcon::fromTheme("status-yellow");
+            }
             if (column == ImageColumn) {
                 return at(row).image({ 32, 32 }, Qt::AspectRatioMode::KeepAspectRatioByExpanding);
             }
             return {};
         }
         case Qt::ToolTipRole: {
-            if (column == ActiveColumn && !at(row).validMCMeta()) {
-                return m_resources[row]->internal_id() + tr("\nWarning: This pack has an invalid pack.mcmeta file.");
-            }
             if (column == PackFormatColumn) {
                 //: The string being explained by this is in the format: ID (Lower version - Upper version)
                 return tr("The resource pack format ID, as well as the Minecraft versions it was designed for.");
             }
             if (column == NameColumn) {
+                QString toolTip = m_resources[row]->internal_id();
                 if (at(row).isSymLinkUnder(instDirPath())) {
-                    return m_resources[row]->internal_id() +
-                           tr("\nWarning: This resource is symbolically linked from elsewhere. Editing it will also change the original."
-                              "\nCanonical Path: %1")
-                               .arg(at(row).fileinfo().canonicalFilePath());
-                    ;
+                    toolTip.append(
+                        tr("\nWarning: This resource is symbolically linked from elsewhere. Editing it will also change the original."
+                           "\nCanonical Path: %1")
+                            .arg(at(row).fileinfo().canonicalFilePath()));
+                } else if (at(row).isMoreThanOneHardLink()) {
+                    toolTip.append(tr("\nWarning: This resource is hard linked elsewhere. Editing it will also change the original."));
                 }
-                if (at(row).isMoreThanOneHardLink()) {
-                    return m_resources[row]->internal_id() +
-                           tr("\nWarning: This resource is hard linked elsewhere. Editing it will also change the original.");
+                if (!at(row).validMCMeta()) {
+                    toolTip.append(tr("\nWarning: This pack has an invalid pack.mcmeta file."));
                 }
+
+                return toolTip;
             }
             return m_resources[row]->internal_id();
         }

--- a/launcher/minecraft/mod/ResourcePackFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourcePackFolderModel.cpp
@@ -94,6 +94,8 @@ QVariant ResourcePackFolderModel::data(const QModelIndex& index, int role) const
                     return {};
             }
         case Qt::DecorationRole: {
+            if (column == ActiveColumn && !(at(row).validMCMeta()))
+                return QIcon::fromTheme("status-yellow");
             if (column == NameColumn && (at(row).isSymLinkUnder(instDirPath()) || at(row).isMoreThanOneHardLink()))
                 return QIcon::fromTheme("status-yellow");
             if (column == ImageColumn) {
@@ -102,6 +104,9 @@ QVariant ResourcePackFolderModel::data(const QModelIndex& index, int role) const
             return {};
         }
         case Qt::ToolTipRole: {
+            if (column == ActiveColumn && !at(row).validMCMeta()) {
+                return m_resources[row]->internal_id() + tr("\nWarning: This pack has an invalid pack.mcmeta file.");
+            }
             if (column == PackFormatColumn) {
                 //: The string being explained by this is in the format: ID (Lower version - Upper version)
                 return tr("The resource pack format ID, as well as the Minecraft versions it was designed for.");

--- a/launcher/minecraft/mod/tasks/LocalDataPackParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalDataPackParseTask.cpp
@@ -51,7 +51,7 @@ bool processFolder(DataPack* pack, ProcessingLevel level)
     Q_ASSERT(pack->type() == ResourceType::FOLDER);
 
     auto mcmeta_invalid = [&pack]() {
-        qWarning() << "Data pack at" << pack->fileinfo().filePath() << "does not have a valid pack.mcmeta";
+        qWarning() << "Data pack at" << pack->fileinfo().filePath() << "does not have a pack.mcmeta";
         return false;  // the mcmeta is not optional
     };
 
@@ -67,7 +67,10 @@ bool processFolder(DataPack* pack, ProcessingLevel level)
 
         mcmeta_file.close();
         if (!mcmeta_result) {
-            return mcmeta_invalid();  // mcmeta invalid
+            qWarning() << "Data pack at" << pack->fileinfo().filePath() << "has a malformed pack.mcmeta";
+            pack->setValidMCMeta(false);
+            pack->setPackFormat(0);
+            pack->setDescription("\u00A7c\u00A7lInvalid pack.mcmeta!");
         }
     } else {
         return mcmeta_invalid();  // mcmeta file isn't a valid file
@@ -113,7 +116,7 @@ bool processZIP(DataPack* pack, ProcessingLevel level)
     QuaZipFile file(&zip);
 
     auto mcmeta_invalid = [&pack]() {
-        qWarning() << "Data pack at" << pack->fileinfo().filePath() << "does not have a valid pack.mcmeta";
+        qWarning() << "Data pack at" << pack->fileinfo().filePath() << "does not have a pack.mcmeta";
         return false;  // the mcmeta is not optional
     };
 
@@ -130,7 +133,10 @@ bool processZIP(DataPack* pack, ProcessingLevel level)
 
         file.close();
         if (!mcmeta_result) {
-            return mcmeta_invalid();  // mcmeta invalid
+            qWarning() << "Data pack at" << pack->fileinfo().filePath() << "has a malformed pack.mcmeta";
+            pack->setValidMCMeta(false);
+            pack->setPackFormat(0);
+            pack->setDescription("\u00A7c\u00A7lInvalid pack.mcmeta!");
         }
     } else {
         return mcmeta_invalid();  // could not set pack.mcmeta as current file.


### PR DESCRIPTION
This is a revision to clean the commit history of #4334, which fixes #4331.