### PR TITLE
ci(package/windows): use absolute paths for signed files

### DIFF
--- a/.github/actions/package/windows/action.yml
+++ b/.github/actions/package/windows/action.yml
@@ -76,9 +76,9 @@ runs:
         certificate-profile-name: PrismLauncher
 
         files: |
-          install/prismlauncher.exe
-          install/prismlauncher_filelink.exe
-          install/prismlauncher_updater.exe
+          ${{ github.workspace }}\install\prismlauncher.exe
+          ${{ github.workspace }}\install\prismlauncher_filelink.exe
+          ${{ github.workspace }}\install\prismlauncher_updater.exe
 
         # TODO(@getchoo): Is this all really needed???
         # https://github.com/Azure/trusted-signing-action/blob/fc390cf8ed0f14e248a542af1d838388a47c7a7c/docs/OIDC.md
@@ -148,7 +148,7 @@ runs:
         certificate-profile-name: PrismLauncher
 
         files: |
-          PrismLauncher-Setup.exe
+          ${{ github.workspace }}\PrismLauncher-Setup.exe
 
         # TODO(@getchoo): Is this all really needed???
         # https://github.com/Azure/trusted-signing-action/blob/fc390cf8ed0f14e248a542af1d838388a47c7a7c/docs/OIDC.md


### PR DESCRIPTION
This is (weirdly) required by the Trusted Signing action

Signed-off-by: Seth Flynn <getchoo@tuta.io>

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
