### PR TITLE
fix(ModrinthPackIndex): set logo name correctly

### DIFF
--- a/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
@@ -52,7 +52,7 @@ void Modrinth::loadIndexedPack(ModPlatform::IndexedPack& pack, QJsonObject& obj)
     pack.description = obj["description"].toString("");
 
     pack.logoUrl = obj["icon_url"].toString("");
-    pack.logoName = QString("%1.%2").arg(obj["slug"].toString()), QFileInfo(QUrl(pack.logoUrl).fileName()).suffix();
+    pack.logoName = QString("%1.%2").arg(obj["slug"].toString(), QFileInfo(QUrl(pack.logoUrl).fileName()).suffix());
 
     if (obj.contains("author")) {
         ModPlatform::ModpackAuthor modAuthor;


### PR DESCRIPTION
Fixes: https://github.com/PrismLauncher/PrismLauncher/commit/f90c0a59a70c9b61d0ac1042c7a5f41a514f527b