### PR TITLE
nix: Disable deprecated PIE flags

### DIFF
--- a/nix/unwrapped.nix
+++ b/nix/unwrapped.nix
@@ -85,8 +85,6 @@ stdenv.mkDerivation {
   ++ lib.optionals stdenv.hostPlatform.isDarwin [ apple-sdk_11 ]
   ++ lib.optional gamemodeSupport gamemode;
 
-  hardeningEnable = lib.optionals stdenv.hostPlatform.isLinux [ "pie" ];
-
   cmakeFlags = [
     # downstream branding
     (lib.cmakeFeature "Launcher_BUILD_PLATFORM" "nixpkgs")


### PR DESCRIPTION
Fixes the following warning with nixos-unstable (and upcoming 25.11)

    evaluation warning: The 'pie' hardening flag has been removed in
    favor of enabling PIE by default in compilers and should no longer
    be used. PIE can be disabled with the -no-pie compiler flag, but
    this is usually not necessary as most build systems pass this if
    needed. Usage of the 'pie' hardening flag will become an error in
    future.
