### PR TITLE
add category selector to icon picker dialog

### DIFF
--- a/launcher/ui/dialogs/IconPickerDialog.cpp
+++ b/launcher/ui/dialogs/IconPickerDialog.cpp
@@ -122,7 +122,7 @@ IconPickerDialog::IconPickerDialog(QWidget* parent) : QDialog(parent), ui(new Ui
         }
     }
 
-    proxyModel = new QSortFilterProxyModel(this);
+    proxyModel = new IconProxyModel(this);
     proxyModel->setSourceModel(APPLICATION->icons());
     proxyModel->setFilterCaseSensitivity(Qt::CaseInsensitive);
     ui->iconView->setModel(proxyModel);

--- a/launcher/ui/dialogs/IconPickerDialog.cpp
+++ b/launcher/ui/dialogs/IconPickerDialog.cpp
@@ -35,9 +35,25 @@ IconPickerDialog::IconPickerDialog(QWidget* parent) : QDialog(parent), ui(new Ui
     ui->setupUi(this);
     setWindowModality(Qt::WindowModal);
 
-    searchBar = new QLineEdit(this);
-    searchBar->setPlaceholderText(tr("Search..."));
-    ui->verticalLayout->insertWidget(0, searchBar);
+    static const QString context_text[] = {
+        tr("All"),
+        tr("Modern"),
+        tr("Legacy"),
+        tr("Modpacks"),
+    };
+    static const Context context_id[] = {
+        Any,
+        Modern,
+        Legacy,
+        Modpacks,
+    };
+    const int cnt = sizeof(context_text) / sizeof(context_text[0]);
+    for (int i = 0; i < cnt; ++i) {
+        ui->contextCombo->addItem(context_text[i], context_id[i]);
+        if (i == 0) {
+            ui->contextCombo->insertSeparator(i + 1);
+        }
+    }
 
     proxyModel = new QSortFilterProxyModel(this);
     proxyModel->setSourceModel(APPLICATION->icons());
@@ -45,11 +61,8 @@ IconPickerDialog::IconPickerDialog(QWidget* parent) : QDialog(parent), ui(new Ui
     ui->iconView->setModel(proxyModel);
 
     auto contentsWidget = ui->iconView;
-    contentsWidget->setViewMode(QListView::IconMode);
     contentsWidget->setFlow(QListView::LeftToRight);
     contentsWidget->setIconSize(QSize(48, 48));
-    contentsWidget->setMovement(QListView::Static);
-    contentsWidget->setResizeMode(QListView::Adjust);
     contentsWidget->setSelectionMode(QAbstractItemView::SingleSelection);
     contentsWidget->setSpacing(5);
     contentsWidget->setWordWrap(false);
@@ -86,7 +99,11 @@ IconPickerDialog::IconPickerDialog(QWidget* parent) : QDialog(parent), ui(new Ui
 
     auto buttonFolder = ui->buttonBox->addButton(tr("Open Folder"), QDialogButtonBox::ResetRole);
     connect(buttonFolder, &QPushButton::clicked, this, &IconPickerDialog::openFolder);
-    connect(searchBar, &QLineEdit::textChanged, this, &IconPickerDialog::filterIcons);
+    connect(ui->searchLine, &QLineEdit::textChanged, this, &IconPickerDialog::filterIcons);
+    connect(ui->contextCombo, &QComboBox::currentIndexChanged, this, [this](int index) {
+        Context category = static_cast<Context>(ui->contextCombo->itemData(index).toInt());
+        filterIconsByCategory(category);
+    });
     // Prevent incorrect indices from e.g. filesystem changes
     connect(APPLICATION->icons(), &IconList::iconUpdated, this, [this]() { proxyModel->invalidate(); });
 }
@@ -181,4 +198,23 @@ void IconPickerDialog::openFolder()
 void IconPickerDialog::filterIcons(const QString& query)
 {
     proxyModel->setFilterFixedString(query);
+}
+
+void IconPickerDialog::filterIconsByCategory(Context category)
+{
+    switch (category) {
+        default:
+        case Any:
+            proxyModel->setFilterRegularExpression("");
+            break;
+        case Modern:
+            proxyModel->setFilterRegularExpression("^(?:ftb_logo|(?!.*_legacy$)(?!^(?:curseforge_|modrinth_|ftb_|technic_|atl_))[A-Za-z0-9._-]+)$");
+            break;
+        case Legacy:
+            proxyModel->setFilterRegularExpression("^(?:[A-Za-z0-9._-]+_legacy|ftb_glow)$");
+            break;
+        case Modpacks:
+            proxyModel->setFilterRegularExpression("^(?!(?:ftb_glow|ftb_logo))(?:curseforge_|modrinth_|ftb_|technic_|atl_)[A-Za-z0-9._-]*$");
+            break;
+    }
 }

--- a/launcher/ui/dialogs/IconPickerDialog.cpp
+++ b/launcher/ui/dialogs/IconPickerDialog.cpp
@@ -41,7 +41,7 @@ IconPickerDialog::IconPickerDialog(QWidget* parent) : QDialog(parent), ui(new Ui
         tr("Legacy"),
         tr("Modpacks"),
     };
-    static const Context context_id[] = {
+    static const IconPickerCategory context_id[] = {
         Any,
         Modern,
         Legacy,
@@ -101,7 +101,7 @@ IconPickerDialog::IconPickerDialog(QWidget* parent) : QDialog(parent), ui(new Ui
     connect(buttonFolder, &QPushButton::clicked, this, &IconPickerDialog::openFolder);
     connect(ui->searchLine, &QLineEdit::textChanged, this, &IconPickerDialog::filterIcons);
     connect(ui->contextCombo, &QComboBox::currentIndexChanged, this, [this](int index) {
-        Context category = static_cast<Context>(ui->contextCombo->itemData(index).toInt());
+        IconPickerCategory category = static_cast<IconPickerCategory>(ui->contextCombo->itemData(index).toInt());
         filterIconsByCategory(category);
     });
     // Prevent incorrect indices from e.g. filesystem changes
@@ -200,7 +200,7 @@ void IconPickerDialog::filterIcons(const QString& query)
     proxyModel->setFilterFixedString(query);
 }
 
-void IconPickerDialog::filterIconsByCategory(Context category)
+void IconPickerDialog::filterIconsByCategory(IconPickerCategory category)
 {
     switch (category) {
         default:

--- a/launcher/ui/dialogs/IconPickerDialog.cpp
+++ b/launcher/ui/dialogs/IconPickerDialog.cpp
@@ -30,6 +30,71 @@
 #include "icons/IconList.h"
 #include "icons/IconUtils.h"
 
+class IconProxyModel : public QSortFilterProxyModel
+{
+public:
+    explicit IconProxyModel(QObject* parent = nullptr) : QSortFilterProxyModel(parent)
+    {
+    }
+
+    void setCategory(IconPickerDialog::IconPickerCategory category)
+    {
+        if (m_category == category)
+            return;
+        m_category = category;
+        invalidateFilter();
+    }
+
+protected:
+    bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const override
+    {
+        if (!QSortFilterProxyModel::filterAcceptsRow(source_row, source_parent))
+            return false;
+
+        if (m_category == IconPickerDialog::Any)
+            return true;
+
+        auto model = static_cast<IconList*>(sourceModel());
+        QModelIndex index = model->index(source_row, 0, source_parent);
+        QString key = model->data(index, Qt::UserRole).toString();
+        const MMCIcon* icon = model->icon(key);
+
+        if (!icon)
+            return false;
+
+        bool isModpack = false;
+        bool isBuiltin = icon->isBuiltIn();
+        bool isLegacy = isBuiltin && icon->name().endsWith("_legacy", Qt::CaseInsensitive);
+
+        if (!isBuiltin) {
+            const QString& name = icon->name();
+            if (name.startsWith("curseforge_", Qt::CaseInsensitive) ||
+                name.startsWith("modrinth_", Qt::CaseInsensitive) ||
+                name.startsWith("ftb_", Qt::CaseInsensitive) ||
+                name.startsWith("technic_", Qt::CaseInsensitive) ||
+                name.startsWith("atl_", Qt::CaseInsensitive)) {
+                isModpack = true;
+            }
+        }
+
+        switch (m_category) {
+            case IconPickerDialog::Legacy:
+                return isBuiltin && isLegacy;
+            case IconPickerDialog::Modpacks:
+                return isModpack;
+            case IconPickerDialog::Modern:
+                return isBuiltin && !isLegacy;
+            case IconPickerDialog::Custom:
+                return !isBuiltin && !isModpack;
+            default:
+                return true;
+        }
+    }
+
+private:
+    IconPickerDialog::IconPickerCategory m_category = IconPickerDialog::Any;
+};
+
 IconPickerDialog::IconPickerDialog(QWidget* parent) : QDialog(parent), ui(new Ui::IconPickerDialog)
 {
     ui->setupUi(this);
@@ -40,12 +105,14 @@ IconPickerDialog::IconPickerDialog(QWidget* parent) : QDialog(parent), ui(new Ui
         tr("Modern"),
         tr("Legacy"),
         tr("Modpacks"),
+        tr("Custom"),
     };
     static const IconPickerCategory context_id[] = {
         Any,
         Modern,
         Legacy,
         Modpacks,
+        Custom,
     };
     const int cnt = sizeof(context_text) / sizeof(context_text[0]);
     for (int i = 0; i < cnt; ++i) {
@@ -202,19 +269,5 @@ void IconPickerDialog::filterIcons(const QString& query)
 
 void IconPickerDialog::filterIconsByCategory(IconPickerCategory category)
 {
-    switch (category) {
-        default:
-        case Any:
-            proxyModel->setFilterRegularExpression("");
-            break;
-        case Modern:
-            proxyModel->setFilterRegularExpression("^(?:ftb_logo|(?!.*_legacy$)(?!^(?:curseforge_|modrinth_|ftb_|technic_|atl_))[A-Za-z0-9._-]+)$");
-            break;
-        case Legacy:
-            proxyModel->setFilterRegularExpression("^(?:[A-Za-z0-9._-]+_legacy|ftb_glow)$");
-            break;
-        case Modpacks:
-            proxyModel->setFilterRegularExpression("^(?!(?:ftb_glow|ftb_logo))(?:curseforge_|modrinth_|ftb_|technic_|atl_)[A-Za-z0-9._-]*$");
-            break;
-    }
+    static_cast<IconProxyModel*>(proxyModel)->setCategory(category);
 }

--- a/launcher/ui/dialogs/IconPickerDialog.cpp
+++ b/launcher/ui/dialogs/IconPickerDialog.cpp
@@ -30,6 +30,71 @@
 #include "icons/IconList.h"
 #include "icons/IconUtils.h"
 
+class IconProxyModel : public QSortFilterProxyModel
+{
+public:
+    explicit IconProxyModel(QObject* parent = nullptr) : QSortFilterProxyModel(parent)
+    {
+    }
+
+    void setCategory(IconPickerDialog::IconPickerCategory category)
+    {
+        if (m_category == category)
+            return;
+        m_category = category;
+        invalidateFilter();
+    }
+
+protected:
+    bool filterAcceptsRow(int source_row, const QModelIndex& source_parent) const override
+    {
+        if (!QSortFilterProxyModel::filterAcceptsRow(source_row, source_parent))
+            return false;
+
+        if (m_category == IconPickerDialog::Any)
+            return true;
+
+        auto model = static_cast<IconList*>(sourceModel());
+        QModelIndex index = model->index(source_row, 0, source_parent);
+        QString key = model->data(index, Qt::UserRole).toString();
+        const MMCIcon* icon = model->icon(key);
+
+        if (!icon)
+            return false;
+
+        bool isModpack = false;
+        bool isBuiltin = icon->isBuiltIn();
+        bool isLegacy = isBuiltin && icon->name().endsWith("_legacy", Qt::CaseInsensitive);
+
+        if (!isBuiltin) {
+            const QString& name = icon->name();
+            if (name.startsWith("curseforge_", Qt::CaseInsensitive) ||
+                name.startsWith("modrinth_", Qt::CaseInsensitive) ||
+                name.startsWith("ftb_", Qt::CaseInsensitive) ||
+                name.startsWith("technic_", Qt::CaseInsensitive) ||
+                name.startsWith("atl_", Qt::CaseInsensitive)) {
+                isModpack = true;
+            }
+        }
+
+        switch (m_category) {
+            case IconPickerDialog::Legacy:
+                return isBuiltin && isLegacy;
+            case IconPickerDialog::Modpacks:
+                return isModpack;
+            case IconPickerDialog::Modern:
+                return isBuiltin && !isLegacy;
+            case IconPickerDialog::Custom:
+                return !isBuiltin && !isModpack;
+            default:
+                return true;
+        }
+    }
+
+private:
+    IconPickerDialog::IconPickerCategory m_category = IconPickerDialog::Any;
+};
+
 IconPickerDialog::IconPickerDialog(QWidget* parent) : QDialog(parent), ui(new Ui::IconPickerDialog)
 {
     ui->setupUi(this);
@@ -40,12 +105,14 @@ IconPickerDialog::IconPickerDialog(QWidget* parent) : QDialog(parent), ui(new Ui
         tr("Modern"),
         tr("Legacy"),
         tr("Modpacks"),
+        tr("Custom"),
     };
     static const IconPickerCategory context_id[] = {
         Any,
         Modern,
         Legacy,
         Modpacks,
+        Custom,
     };
     const int cnt = sizeof(context_text) / sizeof(context_text[0]);
     for (int i = 0; i < cnt; ++i) {
@@ -55,7 +122,7 @@ IconPickerDialog::IconPickerDialog(QWidget* parent) : QDialog(parent), ui(new Ui
         }
     }
 
-    proxyModel = new QSortFilterProxyModel(this);
+    proxyModel = new IconProxyModel(this);
     proxyModel->setSourceModel(APPLICATION->icons().get());
     proxyModel->setFilterCaseSensitivity(Qt::CaseInsensitive);
     ui->iconView->setModel(proxyModel);
@@ -202,19 +269,5 @@ void IconPickerDialog::filterIcons(const QString& query)
 
 void IconPickerDialog::filterIconsByCategory(IconPickerCategory category)
 {
-    switch (category) {
-        default:
-        case Any:
-            proxyModel->setFilterRegularExpression("");
-            break;
-        case Modern:
-            proxyModel->setFilterRegularExpression("^(?:ftb_logo|(?!.*_legacy$)(?!^(?:curseforge_|modrinth_|ftb_|technic_|atl_))[A-Za-z0-9._-]+)$");
-            break;
-        case Legacy:
-            proxyModel->setFilterRegularExpression("^(?:[A-Za-z0-9._-]+_legacy|ftb_glow)$");
-            break;
-        case Modpacks:
-            proxyModel->setFilterRegularExpression("^(?!(?:ftb_glow|ftb_logo))(?:curseforge_|modrinth_|ftb_|technic_|atl_)[A-Za-z0-9._-]*$");
-            break;
-    }
+    static_cast<IconProxyModel*>(proxyModel)->setCategory(category);
 }

--- a/launcher/ui/dialogs/IconPickerDialog.cpp
+++ b/launcher/ui/dialogs/IconPickerDialog.cpp
@@ -35,9 +35,25 @@ IconPickerDialog::IconPickerDialog(QWidget* parent) : QDialog(parent), ui(new Ui
     ui->setupUi(this);
     setWindowModality(Qt::WindowModal);
 
-    searchBar = new QLineEdit(this);
-    searchBar->setPlaceholderText(tr("Search..."));
-    ui->verticalLayout->insertWidget(0, searchBar);
+    static const QString context_text[] = {
+        tr("All"),
+        tr("Modern"),
+        tr("Legacy"),
+        tr("Modpacks"),
+    };
+    static const Context context_id[] = {
+        Any,
+        Modern,
+        Legacy,
+        Modpacks,
+    };
+    const int cnt = sizeof(context_text) / sizeof(context_text[0]);
+    for (int i = 0; i < cnt; ++i) {
+        ui->contextCombo->addItem(context_text[i], context_id[i]);
+        if (i == 0) {
+            ui->contextCombo->insertSeparator(i + 1);
+        }
+    }
 
     proxyModel = new QSortFilterProxyModel(this);
     proxyModel->setSourceModel(APPLICATION->icons().get());
@@ -45,11 +61,8 @@ IconPickerDialog::IconPickerDialog(QWidget* parent) : QDialog(parent), ui(new Ui
     ui->iconView->setModel(proxyModel);
 
     auto contentsWidget = ui->iconView;
-    contentsWidget->setViewMode(QListView::IconMode);
     contentsWidget->setFlow(QListView::LeftToRight);
     contentsWidget->setIconSize(QSize(48, 48));
-    contentsWidget->setMovement(QListView::Static);
-    contentsWidget->setResizeMode(QListView::Adjust);
     contentsWidget->setSelectionMode(QAbstractItemView::SingleSelection);
     contentsWidget->setSpacing(5);
     contentsWidget->setWordWrap(false);
@@ -86,7 +99,11 @@ IconPickerDialog::IconPickerDialog(QWidget* parent) : QDialog(parent), ui(new Ui
 
     auto buttonFolder = ui->buttonBox->addButton(tr("Open Folder"), QDialogButtonBox::ResetRole);
     connect(buttonFolder, &QPushButton::clicked, this, &IconPickerDialog::openFolder);
-    connect(searchBar, &QLineEdit::textChanged, this, &IconPickerDialog::filterIcons);
+    connect(ui->searchLine, &QLineEdit::textChanged, this, &IconPickerDialog::filterIcons);
+    connect(ui->contextCombo, &QComboBox::currentIndexChanged, this, [this](int index) {
+        Context category = static_cast<Context>(ui->contextCombo->itemData(index).toInt());
+        filterIconsByCategory(category);
+    });
     // Prevent incorrect indices from e.g. filesystem changes
     connect(APPLICATION->icons().get(), &IconList::iconUpdated, this, [this]() { proxyModel->invalidate(); });
 }
@@ -181,4 +198,23 @@ void IconPickerDialog::openFolder()
 void IconPickerDialog::filterIcons(const QString& query)
 {
     proxyModel->setFilterFixedString(query);
+}
+
+void IconPickerDialog::filterIconsByCategory(Context category)
+{
+    switch (category) {
+        default:
+        case Any:
+            proxyModel->setFilterRegularExpression("");
+            break;
+        case Modern:
+            proxyModel->setFilterRegularExpression("^(?:ftb_logo|(?!.*_legacy$)(?!^(?:curseforge_|modrinth_|ftb_|technic_|atl_))[A-Za-z0-9._-]+)$");
+            break;
+        case Legacy:
+            proxyModel->setFilterRegularExpression("^(?:[A-Za-z0-9._-]+_legacy|ftb_glow)$");
+            break;
+        case Modpacks:
+            proxyModel->setFilterRegularExpression("^(?!(?:ftb_glow|ftb_logo))(?:curseforge_|modrinth_|ftb_|technic_|atl_)[A-Za-z0-9._-]*$");
+            break;
+    }
 }

--- a/launcher/ui/dialogs/IconPickerDialog.h
+++ b/launcher/ui/dialogs/IconPickerDialog.h
@@ -32,6 +32,14 @@ class IconPickerDialog : public QDialog {
     int execWithSelection(QString selection);
     QString selectedIconKey;
 
+    enum IconPickerCategory {
+        Any,
+        Modern,
+        Legacy,
+        Modpacks,
+    };
+    Q_ENUM(IconPickerCategory)
+
    protected:
     virtual bool eventFilter(QObject*, QEvent*);
 
@@ -41,14 +49,6 @@ class IconPickerDialog : public QDialog {
     QLineEdit* searchBar;
     QSortFilterProxyModel* proxyModel;
 
-    enum Context {
-        Any,
-        Modern,
-        Legacy,
-        Modpacks,
-    };
-    Q_ENUM(Context)
-
    private slots:
     void selectionChanged(QItemSelection, QItemSelection);
     void activated(QModelIndex);
@@ -57,5 +57,5 @@ class IconPickerDialog : public QDialog {
     void removeSelectedIcon();
     void openFolder();
     void filterIcons(const QString& text);
-    void filterIconsByCategory(Context);
+    void filterIconsByCategory(IconPickerCategory);
 };

--- a/launcher/ui/dialogs/IconPickerDialog.h
+++ b/launcher/ui/dialogs/IconPickerDialog.h
@@ -41,6 +41,14 @@ class IconPickerDialog : public QDialog {
     QLineEdit* searchBar;
     QSortFilterProxyModel* proxyModel;
 
+    enum Context {
+        Any,
+        Modern,
+        Legacy,
+        Modpacks,
+    };
+    Q_ENUM(Context)
+
    private slots:
     void selectionChanged(QItemSelection, QItemSelection);
     void activated(QModelIndex);
@@ -49,4 +57,5 @@ class IconPickerDialog : public QDialog {
     void removeSelectedIcon();
     void openFolder();
     void filterIcons(const QString& text);
+    void filterIconsByCategory(Context);
 };

--- a/launcher/ui/dialogs/IconPickerDialog.h
+++ b/launcher/ui/dialogs/IconPickerDialog.h
@@ -37,6 +37,7 @@ class IconPickerDialog : public QDialog {
         Modern,
         Legacy,
         Modpacks,
+        Custom,
     };
     Q_ENUM(IconPickerCategory)
 

--- a/launcher/ui/dialogs/IconPickerDialog.ui
+++ b/launcher/ui/dialogs/IconPickerDialog.ui
@@ -15,7 +15,64 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QListView" name="iconView"/>
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QComboBox" name="contextCombo">
+         <property name="accessibleName">
+          <string>Icon category</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="searchLine">
+         <property name="placeholderText">
+          <string>Search Icons...</string>
+         </property>
+         <property name="clearButtonEnabled">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QListView" name="iconView">
+     <property name="iconSize">
+      <size>
+       <width>60</width>
+       <height>60</height>
+      </size>
+     </property>
+     <property name="movement">
+      <enum>QListView::Static</enum>
+     </property>
+     <property name="resizeMode">
+      <enum>QListView::Adjust</enum>
+     </property>
+     <property name="viewMode">
+      <enum>QListView::IconMode</enum>
+     </property>
+     <property name="uniformItemSizes">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">


### PR DESCRIPTION
it uses some regex shenanigans for this, probably not ideal, idk if theres a good way to filter the icons without adding extra metadata or storing them in subfolders

I think storing in subfolders would be ideal, but wouldn't work with old icons.


This was mostly a experiment from me to see if we can essentially have the KDE IconPicker dialog, but the only major difference is some minor changes in the delegate, and the categories. So I just went and added that
