### PR TITLE
fix multiple retry dialogs

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -1399,6 +1399,7 @@ void Application::showFatalErrorMessage(const QString& title, const QString& con
     m_status = Application::Failed;
     auto dialog = CustomMessageBox::selectable(nullptr, title, content, QMessageBox::Critical);
     dialog->exec();
+    dialog->deleteLater();
 }
 
 Application::~Application()

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -264,12 +264,13 @@ void ResourceFolderModel::deleteMetadata(const QModelIndexList& indexes)
 bool ResourceFolderModel::setResourceEnabled(const QModelIndexList& indexes, EnableAction action)
 {
     if (m_instance != nullptr && m_instance->isRunning()) {
-        auto response =
+        auto dialog =
             CustomMessageBox::selectable(nullptr, tr("Confirm toggle"),
                                          tr("If you enable/disable this resource while the game is running it may crash your game.\n"
                                             "Are you sure you want to do this?"),
-                                         QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No, QMessageBox::No)
-                ->exec();
+                                         QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+        auto response = dialog->exec();
+        dialog->deleteLater();
 
         if (response != QMessageBox::Yes)
             return false;

--- a/launcher/net/NetJob.cpp
+++ b/launcher/net/NetJob.cpp
@@ -162,23 +162,31 @@ void NetJob::emitFailed(QString reason)
 {
 #if defined(LAUNCHER_APPLICATION)
 
-    if (APPLICATION_DYN && m_ask_retry && m_manual_try < APPLICATION->settings()->get("NumberOfManualRetries").toInt() && isOnline()) {
-        m_manual_try++;
-        auto response = CustomMessageBox::selectable(nullptr, "Confirm retry",
-                                                     "The tasks failed.\n"
-                                                     "Failed urls\n" +
-                                                         getFailedFiles().join("\n\t") +
-                                                         ".\n"
-                                                         "If this continues to happen please check the logs of the application.\n"
-                                                         "Do you want to retry?",
-                                                     QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No, QMessageBox::No)
-                            ->exec();
-
-        if (response == QMessageBox::Yes) {
-            m_try = 0;
-            executeNextSubTask();
+    if (APPLICATION_DYN && m_askRetry && m_manualTry < APPLICATION->settings()->get("NumberOfManualRetries").toInt() && isOnline()) {
+        if (m_isDialogDisplayed)
             return;
-        }
+        m_isDialogDisplayed = true;
+        m_manualTry++;
+
+        auto dialog = CustomMessageBox::selectable(nullptr, "Confirm retry",
+                                                   "The tasks failed.\n"
+                                                   "Failed urls\n" +
+                                                       getFailedFiles().join("\n\t") +
+                                                       ".\n"
+                                                       "If this continues to happen please check the logs of the application.\n"
+                                                       "Do you want to retry?",
+                                                   QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
+        connect(dialog, &QDialog::finished, this, [this, reason = std::move(reason)](int result) {
+            m_isDialogDisplayed = false;
+            if (result == QMessageBox::Yes) {
+                m_try = 0;
+                executeNextSubTask();
+            } else {
+                ConcurrentTask::emitFailed(reason);
+            }
+        });
+        dialog->open();
+        return;
     }
 #endif
     ConcurrentTask::emitFailed(reason);
@@ -186,5 +194,5 @@ void NetJob::emitFailed(QString reason)
 
 void NetJob::setAskRetry(bool askRetry)
 {
-    m_ask_retry = askRetry;
+    m_askRetry = askRetry;
 }

--- a/launcher/net/NetJob.h
+++ b/launcher/net/NetJob.h
@@ -81,6 +81,7 @@ class NetJob : public ConcurrentTask {
     QNetworkAccessManager* m_network;
 
     int m_try = 1;
-    bool m_ask_retry = true;
-    int m_manual_try = 0;
+    bool m_askRetry = true;
+    int m_manualTry = 0;
+    bool m_isDialogDisplayed = false;
 };

--- a/launcher/ui/dialogs/CustomMessageBox.cpp
+++ b/launcher/ui/dialogs/CustomMessageBox.cpp
@@ -25,6 +25,9 @@ QMessageBox* selectable(QWidget* parent,
                         QCheckBox* checkBox)
 {
     QMessageBox* messageBox = new QMessageBox(parent);
+    if (parent == nullptr) {
+        messageBox->setAttribute(Qt::WA_DeleteOnClose);
+    }
     messageBox->setWindowTitle(title);
     messageBox->setText(text);
     messageBox->setStandardButtons(buttons);


### PR DESCRIPTION
This is my hacky way to prevent the opening of multiple retry dialogs(not that I've seen this happen in real life)
What causes this(in theory):
- net job is inheriting the concurrent task. 
- this is when executing calls multiple execute tasks in "parallel"(is more like one after the other) 
- if multiple tasks fail, the code enters executeNextSubTask and opens the first dialog
- because it waits for the user input on that one, there may be a chance that executeNextSubTask is called from another task and enter the same code(where the dialog needs to open)

This is in theory, as the task should be executed one after another, and the condition to emitFailed should only happen if no more tasks are running

Another solution would be to add another state to the task API and set that when opening the dialog(but it's the same thing with this PR, but the flag is not in netjob but in task state enum).

Disclaimer: I have not reproduced this bug/crash, so I am unsure if it actually resolves the issue.