### PR TITLE
build: manually specify appimage update information

### DIFF
--- a/.github/actions/package/linux/action.yml
+++ b/.github/actions/package/linux/action.yml
@@ -72,9 +72,12 @@ runs:
 
         appimagetool -s deploy "$INSTALL_APPIMAGE_DIR"/usr/share/applications/*.desktop
         cp ~/bin/AppImageUpdate.AppImage "$INSTALL_APPIMAGE_DIR"/usr/bin/
-        appimagetool "$INSTALL_APPIMAGE_DIR"
-
-        mv "Prism_Launcher-$VERSION-$APPIMAGE_ARCH.AppImage" "PrismLauncher-Linux-$VERSION-${{ inputs.build-type }}-$APPIMAGE_ARCH.AppImage"
+        # FIXME(@getchoo): Validate AppStream information when https://github.com/probonopd/go-appimage/pull/379 is merged
+        mkappimage \
+          --no-appstream \
+          --updateinformation "gh-releases-zsync|${{ github.repository_owner }}|${{ github.event.repository.name }}|latest|PrismLauncher-Linux-$APPIMAGE_ARCH.AppImage.zsync" \
+          "$INSTALL_APPIMAGE_DIR" \
+          "PrismLauncher-Linux-$VERSION-${{ inputs.build-type }}-$APPIMAGE_ARCH.AppImage"
 
     - name: Package portable tarball
       shell: bash
@@ -106,4 +109,4 @@ runs:
       uses: actions/upload-artifact@v5
       with:
         name: PrismLauncher-${{ runner.os }}-${{ inputs.version }}-${{ inputs.build-type }}-${{ env.APPIMAGE_ARCH }}.AppImage.zsync
-        path: Prism_Launcher-${{ inputs.version }}-${{ env.APPIMAGE_ARCH }}.AppImage.zsync
+        path: PrismLauncher-${{ runner.os }}-${{ inputs.version }}-${{ inputs.build-type }}-${{ env.APPIMAGE_ARCH }}.AppImage.zsync

--- a/.github/actions/setup-dependencies/linux/action.yml
+++ b/.github/actions/setup-dependencies/linux/action.yml
@@ -60,7 +60,11 @@ runs:
           --repo probonopd/go-appimage \
           --pattern "appimagetool-*-$APPIMAGE_ARCH.AppImage" \
           --output ~/bin/appimagetool
-        chmod +x ~/bin/appimagetool
+        gh release download continuous \
+          --repo probonopd/go-appimage \
+          --pattern "mkappimage-*-$APPIMAGE_ARCH.AppImage" \
+          --output ~/bin/mkappimage
+        chmod +x ~/bin/appimagetool ~/bin/mkappimage
         echo "$HOME/bin" >> "$GITHUB_PATH"
 
         gh release download \


### PR DESCRIPTION
Previously this targeted the wrong filename from our releases
