### PR TITLE
fix(appimage): launch updater with bundled linker

### DIFF
--- a/launcher/DesktopServices.cpp
+++ b/launcher/DesktopServices.cpp
@@ -2,6 +2,7 @@
 /*
  *  Prism Launcher - Minecraft Launcher
  *  Copyright (C) 2022 dada513 <dada513@protonmail.com>
+ *  Copyright (C) 2025 Seth Flynn <getchoo@tuta.io>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -70,6 +71,15 @@ bool isFlatpak()
 {
 #ifdef Q_OS_LINUX
     return QFile::exists("/.flatpak-info");
+#else
+    return false;
+#endif
+}
+
+bool isSelfContained()
+{
+#ifdef Q_OS_LINUX
+    return QFileInfo(QCoreApplication::applicationFilePath()).fileName().startsWith("ld-linux");
 #else
     return false;
 #endif

--- a/launcher/DesktopServices.h
+++ b/launcher/DesktopServices.h
@@ -38,6 +38,11 @@ bool openUrl(const QUrl& url);
 bool isFlatpak();
 
 /**
+ * Determine whether the launcher is running in a self-contained Linux bundle
+ */
+bool isSelfContained();
+
+/**
  * Determine whether the launcher is running in a Snap environment
  */
 bool isSnap();

--- a/launcher/FileSystem.h
+++ b/launcher/FileSystem.h
@@ -4,6 +4,7 @@
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
  *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *  Copyright (C) 2022 Rachel Powers <508861+Ryex@users.noreply.github.com>
+ *  Copyright (C) 2025 Seth Flynn <getchoo@tuta.io>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -42,11 +43,13 @@
 
 #include <system_error>
 
+#include <QCoreApplication>
 #include <QDir>
 #include <QFlags>
 #include <QLocalServer>
 #include <QObject>
 #include <QPair>
+#include <QProcess>
 #include <QThread>
 
 namespace FS {
@@ -332,6 +335,14 @@ QString pathTruncate(const QString& path, int depth);
  * @return absolute path to executable or null string
  */
 QString ResolveExecutable(QString path);
+
+/**
+ * Create a QProcess instance
+ *
+ * This wrapper is currently only required for wrapping binaries called in
+ * self-contained AppImages (like those created by `go-appimage`)
+ */
+std::unique_ptr<QProcess> createProcess(const QString& program, const QStringList& arguments);
 
 /**
  * Normalize path

--- a/launcher/updater/PrismExternalUpdater.cpp
+++ b/launcher/updater/PrismExternalUpdater.cpp
@@ -26,7 +26,6 @@
 #include <QDebug>
 #include <QDir>
 #include <QMessageBox>
-#include <QProcess>
 #include <QProgressDialog>
 #include <QSettings>
 #include <QTimer>
@@ -35,6 +34,7 @@
 #include "StringUtils.h"
 
 #include "BuildConfig.h"
+#include "FileSystem.h"
 
 #include "ui/dialogs/UpdateAvailableDialog.h"
 
@@ -97,14 +97,9 @@ void PrismExternalUpdater::checkForUpdates(bool triggeredByUser)
     progress.show();
     QCoreApplication::processEvents();
 
-    QProcess proc;
     auto exe_name = QStringLiteral("%1_updater").arg(BuildConfig.LAUNCHER_APP_BINARY_NAME);
 #if defined Q_OS_WIN32
     exe_name.append(".exe");
-
-    auto env = QProcessEnvironment::systemEnvironment();
-    env.insert("__COMPAT_LAYER", "RUNASINVOKER");
-    proc.setProcessEnvironment(env);
 #else
     exe_name = QString("bin/%1").arg(exe_name);
 #endif
@@ -113,15 +108,21 @@ void PrismExternalUpdater::checkForUpdates(bool triggeredByUser)
     if (priv->allowBeta)
         args.append("--pre-release");
 
-    proc.start(priv->appDir.absoluteFilePath(exe_name), args);
-    auto result_start = proc.waitForStarted(5000);
+    auto proc = FS::createProcess(priv->appDir.absoluteFilePath(exe_name), args);
+#if defined Q_OS_WIN32
+    auto env = QProcessEnvironment::systemEnvironment();
+    env.insert("__COMPAT_LAYER", "RUNASINVOKER");
+    proc->setProcessEnvironment(env);
+#endif
+    proc->start(proc->program(), proc->arguments());
+    auto result_start = proc->waitForStarted(5000);
     if (!result_start) {
-        auto err = proc.error();
+        auto err = proc->error();
         qDebug() << "Failed to start updater after 5 seconds."
-                 << "reason:" << err << proc.errorString();
+                 << "reason:" << err << proc->errorString();
         auto msgBox =
             QMessageBox(QMessageBox::Information, tr("Update Check Failed"),
-                        tr("Failed to start after 5 seconds\nReason: %1.").arg(proc.errorString()), QMessageBox::Ok, priv->parent);
+                        tr("Failed to start after 5 seconds\nReason: %1.").arg(proc->errorString()), QMessageBox::Ok, priv->parent);
         msgBox.setMinimumWidth(460);
         msgBox.adjustSize();
         msgBox.exec();
@@ -133,16 +134,16 @@ void PrismExternalUpdater::checkForUpdates(bool triggeredByUser)
     }
     QCoreApplication::processEvents();
 
-    auto result_finished = proc.waitForFinished(60000);
+    auto result_finished = proc->waitForFinished(60000);
     if (!result_finished) {
-        proc.kill();
-        auto err = proc.error();
-        auto output = proc.readAll();
+        proc->kill();
+        auto err = proc->error();
+        auto output = proc->readAll();
         qDebug() << "Updater failed to close after 60 seconds."
-                 << "reason:" << err << proc.errorString();
+                 << "reason:" << err << proc->errorString();
         auto msgBox =
             QMessageBox(QMessageBox::Information, tr("Update Check Failed"),
-                        tr("Updater failed to close 60 seconds\nReason: %1.").arg(proc.errorString()), QMessageBox::Ok, priv->parent);
+                        tr("Updater failed to close 60 seconds\nReason: %1.").arg(proc->errorString()), QMessageBox::Ok, priv->parent);
         msgBox.setDetailedText(output);
         msgBox.setMinimumWidth(460);
         msgBox.adjustSize();
@@ -154,10 +155,10 @@ void PrismExternalUpdater::checkForUpdates(bool triggeredByUser)
         return;
     }
 
-    auto exit_code = proc.exitCode();
+    auto exit_code = proc->exitCode();
 
-    auto std_output = proc.readAllStandardOutput();
-    auto std_error = proc.readAllStandardError();
+    auto std_output = proc->readAllStandardOutput();
+    auto std_error = proc->readAllStandardError();
 
     progress.hide();
     QCoreApplication::processEvents();
@@ -335,14 +336,9 @@ void PrismExternalUpdater::offerUpdate(const QString& version_name, const QStrin
 
 void PrismExternalUpdater::performUpdate(const QString& version_tag)
 {
-    QProcess proc;
     auto exe_name = QStringLiteral("%1_updater").arg(BuildConfig.LAUNCHER_APP_BINARY_NAME);
 #if defined Q_OS_WIN32
     exe_name.append(".exe");
-
-    auto env = QProcessEnvironment::systemEnvironment();
-    env.insert("__COMPAT_LAYER", "RUNASINVOKER");
-    proc.setProcessEnvironment(env);
 #else
     exe_name = QString("bin/%1").arg(exe_name);
 #endif
@@ -351,9 +347,16 @@ void PrismExternalUpdater::performUpdate(const QString& version_tag)
     if (priv->allowBeta)
         args.append("--pre-release");
 
-    auto result = proc.startDetached(priv->appDir.absoluteFilePath(exe_name), args);
+    auto proc = FS::createProcess(exe_name, args);
+#if defined Q_OS_WIN32
+    auto env = QProcessEnvironment::systemEnvironment();
+    env.insert("__COMPAT_LAYER", "RUNASINVOKER");
+    proc->setProcessEnvironment(env);
+#endif
+
+    auto result = proc->startDetached(priv->appDir.absoluteFilePath(exe_name), args);
     if (!result) {
-        qDebug() << "Failed to start updater:" << proc.error() << proc.errorString();
+        qDebug() << "Failed to start updater:" << proc->error() << proc->errorString();
     }
     QCoreApplication::exit();
 }

--- a/launcher/updater/prismupdater/PrismUpdater.cpp
+++ b/launcher/updater/prismupdater/PrismUpdater.cpp
@@ -123,70 +123,6 @@ PrismUpdaterApp::PrismUpdaterApp(int& argc, char** argv) : QApplication(argc, ar
 
     logToConsole = parser.isSet("debug");
 
-    auto updater_executable = QCoreApplication::applicationFilePath();
-
-#ifdef Q_OS_MACOS
-    showFatalErrorMessage(tr("MacOS Not Supported"), tr("The updater does not support installations on MacOS"));
-#endif
-
-    if (updater_executable.startsWith("/tmp/.mount_")) {
-        m_isAppimage = true;
-        m_appimagePath = QProcessEnvironment::systemEnvironment().value(QStringLiteral("APPIMAGE"));
-        if (m_appimagePath.isEmpty()) {
-            showFatalErrorMessage(tr("Unsupported Installation"),
-                                  tr("Updater is running as misconfigured AppImage? ($APPIMAGE environment variable is missing)"));
-        }
-    }
-
-    m_isFlatpak = DesktopServices::isFlatpak();
-
-    QString prism_executable = FS::PathCombine(applicationDirPath(), BuildConfig.LAUNCHER_APP_BINARY_NAME);
-#if defined Q_OS_WIN32
-    prism_executable.append(".exe");
-#endif
-
-    if (!QFileInfo(prism_executable).isFile()) {
-        showFatalErrorMessage(tr("Unsupported Installation"), tr("The updater can not find the main executable."));
-    }
-
-    m_prismExecutable = prism_executable;
-
-    auto prism_update_url = parser.value("update-url");
-    if (prism_update_url.isEmpty())
-        prism_update_url = BuildConfig.UPDATER_GITHUB_REPO;
-
-    m_prismRepoUrl = QUrl::fromUserInput(prism_update_url);
-
-    m_checkOnly = parser.isSet("check-only");
-    m_forceUpdate = parser.isSet("force");
-    m_printOnly = parser.isSet("list");
-    auto user_version = parser.value("install-version");
-    if (!user_version.isEmpty()) {
-        m_userSelectedVersion = Version(user_version);
-    }
-    m_selectUI = parser.isSet("select-ui");
-    m_allowDowngrade = parser.isSet("allow-downgrade");
-
-    auto version = parser.value("prism-version");
-    if (!version.isEmpty()) {
-        if (version.contains('-')) {
-            auto index = version.indexOf('-');
-            m_prsimVersionChannel = version.mid(index + 1);
-            version = version.left(index);
-        } else {
-            m_prsimVersionChannel = "stable";
-        }
-        auto version_parts = version.split('.');
-        m_prismVersionMajor = version_parts.takeFirst().toInt();
-        m_prismVersionMinor = version_parts.takeFirst().toInt();
-        if (!version_parts.isEmpty())
-            m_prismVersionPatch = version_parts.takeFirst().toInt();
-        else
-            m_prismVersionPatch = 0;
-    }
-
-    m_allowPreRelease = parser.isSet("pre-release");
-
     QString origCwdPath = QDir::currentPath();
 #if defined(Q_OS_LINUX)
     // NOTE(@getchoo): In order for `go-appimage` to generate self-contained AppImages, it executes apps from a bundled linker at
@@ -374,6 +310,68 @@ PrismUpdaterApp::PrismUpdaterApp(int& argc, char** argv) : QApplication(argc, ar
         QNetworkProxy proxy = QNetworkProxy::applicationProxy();
         m_network->setProxy(proxy);
     }
+
+#ifdef Q_OS_MACOS
+    showFatalErrorMessage(tr("MacOS Not Supported"), tr("The updater does not support installations on MacOS"));
+#endif
+
+    if (binPath.startsWith("/tmp/.mount_")) {
+        m_isAppimage = true;
+        m_appimagePath = QProcessEnvironment::systemEnvironment().value(QStringLiteral("APPIMAGE"));
+        if (m_appimagePath.isEmpty()) {
+            showFatalErrorMessage(tr("Unsupported Installation"),
+                                  tr("Updater is running as misconfigured AppImage? ($APPIMAGE environment variable is missing)"));
+        }
+    }
+
+    m_isFlatpak = DesktopServices::isFlatpak();
+
+    QString prism_executable = FS::PathCombine(binPath, BuildConfig.LAUNCHER_APP_BINARY_NAME);
+#if defined Q_OS_WIN32
+    prism_executable.append(".exe");
+#endif
+
+    if (!QFileInfo(prism_executable).isFile()) {
+        showFatalErrorMessage(tr("Unsupported Installation"), tr("The updater can not find the main executable."));
+    }
+
+    m_prismExecutable = prism_executable;
+
+    auto prism_update_url = parser.value("update-url");
+    if (prism_update_url.isEmpty())
+        prism_update_url = BuildConfig.UPDATER_GITHUB_REPO;
+
+    m_prismRepoUrl = QUrl::fromUserInput(prism_update_url);
+
+    m_checkOnly = parser.isSet("check-only");
+    m_forceUpdate = parser.isSet("force");
+    m_printOnly = parser.isSet("list");
+    auto user_version = parser.value("install-version");
+    if (!user_version.isEmpty()) {
+        m_userSelectedVersion = Version(user_version);
+    }
+    m_selectUI = parser.isSet("select-ui");
+    m_allowDowngrade = parser.isSet("allow-downgrade");
+
+    auto version = parser.value("prism-version");
+    if (!version.isEmpty()) {
+        if (version.contains('-')) {
+            auto index = version.indexOf('-');
+            m_prsimVersionChannel = version.mid(index + 1);
+            version = version.left(index);
+        } else {
+            m_prsimVersionChannel = "stable";
+        }
+        auto version_parts = version.split('.');
+        m_prismVersionMajor = version_parts.takeFirst().toInt();
+        m_prismVersionMinor = version_parts.takeFirst().toInt();
+        if (!version_parts.isEmpty())
+            m_prismVersionPatch = version_parts.takeFirst().toInt();
+        else
+            m_prismVersionPatch = 0;
+    }
+
+    m_allowPreRelease = parser.isSet("pre-release");
 
     auto marker_file_path = QDir(m_rootPath).absoluteFilePath(".prism_launcher_updater_unpack.marker");
     auto marker_file = QFileInfo(marker_file_path);


### PR DESCRIPTION
This ensures that our updater~~external processes (including our updater and
Minecraft itself)~~ maintains the same compatibility guarantees as the main
binary

## TODO

- ~~Refactor all uses of QProcess with the new `FS::createProcess()`~~
- ~~Refactor manual AppImage/self-contained detection to use `FS::runningInAppImage()` and `FS::runningSelfContained()`~~