### PR TITLE
clang-format: specify access modifier offset used in codebase

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,6 +5,7 @@ AllowShortIfStatementsOnASingleLine: false
 ColumnLimit: 140
 ---
 Language: Cpp
+AccessModifierOffset: -1
 AlignConsecutiveMacros: None
 AlignConsecutiveAssignments: None
 BraceWrapping:


### PR DESCRIPTION
Makes IDEs respect it more often when using auto-formatting