### PR TITLE
EditorConfig: set continuation indent size in CMakeLists for IntelliJ

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,6 @@ root = true
 # C++ Code Style settings
 [*.{c++,cc,cpp,cppm,cxx,h,h++,hh,hpp,hxx,inl,ipp,ixx,tlh,tli}]
 cpp_generate_documentation_comments = doxygen_slash_star
+
+[CMakeLists.txt]
+ij_continuation_indent_size = 4


### PR DESCRIPTION
Fixes CLion completely messing up sources list when automatically adding files to project