### PR TITLE
clang-tidy: enable more checks, run on GitHub Actions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -16,3 +16,4 @@ BraceWrapping:
 BreakBeforeBraces: Custom
 BreakConstructorInitializers: BeforeComma
 Cpp11BracedListStyle: false
+QualifierAlignment: Left

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,7 +10,6 @@ Checks:
   -cppcoreguidelines-pro-type-static-cast-downcast,
   -modernize-use-nodiscard,
   -modernize-use-trailing-return-type,
-  -performance-unnecessary-value-param,
   -portability-avoid-pragma-once,
   -readability-avoid-unconditional-preprocessor-if,
   -readability-function-cognitive-complexity,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,6 +5,7 @@ Checks:
   -*-magic-numbers,
   -*-non-private-member-variables-in-classes,
   -*-special-member-functions,
+  -bugprone-easily-swappable-parameters,
   -cppcoreguidelines-owning-memory,
   -cppcoreguidelines-pro-type-static-cast-downcast,
   -modernize-use-nodiscard,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,10 @@
+FormatStyle: file
+
 Checks:
   'bugprone-*,clang-analyzer-*,cppcoreguidelines-*,hicpp-*,misc-*,modernize-*,performance-*,portability-*,readability-*,
   -cppcoreguidelines-owning-memory,
   -cppcoreguidelines-pro-type-static-cast-downcast,
+  -cppcoreguidelines-special-member-functions,
   -misc-non-private-member-variables-in-classes,
   -modernize-use-nodiscard,
   -modernize-use-trailing-return-type,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,6 +2,7 @@ FormatStyle: file
 
 Checks:
   'bugprone-*,clang-analyzer-*,cppcoreguidelines-*,hicpp-*,misc-*,modernize-*,performance-*,portability-*,readability-*,
+  -*-magic-numbers,
   -*-non-private-member-variables-in-classes,
   -*-special-member-functions,
   -cppcoreguidelines-owning-memory,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,10 +2,10 @@ FormatStyle: file
 
 Checks:
   'bugprone-*,clang-analyzer-*,cppcoreguidelines-*,hicpp-*,misc-*,modernize-*,performance-*,portability-*,readability-*,
+  -*-non-private-member-variables-in-classes,
+  -*-special-member-functions,
   -cppcoreguidelines-owning-memory,
   -cppcoreguidelines-pro-type-static-cast-downcast,
-  -cppcoreguidelines-special-member-functions,
-  -misc-non-private-member-variables-in-classes,
   -modernize-use-nodiscard,
   -modernize-use-trailing-return-type,
   -performance-unnecessary-value-param,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,19 +14,15 @@ Checks:
 
 CheckOptions:
   - { key: misc-include-cleaner.MissingIncludes,                        value: false }
+  - { key: readability-identifier-naming.DefaultCase,                   value: camelBack }
+  - { key: readability-identifier-naming.NamespaceCase,                 value: CamelCase }
   - { key: readability-identifier-naming.ClassCase,                     value: CamelCase }
+  - { key: readability-identifier-naming.ClassConstantCase,             value: CamelCase }
   - { key: readability-identifier-naming.EnumCase,                      value: CamelCase }
-  - { key: readability-identifier-naming.FunctionCase,                  value: camelBack }
-  - { key: readability-identifier-naming.VariableCase,                  value: camelBack }
-  - { key: readability-identifier-naming.ParameterCase,                 value: camelBack }
-  - { key: readability-identifier-naming.GlobalConstantCase,            value: UPPER_CASE }
-  - { key: readability-identifier-naming.MacroDefinitionCase,           value: UPPER_CASE }
-  - { key: readability-identifier-naming.MemberCase,                    value: camelBack }
-  - { key: readability-identifier-naming.PrivateMemberPrefix,           value: m_ }
-  - { key: readability-identifier-naming.ProtectedMemberPrefix,         value: m_ }
-  - { key: readability-identifier-naming.PrivateStaticMemberPrefix,     value: s_ }
-  - { key: readability-identifier-naming.ProtectedStaticMemberPrefix,   value: s_ }
-  - { key: readability-identifier-naming.StaticVariablePrefix,          value: s_ }
-  - { key: readability-identifier-naming.PublicStaticConstantCase,      value: CamelCase }
   - { key: readability-identifier-naming.EnumConstantCase,              value: CamelCase }
+  - { key: readability-identifier-naming.MacroDefinitionCase,           value: UPPER_CASE }
+  - { key: readability-identifier-naming.ClassMemberPrefix,             value: m_ }
+  - { key: readability-identifier-naming.StaticConstantPrefix,          value: s_ }
+  - { key: readability-identifier-naming.StaticVariablePrefix,          value: s_ }
+  - { key: readability-identifier-naming.GlobalConstantPrefix,          value: g_ }
   - { key: readability-implicit-bool-conversion.AllowPointerConditions, value: true }

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,23 +1,32 @@
 Checks:
-  - modernize-use-using
-  - readability-avoid-const-params-in-decls
-  - misc-unused-parameters,
-  - readability-identifier-naming
-
-# ^ Without unused-parameters the readability-identifier-naming check doesn't cause any warnings.
+  'bugprone-*,clang-analyzer-*,cppcoreguidelines-*,misc-*,modernize-*,performance-*,portability-*,readability-*,
+  -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-pro-type-static-cast-downcast,
+  -misc-non-private-member-variables-in-classes,
+  -modernize-use-nodiscard,
+  -modernize-use-trailing-return-type,
+  -performance-unnecessary-value-param,
+  -portability-avoid-pragma-once,
+  -readability-avoid-unconditional-preprocessor-if,
+  -readability-function-cognitive-complexity,
+  -readability-identifier-length,
+  -readability-redundant-access-specifiers'
 
 CheckOptions:
-  - { key: readability-identifier-naming.ClassCase,                   value: PascalCase }
-  - { key: readability-identifier-naming.EnumCase,                    value: PascalCase }
-  - { key: readability-identifier-naming.FunctionCase,                value: camelCase }
-  - { key: readability-identifier-naming.GlobalVariableCase,          value: camelCase }
-  - { key: readability-identifier-naming.GlobalFunctionCase,          value: camelCase }
-  - { key: readability-identifier-naming.GlobalConstantCase,          value: SCREAMING_SNAKE_CASE }
-  - { key: readability-identifier-naming.MacroDefinitionCase,         value: SCREAMING_SNAKE_CASE }
-  - { key: readability-identifier-naming.ClassMemberCase,             value: camelCase }
-  - { key: readability-identifier-naming.PrivateMemberPrefix,         value: m_ }
-  - { key: readability-identifier-naming.ProtectedMemberPrefix,       value: m_ }
-  - { key: readability-identifier-naming.PrivateStaticMemberPrefix,   value: s_ }
-  - { key: readability-identifier-naming.ProtectedStaticMemberPrefix, value: s_ }
-  - { key: readability-identifier-naming.PublicStaticConstantCase,    value: SCREAMING_SNAKE_CASE }
-  - { key: readability-identifier-naming.EnumConstantCase,            value: PascalCase }
+  - { key: misc-include-cleaner.MissingIncludes,                        value: false }
+  - { key: readability-identifier-naming.ClassCase,                     value: CamelCase }
+  - { key: readability-identifier-naming.EnumCase,                      value: CamelCase }
+  - { key: readability-identifier-naming.FunctionCase,                  value: camelBack }
+  - { key: readability-identifier-naming.VariableCase,                  value: camelBack }
+  - { key: readability-identifier-naming.ParameterCase,                 value: camelBack }
+  - { key: readability-identifier-naming.GlobalConstantCase,            value: UPPER_CASE }
+  - { key: readability-identifier-naming.MacroDefinitionCase,           value: UPPER_CASE }
+  - { key: readability-identifier-naming.MemberCase,                    value: camelBack }
+  - { key: readability-identifier-naming.PrivateMemberPrefix,           value: m_ }
+  - { key: readability-identifier-naming.ProtectedMemberPrefix,         value: m_ }
+  - { key: readability-identifier-naming.PrivateStaticMemberPrefix,     value: s_ }
+  - { key: readability-identifier-naming.ProtectedStaticMemberPrefix,   value: s_ }
+  - { key: readability-identifier-naming.StaticVariablePrefix,          value: s_ }
+  - { key: readability-identifier-naming.PublicStaticConstantCase,      value: CamelCase }
+  - { key: readability-identifier-naming.EnumConstantCase,              value: CamelCase }
+  - { key: readability-implicit-bool-conversion.AllowPointerConditions, value: true }

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 Checks:
-  'bugprone-*,clang-analyzer-*,cppcoreguidelines-*,misc-*,modernize-*,performance-*,portability-*,readability-*,
+  'bugprone-*,clang-analyzer-*,cppcoreguidelines-*,hicpp-*,misc-*,modernize-*,performance-*,portability-*,readability-*,
   -cppcoreguidelines-owning-memory,
   -cppcoreguidelines-pro-type-static-cast-downcast,
   -misc-non-private-member-variables-in-classes,

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Install clang-tidy-sarif
         run: |
           cargo install clang-tidy-sarif sarif-fmt
-          
+
       - name: Collect files to analyze
         id: collect-files
         env:
@@ -89,7 +89,7 @@ jobs:
           if [ -n "$FILES" ]; then
             echo "HAS_FILES=true" >> "$GITHUB_OUTPUT"
             nix develop --command bash -c "
-              echo "$FILES" | xargs clang-tidy -p=. --fix-errors --quiet --warnings-as-errors='*' | tee clang-tidy-output.txt
+              echo "$FILES" | xargs clang-tidy -p=. --quiet --warnings-as-errors='*' | tee clang-tidy-output.txt
             "
           else
             echo "HAS_FILES=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -14,6 +14,9 @@ on:
       - "**.cpp"
       - "**.h"
 
+      # Clang-tidy configuration file
+      - ".clang-tidy"
+
       # Workflows
       - ".github/workflows/clang-tidy.yml"
   pull_request:
@@ -21,6 +24,9 @@ on:
       # File types
       - "**.cpp"
       - "**.h"
+
+      # Clang-tidy configuration file
+      - ".clang-tidy"
 
       # Workflows
       - ".github/workflows/clang-tidy.yml"

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,103 @@
+name: Clang-Tidy
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - "develop"
+      - "release-*"
+    paths:
+      # File types
+      - "**.cpp"
+      - "**.h"
+
+      # Workflows
+      - ".github/workflows/clang-tidy.yml"
+  pull_request:
+    paths:
+      # File types
+      - "**.cpp"
+      - "**.h"
+
+      # Workflows
+      - ".github/workflows/clang-tidy.yml"
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  clang-tidy:
+    name: Run clang-tidy
+
+    permissions:
+      security-events: write
+
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+
+        # For PRs
+      - name: Setup Nix Magic Cache
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: DeterminateSystems/magic-nix-cache-action@v13
+        with:
+          diagnostic-endpoint: ""
+          use-flakehub: false
+
+        # For in-tree builds
+      - name: Setup Cachix
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+        uses: cachix/cachix-action@v16
+        with:
+          name: prismlauncher
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Install clang-tidy-sarif
+        run: |
+          cargo install clang-tidy-sarif sarif-fmt
+          
+      - name: Collect files to analyze
+        id: collect-files
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IS_PR: ${{ github.event_name == 'pull_request' }}
+        run: |
+          if [ "$IS_PR" == "true" ]; then
+            echo "FILES=$(gh -R ${{ github.repository }} pr diff ${{ github.event.pull_request.number }} --name-only | grep -E '\.(cpp|h)$' || true)" >> "$GITHUB_OUTPUT"
+          else
+            echo "FILES=$(find launcher/ tests/ -name \*.cpp -o -name \*.h)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run clang-tidy
+        id: clang-tidy
+        env:
+          FILES: ${{ steps.collect-files.outputs.FILES }}
+        run: |
+          if [ -n "$FILES" ]; then
+            echo "HAS_FILES=true" >> "$GITHUB_OUTPUT"
+            nix develop --command bash -c "
+              echo "$FILES" | xargs clang-tidy -p=. --fix-errors --quiet --warnings-as-errors='*' | tee clang-tidy-output.txt
+            "
+          else
+            echo "HAS_FILES=false" >> "$GITHUB_OUTPUT"
+            echo "No source files changed, skipping"
+          fi
+
+      - name: Convert output to SARIF
+        if: ${{ steps.clang-tidy.outputs.HAS_FILES == 'true' }}
+        run:
+          cat clang-tidy-output.txt | clang-tidy-sarif | tee results.sarif | sarif-fmt
+
+      - name: Upload SARIF file
+        if: ${{ steps.clang-tidy.outputs.HAS_FILES == 'true' }}
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: results.sarif
+          category: clang-tidy


### PR DESCRIPTION
This PR enables most of checks provided by clang-tidy, with checks that do not fit us excluded. The table containing naming conventions was using wrong values, that was fixed and now tidy correctly warns and fixes naming convention issues
clang-tidy is now also ran on changed files within pull requests. Warnings are displayed on the pull request itself similar to CodeQL