### PR TITLE
EditorConfig essentials

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,6 +3,17 @@
 # top-most EditorConfig file
 root = true
 
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{yml,nix}]
+indent_size = 2
+
 # C++ Code Style settings
 [*.{c++,cc,cpp,cppm,cxx,h,h++,hh,hpp,hxx,inl,ipp,ixx,tlh,tli}]
 cpp_generate_documentation_comments = doxygen_slash_star


### PR DESCRIPTION
Finally I can stop writing `:set shiftwidth=4 expandtab` in my neovim

I feel slightly concerned by the fact that the whole file shows as being changed... were we NOT using LF and UTF-8 before?