### PR TITLE
Simplify MessageLevel and IndexedVersionType enums

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -241,7 +241,7 @@ void appDebugOutput(QtMsgType type, const QMessageLogContext& context, const QSt
 
     QString out = qFormatLogMessage(type, context, msg);
     if (APPLICATION->logModel) {
-        APPLICATION->logModel->append(MessageLevel::getLevel(type), out);
+        APPLICATION->logModel->append(messageLevelFromQtMsgType(type), out);
     }
 
     out += QChar::LineFeed;

--- a/launcher/LoggedProcess.h
+++ b/launcher/LoggedProcess.h
@@ -58,7 +58,7 @@ class LoggedProcess : public QProcess {
     void setDetachable(bool detachable);
 
    signals:
-    void log(QStringList lines, MessageLevel::Enum level);
+    void log(QStringList lines, MessageLevel level);
     void stateChanged(LoggedProcess::State state);
 
    public slots:

--- a/launcher/MessageLevel.cpp
+++ b/launcher/MessageLevel.cpp
@@ -1,6 +1,6 @@
 #include "MessageLevel.h"
 
-MessageLevel::Enum MessageLevel::getLevel(const QString& levelName)
+MessageLevel messageLevelFromName(const QString& levelName)
 {
     QString name = levelName.toUpper();
     if (name == "LAUNCHER")
@@ -25,7 +25,7 @@ MessageLevel::Enum MessageLevel::getLevel(const QString& levelName)
         return MessageLevel::Unknown;
 }
 
-MessageLevel::Enum MessageLevel::getLevel(QtMsgType type)
+MessageLevel messageLevelFromQtMsgType(QtMsgType type)
 {
     switch (type) {
         case QtDebugMsg:
@@ -43,19 +43,19 @@ MessageLevel::Enum MessageLevel::getLevel(QtMsgType type)
     }
 }
 
-MessageLevel::Enum MessageLevel::fromLine(QString& line)
+MessageLevel messageLevelFromLine(QString& line)
 {
     // Level prefix
     int endmark = line.indexOf("]!");
     if (line.startsWith("!![") && endmark != -1) {
-        auto level = MessageLevel::getLevel(line.left(endmark).mid(3));
+        auto level = messageLevelFromName(line.left(endmark).mid(3));
         line = line.mid(endmark + 2);
         return level;
     }
     return MessageLevel::Unknown;
 }
 
-MessageLevel::Enum MessageLevel::fromLauncherLine(QString& line)
+MessageLevel messageLevelFromLauncherLine(QString& line)
 {
     // Level prefix
     int startMark = 0;
@@ -63,7 +63,7 @@ MessageLevel::Enum MessageLevel::fromLauncherLine(QString& line)
         ++startMark;
     int endmark = line.indexOf(":");
     if (startMark < line.size() && endmark != -1) {
-        auto level = MessageLevel::getLevel(line.left(endmark).mid(startMark));
+        auto level = messageLevelFromName(line.left(endmark).mid(startMark));
         line = line.mid(endmark + 2);
         return level;
     }

--- a/launcher/MessageLevel.h
+++ b/launcher/MessageLevel.h
@@ -7,8 +7,7 @@
  * @brief the MessageLevel Enum
  * defines what level a log message is
  */
-namespace MessageLevel {
-enum Enum {
+enum class MessageLevel {
     Unknown,  /**< No idea what this is or where it came from */
     StdOut,   /**< Undetermined stderr messages */
     StdErr,   /**< Undetermined stdout messages */
@@ -21,12 +20,11 @@ enum Enum {
     Error,    /**< Errors */
     Fatal,    /**< Fatal Errors */
 };
-MessageLevel::Enum getLevel(const QString& levelName);
-MessageLevel::Enum getLevel(QtMsgType type);
+MessageLevel messageLevelFromName(const QString& levelName);
+MessageLevel messageLevelFromQtMsgType(QtMsgType type);
 
 /* Get message level from a line. Line is modified if it was successful. */
-MessageLevel::Enum fromLine(QString& line);
+MessageLevel messageLevelFromLine(QString& line);
 
 /* Get message level from a line from the launcher log. Line is modified if it was successful. */
-MessageLevel::Enum fromLauncherLine(QString& line);
-}  // namespace MessageLevel
+MessageLevel messageLevelFromLauncherLine(QString& line);

--- a/launcher/launch/LaunchStep.h
+++ b/launcher/launch/LaunchStep.h
@@ -28,8 +28,8 @@ class LaunchStep : public Task {
     virtual ~LaunchStep() = default;
 
    signals:
-    void logLines(QStringList lines, MessageLevel::Enum level);
-    void logLine(QString line, MessageLevel::Enum level);
+    void logLines(QStringList lines, MessageLevel level);
+    void logLine(QString line, MessageLevel level);
     void readyForLaunch();
     void progressReportingRequest();
 

--- a/launcher/launch/LaunchTask.cpp
+++ b/launcher/launch/LaunchTask.cpp
@@ -214,7 +214,7 @@ shared_qobject_ptr<LogModel> LaunchTask::getLogModel()
     return m_logModel;
 }
 
-bool LaunchTask::parseXmlLogs(QString const& line, MessageLevel::Enum level)
+bool LaunchTask::parseXmlLogs(QString const& line, MessageLevel level)
 {
     LogParser* parser;
     switch (level) {
@@ -254,7 +254,7 @@ bool LaunchTask::parseXmlLogs(QString const& line, MessageLevel::Enum level)
         } else if (std::holds_alternative<LogParser::PlainText>(item)) {
             auto msg = std::get<LogParser::PlainText>(item).message;
 
-            MessageLevel::Enum newLevel = MessageLevel::fromLine(msg);
+            MessageLevel newLevel = messageLevelFromLine(msg);
 
             if (newLevel == MessageLevel::Unknown)
                 newLevel = LogParser::guessLevel(line);
@@ -271,14 +271,14 @@ bool LaunchTask::parseXmlLogs(QString const& line, MessageLevel::Enum level)
     return true;
 }
 
-void LaunchTask::onLogLines(const QStringList& lines, MessageLevel::Enum defaultLevel)
+void LaunchTask::onLogLines(const QStringList& lines, MessageLevel defaultLevel)
 {
     for (auto& line : lines) {
         onLogLine(line, defaultLevel);
     }
 }
 
-void LaunchTask::onLogLine(QString line, MessageLevel::Enum level)
+void LaunchTask::onLogLine(QString line, MessageLevel level)
 {
     if (parseXmlLogs(line, level)) {
         return;

--- a/launcher/launch/LaunchTask.h
+++ b/launcher/launch/LaunchTask.h
@@ -106,8 +106,8 @@ class LaunchTask : public Task {
     void requestLogging();
 
    public slots:
-    void onLogLines(const QStringList& lines, MessageLevel::Enum defaultLevel = MessageLevel::Launcher);
-    void onLogLine(QString line, MessageLevel::Enum defaultLevel = MessageLevel::Launcher);
+    void onLogLines(const QStringList& lines, MessageLevel defaultLevel = MessageLevel::Launcher);
+    void onLogLine(QString line, MessageLevel defaultLevel = MessageLevel::Launcher);
     void onReadyForLaunch();
     void onStepFinished();
     void onProgressReportingRequested();
@@ -116,7 +116,7 @@ class LaunchTask : public Task {
     void finalizeSteps(bool successful, const QString& error);
 
    protected:
-    bool parseXmlLogs(QString const& line, MessageLevel::Enum level);
+    bool parseXmlLogs(QString const& line, MessageLevel level);
 
    protected: /* data */
     MinecraftInstancePtr m_instance;

--- a/launcher/launch/LogModel.cpp
+++ b/launcher/launch/LogModel.cpp
@@ -24,13 +24,13 @@ QVariant LogModel::data(const QModelIndex& index, int role) const
         return m_content[realRow].line;
     }
     if (role == LevelRole) {
-        return m_content[realRow].level;
+        return static_cast<int>(m_content[realRow].level);
     }
 
     return QVariant();
 }
 
-void LogModel::append(MessageLevel::Enum level, QString line)
+void LogModel::append(MessageLevel level, QString line)
 {
     if (m_suspended) {
         return;
@@ -167,7 +167,7 @@ bool LogModel::isOverFlow()
     return m_numLines >= m_maxLines && m_stopOnOverflow;
 }
 
-MessageLevel::Enum LogModel::previousLevel()
+MessageLevel LogModel::previousLevel()
 {
     if (m_numLines > 0) {
         return m_content[m_numLines - 1].level;

--- a/launcher/launch/LogModel.h
+++ b/launcher/launch/LogModel.h
@@ -12,7 +12,7 @@ class LogModel : public QAbstractListModel {
     int rowCount(const QModelIndex& parent = QModelIndex()) const;
     QVariant data(const QModelIndex& index, int role) const;
 
-    void append(MessageLevel::Enum, QString line);
+    void append(MessageLevel, QString line);
     void clear();
 
     void suspend(bool suspend);
@@ -31,13 +31,13 @@ class LogModel : public QAbstractListModel {
     void setColorLines(bool state);
     bool colorLines() const;
 
-    MessageLevel::Enum previousLevel();
+    MessageLevel previousLevel();
 
     enum Roles { LevelRole = Qt::UserRole };
 
    private /* types */:
     struct entry {
-        MessageLevel::Enum level = MessageLevel::Enum::Unknown;
+        MessageLevel level = MessageLevel::Unknown;
         QString line;
     };
 

--- a/launcher/launch/steps/TextPrint.cpp
+++ b/launcher/launch/steps/TextPrint.cpp
@@ -1,11 +1,11 @@
 #include "TextPrint.h"
 
-TextPrint::TextPrint(LaunchTask* parent, const QStringList& lines, MessageLevel::Enum level) : LaunchStep(parent)
+TextPrint::TextPrint(LaunchTask* parent, const QStringList& lines, MessageLevel level) : LaunchStep(parent)
 {
     m_lines = lines;
     m_level = level;
 }
-TextPrint::TextPrint(LaunchTask* parent, const QString& line, MessageLevel::Enum level) : LaunchStep(parent)
+TextPrint::TextPrint(LaunchTask* parent, const QString& line, MessageLevel level) : LaunchStep(parent)
 {
     m_lines.append(line);
     m_level = level;

--- a/launcher/launch/steps/TextPrint.h
+++ b/launcher/launch/steps/TextPrint.h
@@ -26,8 +26,8 @@
 class TextPrint : public LaunchStep {
     Q_OBJECT
    public:
-    explicit TextPrint(LaunchTask* parent, const QStringList& lines, MessageLevel::Enum level);
-    explicit TextPrint(LaunchTask* parent, const QString& line, MessageLevel::Enum level);
+    explicit TextPrint(LaunchTask* parent, const QStringList& lines, MessageLevel level);
+    explicit TextPrint(LaunchTask* parent, const QString& line, MessageLevel level);
     virtual ~TextPrint() {};
 
     virtual void executeTask();
@@ -36,5 +36,5 @@ class TextPrint : public LaunchStep {
 
    private:
     QStringList m_lines;
-    MessageLevel::Enum m_level;
+    MessageLevel m_level;
 };

--- a/launcher/logs/LogParser.cpp
+++ b/launcher/logs/LogParser.cpp
@@ -60,7 +60,7 @@ std::optional<LogParser::LogEntry> LogParser::parseAttributes()
             entry.timestamp = QDateTime::fromSecsSinceEpoch(value.trimmed().toLongLong());
         } else if (name == "level"_L1) {
             entry.levelText = value.trimmed().toString();
-            entry.level = MessageLevel::getLevel(entry.levelText);
+            entry.level = messageLevelFromName(entry.levelText);
         } else if (name == "thread"_L1) {
             entry.thread = value.trimmed().toString();
         }
@@ -320,7 +320,7 @@ std::optional<LogParser::ParsedItem> LogParser::parseLog4J()
     throw std::runtime_error("unreachable: already verified this was a complete log4j:Event");
 }
 
-MessageLevel::Enum LogParser::guessLevel(const QString& line)
+MessageLevel LogParser::guessLevel(const QString& line)
 {
     static const QRegularExpression LINE_WITH_LEVEL("^\\[(?<timestamp>[0-9:]+)\\] \\[[^/]+/(?<level>[^\\]]+)\\]");
     auto match = LINE_WITH_LEVEL.match(line);
@@ -329,7 +329,7 @@ MessageLevel::Enum LogParser::guessLevel(const QString& line)
         QString timestamp = match.captured("timestamp");
         QString levelStr = match.captured("level");
 
-        return MessageLevel::getLevel(levelStr);
+        return messageLevelFromName(levelStr);
     } else {
         // Old style forge logs
         if (line.contains("[INFO]") || line.contains("[CONFIG]") || line.contains("[FINE]") || line.contains("[FINER]") ||

--- a/launcher/logs/LogParser.h
+++ b/launcher/logs/LogParser.h
@@ -31,7 +31,7 @@ class LogParser {
    public:
     struct LogEntry {
         QString logger;
-        MessageLevel::Enum level;
+        MessageLevel level;
         QString levelText;
         QDateTime timestamp;
         QString thread;
@@ -59,7 +59,7 @@ class LogParser {
     std::optional<Error> getError();
 
     /// guess log level from a line of game log
-    static MessageLevel::Enum guessLevel(const QString& line);
+    static MessageLevel guessLevel(const QString& line);
 
    protected:
     std::optional<LogEntry> parseAttributes();

--- a/launcher/minecraft/launch/LauncherPartLaunch.cpp
+++ b/launcher/minecraft/launch/LauncherPartLaunch.cpp
@@ -56,7 +56,7 @@ LauncherPartLaunch::LauncherPartLaunch(LaunchTask* parent)
         static const QRegularExpression s_settingUser(".*Setting user.+", QRegularExpression::CaseInsensitiveOption);
         std::shared_ptr<QMetaObject::Connection> connection{ new QMetaObject::Connection };
         *connection = connect(&m_process, &LoggedProcess::log, this,
-                              [connection](const QStringList& lines, [[maybe_unused]] MessageLevel::Enum level) {
+                              [connection](const QStringList& lines, [[maybe_unused]] MessageLevel level) {
                                   qDebug() << lines;
                                   if (lines.filter(s_settingUser).length() != 0) {
                                       APPLICATION->closeAllWindows();

--- a/launcher/minecraft/mod/Mod.cpp
+++ b/launcher/minecraft/mod/Mod.cpp
@@ -195,9 +195,9 @@ auto Mod::mcVersions() const -> QString
 auto Mod::releaseType() const -> QString
 {
     if (metadata())
-        return metadata()->releaseType.toString();
+        return ModPlatform::indexedVersionTypeToString(metadata()->releaseType);
 
-    return ModPlatform::IndexedVersionType().toString();
+    return ModPlatform::indexedVersionTypeToString(ModPlatform::IndexedVersionType::Unknown);
 }
 
 auto Mod::description() const -> QString

--- a/launcher/modplatform/ModIndex.cpp
+++ b/launcher/modplatform/ModIndex.cpp
@@ -25,10 +25,10 @@
 
 namespace ModPlatform {
 
-static const QMap<QString, IndexedVersionType::VersionType> s_indexed_version_type_names = {
-    { "release", IndexedVersionType::VersionType::Release },
-    { "beta", IndexedVersionType::VersionType::Beta },
-    { "alpha", IndexedVersionType::VersionType::Alpha }
+static const QMap<QString, IndexedVersionType> s_indexed_version_type_names = {
+    { "release", IndexedVersionType::Release },
+    { "beta", IndexedVersionType::Beta },
+    { "alpha", IndexedVersionType::Alpha }
 };
 
 static const QList<ModLoaderType> loaderList = { NeoForge, Forge, Cauldron,     LiteLoader, Quilt, Fabric,
@@ -45,32 +45,12 @@ QList<ModLoaderType> modLoaderTypesToList(ModLoaderTypes flags)
     return flagList;
 }
 
-IndexedVersionType::IndexedVersionType(const QString& type) : IndexedVersionType(enumFromString(type)) {}
-
-IndexedVersionType::IndexedVersionType(const IndexedVersionType::VersionType& type)
-{
-    m_type = type;
-}
-
-IndexedVersionType::IndexedVersionType(const IndexedVersionType& other)
-{
-    m_type = other.m_type;
-}
-
-IndexedVersionType& IndexedVersionType::operator=(const IndexedVersionType& other)
-{
-    m_type = other.m_type;
-    return *this;
-}
-
-const QString IndexedVersionType::toString(const IndexedVersionType::VersionType& type)
-{
+QString indexedVersionTypeToString(IndexedVersionType type) {
     return s_indexed_version_type_names.key(type, "unknown");
 }
 
-IndexedVersionType::VersionType IndexedVersionType::enumFromString(const QString& type)
-{
-    return s_indexed_version_type_names.value(type, IndexedVersionType::VersionType::Unknown);
+IndexedVersionType indexedVersionTypeFromString(const QString& type) {
+    return s_indexed_version_type_names.value(type, IndexedVersionType::Unknown);
 }
 
 const char* ProviderCapabilities::name(ResourceProvider p)

--- a/launcher/modplatform/ModIndex.h
+++ b/launcher/modplatform/ModIndex.h
@@ -74,33 +74,9 @@ struct DonationData {
     QString url;
 };
 
-struct IndexedVersionType {
-    enum class VersionType { Release = 1, Beta, Alpha, Unknown };
-    IndexedVersionType(const QString& type);
-    IndexedVersionType(const IndexedVersionType::VersionType& type);
-    IndexedVersionType(const IndexedVersionType& type);
-    IndexedVersionType() : IndexedVersionType(IndexedVersionType::VersionType::Unknown) {}
-    static const QString toString(const IndexedVersionType::VersionType& type);
-    static IndexedVersionType::VersionType enumFromString(const QString& type);
-    bool isValid() const { return m_type != IndexedVersionType::VersionType::Unknown; }
-    IndexedVersionType& operator=(const IndexedVersionType& other);
-    bool operator==(const IndexedVersionType& other) const { return m_type == other.m_type; }
-    bool operator==(const IndexedVersionType::VersionType& type) const { return m_type == type; }
-    bool operator!=(const IndexedVersionType& other) const { return m_type != other.m_type; }
-    bool operator!=(const IndexedVersionType::VersionType& type) const { return m_type != type; }
-    bool operator<(const IndexedVersionType& other) const { return m_type < other.m_type; }
-    bool operator<(const IndexedVersionType::VersionType& type) const { return m_type < type; }
-    bool operator<=(const IndexedVersionType& other) const { return m_type <= other.m_type; }
-    bool operator<=(const IndexedVersionType::VersionType& type) const { return m_type <= type; }
-    bool operator>(const IndexedVersionType& other) const { return m_type > other.m_type; }
-    bool operator>(const IndexedVersionType::VersionType& type) const { return m_type > type; }
-    bool operator>=(const IndexedVersionType& other) const { return m_type >= other.m_type; }
-    bool operator>=(const IndexedVersionType::VersionType& type) const { return m_type >= type; }
-
-    QString toString() const { return toString(m_type); }
-
-    IndexedVersionType::VersionType m_type;
-};
+enum class IndexedVersionType { Unknown, Release = 1, Beta, Alpha };
+IndexedVersionType indexedVersionTypeFromString(const QString& type);
+QString indexedVersionTypeToString(IndexedVersionType type);
 
 struct Dependency {
     QVariant addonId;
@@ -131,7 +107,7 @@ struct IndexedVersion {
 
     QString getVersionDisplayString() const
     {
-        auto release_type = version_type.isValid() ? QString(" [%1]").arg(version_type.toString()) : "";
+        auto release_type = version_type != IndexedVersionType::Unknown ? QString(" [%1]").arg(indexedVersionTypeToString(version_type)) : "";
         auto versionStr = !version.contains(version_number) ? version_number : "";
         QString gameVersion = "";
         for (auto v : mcVersion) {

--- a/launcher/modplatform/flame/FlameModIndex.cpp
+++ b/launcher/modplatform/flame/FlameModIndex.cpp
@@ -143,21 +143,22 @@ auto FlameMod::loadIndexedPackVersion(QJsonObject& obj, bool load_changelog) -> 
     file.fileName = Json::requireString(obj, "fileName");
     file.fileName = FS::RemoveInvalidPathChars(file.fileName);
 
-    ModPlatform::IndexedVersionType::VersionType ver_type;
+    ModPlatform::IndexedVersionType ver_type;
     switch (Json::requireInteger(obj, "releaseType")) {
         case 1:
-            ver_type = ModPlatform::IndexedVersionType::VersionType::Release;
+            ver_type = ModPlatform::IndexedVersionType::Release;
             break;
         case 2:
-            ver_type = ModPlatform::IndexedVersionType::VersionType::Beta;
+            ver_type = ModPlatform::IndexedVersionType::Beta;
             break;
         case 3:
-            ver_type = ModPlatform::IndexedVersionType::VersionType::Alpha;
+            ver_type = ModPlatform::IndexedVersionType::Alpha;
             break;
         default:
-            ver_type = ModPlatform::IndexedVersionType::VersionType::Unknown;
+            ver_type = ModPlatform::IndexedVersionType::Unknown;
+	    break;
     }
-    file.version_type = ModPlatform::IndexedVersionType(ver_type);
+    file.version_type = ver_type;
 
     auto hash_list = obj["hashes"].toArray();
     for (auto h : hash_list) {

--- a/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
@@ -145,7 +145,7 @@ ModPlatform::IndexedVersion Modrinth::loadIndexedPackVersion(QJsonObject& obj, Q
     }
     file.version = Json::requireString(obj, "name");
     file.version_number = Json::requireString(obj, "version_number");
-    file.version_type = ModPlatform::IndexedVersionType(Json::requireString(obj, "version_type"));
+    file.version_type = ModPlatform::indexedVersionTypeFromString(Json::requireString(obj, "version_type"));
 
     file.changelog = Json::requireString(obj, "changelog");
 

--- a/launcher/modplatform/packwiz/Packwiz.cpp
+++ b/launcher/modplatform/packwiz/Packwiz.cpp
@@ -198,7 +198,7 @@ void V1::updateModIndex(const QDir& index_dir, Mod& mod)
                                 { "side", ModPlatform::SideUtils::toString(mod.side).toStdString() },
                                 { "x-prismlauncher-loaders", loaders },
                                 { "x-prismlauncher-mc-versions", mcVersions },
-                                { "x-prismlauncher-release-type", mod.releaseType.toString().toStdString() },
+                                { "x-prismlauncher-release-type", ModPlatform::indexedVersionTypeToString(mod.releaseType).toStdString() },
                                 { "x-prismlauncher-version-number", mod.version_number.toStdString() },
                                 { "download",
                                   toml::table{
@@ -272,7 +272,7 @@ auto V1::getIndexForMod(const QDir& index_dir, QString slug) -> Mod
         mod.name = stringEntry(table, "name");
         mod.filename = stringEntry(table, "filename");
         mod.side = ModPlatform::SideUtils::fromString(stringEntry(table, "side"));
-        mod.releaseType = ModPlatform::IndexedVersionType(table["x-prismlauncher-release-type"].value_or(""));
+        mod.releaseType = ModPlatform::indexedVersionTypeFromString(table["x-prismlauncher-release-type"].value_or(""));
         if (auto loaders = table["x-prismlauncher-loaders"]; loaders && loaders.is_array()) {
             for (auto&& loader : *loaders.as_array()) {
                 if (loader.is_string()) {

--- a/launcher/ui/dialogs/ResourceDownloadDialog.cpp
+++ b/launcher/ui/dialogs/ResourceDownloadDialog.cpp
@@ -187,7 +187,8 @@ void ResourceDownloadDialog::confirm()
         auto extraInfo = dependencyExtraInfo.value(task->getPack()->addonId.toString());
         confirm_dialog->appendResource({ task->getName(), task->getFilename(), task->getCustomPath(),
                                          ModPlatform::ProviderCapabilities::name(task->getProvider()), extraInfo.required_by,
-                                         task->getVersion().version_type.toString(), !extraInfo.maybe_installed });
+                                         ModPlatform::indexedVersionTypeToString(task->getVersion().version_type),
+                                         !extraInfo.maybe_installed });
     }
 
     if (confirm_dialog->exec()) {

--- a/launcher/ui/dialogs/ResourceUpdateDialog.cpp
+++ b/launcher/ui/dialogs/ResourceUpdateDialog.cpp
@@ -453,8 +453,8 @@ void ResourceUpdateDialog::appendResource(CheckUpdateTask::Update const& info, Q
 
     if (info.new_version_type.has_value()) {
         auto new_version_type_item = new QTreeWidgetItem(item_top);
-        new_version_type_item->setText(0, tr("New Version Type: %1").arg(info.new_version_type.value().toString()));
-        new_version_type_item->setData(0, Qt::UserRole, info.new_version_type.value().toString());
+        new_version_type_item->setText(0, tr("New Version Type: %1").arg(indexedVersionTypeToString(info.new_version_type.value())));
+        new_version_type_item->setData(0, Qt::UserRole, indexedVersionTypeToString(info.new_version_type.value()));
     }
 
     if (!requiredBy.isEmpty()) {

--- a/launcher/ui/pages/instance/LogPage.cpp
+++ b/launcher/ui/pages/instance/LogPage.cpp
@@ -60,7 +60,7 @@ QVariant LogFormatProxyModel::data(const QModelIndex& index, int role) const
         case Qt::FontRole:
             return m_font;
         case Qt::ForegroundRole: {
-            auto level = static_cast<MessageLevel::Enum>(QIdentityProxyModel::data(index, LogModel::LevelRole).toInt());
+            auto level = static_cast<MessageLevel>(QIdentityProxyModel::data(index, LogModel::LevelRole).toInt());
             QColor result = colors.foreground.value(level);
 
             if (result.isValid())
@@ -69,7 +69,7 @@ QVariant LogFormatProxyModel::data(const QModelIndex& index, int role) const
             break;
         }
         case Qt::BackgroundRole: {
-            auto level = static_cast<MessageLevel::Enum>(QIdentityProxyModel::data(index, LogModel::LevelRole).toInt());
+            auto level = static_cast<MessageLevel>(QIdentityProxyModel::data(index, LogModel::LevelRole).toInt());
             QColor result = colors.background.value(level);
 
             if (result.isValid())

--- a/launcher/ui/pages/instance/OtherLogsPage.cpp
+++ b/launcher/ui/pages/instance/OtherLogsPage.cpp
@@ -274,18 +274,18 @@ void OtherLogsPage::reload()
             showTooBig();
             return;
         }
-        MessageLevel::Enum last = MessageLevel::Unknown;
+        MessageLevel last = MessageLevel::Unknown;
 
         auto handleLine = [this, &last](QString line) {
             if (line.isEmpty())
                 return false;
             if (line.back() == '\n')
                 line = line.remove(line.size() - 1, 1);
-            MessageLevel::Enum level = MessageLevel::Unknown;
+            MessageLevel level = MessageLevel::Unknown;
 
             QString lineTemp = line;  // don't edit out the time and level for clarity
             if (!m_instance) {
-                level = MessageLevel::fromLauncherLine(lineTemp);
+                level = messageLevelFromLauncherLine(lineTemp);
             } else {
                 level = LogParser::guessLevel(line);
 

--- a/launcher/ui/pages/modplatform/ResourcePage.cpp
+++ b/launcher/ui/pages/modplatform/ResourcePage.cpp
@@ -297,8 +297,8 @@ void ResourcePage::versionListUpdated(const QModelIndex& index)
                     continue;
 
                 auto versionText = version.version;
-                if (version.version_type.isValid()) {
-                    versionText += QString(" [%1]").arg(version.version_type.toString());
+                if (version.version_type != ModPlatform::IndexedVersionType::Unknown) {
+                    versionText += QString(" [%1]").arg(ModPlatform::indexedVersionTypeToString(version.version_type));
                 }
                 if (version.fileId == installedVersion) {
                     versionText += tr(" [installed]", "Mod version select");

--- a/launcher/ui/themes/CustomTheme.cpp
+++ b/launcher/ui/themes/CustomTheme.cpp
@@ -229,7 +229,7 @@ bool CustomTheme::read(const QString& path, bool& hasCustomLogColors)
                 hasCustomLogColors = true;
 
                 auto logColorsRoot = Json::requireObject(root, "logColors");
-                auto readAndSetLogColor = [this, readColor, logColorsRoot](MessageLevel::Enum level, bool fg, const QString& colorName) {
+                auto readAndSetLogColor = [this, readColor, logColorsRoot](MessageLevel level, bool fg, const QString& colorName) {
                     auto color = readColor(logColorsRoot, colorName);
                     if (color.isValid()) {
                         if (fg)

--- a/launcher/ui/themes/ITheme.h
+++ b/launcher/ui/themes/ITheme.h
@@ -42,8 +42,8 @@
 class QStyle;
 
 struct LogColors {
-    QMap<MessageLevel::Enum, QColor> background;
-    QMap<MessageLevel::Enum, QColor> foreground;
+    QMap<MessageLevel, QColor> background;
+    QMap<MessageLevel, QColor> foreground;
 };
 
 // TODO: rename to Theme; this is not an interface as it contains method implementations

--- a/launcher/ui/widgets/AppearanceWidget.cpp
+++ b/launcher/ui/widgets/AppearanceWidget.cpp
@@ -232,7 +232,7 @@ void AppearanceWidget::updateConsolePreview()
     m_ui->consolePreview->clear();
     m_defaultFormat.setFont(QFont(fontFamily, fontSize));
 
-    auto print = [this, colors](const QString& message, MessageLevel::Enum level) {
+    auto print = [this, colors](const QString& message, MessageLevel level) {
         QTextCharFormat format(m_defaultFormat);
 
         QColor bg = colors.background.value(level);

--- a/launcher/ui/widgets/ModFilterWidget.cpp
+++ b/launcher/ui/widgets/ModFilterWidget.cpp
@@ -387,13 +387,13 @@ void ModFilterWidget::onReleaseFilterChanged()
 {
     std::list<ModPlatform::IndexedVersionType> releases;
     if (ui->releaseCb->isChecked())
-        releases.push_back(ModPlatform::IndexedVersionType(ModPlatform::IndexedVersionType::VersionType::Release));
+        releases.push_back(ModPlatform::IndexedVersionType::Release);
     if (ui->betaCb->isChecked())
-        releases.push_back(ModPlatform::IndexedVersionType(ModPlatform::IndexedVersionType::VersionType::Beta));
+        releases.push_back(ModPlatform::IndexedVersionType::Beta);
     if (ui->alphaCb->isChecked())
-        releases.push_back(ModPlatform::IndexedVersionType(ModPlatform::IndexedVersionType::VersionType::Alpha));
+        releases.push_back(ModPlatform::IndexedVersionType::Alpha);
     if (ui->unknownCb->isChecked())
-        releases.push_back(ModPlatform::IndexedVersionType(ModPlatform::IndexedVersionType::VersionType::Unknown));
+        releases.push_back(ModPlatform::IndexedVersionType::Unknown);
     m_filter_changed = releases != m_filter->releases;
     m_filter->releases = releases;
     if (m_filter_changed)

--- a/tests/XmlLogs_test.cpp
+++ b/tests/XmlLogs_test.cpp
@@ -47,10 +47,10 @@ class XmlLogParseTest : public QObject {
         QStringList shortTextLevels_s = QString::fromUtf8(FS::read(FS::PathCombine(source, "vanilla-1.21.5-levels.txt")))
                                             .split(QRegularExpression("\n|\r\n|\r"), Qt::SkipEmptyParts);
 
-        QList<MessageLevel::Enum> shortTextLevels;
+        QList<MessageLevel> shortTextLevels;
         shortTextLevels.reserve(24);
         std::transform(shortTextLevels_s.cbegin(), shortTextLevels_s.cend(), std::back_inserter(shortTextLevels),
-                       [](const QString& line) { return MessageLevel::getLevel(line.trimmed()); });
+                       [](const QString& line) { return messageLevelFromName(line.trimmed()); });
 
         QString longXml = QString::fromUtf8(FS::read(FS::PathCombine(source, "TerraFirmaGreg-Modern-forge.xml.log")));
         QString longText = QString::fromUtf8(FS::read(FS::PathCombine(source, "TerraFirmaGreg-Modern-forge.text.log")));
@@ -59,18 +59,18 @@ class XmlLogParseTest : public QObject {
         QStringList longTextLevelsXml_s = QString::fromUtf8(FS::read(FS::PathCombine(source, "TerraFirmaGreg-Modern-xml-levels.txt")))
                                               .split(QRegularExpression("\n|\r\n|\r"), Qt::SkipEmptyParts);
 
-        QList<MessageLevel::Enum> longTextLevelsPlain;
+        QList<MessageLevel> longTextLevelsPlain;
         longTextLevelsPlain.reserve(974);
         std::transform(longTextLevels_s.cbegin(), longTextLevels_s.cend(), std::back_inserter(longTextLevelsPlain),
-                       [](const QString& line) { return MessageLevel::getLevel(line.trimmed()); });
-        QList<MessageLevel::Enum> longTextLevelsXml;
+                       [](const QString& line) { return messageLevelFromName(line.trimmed()); });
+        QList<MessageLevel> longTextLevelsXml;
         longTextLevelsXml.reserve(896);
         std::transform(longTextLevelsXml_s.cbegin(), longTextLevelsXml_s.cend(), std::back_inserter(longTextLevelsXml),
-                       [](const QString& line) { return MessageLevel::getLevel(line.trimmed()); });
+                       [](const QString& line) { return messageLevelFromName(line.trimmed()); });
 
         QTest::addColumn<QString>("log");
         QTest::addColumn<int>("num_entries");
-        QTest::addColumn<QList<MessageLevel::Enum>>("entry_levels");
+        QTest::addColumn<QList<MessageLevel>>("entry_levels");
 
         QTest::newRow("short-vanilla-plain") << shortText << 25 << shortTextLevels;
         QTest::newRow("short-vanilla-xml") << shortXml << 25 << shortTextLevels;
@@ -82,9 +82,9 @@ class XmlLogParseTest : public QObject {
     {
         QFETCH(QString, log);
         QFETCH(int, num_entries);
-        QFETCH(QList<MessageLevel::Enum>, entry_levels);
+        QFETCH(QList<MessageLevel>, entry_levels);
 
-        QList<std::pair<MessageLevel::Enum, QString>> entries = {};
+        QList<std::pair<MessageLevel, QString>> entries = {};
 
         QBENCHMARK
         {
@@ -93,10 +93,10 @@ class XmlLogParseTest : public QObject {
 
         QCOMPARE(entries.length(), num_entries);
 
-        QList<MessageLevel::Enum> levels = {};
+        QList<MessageLevel> levels = {};
 
         std::transform(entries.cbegin(), entries.cend(), std::back_inserter(levels),
-                       [](std::pair<MessageLevel::Enum, QString> entry) { return entry.first; });
+                       [](std::pair<MessageLevel, QString> entry) { return entry.first; });
 
         QCOMPARE(levels, entry_levels);
     }
@@ -104,10 +104,10 @@ class XmlLogParseTest : public QObject {
    private:
     LogParser m_parser;
 
-    QList<std::pair<MessageLevel::Enum, QString>> parseLines(const QStringList& lines)
+    QList<std::pair<MessageLevel, QString>> parseLines(const QStringList& lines)
     {
-        QList<std::pair<MessageLevel::Enum, QString>> out;
-        MessageLevel::Enum last = MessageLevel::Unknown;
+        QList<std::pair<MessageLevel, QString>> out;
+        MessageLevel last = MessageLevel::Unknown;
 
         for (const auto& line : lines) {
             m_parser.appendLine(line);


### PR DESCRIPTION
I'm not a fan of needing to write MessageLevel::Enum and IndexedVersionType::VersionType... and all of those operator overloads