### PR TITLE
chore: Re-simplify `IndexVersionType` and `MessageLevel` with c++20

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -241,7 +241,7 @@ void appDebugOutput(QtMsgType type, const QMessageLogContext& context, const QSt
 
     QString out = qFormatLogMessage(type, context, msg);
     if (APPLICATION->logModel) {
-        APPLICATION->logModel->append(messageLevelFromQtMsgType(type), out);
+        APPLICATION->logModel->append(MessageLevel::fromQtMsgType(type), out);
     }
 
     out += QChar::LineFeed;

--- a/launcher/MessageLevel.cpp
+++ b/launcher/MessageLevel.cpp
@@ -44,7 +44,7 @@ MessageLevel MessageLevel::fromQtMsgType(const QtMsgType& type)
 }
 
 /* Get message level from a line. Line is modified if it was successful. */
-MessageLevel messageLevelFromLine(QString& line)
+MessageLevel MessageLevel::takeFromLine(QString& line)
 {
     // Level prefix
     int endmark = line.indexOf("]!");
@@ -57,7 +57,7 @@ MessageLevel messageLevelFromLine(QString& line)
 }
 
 /* Get message level from a line from the launcher log. Line is modified if it was successful. */
-MessageLevel messageLevelFromLauncherLine(QString& line)
+MessageLevel MessageLevel::takeFromLauncherLine(QString& line)
 {
     // Level prefix
     int startMark = 0;

--- a/launcher/MessageLevel.cpp
+++ b/launcher/MessageLevel.cpp
@@ -1,6 +1,6 @@
 #include "MessageLevel.h"
 
-MessageLevel messageLevelFromName(const QString& levelName)
+MessageLevel MessageLevel::fromName(const QString& levelName)
 {
     QString name = levelName.toUpper();
     if (name == "LAUNCHER")
@@ -25,7 +25,7 @@ MessageLevel messageLevelFromName(const QString& levelName)
         return MessageLevel::Unknown;
 }
 
-MessageLevel messageLevelFromQtMsgType(QtMsgType type)
+MessageLevel MessageLevel::fromQtMsgType(const QtMsgType& type)
 {
     switch (type) {
         case QtDebugMsg:
@@ -43,18 +43,20 @@ MessageLevel messageLevelFromQtMsgType(QtMsgType type)
     }
 }
 
+/* Get message level from a line. Line is modified if it was successful. */
 MessageLevel messageLevelFromLine(QString& line)
 {
     // Level prefix
     int endmark = line.indexOf("]!");
     if (line.startsWith("!![") && endmark != -1) {
-        auto level = messageLevelFromName(line.left(endmark).mid(3));
+        auto level = MessageLevel::fromName(line.left(endmark).mid(3));
         line = line.mid(endmark + 2);
         return level;
     }
     return MessageLevel::Unknown;
 }
 
+/* Get message level from a line from the launcher log. Line is modified if it was successful. */
 MessageLevel messageLevelFromLauncherLine(QString& line)
 {
     // Level prefix
@@ -63,7 +65,7 @@ MessageLevel messageLevelFromLauncherLine(QString& line)
         ++startMark;
     int endmark = line.indexOf(":");
     if (startMark < line.size() && endmark != -1) {
-        auto level = messageLevelFromName(line.left(endmark).mid(startMark));
+        auto level = MessageLevel::fromName(line.left(endmark).mid(startMark));
         line = line.mid(endmark + 2);
         return level;
     }

--- a/launcher/MessageLevel.h
+++ b/launcher/MessageLevel.h
@@ -33,12 +33,12 @@ struct MessageLevel {
     explicit operator int() const { return static_cast<int>(m_type); }
     explicit operator MessageLevel::Enum() { return m_type; }
 
+    /* Get message level from a line. Line is modified if it was successful. */
+    static MessageLevel takeFromLine(QString& line);
+
+    /* Get message level from a line from the launcher log. Line is modified if it was successful. */
+    static MessageLevel takeFromLauncherLine(QString& line);
+
    private:
     Enum m_type;
 };
-
-/* Get message level from a line. Line is modified if it was successful. */
-MessageLevel messageLevelFromLine(QString& line);
-
-/* Get message level from a line from the launcher log. Line is modified if it was successful. */
-MessageLevel messageLevelFromLauncherLine(QString& line);

--- a/launcher/MessageLevel.h
+++ b/launcher/MessageLevel.h
@@ -2,26 +2,40 @@
 
 #include <qlogging.h>
 #include <QString>
+#include <compare>
 
 /**
  * @brief the MessageLevel Enum
  * defines what level a log message is
  */
-enum class MessageLevel {
-    Unknown,  /**< No idea what this is or where it came from */
-    StdOut,   /**< Undetermined stderr messages */
-    StdErr,   /**< Undetermined stdout messages */
-    Launcher, /**< Launcher Messages */
-    Trace,    /**< Trace Messages */
-    Debug,    /**< Debug Messages */
-    Info,     /**< Info Messages */
-    Message,  /**< Standard Messages */
-    Warning,  /**< Warnings */
-    Error,    /**< Errors */
-    Fatal,    /**< Fatal Errors */
+struct MessageLevel {
+    enum class Enum {
+        Unknown,  /**< No idea what this is or where it came from */
+        StdOut,   /**< Undetermined stderr messages */
+        StdErr,   /**< Undetermined stdout messages */
+        Launcher, /**< Launcher Messages */
+        Trace,    /**< Trace Messages */
+        Debug,    /**< Debug Messages */
+        Info,     /**< Info Messages */
+        Message,  /**< Standard Messages */
+        Warning,  /**< Warnings */
+        Error,    /**< Errors */
+        Fatal,    /**< Fatal Errors */
+    };
+    using enum Enum;
+    constexpr MessageLevel(Enum e = Unknown) : m_type(e) {}
+    static MessageLevel fromName(const QString& type);
+    static MessageLevel fromQtMsgType(const QtMsgType& type);
+    static MessageLevel fromLine(const QString& line);
+    inline bool isValid() const { return m_type != Unknown; }
+    std::strong_ordering operator<=>(const MessageLevel& other) const = default;
+    std::strong_ordering operator<=>(const MessageLevel::Enum& other) const { return m_type <=> other; }
+    explicit operator int() const { return static_cast<int>(m_type); }
+    explicit operator MessageLevel::Enum() { return m_type; }
+
+   private:
+    Enum m_type;
 };
-MessageLevel messageLevelFromName(const QString& levelName);
-MessageLevel messageLevelFromQtMsgType(QtMsgType type);
 
 /* Get message level from a line. Line is modified if it was successful. */
 MessageLevel messageLevelFromLine(QString& line);

--- a/launcher/launch/LaunchTask.cpp
+++ b/launcher/launch/LaunchTask.cpp
@@ -254,7 +254,7 @@ bool LaunchTask::parseXmlLogs(QString const& line, MessageLevel level)
         } else if (std::holds_alternative<LogParser::PlainText>(item)) {
             auto msg = std::get<LogParser::PlainText>(item).message;
 
-            MessageLevel newLevel = messageLevelFromLine(msg);
+            MessageLevel newLevel = MessageLevel::takeFromLine(msg);
 
             if (newLevel == MessageLevel::Unknown)
                 newLevel = LogParser::guessLevel(line, model->previousLevel());

--- a/launcher/launch/LaunchTask.cpp
+++ b/launcher/launch/LaunchTask.cpp
@@ -217,7 +217,7 @@ shared_qobject_ptr<LogModel> LaunchTask::getLogModel()
 bool LaunchTask::parseXmlLogs(QString const& line, MessageLevel level)
 {
     LogParser* parser;
-    switch (level) {
+    switch (static_cast<MessageLevel::Enum>(level)) {
         case MessageLevel::StdErr:
             parser = &m_stderrParser;
             break;
@@ -234,7 +234,7 @@ bool LaunchTask::parseXmlLogs(QString const& line, MessageLevel level)
         auto& model = *getLogModel();
         model.append(MessageLevel::Error, tr("[Log4j Parse Error] Failed to parse log4j log event: %1").arg(err.value().errMessage));
         return false;
-    } 
+    }
 
     if (items.isEmpty())
         return true;

--- a/launcher/logs/LogParser.cpp
+++ b/launcher/logs/LogParser.cpp
@@ -60,7 +60,7 @@ std::optional<LogParser::LogEntry> LogParser::parseAttributes()
             entry.timestamp = QDateTime::fromSecsSinceEpoch(value.trimmed().toLongLong());
         } else if (name == "level"_L1) {
             entry.levelText = value.trimmed().toString();
-            entry.level = messageLevelFromName(entry.levelText);
+            entry.level = MessageLevel::fromName(entry.levelText);
         } else if (name == "thread"_L1) {
             entry.thread = value.trimmed().toString();
         }
@@ -329,7 +329,7 @@ MessageLevel LogParser::guessLevel(const QString& line, MessageLevel previous)
         QString timestamp = match.captured("timestamp");
         QString levelStr = match.captured("level");
 
-        return messageLevelFromName(levelStr);
+        return MessageLevel::fromName(levelStr);
     } else {
         // Old style forge logs
         if (line.contains("[INFO]") || line.contains("[CONFIG]") || line.contains("[FINE]") || line.contains("[FINER]") ||

--- a/launcher/minecraft/mod/Mod.cpp
+++ b/launcher/minecraft/mod/Mod.cpp
@@ -195,9 +195,9 @@ auto Mod::mcVersions() const -> QString
 auto Mod::releaseType() const -> QString
 {
     if (metadata())
-        return ModPlatform::indexedVersionTypeToString(metadata()->releaseType);
+        return metadata()->releaseType.toString();
 
-    return ModPlatform::indexedVersionTypeToString(ModPlatform::IndexedVersionType::Unknown);
+    return ModPlatform::IndexedVersionType(ModPlatform::IndexedVersionType::Unknown).toString();
 }
 
 auto Mod::description() const -> QString

--- a/launcher/modplatform/ModIndex.cpp
+++ b/launcher/modplatform/ModIndex.cpp
@@ -45,11 +45,11 @@ QList<ModLoaderType> modLoaderTypesToList(ModLoaderTypes flags)
     return flagList;
 }
 
-QString indexedVersionTypeToString(IndexedVersionType type) {
-    return s_indexed_version_type_names.key(type, "unknown");
+QString IndexedVersionType::toString() const {
+    return s_indexed_version_type_names.key(m_type, "unknown");
 }
 
-IndexedVersionType indexedVersionTypeFromString(const QString& type) {
+IndexedVersionType IndexedVersionType::fromString(const QString& type) {
     return s_indexed_version_type_names.value(type, IndexedVersionType::Unknown);
 }
 

--- a/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
@@ -145,7 +145,7 @@ ModPlatform::IndexedVersion Modrinth::loadIndexedPackVersion(QJsonObject& obj, Q
     }
     file.version = Json::requireString(obj, "name");
     file.version_number = Json::requireString(obj, "version_number");
-    file.version_type = ModPlatform::indexedVersionTypeFromString(Json::requireString(obj, "version_type"));
+    file.version_type = ModPlatform::IndexedVersionType::fromString(Json::requireString(obj, "version_type"));
 
     file.changelog = Json::requireString(obj, "changelog");
 

--- a/launcher/modplatform/packwiz/Packwiz.cpp
+++ b/launcher/modplatform/packwiz/Packwiz.cpp
@@ -198,7 +198,7 @@ void V1::updateModIndex(const QDir& index_dir, Mod& mod)
                                 { "side", ModPlatform::SideUtils::toString(mod.side).toStdString() },
                                 { "x-prismlauncher-loaders", loaders },
                                 { "x-prismlauncher-mc-versions", mcVersions },
-                                { "x-prismlauncher-release-type", ModPlatform::indexedVersionTypeToString(mod.releaseType).toStdString() },
+                                { "x-prismlauncher-release-type", mod.releaseType.toString().toStdString() },
                                 { "x-prismlauncher-version-number", mod.version_number.toStdString() },
                                 { "download",
                                   toml::table{
@@ -272,7 +272,7 @@ auto V1::getIndexForMod(const QDir& index_dir, QString slug) -> Mod
         mod.name = stringEntry(table, "name");
         mod.filename = stringEntry(table, "filename");
         mod.side = ModPlatform::SideUtils::fromString(stringEntry(table, "side"));
-        mod.releaseType = ModPlatform::indexedVersionTypeFromString(table["x-prismlauncher-release-type"].value_or(""));
+        mod.releaseType = ModPlatform::IndexedVersionType::fromString(table["x-prismlauncher-release-type"].value_or(""));
         if (auto loaders = table["x-prismlauncher-loaders"]; loaders && loaders.is_array()) {
             for (auto&& loader : *loaders.as_array()) {
                 if (loader.is_string()) {

--- a/launcher/ui/dialogs/ResourceDownloadDialog.cpp
+++ b/launcher/ui/dialogs/ResourceDownloadDialog.cpp
@@ -186,8 +186,7 @@ void ResourceDownloadDialog::confirm()
     for (auto& task : selected) {
         auto extraInfo = dependencyExtraInfo.value(task->getPack()->addonId.toString());
         confirm_dialog->appendResource({ task->getName(), task->getFilename(), ModPlatform::ProviderCapabilities::name(task->getProvider()),
-                                         extraInfo.required_by, ModPlatform::indexedVersionTypeToString(task->getVersion().version_type),
-                                         !extraInfo.maybe_installed });
+                                         extraInfo.required_by, task->getVersion().version_type.toString(), !extraInfo.maybe_installed });
     }
 
     if (confirm_dialog->exec()) {

--- a/launcher/ui/dialogs/ResourceUpdateDialog.cpp
+++ b/launcher/ui/dialogs/ResourceUpdateDialog.cpp
@@ -453,8 +453,8 @@ void ResourceUpdateDialog::appendResource(CheckUpdateTask::Update const& info, Q
 
     if (info.new_version_type.has_value()) {
         auto new_version_type_item = new QTreeWidgetItem(item_top);
-        new_version_type_item->setText(0, tr("New Version Type: %1").arg(indexedVersionTypeToString(info.new_version_type.value())));
-        new_version_type_item->setData(0, Qt::UserRole, indexedVersionTypeToString(info.new_version_type.value()));
+        new_version_type_item->setText(0, tr("New Version Type: %1").arg(info.new_version_type.value().toString()));
+        new_version_type_item->setData(0, Qt::UserRole, info.new_version_type.value().toString());
     }
 
     if (!requiredBy.isEmpty()) {

--- a/launcher/ui/pages/instance/LogPage.cpp
+++ b/launcher/ui/pages/instance/LogPage.cpp
@@ -60,7 +60,7 @@ QVariant LogFormatProxyModel::data(const QModelIndex& index, int role) const
         case Qt::FontRole:
             return m_font;
         case Qt::ForegroundRole: {
-            auto level = static_cast<MessageLevel>(QIdentityProxyModel::data(index, LogModel::LevelRole).toInt());
+            MessageLevel level = static_cast<MessageLevel::Enum>(QIdentityProxyModel::data(index, LogModel::LevelRole).toInt());
             QColor result = colors.foreground.value(level);
 
             if (result.isValid())
@@ -69,7 +69,7 @@ QVariant LogFormatProxyModel::data(const QModelIndex& index, int role) const
             break;
         }
         case Qt::BackgroundRole: {
-            auto level = static_cast<MessageLevel>(QIdentityProxyModel::data(index, LogModel::LevelRole).toInt());
+            MessageLevel level = static_cast<MessageLevel::Enum>(QIdentityProxyModel::data(index, LogModel::LevelRole).toInt());
             QColor result = colors.background.value(level);
 
             if (result.isValid())

--- a/launcher/ui/pages/instance/OtherLogsPage.cpp
+++ b/launcher/ui/pages/instance/OtherLogsPage.cpp
@@ -285,7 +285,7 @@ void OtherLogsPage::reload()
 
             QString lineTemp = line;  // don't edit out the time and level for clarity
             if (!m_instance) {
-                level = messageLevelFromLauncherLine(lineTemp);
+                level = MessageLevel::takeFromLauncherLine(lineTemp);
             } else {
                 level = LogParser::guessLevel(line, last);
             }

--- a/launcher/ui/pages/modplatform/ResourcePage.cpp
+++ b/launcher/ui/pages/modplatform/ResourcePage.cpp
@@ -297,8 +297,8 @@ void ResourcePage::versionListUpdated(const QModelIndex& index)
                     continue;
 
                 auto versionText = version.version;
-                if (version.version_type != ModPlatform::IndexedVersionType::Unknown) {
-                    versionText += QString(" [%1]").arg(ModPlatform::indexedVersionTypeToString(version.version_type));
+                if (version.version_type.isValid()) {
+                    versionText += QString(" [%1]").arg(version.version_type.toString());
                 }
                 if (version.fileId == installedVersion) {
                     versionText += tr(" [installed]", "Mod version select");

--- a/tests/XmlLogs_test.cpp
+++ b/tests/XmlLogs_test.cpp
@@ -50,7 +50,7 @@ class XmlLogParseTest : public QObject {
         QList<MessageLevel> shortTextLevels;
         shortTextLevels.reserve(24);
         std::transform(shortTextLevels_s.cbegin(), shortTextLevels_s.cend(), std::back_inserter(shortTextLevels),
-                       [](const QString& line) { return messageLevelFromName(line.trimmed()); });
+                       [](const QString& line) { return MessageLevel::fromName(line.trimmed()); });
 
         QString longXml = QString::fromUtf8(FS::read(FS::PathCombine(source, "TerraFirmaGreg-Modern-forge.xml.log")));
         QString longText = QString::fromUtf8(FS::read(FS::PathCombine(source, "TerraFirmaGreg-Modern-forge.text.log")));
@@ -62,11 +62,11 @@ class XmlLogParseTest : public QObject {
         QList<MessageLevel> longTextLevelsPlain;
         longTextLevelsPlain.reserve(974);
         std::transform(longTextLevels_s.cbegin(), longTextLevels_s.cend(), std::back_inserter(longTextLevelsPlain),
-                       [](const QString& line) { return messageLevelFromName(line.trimmed()); });
+                       [](const QString& line) { return MessageLevel::fromName(line.trimmed()); });
         QList<MessageLevel> longTextLevelsXml;
         longTextLevelsXml.reserve(896);
         std::transform(longTextLevelsXml_s.cbegin(), longTextLevelsXml_s.cend(), std::back_inserter(longTextLevelsXml),
-                       [](const QString& line) { return messageLevelFromName(line.trimmed()); });
+                       [](const QString& line) { return MessageLevel::fromName(line.trimmed()); });
 
         QTest::addColumn<QString>("log");
         QTest::addColumn<int>("num_entries");


### PR DESCRIPTION
Since we have c++20 we can keep the nice api surface without needing all the boilerplate overloads.

This sets our compiler requirements to gcc 11 and clang 13.
If we forgo the use of `using enum` we can drop to gcc 10 and clang 10 but that means using `MessageLevel::Enum::Unknown` for direct enum access

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
