### PR TITLE
Use multibyte encoding aware libarchive functions when dealing with filenames

### DIFF
--- a/launcher/archive/ArchiveReader.cpp
+++ b/launcher/archive/ArchiveReader.cpp
@@ -41,7 +41,7 @@ bool ArchiveReader::collectFiles(bool onlyFiles)
 
 QString ArchiveReader::File::filename()
 {
-    return QString::fromUtf8(archive_entry_pathname(m_entry));
+    return QString::fromUtf8(archive_entry_pathname_utf8(m_entry));
 }
 
 QByteArray ArchiveReader::File::readAll(int* outStatus)
@@ -83,8 +83,8 @@ auto ArchiveReader::goToFile(QString filename) -> std::unique_ptr<File>
     auto a = f->m_archive.get();
     archive_read_support_format_all(a);
     archive_read_support_filter_all(a);
-    auto fileName = m_archivePath.toUtf8();
-    if (archive_read_open_filename(a, fileName.constData(), m_blockSize) != ARCHIVE_OK) {
+    auto fileName = m_archivePath.toStdWString();
+    if (archive_read_open_filename_w(a, fileName.data(), m_blockSize) != ARCHIVE_OK) {
         qCritical() << "Failed to open archive file:" << m_archivePath << "-" << archive_error_string(a);
         return nullptr;
     }
@@ -133,7 +133,7 @@ bool ArchiveReader::File::writeFile(archive* out, QString targetFileName, bool n
     if (!targetFileName.isEmpty()) {
         entry = archive_entry_clone(m_entry);
         auto nameUtf8 = targetFileName.toUtf8();
-        archive_entry_set_pathname(entry, nameUtf8.constData());
+        archive_entry_set_pathname_utf8(entry, nameUtf8.constData());
     }
     if (archive_write_header(out, entry) < ARCHIVE_OK) {
         qCritical() << "Failed to write header to entry:" << filename() << "-" << archive_error_string(out);
@@ -157,8 +157,8 @@ bool ArchiveReader::parse(std::function<bool(File*, bool&)> doStuff)
     auto a = f->m_archive.get();
     archive_read_support_format_all(a);
     archive_read_support_filter_all(a);
-    auto fileName = m_archivePath.toUtf8();
-    if (archive_read_open_filename(a, fileName.constData(), m_blockSize) != ARCHIVE_OK) {
+    auto fileName = m_archivePath.toStdWString();
+    if (archive_read_open_filename_w(a, fileName.data(), m_blockSize) != ARCHIVE_OK) {
         qCritical() << "Failed to open archive file:" << m_archivePath << "-" << f->error();
         return false;
     }

--- a/launcher/archive/ArchiveWriter.cpp
+++ b/launcher/archive/ArchiveWriter.cpp
@@ -132,8 +132,8 @@ bool ArchiveWriter::addFile(const QString& fileName, const QString& fileDest)
     }
 #else
     {
-        // this only works for myltibyte encoded filenames if the local is properly set,
-        // a wide charater version doens't seem to exist: here's hopeing...
+        // this only works for multibyte encoded filenames if the local is properly set,
+        // a wide character version doesn't seem to exist: here's hoping...
 
         QByteArray utf8 = fileInfo.absoluteFilePath().toUtf8();
         const char* cpath = utf8.constData();

--- a/launcher/main.cpp
+++ b/launcher/main.cpp
@@ -37,13 +37,6 @@
 
 int main(int argc, char* argv[])
 {
-    // try to set the utf-8 locale for the libarchive
-    for (auto name : { ".UTF-8", "en_US.UTF-8", "C.UTF-8" }) {
-        if (std::setlocale(LC_CTYPE, name)) {
-            break;
-        }
-    }
-
     // initialize Qt
     Application app(argc, argv);
 


### PR DESCRIPTION
Per discussion https://discord.com/channels/1031648380885147709/1031823065937629267/1447768203894718495

Use the utf8 aware functions from libarchive or the wide character versions when opening or stating files if available.
