### PR TITLE
fix(InstanceImportTask): stream archive reads

### DIFF
--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -121,7 +121,6 @@ QString cleanPath(QString path)
 void InstanceImportTask::processZipPack()
 {
     setStatus(tr("Attempting to determine instance type"));
-    setDetails("");
     QDir extractDir(m_stagingPath);
     qDebug() << "Attempting to create instance from" << m_archivePath;
 

--- a/launcher/InstanceImportTask.h
+++ b/launcher/InstanceImportTask.h
@@ -56,7 +56,6 @@ class InstanceImportTask : public InstanceTask {
     void processTechnic();
     void processFlame();
     void processModrinth();
-    QString getRootFromZip(QStringList files);
 
    private slots:
     void processZipPack();

--- a/launcher/archive/ArchiveReader.cpp
+++ b/launcher/archive/ArchiveReader.cpp
@@ -165,7 +165,7 @@ bool ArchiveReader::parse(std::function<bool(File*, bool&)> doStuff)
 
     bool breakControl = false;
     while (f->readNextHeader() == ARCHIVE_OK) {
-        if (!doStuff(f.get(), breakControl)) {
+        if (f && !doStuff(f.get(), breakControl)) {
             qCritical() << "Failed to parse file:" << f->filename() << "-" << f->error();
             return false;
         }

--- a/launcher/archive/ExportToZipTask.h
+++ b/launcher/archive/ExportToZipTask.h
@@ -30,12 +30,12 @@ class ExportToZipTask : public Task {
     Q_OBJECT
    public:
     ExportToZipTask(QString outputPath, QDir dir, QFileInfoList files, QString destinationPrefix = "", bool followSymlinks = false)
-        : m_output_path(outputPath)
+        : m_outputPath(outputPath)
         , m_output(outputPath)
         , m_dir(dir)
         , m_files(files)
-        , m_destination_prefix(destinationPrefix)
-        , m_follow_symlinks(followSymlinks)
+        , m_destinationPrefix(destinationPrefix)
+        , m_followSymlinks(followSymlinks)
     {
         setAbortable(true);
     };
@@ -44,8 +44,8 @@ class ExportToZipTask : public Task {
 
     virtual ~ExportToZipTask() = default;
 
-    void setExcludeFiles(QStringList excludeFiles) { m_exclude_files = excludeFiles; }
-    void addExtraFile(QString fileName, QByteArray data) { m_extra_files.insert(fileName, data); }
+    void setExcludeFiles(QStringList excludeFiles) { m_excludeFiles = excludeFiles; }
+    void addExtraFile(QString fileName, QByteArray data) { m_extraFiles.insert(fileName, data); }
 
     using ZipResult = std::optional<QString>;
 
@@ -57,16 +57,16 @@ class ExportToZipTask : public Task {
     void finish();
 
    private:
-    QString m_output_path;
+    QString m_outputPath;
     ArchiveWriter m_output;
     QDir m_dir;
     QFileInfoList m_files;
-    QString m_destination_prefix;
-    bool m_follow_symlinks;
-    QStringList m_exclude_files;
-    QHash<QString, QByteArray> m_extra_files;
+    QString m_destinationPrefix;
+    bool m_followSymlinks;
+    QStringList m_excludeFiles;
+    QHash<QString, QByteArray> m_extraFiles;
 
-    QFuture<ZipResult> m_build_zip_future;
-    QFutureWatcher<ZipResult> m_build_zip_watcher;
+    QFuture<ZipResult> m_buildZipFuture;
+    QFutureWatcher<ZipResult> m_buildZipWatcher;
 };
 }  // namespace MMCZip

--- a/launcher/archive/ExtractZipTask.h
+++ b/launcher/archive/ExtractZipTask.h
@@ -29,7 +29,7 @@ class ExtractZipTask : public Task {
     Q_OBJECT
    public:
     ExtractZipTask(QString input, QDir outputDir, QString subdirectory = "")
-        : m_input(input), m_output_dir(outputDir), m_subdirectory(subdirectory)
+        : m_input(input), m_outputDir(outputDir), m_subdirectory(subdirectory)
     {}
     virtual ~ExtractZipTask() = default;
 
@@ -44,10 +44,10 @@ class ExtractZipTask : public Task {
 
    private:
     ArchiveReader m_input;
-    QDir m_output_dir;
+    QDir m_outputDir;
     QString m_subdirectory;
 
-    QFuture<ZipResult> m_zip_future;
-    QFutureWatcher<ZipResult> m_zip_watcher;
+    QFuture<ZipResult> m_zipFuture;
+    QFutureWatcher<ZipResult> m_zipWatcher;
 };
 }  // namespace MMCZip


### PR DESCRIPTION
Parent PR: #3959 
fixes #4435

Well looks like the detection code for libarchive was a bit more than bad.
It loaded once all the filenames into the memory when it could have just stream the process and exit early.

Also the second commit(other than the renames) fixes a regression regarding qtConcurrent accessing this member variables after the task was ended: 
- removed isCanceled check: if the task is not deleted the flag is handled in the signal otherwise the result is not used anymore anyway.
- created a stack variable for the file name so I do not need to access any member of the task. Only used for the final result in case something actually fails.
