### PR TITLE
fix partial java download

### DIFF
--- a/launcher/ui/java/InstallJavaDialog.cpp
+++ b/launcher/ui/java/InstallJavaDialog.cpp
@@ -315,6 +315,7 @@ void InstallDialog::done(int result)
                         QString error = QString(tr("Could not determine Java download type!"));
                         CustomMessageBox::selectable(this, tr("Error"), error, QMessageBox::Warning)->show();
                         deletePath();
+                        return;
                 }
 #if defined(Q_OS_MACOS)
                 auto seq = makeShared<SequentialTask>(tr("Install Java"));


### PR DESCRIPTION
fixes #4222

From my understanding, when an abort occurs, the Java files are kept for some reason (I will blame Windows for not allowing us to delete them). However, codewise, we always delete the downloaded files on abort. 

So instead of focusing on that part, I just made the check for the binary more strict, allowing the launch step to try and redownload the Java if the binary is missing.
Note: We do not have any way to check the integrity of the downloaded Java. May be possible that because of the partial delete on Windows, the only file present will be the Java executable, and that may not work.