### PR TITLE
update local pack by url

### DIFF
--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -123,6 +123,7 @@ BaseInstance::BaseInstance(SettingsObject* globalSettings, std::unique_ptr<Setti
     m_settings->registerSetting("ManagedPackName", "");
     m_settings->registerSetting("ManagedPackVersionID", "");
     m_settings->registerSetting("ManagedPackVersionName", "");
+    m_settings->registerSetting("ManagedPackURL", "");
 
     m_settings->registerSetting("Profiler", "");
 }

--- a/launcher/ui/pages/instance/ManagedPackPage.h
+++ b/launcher/ui/pages/instance/ManagedPackPage.h
@@ -86,6 +86,8 @@ class ManagedPackPage : public QWidget, public BasePage {
      */
     bool runUpdateTask(InstanceTask*);
 
+    void updatePack(const QUrl& url, QString versionID = {}, QString versionName = {});
+
    protected:
     InstanceWindow* m_instance_window = nullptr;
 

--- a/launcher/ui/pages/instance/ManagedPackPage.ui
+++ b/launcher/ui/pages/instance/ManagedPackPage.ui
@@ -138,6 +138,9 @@
         <widget class="QComboBox" name="versionsComboBox"/>
        </item>
        <item>
+        <widget class="QLineEdit" name="urlLine"/>
+       </item>
+       <item>
         <widget class="QPushButton" name="updateButton">
          <property name="enabled">
           <bool>false</bool>


### PR DESCRIPTION
fixes #932
allow the user to paste a URL there and hit the update button(this will download the file and update the pack)
Note, this only works with Modrith and Curseforge, similar tothe  Update from file functionality.
In case the user provides a link to a pack that is neither Curseforge nor Modrith, then it will create a new instance(update from file already does a similar thing). 

To allow updating in prism format, the format needs to be updated to include some kind of manifest to know what files should be kept and what files should be deleted(maybe next time).