### PR TITLE
fix: bundle cmark in portable build

### DIFF
--- a/.github/actions/package/linux/action.yml
+++ b/.github/actions/package/linux/action.yml
@@ -89,6 +89,10 @@ runs:
         cmake --install ${{ env.BUILD_DIR }} --config ${{ inputs.build-type }} --prefix ${{ env.INSTALL_PORTABLE_DIR }}
         cmake --install ${{ env.BUILD_DIR }} --config ${{ inputs.build-type }} --prefix ${{ env.INSTALL_PORTABLE_DIR }} --component portable
 
+        #the linked cmark .so is of the version that ubuntu uses, so without this it breaks on most updated distros
+        mkdir ${{ env.INSTALL_PORTABLE_DIR }}/lib
+        cp /lib/$APPIMAGE_ARCH-linux-gnu/libcmark.so.0.* ${{ env.INSTALL_PORTABLE_DIR }}/lib
+
         for l in $(find ${{ env.INSTALL_PORTABLE_DIR }} -type f); do l=${l#$(pwd)/}; l=${l#${{ env.INSTALL_PORTABLE_DIR }}/}; l=${l#./}; echo $l; done > ${{ env.INSTALL_PORTABLE_DIR }}/manifest.txt
         cd ${{ env.INSTALL_PORTABLE_DIR }}
         tar -czf ../PrismLauncher-portable.tar.gz *


### PR DESCRIPTION
fixes portable not working outside ubuntu


we should be switching our portable build to just using AppImage but for now we need this