### PR TITLE
change(Actions): cancel outdated builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 name: Build
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,5 +1,9 @@
 name: "CodeQL Code Scanning"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -1,5 +1,9 @@
 name: Flatpak
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,5 +1,9 @@
 name: Nix
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches:


### PR DESCRIPTION
This PR makes Actions automatically cancel builds in progress for workflows involving full launcher compilation. This reduces wasted runner time and jobs being stuck in `Queued`

~~(ironic that this PR is currently wasting runner time and not letting other jobs run)~~