### PR TITLE
fix leak of cloned entry

### DIFF
--- a/launcher/archive/ArchiveReader.cpp
+++ b/launcher/archive/ArchiveReader.cpp
@@ -23,6 +23,7 @@
 #include <archive_entry.h>
 #include <QDir>
 #include <QFileInfo>
+#include <memory>
 
 namespace MMCZip {
 QStringList ArchiveReader::getFiles()
@@ -130,8 +131,10 @@ static int copy_data(struct archive* ar, struct archive* aw, bool notBlock = fal
 bool ArchiveReader::File::writeFile(archive* out, QString targetFileName, bool notBlock)
 {
     auto entry = m_entry;
+    std::unique_ptr<archive_entry, decltype(&archive_entry_free)> entryClone(nullptr, &archive_entry_free);
     if (!targetFileName.isEmpty()) {
-        entry = archive_entry_clone(m_entry);
+        entryClone.reset(archive_entry_clone(m_entry));
+        entry = entryClone.get();
         auto nameUtf8 = targetFileName.toUtf8();
         archive_entry_set_pathname(entry, nameUtf8.constData());
     }


### PR DESCRIPTION
Parent PR: #3959 

Usually, I do not need to care about the archive_entry because it is handled by the archive, but in this case, since I clone the managed entry, I also need to delete it