### PR TITLE
feat+fix: Rework modrinth fallback for blocked mods a bit

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -886,6 +886,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
                 m_settings->set("FlameKeyOverride", flameKey);
             m_settings->reset("CFKeyOverride");
         }
+        m_settings->registerSetting("FallbackMRBlockedMods", true);
         m_settings->registerSetting("ModrinthToken", "");
         m_settings->registerSetting("UserAgentOverride", "");
 

--- a/launcher/modplatform/flame/FileResolvingTask.cpp
+++ b/launcher/modplatform/flame/FileResolvingTask.cpp
@@ -29,6 +29,8 @@
 #include "net/NetJob.h"
 #include "tasks/Task.h"
 
+#include "Application.h"
+
 static const FlameAPI flameAPI;
 static ModrinthAPI modrinthAPI;
 
@@ -169,34 +171,30 @@ void Flame::FileResolvingTask::netJobFinished(QByteArray* response)
 
             getFlameProjects();
             return;
-        }
+            }
+        if (APPLICATION->settings()->get("FallbackMRBlockedMods").toBool()){ 
+            try {
+                auto entries = Json::requireObject(doc);
+                for (auto& out : m_manifest.files) {
+                    auto url = QUrl(out.version.downloadUrl, QUrl::TolerantMode);
+                    if (!url.isValid() && "sha1" == out.version.hash_type && !out.version.hash.isEmpty()) {
+                        try {
+                            auto entry = Json::requireObject(entries, out.version.hash);
 
-        try {
-            auto entries = Json::requireObject(doc);
-            for (auto& out : m_manifest.files) {
-                auto url = QUrl(out.version.downloadUrl, QUrl::TolerantMode);
-                if (!url.isValid() && "sha1" == out.version.hash_type && !out.version.hash.isEmpty()) {
-                    try {
-                        auto entry = Json::requireObject(entries, out.version.hash);
+                            auto file = Modrinth::loadIndexedPackVersion(entry);
 
-                        auto file = Modrinth::loadIndexedPackVersion(entry);
-
-                        // If there's more than one mod loader for this version, we can't know for sure
-                        // which file is relative to each loader, so it's best to not use any one and
-                        // let the user download it manually.
-                        if (!file.loaders || hasSingleModLoaderSelected(file.loaders)) {
                             out.version.downloadUrl = file.downloadUrl;
                             qDebug() << "Found alternative on modrinth" << out.version.fileName;
+                        } catch (Json::JsonException& e) {
+                            qDebug() << e.cause();
+                            qDebug() << entries;
                         }
-                    } catch (Json::JsonException& e) {
-                        qDebug() << e.cause();
-                        qDebug() << entries;
                     }
                 }
+            } catch (Json::JsonException& e) {
+                qDebug() << e.cause();
+                qDebug() << doc;
             }
-        } catch (Json::JsonException& e) {
-            qDebug() << e.cause();
-            qDebug() << doc;
         }
         getFlameProjects();
     });
@@ -215,7 +213,6 @@ void Flame::FileResolvingTask::netJobFinished(QByteArray* response)
         step_progress->status = status;
         stepProgress(*step_progress);
     });
-
     m_task->start();
 }
 

--- a/launcher/ui/pages/global/APIPage.cpp
+++ b/launcher/ui/pages/global/APIPage.cpp
@@ -135,6 +135,10 @@ void APIPage::loadSettings()
 
     ui->pasteTypeComboBox->setCurrentIndex(pasteTypeIndex);
 
+    if (bool fallbackMRBlockedMods = s->get("FallbackMRBlockedMods").toBool()) {
+        ui->FallbackMRBlockedMods->setChecked(fallbackMRBlockedMods);
+    }
+
     QString msaClientID = s->get("MSAClientIDOverride").toString();
     ui->msaClientID->setText(msaClientID);
     QString metaURL = s->get("MetaURLOverride").toString();
@@ -188,6 +192,7 @@ void APIPage::applySettings()
     upgradeToHTTPS(resourceURL);
     upgradeToHTTPS(fmlLibsURL);
 
+    s->set("FallbackMRBlockedMods", ui->FallbackMRBlockedMods->checkState());
     s->set("MetaURLOverride", metaURL.toString());
     s->set("ResourceURLOverride", resourceURL.toString());
     s->set("LegacyFMLLibsURLOverride", fmlLibsURL.toString());

--- a/launcher/ui/pages/global/APIPage.ui
+++ b/launcher/ui/pages/global/APIPage.ui
@@ -32,9 +32,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-216</y>
-        <width>816</width>
-        <height>832</height>
+        <y>-262</y>
+        <width>820</width>
+        <height>908</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -376,6 +376,13 @@
             </property>
             <property name="wordWrap">
              <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="FallbackMRBlockedMods">
+            <property name="text">
+             <string>Enable fallback to Modrinth for blocked mods</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
since e6e92f2b0e9ef16bdbae371ccb284339a70cff02, we started only falling back to modrinth only if they don't have 2 modloaders set in the same version. This was done because in the past, a bunch of mods that were both for Quilt and for Fabric used the same version but with different files. However that was never supported by modrinth and nowadays this doesn't seem to be a problem anymore, so all that does is increasing the number of mods to manually download, especially since:
- on 1.20.1, very popular version, many mods have both forge and neoforge tags
- many times fabric mods also get quilt tagged just because of backwards compat
- deobfuscation will make same jar multi-platform modding more popular

This reduces manually downloaded mods quite a bit, for example direwolf20 1.21 now has *no* mods to manually download.

This also makes modrinth fallback a toggle so if you have any problem with fallback not working correctly, just disable it.
