### PR TITLE
server player req: parse malformed json

### DIFF
--- a/launcher/ui/pages/instance/McClient.cpp
+++ b/launcher/ui/pages/instance/McClient.cpp
@@ -80,7 +80,18 @@ void McClient::parseResponse()
     Q_UNUSED(readVarInt(m_resp));  // json length
 
     // 'resp' should now be the JSON string
-    QJsonDocument doc = QJsonDocument::fromJson(m_resp);
+    QJsonParseError parseError;
+    QJsonDocument doc = QJsonDocument::fromJson(m_resp, &parseError);
+    if (parseError.error != QJsonParseError::NoError) {
+        QByteArray validJson = m_resp.left(parseError.offset);
+        doc = QJsonDocument::fromJson(validJson, &parseError);
+
+        if (parseError.error != QJsonParseError::NoError) {
+            qDebug() << "Failed to parse JSON:" << parseError.errorString();
+            emitFail(parseError.errorString());
+            return;
+        }
+    }
     emitSucceed(doc.object());
 }
 

--- a/launcher/ui/pages/instance/ServerPingTask.cpp
+++ b/launcher/ui/pages/instance/ServerPingTask.cpp
@@ -1,13 +1,19 @@
 #include <QFutureWatcher>
 
 #include <Json.h>
+#include "Exception.h"
 #include "McClient.h"
 #include "McResolver.h"
 #include "ServerPingTask.h"
 
 unsigned getOnlinePlayers(QJsonObject data)
 {
-    return Json::requireInteger(Json::requireObject(data, "players"), "online");
+    try {
+        return Json::requireInteger(Json::requireObject(data, "players"), "online");
+    } catch (Exception& e) {
+        qWarning() << "server ping failed to parse response" << e.what();
+        return 0;
+    }
 }
 
 void ServerPingTask::executeTask()


### PR DESCRIPTION
Parent PR: #3112

ATM10 server seems to send a extra json object after the default response, that we need to cut off.

Thanks trial for the error handling code! I tested it with a friends' server, that was previously causing a crash.

simplified example data:
```json
{"players":[],"version":{"name":"1.21.1","protocol":767},"preventsChatReports":true}*{"name":"All the Mods 10","version":"5.3"}
```
