### PR TITLE
make sure that the files are deleted on windows

### DIFF
--- a/launcher/FileSystem.cpp
+++ b/launcher/FileSystem.cpp
@@ -674,11 +674,23 @@ bool deletePath(QString path)
 
     fs::remove_all(StringUtils::toStdString(path), err);
 
-    if (err) {
-        qWarning() << "Failed to remove files:" << QString::fromStdString(err.message());
+    if (err.value() == 0) {
+        return true;
+    }
+    qWarning() << "Failed to remove files:" << QString::fromStdString(err.message());
+#ifdef Q_OS_WIN
+    // Schedule deletion on reboot (Windows only)
+    const std::wstring widePath = path.toStdWString();
+
+    if (MoveFileExW(widePath.c_str(), nullptr, MOVEFILE_DELAY_UNTIL_REBOOT)) {
+        qWarning() << "Marked for deletion on next reboot:" << path;
+        return true;
     }
 
-    return err.value() == 0;
+    qWarning() << "Failed to mark for deletion on reboot. Win32 error:" << GetLastError();
+#endif
+
+    return false;
 }
 
 bool trash(QString path, QString* pathInTrash)
@@ -1737,7 +1749,7 @@ bool removeFiles(QStringList listFile)
     // For each file
     for (int i = 0; i < listFile.count(); i++) {
         // Remove
-        ret = ret && QFile::remove(listFile.at(i));
+        ret = ret && deletePath(listFile.at(i));
     }
     return ret;
 }

--- a/launcher/InstanceCreationTask.cpp
+++ b/launcher/InstanceCreationTask.cpp
@@ -50,7 +50,7 @@ void InstanceCreationTask::executeTask()
 
             qDebug() << "Removing" << path;
 
-            if (!QFile::remove(path)) {
+            if (!FS::deletePath(path)) {
                 qCritical() << "Could not remove" << path;
                 deleteFailed = true;
             }

--- a/launcher/minecraft/skins/SkinList.cpp
+++ b/launcher/minecraft/skins/SkinList.cpp
@@ -344,7 +344,7 @@ bool SkinList::deleteSkin(const QString& key, bool trash)
                 save();
                 return true;
             }
-        } else if (QFile::remove(s.getPath())) {
+        } else if (FS::deletePath(s.getPath())) {
             m_skinList.remove(idx);
             save();
             return true;

--- a/launcher/ui/dialogs/skins/SkinManageDialog.cpp
+++ b/launcher/ui/dialogs/skins/SkinManageDialog.cpp
@@ -394,7 +394,7 @@ void SkinManageDialog::on_urlBtn_clicked()
                                                              : tr("Unable to download the skin: '%1'.").arg(m_ui->urlLine->text()),
                                      QMessageBox::Critical)
             ->show();
-        QFile::remove(path);
+        FS::deletePath(path);
         return;
     }
     m_ui->urlLine->setText("");
@@ -521,7 +521,7 @@ void SkinManageDialog::on_userBtn_clicked()
         CustomMessageBox::selectable(this, tr("Username not found"),
                                      tr("Unable to find the skin for '%1'\n because: %2.").arg(user, failReason), QMessageBox::Critical)
             ->show();
-        QFile::remove(path);
+        FS::deletePath(path);
         return;
     }
     m_ui->urlLine->setText("");

--- a/launcher/ui/pages/modplatform/import_ftb/ImportFTBPage.cpp
+++ b/launcher/ui/pages/modplatform/import_ftb/ImportFTBPage.cpp
@@ -110,7 +110,7 @@ QString saveIconToTempFile(const QIcon& icon)
     tempFile.close();
 
     if (!pixmap.save(tempPath, "PNG")) {
-        QFile::remove(tempPath);
+        FS::deletePath(tempPath);
         return QString();
     }
 


### PR DESCRIPTION
If the file is open the deletePath ussualy fails. This change will delete the file when the PC reboots.

Hopefully this will fix any issues with the fact that prism can't delete files