### PR TITLE
Trim unexpected info from pack.mcmeta

### DIFF
--- a/launcher/Json.cpp
+++ b/launcher/Json.cpp
@@ -101,12 +101,16 @@ QJsonArray requireArray(const QJsonDocument& doc, const QString& what)
     return doc.array();
 }
 
-QJsonDocument parseUntilMalformed(const QByteArray& json, QJsonParseError* error)
+QJsonDocument parseUntilGarbage(const QByteArray& json, QJsonParseError* error, QString* garbage)
 {
     auto doc = QJsonDocument::fromJson(json, error);
-    if (error->error != QJsonParseError::NoError) {
-        QByteArray validJson = json.left(error->offset);
+    if (error->error == QJsonParseError::GarbageAtEnd) {
+        qsizetype offset = error->offset;
+        QByteArray validJson = json.left(offset);
         doc = QJsonDocument::fromJson(validJson, error);
+
+        if (garbage)
+            *garbage = json.right(json.size() - offset);
     }
 
     return doc;

--- a/launcher/Json.cpp
+++ b/launcher/Json.cpp
@@ -101,6 +101,17 @@ QJsonArray requireArray(const QJsonDocument& doc, const QString& what)
     return doc.array();
 }
 
+QJsonDocument parseUntilMalformed(const QByteArray& json, QJsonParseError* error)
+{
+    auto doc = QJsonDocument::fromJson(json, error);
+    if (error->error != QJsonParseError::NoError) {
+        QByteArray validJson = json.left(error->offset);
+        doc = QJsonDocument::fromJson(validJson, error);
+    }
+
+    return doc;
+}
+
 void writeString(QJsonObject& to, const QString& key, const QString& value)
 {
     if (!value.isEmpty()) {

--- a/launcher/Json.h
+++ b/launcher/Json.h
@@ -107,8 +107,8 @@ QJsonArray toJsonArray(const QList<T>& container)
 
 ////////////////// READING ////////////////////
 
-// Attempt to parse JSON up until unexpected data is encountered
-QJsonDocument parseUntilMalformed(const QByteArray& json, QJsonParseError* error = nullptr);
+// Attempt to parse JSON up until garbage is encountered
+QJsonDocument parseUntilGarbage(const QByteArray& json, QJsonParseError* error = nullptr, QString* garbage = nullptr);
 
 /// @throw JsonException
 template <typename T>

--- a/launcher/Json.h
+++ b/launcher/Json.h
@@ -107,6 +107,9 @@ QJsonArray toJsonArray(const QList<T>& container)
 
 ////////////////// READING ////////////////////
 
+// Attempt to parse JSON up until unexpected data is encountered
+QJsonDocument parseUntilMalformed(const QByteArray& json, QJsonParseError* error = nullptr);
+
 /// @throw JsonException
 template <typename T>
 T requireIsType(const QJsonValue& value, const QString& what = "Value");

--- a/launcher/minecraft/mod/tasks/LocalDataPackParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalDataPackParseTask.cpp
@@ -169,7 +169,7 @@ bool processZIP(DataPack* pack, ProcessingLevel level)
 bool processMCMeta(DataPack* pack, QByteArray&& raw_data)
 {
     QJsonParseError parse_error;
-    auto json_doc = Json::parseUntilMalformed(raw_data, &parse_error);
+    auto json_doc = Json::parseUntilGarbage(raw_data, &parse_error);
     if (parse_error.error != QJsonParseError::NoError) {
         qWarning() << "Failed to parse JSON:" << parse_error.errorString();
         return false;

--- a/launcher/minecraft/mod/tasks/LocalDataPackParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalDataPackParseTask.cpp
@@ -169,15 +169,9 @@ bool processZIP(DataPack* pack, ProcessingLevel level)
 bool processMCMeta(DataPack* pack, QByteArray&& raw_data)
 {
     QJsonParseError parse_error;
-    auto json_doc = QJsonDocument::fromJson(raw_data, &parse_error);
+    auto json_doc = Json::parseUntilMalformed(raw_data, &parse_error);
     if (parse_error.error != QJsonParseError::NoError) {
-        QByteArray validJson = raw_data.left(parse_error.offset);
-        json_doc = QJsonDocument::fromJson(validJson, &parse_error);
-
-        if (parse_error.error != QJsonParseError::NoError) {
-            qWarning() << "Failed to parse JSON:" << parse_error.errorString();
-            return false;
-        }
+        qWarning() << "Failed to parse JSON:" << parse_error.errorString();
     }
 
     try {

--- a/launcher/minecraft/mod/tasks/LocalDataPackParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalDataPackParseTask.cpp
@@ -168,10 +168,20 @@ bool processZIP(DataPack* pack, ProcessingLevel level)
 // https://minecraft.wiki/w/Tutorials/Creating_a_resource_pack#Formatting_pack.mcmeta
 bool processMCMeta(DataPack* pack, QByteArray&& raw_data)
 {
-    try {
-        auto json_doc = QJsonDocument::fromJson(raw_data);
-        auto pack_obj = Json::requireObject(json_doc.object(), "pack", {});
+    QJsonParseError parse_error;
+    auto json_doc = QJsonDocument::fromJson(raw_data, &parse_error);
+    if (parse_error.error != QJsonParseError::NoError) {
+        QByteArray validJson = raw_data.left(parse_error.offset);
+        json_doc = QJsonDocument::fromJson(validJson, &parse_error);
 
+        if (parse_error.error != QJsonParseError::NoError) {
+            qWarning() << "Failed to parse JSON:" << parse_error.errorString();
+            return false;
+        }
+    }
+
+    try {
+        auto pack_obj = Json::requireObject(json_doc.object(), "pack", {});
         pack->setPackFormat(pack_obj["pack_format"].toInt());
         pack->setDescription(DataPackUtils::processComponent(pack_obj.value("description")));
     } catch (Json::JsonException& e) {

--- a/launcher/minecraft/mod/tasks/LocalDataPackParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalDataPackParseTask.cpp
@@ -172,6 +172,7 @@ bool processMCMeta(DataPack* pack, QByteArray&& raw_data)
     auto json_doc = Json::parseUntilMalformed(raw_data, &parse_error);
     if (parse_error.error != QJsonParseError::NoError) {
         qWarning() << "Failed to parse JSON:" << parse_error.errorString();
+        return false;
     }
 
     try {

--- a/launcher/ui/pages/instance/McClient.cpp
+++ b/launcher/ui/pages/instance/McClient.cpp
@@ -81,7 +81,7 @@ void McClient::parseResponse()
 
     // 'resp' should now be the JSON string
     QJsonParseError parseError;
-    QJsonDocument doc = Json::parseUntilMalformed(m_resp, &parseError);
+    QJsonDocument doc = Json::parseUntilGarbage(m_resp, &parseError);
     if (parseError.error != QJsonParseError::NoError) {
         qDebug() << "Failed to parse JSON:" << parseError.errorString();
         emitFail(parseError.errorString());

--- a/launcher/ui/pages/instance/McClient.cpp
+++ b/launcher/ui/pages/instance/McClient.cpp
@@ -81,16 +81,11 @@ void McClient::parseResponse()
 
     // 'resp' should now be the JSON string
     QJsonParseError parseError;
-    QJsonDocument doc = QJsonDocument::fromJson(m_resp, &parseError);
+    QJsonDocument doc = Json::parseUntilMalformed(m_resp, &parseError);
     if (parseError.error != QJsonParseError::NoError) {
-        QByteArray validJson = m_resp.left(parseError.offset);
-        doc = QJsonDocument::fromJson(validJson, &parseError);
-
-        if (parseError.error != QJsonParseError::NoError) {
-            qDebug() << "Failed to parse JSON:" << parseError.errorString();
-            emitFail(parseError.errorString());
-            return;
-        }
+        qDebug() << "Failed to parse JSON:" << parseError.errorString();
+        emitFail(parseError.errorString());
+        return;
     }
     emitSucceed(doc.object());
 }


### PR DESCRIPTION
Fixes #4331 

This applies the same fix implemented in 5ebd386797bf7c65da079959d32b89cd3783eda0 to DataPackUtils::processMCMeta.