### PR TITLE
Preserve original file extensions when installing icons

### DIFF
--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -271,7 +271,9 @@ bool installIcon(QString root, QString instIconKey)
         if (iconList->iconFileExists(instIconKey)) {
             iconList->deleteIcon(instIconKey);
         }
-        iconList->installIcon(importIconPath, instIconKey + ".png");
+        // Preserve the original file extension
+        QFileInfo iconFileInfo(importIconPath);
+        iconList->installIcon(importIconPath, instIconKey + "." + iconFileInfo.suffix());
         return true;
     }
     return false;

--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -258,44 +258,24 @@ void InstanceImportTask::extractFinished()
     }
 }
 
-bool InstanceImportTask::installIcon(const QString& root, const QString& instIconFileName)
+bool installIcon(QString root, QString instIconKey)
 {
-    QString importIconPath;
-    QString detectedExtension;
-
-    QString tryPath = FS::PathCombine(root, instIconFileName);
-    if (QFile::exists(tryPath)) {
-        // Try exact match
-        importIconPath = tryPath;
-        detectedExtension = QFileInfo(tryPath).suffix();
-    } else {
-        // Compatibility fallback: try with .png appended (legacy behavior)
-        QString pngName = instIconFileName;
-        if (!pngName.endsWith(QLatin1String(".png"), Qt::CaseInsensitive))
-            pngName += QLatin1String(".png");
-        tryPath = FS::PathCombine(root, pngName);
-        if (QFile::exists(tryPath)) {
-            importIconPath = tryPath;
-            detectedExtension = QFileInfo(tryPath).suffix();
+    auto importIconPath = IconUtils::findBestIconIn(root, instIconKey);
+    if (importIconPath.isNull() || !QFile::exists(importIconPath))
+        importIconPath = IconUtils::findBestIconIn(root, "icon.png");
+    if (importIconPath.isNull() || !QFile::exists(importIconPath))
+        importIconPath = IconUtils::findBestIconIn(FS::PathCombine(root, "overrides"), "icon.png");
+    if (!importIconPath.isNull() && QFile::exists(importIconPath)) {
+        // import icon
+        auto iconList = APPLICATION->icons();
+        if (iconList->iconFileExists(instIconKey)) {
+            iconList->deleteIcon(instIconKey);
         }
+        // Let IconList::installIcon preserve the original file extension
+        iconList->installIcon(importIconPath, instIconKey);
+        return true;
     }
-
-    if (importIconPath.isEmpty() || !QFile::exists(importIconPath))
-        return false;
-
-    auto iconList = APPLICATION->icons();
-
-    QString baseName = QFileInfo(instIconFileName).completeBaseName();
-    QString ext = detectedExtension.isEmpty() ? QFileInfo(instIconFileName).suffix() : detectedExtension;
-    QString finalIconName = baseName;
-    if (!ext.isEmpty())
-        finalIconName += QLatin1Char('.') + ext;
-
-    if (iconList->iconFileExists(finalIconName))
-        iconList->deleteIcon(finalIconName);
-
-    iconList->installIcon(importIconPath, finalIconName);
-    return true;
+    return false;
 }
 
 void InstanceImportTask::processFlame()
@@ -325,10 +305,10 @@ void InstanceImportTask::processFlame()
     inst_creation_task->setName(*this);
     // if the icon was specified by user, use that. otherwise pull icon from the pack
     if (m_instIcon == "default") {
-        auto iconFileName = QString("Flame_%1_Icon.png").arg(name());
+        auto iconKey = QString("Flame_%1_Icon").arg(name());
 
-        if (installIcon(m_stagingPath, iconFileName)) {
-            m_instIcon = QFileInfo(iconFileName).completeBaseName();
+        if (installIcon(m_stagingPath, iconKey)) {
+            m_instIcon = iconKey;
         }
     }
     inst_creation_task->setIcon(m_instIcon);
@@ -383,11 +363,9 @@ void InstanceImportTask::processMultiMC()
     if (m_instIcon != "default") {
         instance.setIconKey(m_instIcon);
     } else {
-        QString currentIconKey = instance.iconKey();
+        m_instIcon = instance.iconKey();
 
-        // Pass full filename (assume png for compatibility with existing instances)
-        installIcon(instance.instanceRoot(), currentIconKey + QLatin1String(".png"));
-        m_instIcon = currentIconKey;
+        installIcon(instance.instanceRoot(), m_instIcon);
     }
     emitSucceeded();
 }
@@ -426,10 +404,10 @@ void InstanceImportTask::processModrinth()
     inst_creation_task->setName(*this);
     // if the icon was specified by user, use that. otherwise pull icon from the pack
     if (m_instIcon == "default") {
-        auto iconFileName = QString("Modrinth_%1_Icon.png").arg(name());
+        auto iconKey = QString("Modrinth_%1_Icon").arg(name());
 
-        if (installIcon(m_stagingPath, iconFileName)) {
-            m_instIcon = QFileInfo(iconFileName).completeBaseName();
+        if (installIcon(m_stagingPath, iconKey)) {
+            m_instIcon = iconKey;
         }
     }
     inst_creation_task->setIcon(m_instIcon);

--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -272,7 +272,6 @@ bool installIcon(QString root, QString instIconKey)
             iconList->deleteIcon(instIconKey);
         }
         // Let IconList::installIcon preserve the original file extension
-        QFileInfo iconFileInfo(importIconPath);
         iconList->installIcon(importIconPath, instIconKey);
         return true;
     }

--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -258,24 +258,44 @@ void InstanceImportTask::extractFinished()
     }
 }
 
-bool installIcon(QString root, QString instIconKey)
+bool InstanceImportTask::installIcon(const QString& root, const QString& instIconFileName)
 {
-    auto importIconPath = IconUtils::findBestIconIn(root, instIconKey);
-    if (importIconPath.isNull() || !QFile::exists(importIconPath))
-        importIconPath = IconUtils::findBestIconIn(root, "icon.png");
-    if (importIconPath.isNull() || !QFile::exists(importIconPath))
-        importIconPath = IconUtils::findBestIconIn(FS::PathCombine(root, "overrides"), "icon.png");
-    if (!importIconPath.isNull() && QFile::exists(importIconPath)) {
-        // import icon
-        auto iconList = APPLICATION->icons();
-        if (iconList->iconFileExists(instIconKey)) {
-            iconList->deleteIcon(instIconKey);
+    QString importIconPath;
+    QString detectedExtension;
+
+    QString tryPath = FS::PathCombine(root, instIconFileName);
+    if (QFile::exists(tryPath)) {
+        // Try exact match
+        importIconPath = tryPath;
+        detectedExtension = QFileInfo(tryPath).suffix();
+    } else {
+        // Compatibility fallback: try with .png appended (legacy behavior)
+        QString pngName = instIconFileName;
+        if (!pngName.endsWith(QLatin1String(".png"), Qt::CaseInsensitive))
+            pngName += QLatin1String(".png");
+        tryPath = FS::PathCombine(root, pngName);
+        if (QFile::exists(tryPath)) {
+            importIconPath = tryPath;
+            detectedExtension = QFileInfo(tryPath).suffix();
         }
-        // Let IconList::installIcon preserve the original file extension
-        iconList->installIcon(importIconPath, instIconKey);
-        return true;
     }
-    return false;
+
+    if (importIconPath.isEmpty() || !QFile::exists(importIconPath))
+        return false;
+
+    auto iconList = APPLICATION->icons();
+
+    QString baseName = QFileInfo(instIconFileName).completeBaseName();
+    QString ext = detectedExtension.isEmpty() ? QFileInfo(instIconFileName).suffix() : detectedExtension;
+    QString finalIconName = baseName;
+    if (!ext.isEmpty())
+        finalIconName += QLatin1Char('.') + ext;
+
+    if (iconList->iconFileExists(finalIconName))
+        iconList->deleteIcon(finalIconName);
+
+    iconList->installIcon(importIconPath, finalIconName);
+    return true;
 }
 
 void InstanceImportTask::processFlame()
@@ -305,10 +325,10 @@ void InstanceImportTask::processFlame()
     inst_creation_task->setName(*this);
     // if the icon was specified by user, use that. otherwise pull icon from the pack
     if (m_instIcon == "default") {
-        auto iconKey = QString("Flame_%1_Icon").arg(name());
+        auto iconFileName = QString("Flame_%1_Icon.png").arg(name());
 
-        if (installIcon(m_stagingPath, iconKey)) {
-            m_instIcon = iconKey;
+        if (installIcon(m_stagingPath, iconFileName)) {
+            m_instIcon = QFileInfo(iconFileName).completeBaseName();
         }
     }
     inst_creation_task->setIcon(m_instIcon);
@@ -363,9 +383,11 @@ void InstanceImportTask::processMultiMC()
     if (m_instIcon != "default") {
         instance.setIconKey(m_instIcon);
     } else {
-        m_instIcon = instance.iconKey();
+        QString currentIconKey = instance.iconKey();
 
-        installIcon(instance.instanceRoot(), m_instIcon);
+        // Pass full filename (assume png for compatibility with existing instances)
+        installIcon(instance.instanceRoot(), currentIconKey + QLatin1String(".png"));
+        m_instIcon = currentIconKey;
     }
     emitSucceeded();
 }
@@ -404,10 +426,10 @@ void InstanceImportTask::processModrinth()
     inst_creation_task->setName(*this);
     // if the icon was specified by user, use that. otherwise pull icon from the pack
     if (m_instIcon == "default") {
-        auto iconKey = QString("Modrinth_%1_Icon").arg(name());
+        auto iconFileName = QString("Modrinth_%1_Icon.png").arg(name());
 
-        if (installIcon(m_stagingPath, iconKey)) {
-            m_instIcon = iconKey;
+        if (installIcon(m_stagingPath, iconFileName)) {
+            m_instIcon = QFileInfo(iconFileName).completeBaseName();
         }
     }
     inst_creation_task->setIcon(m_instIcon);

--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -271,9 +271,9 @@ bool installIcon(QString root, QString instIconKey)
         if (iconList->iconFileExists(instIconKey)) {
             iconList->deleteIcon(instIconKey);
         }
-        // Preserve the original file extension
+        // Let IconList::installIcon preserve the original file extension
         QFileInfo iconFileInfo(importIconPath);
-        iconList->installIcon(importIconPath, instIconKey + "." + iconFileInfo.suffix());
+        iconList->installIcon(importIconPath, instIconKey);
         return true;
     }
     return false;

--- a/launcher/InstanceImportTask.h
+++ b/launcher/InstanceImportTask.h
@@ -57,8 +57,6 @@ class InstanceImportTask : public InstanceTask {
     void processFlame();
     void processModrinth();
 
-    bool installIcon(const QString &importDir, const QString &instIconFileName);
-
    private slots:
     void processZipPack();
     void extractFinished();

--- a/launcher/InstanceImportTask.h
+++ b/launcher/InstanceImportTask.h
@@ -57,6 +57,8 @@ class InstanceImportTask : public InstanceTask {
     void processFlame();
     void processModrinth();
 
+    bool installIcon(const QString &importDir, const QString &instIconFileName);
+
    private slots:
     void processZipPack();
     void extractFinished();

--- a/launcher/icons/IconList.cpp
+++ b/launcher/icons/IconList.cpp
@@ -338,7 +338,7 @@ void IconList::installIcon(const QString& file, const QString& name)
         return;
 
     const auto targetInfo = name.isEmpty() ? fileinfo : QFileInfo(name);
-    if (!IconUtils::isIconSuffix(fileinfo.suffix()) || !Iconutils::isIconSuffix(targetInfo.suffix()))
+    if (!IconUtils::isIconSuffix(fileinfo.suffix()) || !IconUtils::isIconSuffix(targetInfo.suffix()))
         return;
 
     const QString targetName = targetInfo.completeBaseName() + QLatin1Char('.') + targetInfo.suffix();

--- a/launcher/icons/IconList.cpp
+++ b/launcher/icons/IconList.cpp
@@ -340,7 +340,13 @@ void IconList::installIcon(const QString& file, const QString& name)
     if (!IconUtils::isIconSuffix(fileinfo.suffix()))
         return;
 
-    QString target = FS::PathCombine(getDirectory(), name.isEmpty() ? fileinfo.fileName() : name);
+    QString targetName = name.isEmpty() ? fileinfo.fileName() : name;
+    // Ensure the target has the correct extension from the source file
+    QFileInfo targetInfo(targetName);
+    if (!IconUtils::isIconSuffix(targetInfo.suffix())) {
+        targetName = targetInfo.completeBaseName() + "." + fileinfo.suffix();
+    }
+    QString target = FS::PathCombine(getDirectory(), targetName);
     QFile::copy(file, target);
 }
 

--- a/launcher/icons/IconList.cpp
+++ b/launcher/icons/IconList.cpp
@@ -341,11 +341,7 @@ void IconList::installIcon(const QString& file, const QString& name)
     if (!IconUtils::isIconSuffix(fileinfo.suffix()) || !Iconutils::isIconSuffix(targetInfo.suffix()))
         return;
 
-    const QFileInfo targetInfo = name.isEmpty() ? fileinfo : QFileInfo{ name };
-    const QString targetSuffix = targetInfo.suffix();
-    const QString suffix = IconUtils::isIconSuffix(targetSuffix) ? targetSuffix : sourceSuffix;
-
-    const QString targetName = targetInfo.completeBaseName() + QLatin1Char('.') + suffix;
+    const QString targetName = targetInfo.completeBaseName() + QLatin1Char('.') + targetInfo.suffix();
     QString target = FS::PathCombine(getDirectory(), targetName);
     QFile::copy(file, target);
 }

--- a/launcher/icons/IconList.cpp
+++ b/launcher/icons/IconList.cpp
@@ -337,8 +337,8 @@ void IconList::installIcon(const QString& file, const QString& name)
     if (!fileinfo.isReadable() || !fileinfo.isFile())
         return;
 
-    const QString sourceSuffix = fileinfo.suffix();
-    if (!IconUtils::isIconSuffix(sourceSuffix))
+    const auto targetInfo = name.isEmpty() ? fileinfo : QFileInfo(name);
+    if (!IconUtils::isIconSuffix(fileinfo.suffix()) || !Iconutils::isIconSuffix(targetInfo.suffix()))
         return;
 
     const QFileInfo targetInfo = name.isEmpty() ? fileinfo : QFileInfo{ name };

--- a/launcher/icons/IconList.cpp
+++ b/launcher/icons/IconList.cpp
@@ -337,15 +337,15 @@ void IconList::installIcon(const QString& file, const QString& name)
     if (!fileinfo.isReadable() || !fileinfo.isFile())
         return;
 
-    if (!IconUtils::isIconSuffix(fileinfo.suffix()))
+    const QString sourceSuffix = fileinfo.suffix();
+    if (!IconUtils::isIconSuffix(sourceSuffix))
         return;
 
-    QString targetName = name.isEmpty() ? fileinfo.fileName() : name;
-    // Ensure the target has the correct extension from the source file
-    QFileInfo targetInfo(targetName);
-    if (!IconUtils::isIconSuffix(targetInfo.suffix())) {
-        targetName = targetInfo.completeBaseName() + "." + fileinfo.suffix();
-    }
+    const QFileInfo targetInfo = name.isEmpty() ? fileinfo : QFileInfo{ name };
+    const QString targetSuffix = targetInfo.suffix();
+    const QString suffix = IconUtils::isIconSuffix(targetSuffix) ? targetSuffix : sourceSuffix;
+
+    const QString targetName = targetInfo.completeBaseName() + QLatin1Char('.') + suffix;
     QString target = FS::PathCombine(getDirectory(), targetName);
     QFile::copy(file, target);
 }


### PR DESCRIPTION
This pull request improves how icon files are installed and named, ensuring that the original file extension of the icon is preserved during the import and installation process. This helps avoid issues with mismatched or missing file extensions for icons.

**Icon installation and naming improvements:**

* Modified `installIcon` in `InstanceImportTask.cpp` to preserve the original icon file's extension when installing, instead of always appending `.png`.
* Updated `IconList::installIcon` in `IconList.cpp` to ensure the target icon file has the correct extension from the source file, even if the provided name lacks a valid icon suffix.

For example, now svg icons are handled correctly when importing a modpack from a .zip.

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
