### PR TITLE
fix skin preview leg rendering

### DIFF
--- a/launcher/minecraft/skins/SkinModel.cpp
+++ b/launcher/minecraft/skins/SkinModel.cpp
@@ -66,8 +66,8 @@ static QImage generatePreviews(QImage texture, bool slim)
     paint.drawImage(4, 22, texture.copy(4, 20, 4, 12));
     paint.drawImage(4, 22, texture.copy(4, 36, 4, 12));
     // left leg
-    paint.drawImage(8, 22, texture.copy(4, 52, 4, 12));
     paint.drawImage(8, 22, texture.copy(20, 52, 4, 12));
+    paint.drawImage(8, 22, texture.copy(4, 52, 4, 12));
 
     auto armWidth = slim ? 3 : 4;
     auto armPosX = slim ? 1 : 0;
@@ -89,8 +89,8 @@ static QImage generatePreviews(QImage texture, bool slim)
     paint.drawImage(24, 22, texture.copy(12, 20, 4, 12));
     paint.drawImage(24, 22, texture.copy(12, 36, 4, 12));
     // left leg
-    paint.drawImage(28, 22, texture.copy(12, 52, 4, 12));
     paint.drawImage(28, 22, texture.copy(28, 52, 4, 12));
+    paint.drawImage(28, 22, texture.copy(12, 52, 4, 12));
 
     // right arm
     paint.drawImage(armPosX + 20, 10, texture.copy(48 + armWidth, 20, armWidth, 12));


### PR DESCRIPTION
leg was rendered after its corresponding top layer

before:
<img width="556" height="135" alt="image" src="https://github.com/user-attachments/assets/6feef935-87f9-40df-bd78-b690fbaeb853" />


after:
<img width="550" height="114" alt="image" src="https://github.com/user-attachments/assets/b3fb5899-759f-49ee-a15b-64dfba1836e5" />


<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
