### PR TITLE
fix accounts crash

### DIFF
--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -669,7 +669,7 @@ void AccountList::beginActivity()
 void AccountList::endActivity()
 {
     if (m_activityCount == 0) {
-        qWarning() << m_name << " - Activity count would become below zero";
+        qWarning() << "Activity count would become below zero";
         return;
     }
     bool deactivating = m_activityCount == 1;

--- a/launcher/minecraft/auth/AccountList.h
+++ b/launcher/minecraft/auth/AccountList.h
@@ -111,7 +111,6 @@ class AccountList : public QAbstractListModel {
     void endActivity();
 
    private:
-    const char* m_name;
     uint32_t m_activityCount = 0;
    signals:
     void listChanged();


### PR DESCRIPTION
fixes #4541
introduced in
https://github.com/PrismLauncher/PrismLauncher/commit/3c46d8a412956a759f61ae802c540ef72d00b35d 
The original commit introduced m_name but never used it. When the endActivity would be called with a count of 0 this would crash the laucnher.
How to reproduce: try to switch your skin in quick succession until you get 429 too many requests as response to the login. I will also presume this is not the only crash caused by this(hopefully it is as it was not catched for four years)

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
