### PR TITLE
match disabled mods on uninstall

### DIFF
--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -207,7 +207,13 @@ void ResourceFolderModel::installResourceWithFlameMetadata(QString path, ModPlat
 bool ResourceFolderModel::uninstallResource(const QString& file_name, bool preserve_metadata)
 {
     for (auto& resource : m_resources) {
-        if (resource->fileinfo().fileName() == file_name) {
+        auto resourceFileInfo = resource->fileinfo();
+        auto resourceFileName = resource->fileinfo().fileName();
+        if (!resource->enabled() && resourceFileName.endsWith(".disabled")) {
+            resourceFileName.chop(9);
+        }
+
+        if (resourceFileName == file_name) {
             auto res = resource->destroy(indexDir(), preserve_metadata, false);
 
             update();


### PR DESCRIPTION
fixes #4537
This ensures that when looking to uninstall a resource prism will consider the disabled ones to.
Right now we have a guard in place to prevent resources using the same name so this check will allways match with the correct resouce.

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
