### PR TITLE
fix modrinth modpack always downloading latest

### DIFF
--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
@@ -203,7 +203,7 @@ void ModrinthPage::onSelectionChanged(QModelIndex curr, [[maybe_unused]] QModelI
                     ++it;
 #endif
             for (const auto& version : m_current->versions) {
-                m_ui->versionSelectionBox->addItem(version.getVersionDisplayString(), QVariant(version.addonId));
+                m_ui->versionSelectionBox->addItem(version.getVersionDisplayString(), QVariant(version.fileId));
             }
 
             QVariant current_updated;
@@ -227,9 +227,9 @@ void ModrinthPage::onSelectionChanged(QModelIndex curr, [[maybe_unused]] QModelI
         for (auto version : m_current->versions) {
             if (!version.version.contains(version.version))
                 m_ui->versionSelectionBox->addItem(QString("%1 - %2").arg(version.version, version.version_number),
-                                                   QVariant(version.addonId));
+                                                   QVariant(version.fileId));
             else
-                m_ui->versionSelectionBox->addItem(version.version, QVariant(version.addonId));
+                m_ui->versionSelectionBox->addItem(version.version, QVariant(version.fileId));
         }
 
         suggestCurrent();
@@ -312,7 +312,7 @@ void ModrinthPage::suggestCurrent()
     }
 
     for (auto& ver : m_current->versions) {
-        if (ver.addonId == m_selectedVersion) {
+        if (ver.fileId == m_selectedVersion) {
             QMap<QString, QString> extra_info;
             extra_info.insert("pack_id", m_current->addonId.toString());
             extra_info.insert("pack_version_id", ver.fileId.toString());


### PR DESCRIPTION
Parent PR: #3828
fixes #4547
introduced by #3828
made a mistake to use addonId instead ov fileId
this only applies to modrinth
on curseforge I could not reproduce this bug

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
