### PR TITLE
handle mod formatting codes

### DIFF
--- a/launcher/ui/widgets/InfoFrame.cpp
+++ b/launcher/ui/widgets/InfoFrame.cpp
@@ -36,6 +36,7 @@
 
 #include <QLabel>
 #include <QMessageBox>
+#include <QScrollBar>
 #include <QTextCursor>
 #include <QTextDocument>
 #include <QToolTip>
@@ -75,7 +76,7 @@ InfoFrame::~InfoFrame()
     delete ui;
 }
 
-void InfoFrame::updateWithMod(Mod const& m)
+void InfoFrame::updateWithMod(const Mod& m)
 {
     if (m.type() == ResourceType::FOLDER) {
         clear();
@@ -182,10 +183,10 @@ QString InfoFrame::renderColorCodes(QString input)
     while (it != input.constEnd()) {
         // is current char § and is there a following char
         if (*it == u'§' && (it + 1) != input.constEnd()) {
-            auto const& code = *(++it);  // incrementing here!
+            const auto& code = *(++it);  // incrementing here!
 
-            auto const color_entry = color_codes_map.constFind(code);
-            auto const tag_entry = formatting_codes_map.constFind(code);
+            const auto color_entry = color_codes_map.constFind(code);
+            const auto tag_entry = formatting_codes_map.constFind(code);
 
             if (color_entry != color_codes_map.constEnd()) {  // color code
                 html += QString("<span style=\"color: %1;\">").arg(color_entry.value());
@@ -270,7 +271,7 @@ void InfoFrame::updateHiddenState()
 
 void InfoFrame::setName(QString text)
 {
-    resetScrolll();
+    resetScroll();
     if (text.isEmpty()) {
         ui->nameLabel->setHidden(true);
     } else {
@@ -421,7 +422,7 @@ void InfoFrame::boxClosed([[maybe_unused]] int result)
     m_current_box = nullptr;
 }
 
-void InfoFrame::resetScrolll()
+void InfoFrame::resetScroll()
 {
     ui->scrollArea->horizontalScrollBar()->setValue(0);
     ui->scrollArea->verticalScrollBar()->setValue(0);

--- a/launcher/ui/widgets/InfoFrame.cpp
+++ b/launcher/ui/widgets/InfoFrame.cpp
@@ -88,7 +88,7 @@ void InfoFrame::updateWithMod(Mod const& m)
     if (m.name().isEmpty())
         name = m.internal_id();
     else
-        name = m.name();
+        name = renderColorCodes(m.name());
 
     if (link.isEmpty())
         text = name;
@@ -103,7 +103,7 @@ void InfoFrame::updateWithMod(Mod const& m)
     if (m.description().isEmpty()) {
         setDescription(QString());
     } else {
-        setDescription(m.description());
+        setDescription(renderColorCodes(m.description()));
     }
 
     setImage(m.icon({ 64, 64 }));
@@ -146,11 +146,12 @@ void InfoFrame::updateWithMod(Mod const& m)
 void InfoFrame::updateWithResource(const Resource& resource)
 {
     const QString homepage = resource.homepage();
+    auto name = renderColorCodes(resource.name());
 
     if (!homepage.isEmpty())
-        setName("<a href=\"" + homepage + "\">" + resource.name() + "</a>");
+        setName("<a href=\"" + homepage + "\">" + name + "</a>");
     else
-        setName(resource.name());
+        setName(name);
 
     setImage();
 }

--- a/launcher/ui/widgets/InfoFrame.cpp
+++ b/launcher/ui/widgets/InfoFrame.cpp
@@ -270,6 +270,7 @@ void InfoFrame::updateHiddenState()
 
 void InfoFrame::setName(QString text)
 {
+    resetScrolll();
     if (text.isEmpty()) {
         ui->nameLabel->setHidden(true);
     } else {
@@ -418,4 +419,10 @@ void InfoFrame::licenseEllipsisHandler([[maybe_unused]] QString link)
 void InfoFrame::boxClosed([[maybe_unused]] int result)
 {
     m_current_box = nullptr;
+}
+
+void InfoFrame::resetScrolll()
+{
+    ui->scrollArea->horizontalScrollBar()->setValue(0);
+    ui->scrollArea->verticalScrollBar()->setValue(0);
 }

--- a/launcher/ui/widgets/InfoFrame.h
+++ b/launcher/ui/widgets/InfoFrame.h
@@ -76,7 +76,7 @@ class InfoFrame : public QFrame {
 
    private:
     void updateHiddenState();
-    void resetScrolll();
+    void resetScroll();
 
    private:
     Ui::InfoFrame* ui;

--- a/launcher/ui/widgets/InfoFrame.h
+++ b/launcher/ui/widgets/InfoFrame.h
@@ -76,6 +76,7 @@ class InfoFrame : public QFrame {
 
    private:
     void updateHiddenState();
+    void resetScrolll();
 
    private:
     Ui::InfoFrame* ui;

--- a/launcher/ui/widgets/InfoFrame.ui
+++ b/launcher/ui/widgets/InfoFrame.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>527</width>
-    <height>113</height>
+    <height>120</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -22,7 +22,7 @@
     <height>120</height>
    </size>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
+  <layout class="QHBoxLayout" name="horizontalLayout">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -35,7 +35,7 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="0" column="0" rowspan="2">
+   <item>
     <widget class="QLabel" name="iconLabel">
      <property name="minimumSize">
       <size>
@@ -60,95 +60,120 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="QLabel" name="descriptionLabel">
-     <property name="toolTip">
-      <string notr="true"/>
+   <item>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
      </property>
-     <property name="text">
-      <string notr="true"/>
-     </property>
-     <property name="textFormat">
-      <enum>Qt::RichText</enum>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-     <property name="wordWrap">
+     <property name="widgetResizable">
       <bool>true</bool>
      </property>
-     <property name="openExternalLinks">
-      <bool>true</bool>
-     </property>
-     <property name="textInteractionFlags">
-      <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QLabel" name="nameLabel">
-     <property name="text">
-      <string notr="true"/>
-     </property>
-     <property name="textFormat">
-      <enum>Qt::RichText</enum>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-     <property name="openExternalLinks">
-      <bool>true</bool>
-     </property>
-     <property name="textInteractionFlags">
-      <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QLabel" name="licenseLabel">
-     <property name="text">
-      <string/>
-     </property>
-     <property name="textFormat">
-      <enum>Qt::RichText</enum>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-     <property name="openExternalLinks">
-      <bool>true</bool>
-     </property>
-     <property name="textInteractionFlags">
-      <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QLabel" name="issueTrackerLabel">
-     <property name="text">
-      <string/>
-     </property>
-     <property name="textFormat">
-      <enum>Qt::RichText</enum>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-     <property name="openExternalLinks">
-      <bool>true</bool>
-     </property>
-     <property name="textInteractionFlags">
-      <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
-     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents_2">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>455</width>
+        <height>118</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QLabel" name="nameLabel">
+         <property name="text">
+          <string notr="true"/>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::RichText</enum>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="openExternalLinks">
+          <bool>true</bool>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="descriptionLabel">
+         <property name="toolTip">
+          <string notr="true"/>
+         </property>
+         <property name="text">
+          <string notr="true"/>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::RichText</enum>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="openExternalLinks">
+          <bool>true</bool>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="issueTrackerLabel">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::RichText</enum>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="openExternalLinks">
+          <bool>true</bool>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="licenseLabel">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="textFormat">
+          <enum>Qt::RichText</enum>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="openExternalLinks">
+          <bool>true</bool>
+         </property>
+         <property name="textInteractionFlags">
+          <set>Qt::LinksAccessibleByKeyboard|Qt::LinksAccessibleByMouse|Qt::TextBrowserInteraction|Qt::TextSelectableByKeyboard|Qt::TextSelectableByMouse</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
fixes #4535
this changes the info frame to be an actuall scrollbar so if the description is too long the text is not directly cut off, and let's the user to view it all.

This is may not be the best ui decssion but feel free to pick this issue up yourself or suggest changes to this PR(the important bit is in the cpp file).

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
