### PR TITLE
fix Pre-release filter

### DIFF
--- a/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
@@ -126,7 +126,8 @@ ModPlatform::IndexedVersion Modrinth::loadIndexedPackVersion(QJsonObject& obj, Q
         return {};
     }
     for (auto mcVer : versionArray) {
-        file.mcVersion.append(ModrinthAPI::mapMCVersionFromModrinth(mcVer.toString()));
+        file.mcVersion.append({ ModrinthAPI::mapMCVersionFromModrinth(mcVer.toString()),
+                                mcVer.toString() });  // double this so we can check both strings when filtering
     }
     auto loaders = Json::requireArray(obj, "loaders");
     for (auto loader : loaders) {


### PR DESCRIPTION
introduced here https://github.com/PrismLauncher/PrismLauncher/pull/3260 fixes #4415
reason: some snapshot have Pre-Release in our meta but when searching in Modrinth this needs to be translated to -pre and the reverse needed to be done for filtering after we fetched the version. Now there are snapshots with -pre in name and that works with Modrinth but when we translate it back we replace it with Pre-Release so the easeiest patch is just to double the version(one with -pre one with Pre-Release)

The correct one would be to complicate the code and identify the versions that need the transition and only apply this for those.

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
