### PR TITLE
preserve original file extension when importing modpack icon

### DIFF
--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -271,7 +271,7 @@ bool installIcon(QString root, QString instIconKey)
         if (iconList->iconFileExists(instIconKey)) {
             iconList->deleteIcon(instIconKey);
         }
-        iconList->installIcon(importIconPath, instIconKey + ".png");
+        iconList->installIcon(importIconPath, instIconKey + "." + QFileInfo(importIconPath).suffix());
         return true;
     }
     return false;


### PR DESCRIPTION
fixes the issue described in https://github.com/PrismLauncher/PrismLauncher/pull/4528
so if you merge this you can close the other PR