### PR TITLE
CMakeLists: fix ASan compile options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,24 +105,22 @@ option(DEBUG_ADDRESS_SANITIZER "Enable Address Sanitizer in Debug builds" OFF)
 # If this is a Debug build turn on address sanitiser
 if (DEBUG_ADDRESS_SANITIZER)
     message(STATUS "Address Sanitizer enabled for Debug builds, Turn it off with -DDEBUG_ADDRESS_SANITIZER=off")
-    if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
-        if (CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
-            # using clang with clang-cl front end
-            message(STATUS "Address Sanitizer available on Clang MSVC frontend")
-            add_compile_options($<$<AND:$<CONFIG:Debug,RelWithDebInfo>,$<COMPILE_LANGUAGE:C,CXX>>:/fsanitize=address /Oy->)
-        else()
-            # AppleClang and Clang
-            message(STATUS "Address Sanitizer available on Clang")
-            add_compile_options($<$<AND:$<CONFIG:Debug,RelWithDebInfo>,$<COMPILE_LANGUAGE:C,CXX>>:-fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=null>)
-        endif()
-    elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-        # GCC
-        message(STATUS "Address Sanitizer available on GCC")
-        add_compile_options($<$<AND:$<CONFIG:Debug,RelWithDebInfo>,$<COMPILE_LANGUAGE:C,CXX>>:-fsanitize=address -fno-omit-frame-pointer -fsanitize=undefined -fno-sanitize-recover=null>)
-        link_libraries("asan")
-    elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-        message(STATUS "Address Sanitizer available on MSVC")
-        add_compile_options($<$<AND:$<CONFIG:Debug,RelWithDebInfo>,$<COMPILE_LANGUAGE:C,CXX>>:/fsanitize=address /Oy->)
+
+    set(USE_ASAN_COMPILE_OPTIONS $<AND:$<CONFIG:Debug,RelWithDebInfo>,$<COMPILE_LANGUAGE:C,CXX>>)
+    if (CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
+        message(STATUS "Using Address Sanitizer compile options for MSVC frontend")
+        add_compile_options(
+                $<${USE_ASAN_COMPILE_OPTIONS}:/fsanitize=address>
+                $<${USE_ASAN_COMPILE_OPTIONS}:/Oy->
+        )
+    elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+        message(STATUS "Using Address Sanitizer compile options for GCC/Clang")
+        add_compile_options(
+                $<${USE_ASAN_COMPILE_OPTIONS}:-fsanitize=address,undefined>
+                $<${USE_ASAN_COMPILE_OPTIONS}:-fno-omit-frame-pointer>
+                $<${USE_ASAN_COMPILE_OPTIONS}:-fno-sanitize-recover=null>
+        )
+        link_libraries("asan" "ubsan")
     else()
         message(STATUS "Address Sanitizer not available on compiler ${CMAKE_CXX_COMPILER_ID}")
     endif()
@@ -389,14 +387,14 @@ if(UNIX AND APPLE)
             OUTPUT_VARIABLE XCODE_VERSION_OUTPUT
             OUTPUT_STRIP_TRAILING_WHITESPACE
         )
-        
+
         string(REGEX MATCH "Xcode ([0-9]+\.[0-9]+)" XCODE_VERSION_MATCH "${XCODE_VERSION_OUTPUT}")
         if(XCODE_VERSION_MATCH)
             set(XCODE_VERSION ${CMAKE_MATCH_1})
         else()
             set(XCODE_VERSION 0.0)
         endif()
-        
+
         if(XCODE_VERSION VERSION_GREATER_EQUAL 26.0)
             set(ASSETS_OUT_DIR "${CMAKE_BINARY_DIR}/program_info")
             set(GENERATED_ASSETS_CAR "${ASSETS_OUT_DIR}/Assets.car")
@@ -421,12 +419,12 @@ if(UNIX AND APPLE)
         else()
             message(WARNING "Xcode ${XCODE_VERSION} is too old. Minimum required version is 26.0. Not compiling liquid glass icons.")
         endif()
-        
+
     else()
         message(WARNING "actool not found. Cannot compile macOS app icons.\n"
 				"Install Xcode command line tools: 'xcode-select --install'")
     endif()
-    
+
 
 elseif(UNIX)
     include(KDEInstallDirs)


### PR DESCRIPTION
Fixes: https://github.com/PrismLauncher/PrismLauncher/commit/85849fea41cd58888042a1347b97af678eb12ff0

Compiling the develop branch with DEBUG_ADDRESS_SANITIZER results in
<img width="1432" height="516" alt="Снимок экрана_20251226_185841" src="https://github.com/user-attachments/assets/1a15c281-440e-4062-9c34-627c32787a92" />

The code was simplified to avoid repeating the same compiler arguments
Tested on Clang (Linux) and MSVC (Windows)