### PR TITLE
feat: use Qt 6.10.1 outside mac and use sharun for portable builds too

### DIFF
--- a/.github/actions/package/linux/action.yml
+++ b/.github/actions/package/linux/action.yml
@@ -99,9 +99,14 @@ runs:
         cmake --install ${{ env.BUILD_DIR }} --config ${{ inputs.build-type }} --prefix ${{ env.INSTALL_PORTABLE_DIR }}
         cmake --install ${{ env.BUILD_DIR }} --config ${{ inputs.build-type }} --prefix ${{ env.INSTALL_PORTABLE_DIR }} --component portable
 
-        #the linked cmark .so is of the version that ubuntu uses, so without this it breaks on most updated distros
-        mkdir ${{ env.INSTALL_PORTABLE_DIR }}/lib
-        cp /lib/$APPIMAGE_ARCH-linux-gnu/libcmark.so.0.* ${{ env.INSTALL_PORTABLE_DIR }}/lib
+        sharun lib4bin \
+          --with-hooks \
+          --hard-links \
+          --dst-dir "$INSTALL_PORTABLE_DIR" \
+          "$INSTALL_PORTABLE_DIR"/bin/* "$QT_PLUGIN_PATH"/*/*.so
+
+        # FIXME(@getchoo): gamemode doesn't seem to be very portable with DBus. Find a way to make it work!
+        find "$INSTALL_PORTABLE_DIR" -name '*gamemode*' -exec rm {} +
 
         for l in $(find ${{ env.INSTALL_PORTABLE_DIR }} -type f); do l=${l#$(pwd)/}; l=${l#${{ env.INSTALL_PORTABLE_DIR }}/}; l=${l#./}; echo $l; done > ${{ env.INSTALL_PORTABLE_DIR }}/manifest.txt
         cd ${{ env.INSTALL_PORTABLE_DIR }}

--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -21,7 +21,6 @@ inputs:
   qt-version:
     description: Version of Qt to use
     required: true
-    default: 6.9.3
 
 outputs:
   build-type:
@@ -78,6 +77,5 @@ runs:
       with:
         aqtversion: "==3.1.*"
         version: ${{ inputs.qt-version }}
-        arch: ${{ inputs.qt-architecture }}
         modules: qtimageformats qtnetworkauth
         cache: ${{ inputs.build-type == 'Debug' }}

--- a/.github/actions/setup-dependencies/linux/action.yml
+++ b/.github/actions/setup-dependencies/linux/action.yml
@@ -12,29 +12,7 @@ runs:
           dpkg-dev \
           ninja-build extra-cmake-modules pkg-config scdoc \
           cmark gamemode-dev libarchive-dev libcmark-dev libqrencode-dev zlib1g-dev \
-          libxcb-cursor-dev
-
-      # TODO(@getchoo): Install with the above when all targets use Ubuntu 24.04
-    - name: Install tomlplusplus
-      if: ${{ runner.arch == 'ARM64' }}
-      shell: bash
-      run: |
-        sudo apt-get -y install libtomlplusplus-dev
-
-      # FIXME(@getchoo): THIS IS HORRIBLE TO DO!
-      # Install tomlplusplus from Ubuntu 24.04, since it never got backported to 22.04
-      # I've done too much to continue keeping this as a submodule....
-    - name: Install tomlplusplus from 24.04
-      if: ${{ runner.arch != 'ARM64' }}
-      shell: bash
-      run: |
-        deb_arch="$(dpkg-architecture -q DEB_HOST_ARCH)"
-        curl -Lo libtomlplusplus-dev.deb http://mirrors.kernel.org/ubuntu/pool/universe/t/tomlplusplus/libtomlplusplus-dev_3.4.0+ds-0.2build1_"$deb_arch".deb
-        curl -Lo libtomlplusplus3t64.deb http://mirrors.kernel.org/ubuntu/pool/universe/t/tomlplusplus/libtomlplusplus3t64_3.4.0+ds-0.2build1_"$deb_arch".deb
-        sudo dpkg -i libtomlplusplus3t64.deb
-        sudo dpkg -i libtomlplusplus-dev.deb
-        rm *.deb
-        sudo apt-get install -f
+          libxcb-cursor-dev libtomlplusplus-dev
 
     - name: Setup AppImage tooling
       shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,15 +83,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             artifact-name: Linux
             cmake-preset: linux
             qt-version: 6.10.1
 
-            # NOTE(@getchoo): Yes, we're intentionally using 24.04 here!!!
-            #
-            # It's not really documented anywhere AFAICT, but upstream Qt binaries
-            # *for the same version* are compiled against 24.04 on ARM, and *not* 22.04 like x64
           - os: ubuntu-24.04-arm
             artifact-name: Linux-aarch64
             cmake-preset: linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,7 @@ jobs:
           - os: ubuntu-22.04
             artifact-name: Linux
             cmake-preset: linux
+            qt-version: 6.10.1
 
             # NOTE(@getchoo): Yes, we're intentionally using 24.04 here!!!
             #
@@ -94,6 +95,7 @@ jobs:
           - os: ubuntu-24.04-arm
             artifact-name: Linux-aarch64
             cmake-preset: linux
+            qt-version: 6.10.1
 
           - os: windows-2022
             artifact-name: Windows-MinGW-w64
@@ -112,16 +114,19 @@ jobs:
             cmake-preset: windows_msvc
             # TODO(@getchoo): This is the default in setup-dependencies/windows. Why isn't it working?!?!
             vcvars-arch: amd64
+            qt-version: 6.10.1
 
           - os: windows-11-arm
             artifact-name: Windows-MSVC-arm64
             cmake-preset: windows_msvc
             vcvars-arch: arm64
+            qt-version: 6.10.1
 
           - os: macos-26
             artifact-name: macOS
             cmake-preset: macos_universal
             macosx-deployment-target: 12.0
+            qt-version: 6.9.3
 
     runs-on: ${{ matrix.os }}
 
@@ -155,7 +160,7 @@ jobs:
           artifact-name: ${{ matrix.artifact-name }}
           msystem: ${{ matrix.msystem }}
           vcvars-arch: ${{ matrix.vcvars-arch }}
-          qt-architecture: ${{ matrix.qt-architecture }}
+          qt-version: ${{ matrix.qt-version }}
 
       ##
       # BUILD

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -79,6 +79,7 @@ jobs:
         uses: ./.github/actions/setup-dependencies
         with:
           build-type: Debug
+          qt-version: 6.10.1
 
       - name: Configure and Build
         run: |

--- a/launcher/Launcher.in
+++ b/launcher/Launcher.in
@@ -18,89 +18,19 @@ LAUNCHER_NAME=@Launcher_APP_BINARY_NAME@
 LAUNCHER_DIR="$(dirname "$(readlink -f "$0")")"
 echo "Launcher Dir: ${LAUNCHER_DIR}"
 
-# Set up env.
-# Pass our custom variables separately so that the launcher can remove them for child processes
-export LAUNCHER_LD_LIBRARY_PATH="${LAUNCHER_DIR}/lib@LIB_SUFFIX@"
-export LAUNCHER_LD_PRELOAD=""
-export LAUNCHER_QT_PLUGIN_PATH="${LAUNCHER_DIR}/plugins"
-export LAUNCHER_QT_FONTPATH="${LAUNCHER_DIR}/fonts"
+# Makes the launcher use portals for file picking
+export QT_QPA_PLATFORMTHEME=xdgdesktopportal
 
-export LD_LIBRARY_PATH="$LAUNCHER_LD_LIBRARY_PATH:$LD_LIBRARY_PATH"
-export LD_PRELOAD="$LAUNCHER_LD_PRELOAD:$LD_PRELOAD"
-export QT_PLUGIN_PATH="$LAUNCHER_QT_PLUGIN_PATH:$QT_PLUGIN_PATH"
-export QT_FONTPATH="$LAUNCHER_QT_FONTPATH:$QT_FONTPATH"
+# Just to be sure...
+chmod +x "${LAUNCHER_DIR}/bin/${LAUNCHER_NAME}"
 
-# Detect missing dependencies...
-DEPS_LIST=`ldd "${LAUNCHER_DIR}"/plugins/*/*.so 2>/dev/null | grep "not found" | sort -u | awk -vORS=", " '{ print $1 }'`
-if [ "x$DEPS_LIST" = "x" ]; then
-    # We have all our dependencies. Run the launcher.
-    echo "No missing dependencies found."
+ARGS=("${LAUNCHER_DIR}/${LAUNCHER_NAME}" "${LAUNCHER_DIR}/bin/${LAUNCHER_NAME}")
 
-    # Just to be sure...
-    chmod +x "${LAUNCHER_DIR}/bin/${LAUNCHER_NAME}"
-
-    ARGS=("${LAUNCHER_DIR}/${LAUNCHER_NAME}" "${LAUNCHER_DIR}/bin/${LAUNCHER_NAME}")
-
-    if [ -f portable.txt ]; then
-        ARGS+=("-d" "${LAUNCHER_DIR}")
-    fi
-
-    ARGS+=("$@")
-
-    # Run the launcher
-    exec -a "${ARGS[@]}"
-
-    # Run the launcher in valgrind
-    # valgrind --log-file="valgrind.log" --leak-check=full --track-origins=yes "${LAUNCHER_DIR}/bin/${LAUNCHER_NAME}" -d "${LAUNCHER_DIR}" "$@"
-
-    # Run the launcher with callgrind, delay instrumentation
-    # valgrind --log-file="valgrind.log" --tool=callgrind --instr-atstart=no "${LAUNCHER_DIR}/bin/${LAUNCHER_NAME}" -d "${LAUNCHER_DIR}" "$@"
-    # use callgrind_control -i on/off to profile actions
-
-    # Exit with launcher's exit code.
-    # exit $?
-else
-    # apt
-    if which apt-file &>/dev/null; then
-        LIBRARIES=`echo "$DEPS_LIST" | grep -oP "[^, ]*" | sort -u`
-        COMMAND_LIBS=`for LIBRARY in $LIBRARIES; do apt-file -l search $LIBRARY; done`
-        COMMAND_LIBS=`echo "$COMMAND_LIBS" | sort -u | awk -vORS=" " '{ print $1 }'`
-        INSTALL_CMD="sudo apt-get install $COMMAND_LIBS"
-    # pacman
-    elif which pkgfile &>/dev/null; then
-        LIBRARIES=`echo "$DEPS_LIST" | grep -oP "[^, ]*" | sort -u`
-        COMMAND_LIBS=`for LIBRARY in $LIBRARIES; do pkgfile $LIBRARY; done`
-        COMMAND_LIBS=`echo "$COMMAND_LIBS" | sort -u | awk -vORS=" " '{ print $1 }'`
-        INSTALL_CMD="sudo pacman -S $COMMAND_LIBS"
-    # dnf
-    elif which dnf &>/dev/null; then
-        LIBRARIES=`echo "$DEPS_LIST" | grep -oP "[^, ]*" | sort -u`
-        COMMAND_LIBS=`for LIBRARY in $LIBRARIES; do dnf whatprovides -q $LIBRARY; done`
-        COMMAND_LIBS=`echo "$COMMAND_LIBS" | grep -v 'Repo' | sort -u | awk -vORS=" " '{ print $1 }'`
-        INSTALL_CMD="sudo dnf install $COMMAND_LIBS"
-    # yum
-    elif which yum &>/dev/null; then
-        LIBRARIES=`echo "$DEPS_LIST" | grep -oP "[^, ]*" | sort -u`
-        COMMAND_LIBS=`for LIBRARY in $LIBRARIES; do yum whatprovides $LIBRARY; done`
-        COMMAND_LIBS=`echo "$COMMAND_LIBS" | sort -u | awk -vORS=" " '{ print $1 }'`
-        INSTALL_CMD="sudo yum install $COMMAND_LIBS"
-    # zypper
-    elif which zypper &>/dev/null; then
-        LIBRARIES=`echo "$DEPS_LIST" | grep -oP "[^, ]*" | sort -u`
-        COMMAND_LIBS=`for LIBRARY in $LIBRARIES; do zypper wp $LIBRARY; done`
-        COMMAND_LIBS=`echo "$COMMAND_LIBS" | sort -u | awk -vORS=" " '{ print $1 }'`
-        INSTALL_CMD="sudo zypper install $COMMAND_LIBS"
-    # emerge
-    elif which pfl &>/dev/null; then
-        LIBRARIES=`echo "$DEPS_LIST" | grep -oP "[^, ]*" | sort -u`
-        COMMAND_LIBS=`for LIBRARY in $LIBRARIES; do pfl $LIBRARY; done`
-        COMMAND_LIBS=`echo "$COMMAND_LIBS" | sort -u | awk -vORS=" " '{ print $1 }'`
-        INSTALL_CMD="sudo emerge $COMMAND_LIBS"
-    fi
-
-    MESSAGE="Error: The launcher is missing the following libraries that it needs to work correctly:\n\t${DEPS_LIST}\nPlease install them from your distribution's package manager."
-    MESSAGE="$MESSAGE\n\nHint (please apply common sense): $INSTALL_CMD\n"
-
-    printerror "$MESSAGE"
-    exit 1
+if [ -f portable.txt ]; then
+    ARGS+=("-d" "${LAUNCHER_DIR}")
 fi
+
+ARGS+=("$@")
+
+# Run the launcher
+exec -a "${ARGS[@]}"


### PR DESCRIPTION
fixes #4518 and fixes #2821 because everything is just bundled in

this reworks portable builds so that they use sharun instead of hoping for the best. This means no more dependency mess in portable builds! Also, we can FINALLY just bump to Ubuntu 24.04!

I also bumped Qt to 6.10.1 on linux (we no longer have to care about abi compat with old qt in distros with portable) and in windows (i've seen a few fixes for qwindows11style in qtbase with Pick-to: 6.10, hopefully they'll be picked up in 6.10.2.