### PR TITLE
ci: use Release env for releases

### DIFF
--- a/.github/actions/package/windows/action.yml
+++ b/.github/actions/package/windows/action.yml
@@ -140,7 +140,7 @@ runs:
         makensis -NOCD "${{ github.workspace }}/${{ env.BUILD_DIR }}/program_info/win_install.nsi"
 
     - name: Sign installer
-      if: ${{ github.ref_name == 'develop' && inputs.azure-client-id != '' }}
+      if: ${{ env.CI_HAS_ACCESS_TO_AZURE != '' && inputs.azure-client-id != '' }}
       uses: azure/trusted-signing-action@v0
       with:
         endpoint: https://eus.codesigning.azure.net/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,6 +62,9 @@ on:
         description: Type of build (Debug or Release)
         type: string
         default: Debug
+      environment:
+        description: Deployment environment to run under
+        type: string
   workflow_dispatch:
     inputs:
       build-type:
@@ -72,6 +75,8 @@ on:
 jobs:
   build:
     name: Build (${{ matrix.artifact-name }})
+
+    environment: ${{ inputs.environment || '' }}
 
     permissions:
       # Required for Azure Trusted Signing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       build-type: Release
+      environment: Release
     secrets: inherit
 
   create_release:


### PR DESCRIPTION
Parent PR: #4348
This ensures we have access to Azure on CI runs for tags

Signed-off-by: Seth Flynn <getchoo@tuta.io>

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
