### PR TITLE
Remove some CI jobs

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -77,9 +77,6 @@ jobs:
           - os: ubuntu-22.04
             arch: x86_64
 
-          - os: ubuntu-22.04-arm
-            arch: aarch64
-
     runs-on: ${{ matrix.os }}
 
     container:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -86,9 +86,6 @@ jobs:
           - os: ubuntu-22.04-arm
             system: aarch64-linux
 
-          - os: macos-15-intel
-            system: x86_64-darwin
-
           - os: macos-14
             system: aarch64-darwin
 


### PR DESCRIPTION
This removes our Nix builds for Intel Macs, and Flatpak builds for ARM

AFAICT these are not often used, take longer than our standard build.yml pipeline, and don't really help with us avoiding the concurrent job limit. Removing them shouldn't have much impact to users, but this can be easily reverted if it does