### PR TITLE
Change enum style guideline to PascalCase

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,17 +7,17 @@ Checks:
 # ^ Without unused-parameters the readability-identifier-naming check doesn't cause any warnings.
 
 CheckOptions:
-  - { key: readability-identifier-naming.ClassCase,              value: PascalCase }
-  - { key: readability-identifier-naming.EnumCase,               value: PascalCase }
-  - { key: readability-identifier-naming.FunctionCase,           value: camelCase }
-  - { key: readability-identifier-naming.GlobalVariableCase,     value: camelCase }
-  - { key: readability-identifier-naming.GlobalFunctionCase,     value: camelCase }
-  - { key: readability-identifier-naming.GlobalConstantCase,     value: SCREAMING_SNAKE_CASE }
-  - { key: readability-identifier-naming.MacroDefinitionCase,    value: SCREAMING_SNAKE_CASE }
-  - { key: readability-identifier-naming.ClassMemberCase,        value: camelCase }
-  - { key: readability-identifier-naming.PrivateMemberPrefix,    value: m_ }
-  - { key: readability-identifier-naming.ProtectedMemberPrefix,  value: m_ }
-  - { key: readability-identifier-naming.PrivateStaticMemberPrefix, value: s_ }
+  - { key: readability-identifier-naming.ClassCase,                   value: PascalCase }
+  - { key: readability-identifier-naming.EnumCase,                    value: PascalCase }
+  - { key: readability-identifier-naming.FunctionCase,                value: camelCase }
+  - { key: readability-identifier-naming.GlobalVariableCase,          value: camelCase }
+  - { key: readability-identifier-naming.GlobalFunctionCase,          value: camelCase }
+  - { key: readability-identifier-naming.GlobalConstantCase,          value: SCREAMING_SNAKE_CASE }
+  - { key: readability-identifier-naming.MacroDefinitionCase,         value: SCREAMING_SNAKE_CASE }
+  - { key: readability-identifier-naming.ClassMemberCase,             value: camelCase }
+  - { key: readability-identifier-naming.PrivateMemberPrefix,         value: m_ }
+  - { key: readability-identifier-naming.ProtectedMemberPrefix,       value: m_ }
+  - { key: readability-identifier-naming.PrivateStaticMemberPrefix,   value: s_ }
   - { key: readability-identifier-naming.ProtectedStaticMemberPrefix, value: s_ }
-  - { key: readability-identifier-naming.PublicStaticConstantCase, value: SCREAMING_SNAKE_CASE }
-  - { key: readability-identifier-naming.EnumConstantCase,       value: SCREAMING_SNAKE_CASE }
+  - { key: readability-identifier-naming.PublicStaticConstantCase,    value: SCREAMING_SNAKE_CASE }
+  - { key: readability-identifier-naming.EnumConstantCase,            value: PascalCase }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,8 @@ Please also follow the project's conventions for C++:
 - Public, private or protected `static const` class data members should be formatted as `SCREAMING_SNAKE_CASE`: `MAX_VALUE`.
 - Class function members should be formatted as `camelCase` without a prefix: `incrementCounter`.
 - Global functions and non-`const` global variables should be formatted as `camelCase` without a prefix: `globalData`.
-- `const` global variables, macros, and enum constants should be formatted as `SCREAMING_SNAKE_CASE`: `LIGHT_GRAY`.
+- `const` global variables and macros should be formatted as `SCREAMING_SNAKE_CASE`: `LIGHT_GRAY`.
+- enum constants should be formatted as `PascalCase`: `CamelusBactrianus`
 - Avoid inventing acronyms or abbreviations especially for a name of multiple words - like `tp` for `texturePack`.
 - Avoid using `[[nodiscard]]` unless ignoring the return value is likely to cause a bug in cases such as:
   - A function allocates memory or another resource and the caller needs to clean it up.
@@ -30,7 +31,7 @@ Here is what these conventions with the formatting configuration look like:
 
 constexpr double PI = 3.14159;
 
-enum class PizzaToppings { HAM_AND_PINEAPPLE, OREO_AND_KETCHUP };
+enum class PizzaToppings { HamAndPineapple, OreoAndKetchup };
 
 struct Person {
     QString name;


### PR DESCRIPTION
Relavent cppcoreguidelines section: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#enum5-dont-use-all_caps-for-enumerators

Maybe we should also encourage braces even where not required?

e.g. the example in the contribution guidelines is currently
```c++
if (m_counter + 1 > MAX_COUNTER_VALUE)
     throw std::runtime_error("Counter has reached limit!");
```
perhaps it should be 

```c++
if (m_counter + 1 > MAX_COUNTER_VALUE) {
     throw std::runtime_error("Counter has reached limit!");
}
```
and perhaps we should state that this is preferred

I don't really think it's very important... but probably more maintainers use the latter style.  (and I recently saw a request to use them on a pr review which feels very odd considering our code style encourages the opposite right now)