### PR TITLE
Automatically use `vcpkg` to build on macOS and Windows

### DIFF
--- a/.github/actions/setup-dependencies/macos/action.yml
+++ b/.github/actions/setup-dependencies/macos/action.yml
@@ -44,4 +44,4 @@ runs:
     - name: Setup vcpkg environment
       shell: bash
       run: |
-        echo "CMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" >> "$GITHUB_ENV"
+        echo "VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT" >> "$GITHUB_ENV"

--- a/.github/actions/setup-dependencies/windows/action.yml
+++ b/.github/actions/setup-dependencies/windows/action.yml
@@ -57,7 +57,7 @@ runs:
       if: ${{ inputs.msystem == '' }}
       shell: bash
       run: |
-        echo "CMAKE_TOOLCHAIN_FILE=$VCPKG_INSTALLATION_ROOT/scripts/buildsystems/vcpkg.cmake" >> "$GITHUB_ENV"
+        echo "VCPKG_ROOT=$VCPKG_INSTALLATION_ROOT" >> "$GITHUB_ENV"
 
     - name: Setup MSYS2 (MinGW)
       if: ${{ inputs.msystem != '' }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -41,6 +41,9 @@
 				"type": "equals",
 				"lhs": "${hostSystemName}",
 				"rhs": "Darwin"
+			},
+			"cacheVariables": {
+				"CMAKE_TOOLCHAIN_FILE": "$penv{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
 			}
 		},
 		{
@@ -50,6 +53,7 @@
 				"macos"
 			],
 			"cacheVariables": {
+				"CMAKE_TOOLCHAIN_FILE": "$penv{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
 				"CMAKE_OSX_ARCHITECTURES": "x86_64;arm64",
 				"VCPKG_TARGET_TRIPLET": "universal-osx"
 			}
@@ -76,6 +80,9 @@
 				"type": "equals",
 				"lhs": "${hostSystemName}",
 				"rhs": "Windows"
+			},
+			"cacheVariables": {
+				"CMAKE_TOOLCHAIN_FILE": "$penv{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
 			}
 		}
 	],


### PR DESCRIPTION
Previously `CMAKE_TOOLCHAIN_FILE` needed to be set manually, which was
kinda pointless when vcpkg is already installed and meant to be used

Signed-off-by: Seth Flynn <getchoo@tuta.io>

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
