### PR TITLE
refactor!!!: migrate from shared pointers

### DIFF
--- a/launcher/Application.h
+++ b/launcher/Application.h
@@ -112,7 +112,7 @@ class Application : public QApplication {
 
     bool event(QEvent* event) override;
 
-    std::shared_ptr<SettingsObject> settings() const { return m_settings; }
+    SettingsObject* settings() const { return m_settings.get(); }
 
     qint64 timeSinceStart() const { return m_startTime.msecsTo(QDateTime::currentDateTime()); }
 
@@ -120,21 +120,21 @@ class Application : public QApplication {
 
     ThemeManager* themeManager() { return m_themeManager.get(); }
 
-    shared_qobject_ptr<ExternalUpdater> updater() { return m_updater; }
+    ExternalUpdater* updater() { return m_updater.get(); }
 
     void triggerUpdateCheck();
 
-    std::shared_ptr<TranslationsModel> translations();
+    TranslationsModel* translations();
 
-    std::shared_ptr<JavaInstallList> javalist();
+    JavaInstallList* javalist();
 
-    std::shared_ptr<InstanceList> instances() const { return m_instances; }
+    InstanceList* instances() const { return m_instances.get(); }
 
-    std::shared_ptr<IconList> icons() const { return m_icons; }
+    IconList* icons() const { return m_icons.get(); }
 
     MCEditTool* mcedit() const { return m_mcedit.get(); }
 
-    shared_qobject_ptr<AccountList> accounts() const { return m_accounts; }
+    AccountList* accounts() const { return m_accounts.get(); }
 
     Status status() const { return m_status; }
 
@@ -142,11 +142,11 @@ class Application : public QApplication {
 
     void updateProxySettings(QString proxyTypeStr, QString addr, int port, QString user, QString password);
 
-    shared_qobject_ptr<QNetworkAccessManager> network();
+    QNetworkAccessManager* network();
 
-    shared_qobject_ptr<HttpMetaCache> metacache();
+    HttpMetaCache* metacache();
 
-    shared_qobject_ptr<Meta::Index> metadataIndex();
+    Meta::Index* metadataIndex();
 
     void updateCapabilities();
 
@@ -182,7 +182,7 @@ class Application : public QApplication {
      */
     bool openJsonEditor(const QString& filename);
 
-    InstanceWindow* showInstanceWindow(InstancePtr instance, QString page = QString());
+    InstanceWindow* showInstanceWindow(BaseInstance* instance, QString page = QString());
     MainWindow* showMainWindow(bool minimized = false);
     ViewLogWindow* showLogWindow();
 
@@ -209,13 +209,13 @@ class Application : public QApplication {
 #endif
 
    public slots:
-    bool launch(InstancePtr instance,
+    bool launch(BaseInstance* instance,
                 bool online = true,
                 bool demo = false,
                 MinecraftTarget::Ptr targetToJoin = nullptr,
                 MinecraftAccountPtr accountToUse = nullptr,
                 const QString& offlineName = QString());
-    bool kill(InstancePtr instance);
+    bool kill(BaseInstance* instance);
     void closeCurrentWindow();
 
    private slots:
@@ -239,22 +239,26 @@ class Application : public QApplication {
     bool shouldExitNow() const;
 
    private:
+    QHash<QString, int> m_qsaveResources;
+    mutable QMutex m_qsaveResourcesMutex;
+
+   private:
     QDateTime m_startTime;
 
-    shared_qobject_ptr<QNetworkAccessManager> m_network;
+    std::unique_ptr<QNetworkAccessManager> m_network;
 
-    shared_qobject_ptr<ExternalUpdater> m_updater;
-    shared_qobject_ptr<AccountList> m_accounts;
+    std::unique_ptr<ExternalUpdater> m_updater;
+    std::unique_ptr<AccountList> m_accounts;
 
-    shared_qobject_ptr<HttpMetaCache> m_metacache;
-    shared_qobject_ptr<Meta::Index> m_metadataIndex;
+    std::unique_ptr<HttpMetaCache> m_metacache;
+    std::unique_ptr<Meta::Index> m_metadataIndex;
 
-    std::shared_ptr<SettingsObject> m_settings;
-    std::shared_ptr<InstanceList> m_instances;
-    std::shared_ptr<IconList> m_icons;
-    std::shared_ptr<JavaInstallList> m_javalist;
-    std::shared_ptr<TranslationsModel> m_translations;
-    std::shared_ptr<GenericPageProvider> m_globalSettingsProvider;
+    std::unique_ptr<SettingsObject> m_settings;
+    std::unique_ptr<InstanceList> m_instances;
+    std::unique_ptr<IconList> m_icons;
+    std::unique_ptr<JavaInstallList> m_javalist;
+    std::unique_ptr<TranslationsModel> m_translations;
+    std::unique_ptr<GenericPageProvider> m_globalSettingsProvider;
     std::unique_ptr<MCEditTool> m_mcedit;
     QSet<QString> m_features;
     std::unique_ptr<ThemeManager> m_themeManager;
@@ -279,7 +283,7 @@ class Application : public QApplication {
     // FIXME: attach to instances instead.
     struct InstanceXtras {
         InstanceWindow* window = nullptr;
-        shared_qobject_ptr<LaunchController> controller;
+        std::unique_ptr<LaunchController> controller;
     };
     std::map<QString, InstanceXtras> m_instanceExtras;
     mutable QMutex m_instanceExtrasMutex;
@@ -313,14 +317,10 @@ class Application : public QApplication {
     QList<QUrl> m_urlsToImport;
     QString m_instanceIdToShowWindowOf;
     std::unique_ptr<QFile> logFile;
-    shared_qobject_ptr<LogModel> logModel;
+    std::unique_ptr<LogModel> logModel;
 
    public:
     void addQSavePath(QString);
     void removeQSavePath(QString);
     bool checkQSavePath(QString);
-
-   private:
-    QHash<QString, int> m_qsaveResources;
-    mutable QMutex m_qsaveResourcesMutex;
 };

--- a/launcher/BaseVersion.h
+++ b/launcher/BaseVersion.h
@@ -24,6 +24,7 @@
  */
 class BaseVersion {
    public:
+    // TODO: delete
     using Ptr = std::shared_ptr<BaseVersion>;
     virtual ~BaseVersion() {}
     /*!

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -119,6 +119,7 @@ set(NET_SOURCES
     net/ChecksumValidator.h
     net/Download.cpp
     net/Download.h
+    net/DummySink.h
     net/FileSink.cpp
     net/FileSink.h
     net/HttpMetaCache.cpp

--- a/launcher/InstanceCopyTask.cpp
+++ b/launcher/InstanceCopyTask.cpp
@@ -8,7 +8,7 @@
 #include "settings/INISettingsObject.h"
 #include "tasks/Task.h"
 
-InstanceCopyTask::InstanceCopyTask(InstancePtr origInstance, const InstanceCopyPrefs& prefs)
+InstanceCopyTask::InstanceCopyTask(BaseInstance* origInstance, const InstanceCopyPrefs& prefs)
 {
     m_origInstance = origInstance;
     m_keepPlaytime = prefs.isKeepPlaytimeEnabled();
@@ -147,9 +147,9 @@ void InstanceCopyTask::copyFinished()
     }
 
     // FIXME: shouldn't this be able to report errors?
-    auto instanceSettings = std::make_shared<INISettingsObject>(FS::PathCombine(m_stagingPath, "instance.cfg"));
+    auto instanceSettings = std::make_unique<INISettingsObject>(FS::PathCombine(m_stagingPath, "instance.cfg"));
 
-    InstancePtr inst(new NullInstance(m_globalSettings, instanceSettings, m_stagingPath));
+    BaseInstance* inst(new NullInstance(m_globalSettings, std::move(instanceSettings), m_stagingPath));
     inst->setName(name());
     inst->setIconKey(m_instIcon);
     if (!m_keepPlaytime) {

--- a/launcher/InstanceCopyTask.h
+++ b/launcher/InstanceCopyTask.h
@@ -15,7 +15,7 @@
 class InstanceCopyTask : public InstanceTask {
     Q_OBJECT
    public:
-    explicit InstanceCopyTask(InstancePtr origInstance, const InstanceCopyPrefs& prefs);
+    explicit InstanceCopyTask(BaseInstance* origInstance, const InstanceCopyPrefs& prefs);
 
    protected:
     //! Entry point for tasks.
@@ -26,7 +26,7 @@ class InstanceCopyTask : public InstanceTask {
 
    private:
     /* data */
-    InstancePtr m_origInstance;
+    BaseInstance* m_origInstance;
     QFuture<bool> m_copyFuture;
     QFutureWatcher<bool> m_copyFutureWatcher;
     Filter m_matcher;

--- a/launcher/InstanceDirUpdate.cpp
+++ b/launcher/InstanceDirUpdate.cpp
@@ -42,7 +42,7 @@
 #include "InstanceList.h"
 #include "ui/dialogs/CustomMessageBox.h"
 
-QString askToUpdateInstanceDirName(InstancePtr instance, const QString& oldName, const QString& newName, QWidget* parent)
+QString askToUpdateInstanceDirName(BaseInstance* instance, const QString& oldName, const QString& newName, QWidget* parent)
 {
     if (oldName == newName)
         return QString();

--- a/launcher/InstanceDirUpdate.h
+++ b/launcher/InstanceDirUpdate.h
@@ -37,7 +37,7 @@
 #include "BaseInstance.h"
 
 /// Update instanceRoot to make it sync with name/id; return newRoot if a directory rename happened
-QString askToUpdateInstanceDirName(InstancePtr instance, const QString& oldName, const QString& newName, QWidget* parent);
+QString askToUpdateInstanceDirName(BaseInstance* instance, const QString& oldName, const QString& newName, QWidget* parent);
 
 /// Check if there are linked instances, and display a warning; return true if the operation should proceed
 bool checkLinkedInstances(const QString& id, QWidget* parent, const QString& verb);

--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -343,9 +343,9 @@ void InstanceImportTask::processTechnic()
 void InstanceImportTask::processMultiMC()
 {
     QString configPath = FS::PathCombine(m_stagingPath, "instance.cfg");
-    auto instanceSettings = std::make_shared<INISettingsObject>(configPath);
+    auto instanceSettings = std::make_unique<INISettingsObject>(configPath);
 
-    NullInstance instance(m_globalSettings, instanceSettings, m_stagingPath);
+    NullInstance instance(m_globalSettings, std::move(instanceSettings), m_stagingPath);
 
     // reset time played on import... because packs.
     instance.resetTimePlayed();

--- a/launcher/InstanceList.cpp
+++ b/launcher/InstanceList.cpp
@@ -69,7 +69,7 @@
 
 const static int GROUP_FILE_FORMAT_VERSION = 1;
 
-InstanceList::InstanceList(SettingsObjectPtr settings, const QString& instDir, QObject* parent)
+InstanceList::InstanceList(SettingsObject* settings, const QString& instDir, QObject* parent)
     : QAbstractListModel(parent), m_globalSettings(settings)
 {
     resumeWatch();
@@ -87,7 +87,10 @@ InstanceList::InstanceList(SettingsObjectPtr settings, const QString& instDir, Q
     m_watcher->addPath(m_instDir);
 }
 
-InstanceList::~InstanceList() {}
+InstanceList::~InstanceList()
+{
+    qDeleteAll(m_instances);
+}
 
 Qt::DropActions InstanceList::supportedDragActions() const
 {
@@ -161,7 +164,7 @@ QModelIndex InstanceList::index(int row, int column, const QModelIndex& parent) 
     Q_UNUSED(parent);
     if (row < 0 || row >= m_instances.size())
         return QModelIndex();
-    return createIndex(row, column, (void*)m_instances.at(row).get());
+    return createIndex(row, column, (void*)m_instances.at(row));
 }
 
 QVariant InstanceList::data(const QModelIndex& index, int role) const
@@ -266,7 +269,7 @@ void InstanceList::setInstanceGroup(const InstanceId& id, GroupId name)
 
     if (changed) {
         increaseGroupCount(name);
-        auto idx = getInstIndex(inst.get());
+        auto idx = getInstIndex(inst);
         emit dataChanged(index(idx), index(idx), { GroupRole });
         saveGroupList();
     }
@@ -291,7 +294,7 @@ void InstanceList::deleteGroup(const GroupId& name)
             m_instanceGroupIndex.remove(instID);
             qDebug() << "Remove" << instID << "from group" << name;
             removed = true;
-            auto idx = getInstIndex(instance.get());
+            auto idx = getInstIndex(instance);
             if (idx >= 0)
                 emit dataChanged(index(idx), index(idx), { GroupRole });
         }
@@ -316,7 +319,7 @@ void InstanceList::renameGroup(const QString& src, const QString& dst)
             increaseGroupCount(dst);
             qDebug() << "Set" << instID << "group to" << dst;
             modified = true;
-            auto idx = getInstIndex(instance.get());
+            auto idx = getInstIndex(instance);
             if (idx >= 0)
                 emit dataChanged(index(idx), index(idx), { GroupRole });
         }
@@ -457,11 +460,11 @@ void InstanceList::deleteInstance(const InstanceId& id)
     }
 }
 
-static QMap<InstanceId, InstanceLocator> getIdMapping(const QList<InstancePtr>& list)
+static QMap<InstanceId, InstanceLocator> getIdMapping(const QList<InstanceList::BaseInstanceOwner>& list)
 {
     QMap<InstanceId, InstanceLocator> out;
     int i = 0;
-    for (auto& item : list) {
+    for (auto item : list) {
         auto id = item->id();
         if (out.contains(id)) {
             qWarning() << "Duplicate ID" << id << "in instance list";
@@ -504,7 +507,7 @@ InstanceList::InstListError InstanceList::loadList()
 {
     auto existingIds = getIdMapping(m_instances);
 
-    QList<InstancePtr> newList;
+    QList<BaseInstanceOwner> newList;
 
     for (auto& id : discoverInstances()) {
         if (existingIds.contains(id)) {
@@ -512,7 +515,7 @@ InstanceList::InstListError InstanceList::loadList()
             existingIds.remove(id);
             qInfo() << "Should keep and soft-reload" << id;
         } else {
-            InstancePtr instPtr = loadInstance(id);
+            BaseInstanceOwner instPtr = loadInstance(id);
             if (instPtr) {
                 newList.append(instPtr);
             }
@@ -567,7 +570,7 @@ void InstanceList::updateTotalPlayTime()
 {
     totalPlayTime = 0;
     for (auto const& itr : m_instances) {
-        totalPlayTime += itr.get()->totalTimePlayed();
+        totalPlayTime += itr->totalTimePlayed();
     }
 }
 
@@ -578,12 +581,12 @@ void InstanceList::saveNow()
     }
 }
 
-void InstanceList::add(const QList<InstancePtr>& t)
+void InstanceList::add(const QList<BaseInstanceOwner>& t)
 {
     beginInsertRows(QModelIndex(), m_instances.count(), m_instances.count() + t.size() - 1);
     m_instances.append(t);
-    for (auto& ptr : t) {
-        connect(ptr.get(), &BaseInstance::propertiesChanged, this, &InstanceList::propertiesChanged);
+    for (auto ptr : t) {
+        connect(ptr, &BaseInstance::propertiesChanged, this, &InstanceList::propertiesChanged);
     }
     endInsertRows();
 }
@@ -613,19 +616,19 @@ void InstanceList::providerUpdated()
     }
 }
 
-InstancePtr InstanceList::getInstanceById(QString instId) const
+BaseInstance* InstanceList::getInstanceById(QString instId) const
 {
     if (instId.isEmpty())
-        return InstancePtr();
+        return nullptr;
     for (auto& inst : m_instances) {
         if (inst->id() == instId) {
             return inst;
         }
     }
-    return InstancePtr();
+    return nullptr;
 }
 
-InstancePtr InstanceList::getInstanceByManagedName(const QString& managed_name) const
+BaseInstance* InstanceList::getInstanceByManagedName(const QString& managed_name) const
 {
     if (managed_name.isEmpty())
         return {};
@@ -640,14 +643,14 @@ InstancePtr InstanceList::getInstanceByManagedName(const QString& managed_name) 
 
 QModelIndex InstanceList::getInstanceIndexById(const QString& id) const
 {
-    return index(getInstIndex(getInstanceById(id).get()));
+    return index(getInstIndex(getInstanceById(id)));
 }
 
 int InstanceList::getInstIndex(BaseInstance* inst) const
 {
     int count = m_instances.count();
     for (int i = 0; i < count; i++) {
-        if (inst == m_instances[i].get()) {
+        if (inst == m_instances[i]) {
             return i;
         }
     }
@@ -663,15 +666,15 @@ void InstanceList::propertiesChanged(BaseInstance* inst)
     }
 }
 
-InstancePtr InstanceList::loadInstance(const InstanceId& id)
+InstanceList::BaseInstanceOwner InstanceList::loadInstance(const InstanceId& id)
 {
     if (!m_groupsLoaded) {
         loadGroupList();
     }
 
     auto instanceRoot = FS::PathCombine(m_instDir, id);
-    auto instanceSettings = std::make_shared<INISettingsObject>(FS::PathCombine(instanceRoot, "instance.cfg"));
-    InstancePtr inst;
+    auto instanceSettings = std::make_unique<INISettingsObject>(FS::PathCombine(instanceRoot, "instance.cfg"));
+    BaseInstanceOwner inst;
 
     instanceSettings->registerSetting("InstanceType", "");
 
@@ -680,9 +683,9 @@ InstancePtr InstanceList::loadInstance(const InstanceId& id)
     // NOTE: Some launcher versions didn't save the InstanceType properly. We will just bank on the probability that this is probably a
     // OneSix instance
     if (inst_type == "OneSix" || inst_type.isEmpty()) {
-        inst.reset(new MinecraftInstance(m_globalSettings, instanceSettings, instanceRoot));
+        inst = new MinecraftInstance(m_globalSettings, std::move(instanceSettings), instanceRoot);
     } else {
-        inst.reset(new NullInstance(m_globalSettings, instanceSettings, instanceRoot));
+        inst = new NullInstance(m_globalSettings, std::move(instanceSettings), instanceRoot);
     }
     qDebug() << "Loaded instance" << inst->name() << "from" << inst->instanceRoot();
 
@@ -911,15 +914,14 @@ class InstanceStaging : public Task {
     const unsigned maxBackoff = 16;
 
    public:
-    InstanceStaging(InstanceList* parent, InstanceTask* child, SettingsObjectPtr settings)
-        : m_parent(parent), backoff(minBackoff, maxBackoff)
+    InstanceStaging(InstanceList* parent, InstanceTask* child, SettingsObject* settings) : m_parent(parent), backoff(minBackoff, maxBackoff)
     {
         m_stagingPath = parent->getStagedInstancePath();
 
         m_child.reset(child);
 
         m_child->setStagingPath(m_stagingPath);
-        m_child->setParentSettings(std::move(settings));
+        m_child->setParentSettings(settings);
 
         connect(child, &Task::succeeded, this, &InstanceStaging::childSucceeded);
         connect(child, &Task::failed, this, &InstanceStaging::childFailed);
@@ -995,7 +997,7 @@ class InstanceStaging : public Task {
      */
     ExponentialSeries backoff;
     QString m_stagingPath;
-    unique_qobject_ptr<InstanceTask> m_child;
+    std::unique_ptr<InstanceTask> m_child;
     QTimer m_backoffTimer;
 };
 
@@ -1036,7 +1038,7 @@ bool InstanceList::commitStagedInstance(const QString& path,
         groupName = QString();
 
     QString instID;
-    InstancePtr inst;
+    BaseInstance* inst;
 
     auto should_override = commiting.shouldOverride();
 

--- a/launcher/InstanceList.h
+++ b/launcher/InstanceList.h
@@ -73,8 +73,6 @@ class InstanceList : public QAbstractListModel {
     Q_OBJECT
 
    public:
-    using BaseInstanceOwner = BaseInstance*;
-
     explicit InstanceList(SettingsObject* settings, const QString& instDir, QObject* parent = 0);
     virtual ~InstanceList();
 
@@ -98,9 +96,9 @@ class InstanceList : public QAbstractListModel {
      */
     enum InstListError { NoError = 0, UnknownError };
 
-    BaseInstance* at(int i) const { return m_instances.at(i); }
+    BaseInstance* at(int i) const { return m_instances.at(i).get(); }
 
-    int count() const { return m_instances.count(); }
+    int count() const { return m_instances.size(); }
 
     InstListError loadList();
     void saveNow();
@@ -181,11 +179,11 @@ class InstanceList : public QAbstractListModel {
     void updateTotalPlayTime();
     void suspendWatch();
     void resumeWatch();
-    void add(const QList<BaseInstanceOwner>& list);
+    void add(std::vector<std::unique_ptr<BaseInstance>>& list);
     void loadGroupList();
     void saveGroupList();
     QList<InstanceId> discoverInstances();
-    BaseInstanceOwner loadInstance(const InstanceId& id);
+    std::unique_ptr<BaseInstance> loadInstance(const InstanceId& id);
 
     void increaseGroupCount(const QString& group);
     void decreaseGroupCount(const QString& group);
@@ -194,7 +192,7 @@ class InstanceList : public QAbstractListModel {
     int m_watchLevel = 0;
     int totalPlayTime = 0;
     bool m_dirty = false;
-    QList<BaseInstanceOwner> m_instances;
+    std::vector<std::unique_ptr<BaseInstance>> m_instances;
     // id -> refs
     QMap<QString, int> m_groupNameCache;
 

--- a/launcher/InstanceList.h
+++ b/launcher/InstanceList.h
@@ -50,7 +50,7 @@ struct InstanceName;
 
 using InstanceId = QString;
 using GroupId = QString;
-using InstanceLocator = std::pair<InstancePtr, int>;
+using InstanceLocator = std::pair<BaseInstance*, int>;
 
 enum class InstCreateError { NoCreateError = 0, NoSuchVersion, UnknownCreateError, InstExists, CantCreateDir };
 
@@ -73,7 +73,9 @@ class InstanceList : public QAbstractListModel {
     Q_OBJECT
 
    public:
-    explicit InstanceList(SettingsObjectPtr settings, const QString& instDir, QObject* parent = 0);
+    using BaseInstanceOwner = BaseInstance*;
+
+    explicit InstanceList(SettingsObject* settings, const QString& instDir, QObject* parent = 0);
     virtual ~InstanceList();
 
    public:
@@ -96,7 +98,7 @@ class InstanceList : public QAbstractListModel {
      */
     enum InstListError { NoError = 0, UnknownError };
 
-    InstancePtr at(int i) const { return m_instances.at(i); }
+    BaseInstance* at(int i) const { return m_instances.at(i); }
 
     int count() const { return m_instances.count(); }
 
@@ -104,9 +106,9 @@ class InstanceList : public QAbstractListModel {
     void saveNow();
 
     /* O(n) */
-    InstancePtr getInstanceById(QString id) const;
+    BaseInstance* getInstanceById(QString id) const;
     /* O(n) */
-    InstancePtr getInstanceByManagedName(const QString& managed_name) const;
+    BaseInstance* getInstanceByManagedName(const QString& managed_name) const;
     QModelIndex getInstanceIndexById(const QString& id) const;
     QStringList getGroups();
     bool isGroupCollapsed(const QString& groupName);
@@ -179,11 +181,11 @@ class InstanceList : public QAbstractListModel {
     void updateTotalPlayTime();
     void suspendWatch();
     void resumeWatch();
-    void add(const QList<InstancePtr>& list);
+    void add(const QList<BaseInstanceOwner>& list);
     void loadGroupList();
     void saveGroupList();
     QList<InstanceId> discoverInstances();
-    InstancePtr loadInstance(const InstanceId& id);
+    BaseInstanceOwner loadInstance(const InstanceId& id);
 
     void increaseGroupCount(const QString& group);
     void decreaseGroupCount(const QString& group);
@@ -192,11 +194,11 @@ class InstanceList : public QAbstractListModel {
     int m_watchLevel = 0;
     int totalPlayTime = 0;
     bool m_dirty = false;
-    QList<InstancePtr> m_instances;
+    QList<BaseInstanceOwner> m_instances;
     // id -> refs
     QMap<QString, int> m_groupNameCache;
 
-    SettingsObjectPtr m_globalSettings;
+    SettingsObject* m_globalSettings;
     QString m_instDir;
     QFileSystemWatcher* m_watcher;
     // FIXME: this is so inefficient that looking at it is almost painful.

--- a/launcher/InstancePageProvider.h
+++ b/launcher/InstancePageProvider.h
@@ -21,26 +21,26 @@
 class InstancePageProvider : protected QObject, public BasePageProvider {
     Q_OBJECT
    public:
-    explicit InstancePageProvider(InstancePtr parent) { inst = parent; }
+    explicit InstancePageProvider(BaseInstance* parent) { inst = parent; }
 
     virtual ~InstancePageProvider() = default;
     virtual QList<BasePage*> getPages() override
     {
         QList<BasePage*> values;
         values.append(new LogPage(inst));
-        std::shared_ptr<MinecraftInstance> onesix = std::dynamic_pointer_cast<MinecraftInstance>(inst);
-        values.append(new VersionPage(onesix.get()));
-        values.append(ManagedPackPage::createPage(onesix.get()));
-        auto modsPage = new ModFolderPage(onesix.get(), onesix->loaderModList());
+        MinecraftInstance* onesix = dynamic_cast<MinecraftInstance*>(inst);
+        values.append(new VersionPage(onesix));
+        values.append(ManagedPackPage::createPage(onesix));
+        auto modsPage = new ModFolderPage(onesix, onesix->loaderModList());
         modsPage->setFilter("%1 (*.zip *.jar *.litemod *.nilmod)");
         values.append(modsPage);
-        values.append(new CoreModFolderPage(onesix.get(), onesix->coreModList()));
-        values.append(new NilModFolderPage(onesix.get(), onesix->nilModList()));
-        values.append(new ResourcePackPage(onesix.get(), onesix->resourcePackList()));
-        values.append(new GlobalDataPackPage(onesix.get()));
-        values.append(new TexturePackPage(onesix.get(), onesix->texturePackList()));
-        values.append(new ShaderPackPage(onesix.get(), onesix->shaderPackList()));
-        values.append(new NotesPage(onesix.get()));
+        values.append(new CoreModFolderPage(onesix, onesix->coreModList()));
+        values.append(new NilModFolderPage(onesix, onesix->nilModList()));
+        values.append(new ResourcePackPage(onesix, onesix->resourcePackList()));
+        values.append(new GlobalDataPackPage(onesix));
+        values.append(new TexturePackPage(onesix, onesix->texturePackList()));
+        values.append(new ShaderPackPage(onesix, onesix->shaderPackList()));
+        values.append(new NotesPage(onesix));
         values.append(new WorldListPage(onesix, onesix->worldList()));
         values.append(new ServersPage(onesix));
         values.append(new ScreenshotsPage(FS::PathCombine(onesix->gameRoot(), "screenshots")));
@@ -52,5 +52,5 @@ class InstancePageProvider : protected QObject, public BasePageProvider {
     virtual QString dialogTitle() override { return tr("Edit Instance (%1)").arg(inst->name()); }
 
    protected:
-    InstancePtr inst;
+    BaseInstance* inst;
 };

--- a/launcher/InstanceTask.h
+++ b/launcher/InstanceTask.h
@@ -35,7 +35,7 @@ class InstanceTask : public Task, public InstanceName {
     InstanceTask();
     ~InstanceTask() override = default;
 
-    void setParentSettings(SettingsObjectPtr settings) { m_globalSettings = settings; }
+    void setParentSettings(SettingsObject* settings) { m_globalSettings = settings; }
 
     void setStagingPath(const QString& stagingPath) { m_stagingPath = stagingPath; }
 
@@ -60,7 +60,7 @@ class InstanceTask : public Task, public InstanceName {
     }
 
    protected: /* data */
-    SettingsObjectPtr m_globalSettings;
+    SettingsObject* m_globalSettings;
     QString m_instIcon;
     QString m_instGroup;
     QString m_stagingPath;

--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -403,10 +403,10 @@ void LaunchController::launchInstance()
     if (!console && showConsole) {
         APPLICATION->showInstanceWindow(m_instance);
     }
-    connect(m_launcher.get(), &LaunchTask::readyForLaunch, this, &LaunchController::readyForLaunch);
-    connect(m_launcher.get(), &LaunchTask::succeeded, this, &LaunchController::onSucceeded);
-    connect(m_launcher.get(), &LaunchTask::failed, this, &LaunchController::onFailed);
-    connect(m_launcher.get(), &LaunchTask::requestProgress, this, &LaunchController::onProgressRequested);
+    connect(m_launcher, &LaunchTask::readyForLaunch, this, &LaunchController::readyForLaunch);
+    connect(m_launcher, &LaunchTask::succeeded, this, &LaunchController::onSucceeded);
+    connect(m_launcher, &LaunchTask::failed, this, &LaunchController::onFailed);
+    connect(m_launcher, &LaunchTask::requestProgress, this, &LaunchController::onProgressRequested);
 
     // Prepend Online and Auth Status
     QString online_mode;
@@ -416,19 +416,18 @@ void LaunchController::launchInstance()
         // Prepend Server Status
         QStringList servers = { "login.microsoftonline.com", "session.minecraft.net", "textures.minecraft.net", "api.mojang.com" };
 
-        m_launcher->prependStep(makeShared<PrintServers>(m_launcher.get(), servers));
+        m_launcher->prependStep(makeShared<PrintServers>(m_launcher, servers));
     } else {
         online_mode = m_demo ? "demo" : "offline";
     }
 
-    m_launcher->prependStep(
-        makeShared<TextPrint>(m_launcher.get(), "Launched instance in " + online_mode + " mode\n", MessageLevel::Launcher));
+    m_launcher->prependStep(makeShared<TextPrint>(m_launcher, "Launched instance in " + online_mode + " mode\n", MessageLevel::Launcher));
 
     // Prepend Version
     {
         auto versionString = QString("%1 version: %2 (%3)")
                                  .arg(BuildConfig.LAUNCHER_DISPLAYNAME, BuildConfig.printableVersionString(), BuildConfig.BUILD_PLATFORM);
-        m_launcher->prependStep(makeShared<TextPrint>(m_launcher.get(), versionString + "\n\n", MessageLevel::Launcher));
+        m_launcher->prependStep(makeShared<TextPrint>(m_launcher, versionString + "\n\n", MessageLevel::Launcher));
     }
     m_launcher->start();
 }

--- a/launcher/LaunchController.h
+++ b/launcher/LaunchController.h
@@ -50,9 +50,9 @@ class LaunchController : public Task {
     LaunchController();
     virtual ~LaunchController() = default;
 
-    void setInstance(InstancePtr instance) { m_instance = instance; }
+    void setInstance(BaseInstance* instance) { m_instance = instance; }
 
-    InstancePtr instance() { return m_instance; }
+    BaseInstance* instance() { return m_instance; }
 
     void setOnline(bool online) { m_online = online; }
 
@@ -92,11 +92,11 @@ class LaunchController : public Task {
     bool m_online = true;
     QString m_offlineName;
     bool m_demo = false;
-    InstancePtr m_instance;
+    BaseInstance* m_instance;
     QWidget* m_parentWidget = nullptr;
     InstanceWindow* m_console = nullptr;
     MinecraftAccountPtr m_accountToUse = nullptr;
     AuthSessionPtr m_session;
-    shared_qobject_ptr<LaunchTask> m_launcher;
+    LaunchTask* m_launcher;
     MinecraftTarget::Ptr m_targetToJoin;
 };

--- a/launcher/NullInstance.h
+++ b/launcher/NullInstance.h
@@ -41,8 +41,8 @@
 class NullInstance : public BaseInstance {
     Q_OBJECT
    public:
-    NullInstance(SettingsObjectPtr globalSettings, SettingsObjectPtr settings, const QString& rootDir)
-        : BaseInstance(globalSettings, settings, rootDir)
+    NullInstance(SettingsObject* globalSettings, std::unique_ptr<SettingsObject> settings, const QString& rootDir)
+        : BaseInstance(globalSettings, std::move(settings), rootDir)
     {
         setVersionBroken(true);
     }
@@ -52,7 +52,7 @@ class NullInstance : public BaseInstance {
     QString getStatusbarDescription() override { return tr("Unknown instance type"); };
     QSet<QString> traits() const override { return {}; };
     QString instanceConfigFolder() const override { return instanceRoot(); };
-    shared_qobject_ptr<LaunchTask> createLaunchTask(AuthSessionPtr, MinecraftTarget::Ptr) override { return nullptr; }
+    LaunchTask* createLaunchTask(AuthSessionPtr, MinecraftTarget::Ptr) override { return nullptr; }
     QList<Task::Ptr> createUpdateTask() override { return {}; }
     QProcessEnvironment createEnvironment() override { return QProcessEnvironment(); }
     QProcessEnvironment createLaunchEnvironment() override { return QProcessEnvironment(); }

--- a/launcher/ResourceDownloadTask.cpp
+++ b/launcher/ResourceDownloadTask.cpp
@@ -31,7 +31,7 @@
 
 ResourceDownloadTask::ResourceDownloadTask(ModPlatform::IndexedPack::Ptr pack,
                                            ModPlatform::IndexedVersion version,
-                                           const std::shared_ptr<ResourceFolderModel> packs,
+                                           ResourceFolderModel* packs,
                                            bool is_indexed)
     : m_pack(std::move(pack)), m_pack_version(std::move(version)), m_pack_model(packs)
 {
@@ -88,7 +88,7 @@ void ResourceDownloadTask::downloadSucceeded()
     m_pack_model->uninstallResource(oldFilename, true);
 
     // also rename the shader config file
-    if (dynamic_cast<ShaderPackFolderModel*>(m_pack_model.get()) != nullptr) {
+    if (dynamic_cast<ShaderPackFolderModel*>(m_pack_model) != nullptr) {
         QFileInfo oldConfig(m_pack_model->dir(), oldFilename + ".txt");
         QFileInfo newConfig(m_pack_model->dir(), getFilename() + ".txt");
 

--- a/launcher/ResourceDownloadTask.h
+++ b/launcher/ResourceDownloadTask.h
@@ -32,7 +32,7 @@ class ResourceDownloadTask : public SequentialTask {
    public:
     explicit ResourceDownloadTask(ModPlatform::IndexedPack::Ptr pack,
                                   ModPlatform::IndexedVersion version,
-                                  std::shared_ptr<ResourceFolderModel> packs,
+                                  ResourceFolderModel* packs,
                                   bool is_indexed = true);
     const QString& getFilename() const { return m_pack_version.fileName; }
     const QVariant& getVersionID() const { return m_pack_version.fileId; }
@@ -44,7 +44,7 @@ class ResourceDownloadTask : public SequentialTask {
    private:
     ModPlatform::IndexedPack::Ptr m_pack;
     ModPlatform::IndexedVersion m_pack_version;
-    const std::shared_ptr<ResourceFolderModel> m_pack_model;
+    ResourceFolderModel* m_pack_model;
 
     NetJob::Ptr m_filesNetJob;
     LocalResourceUpdateTask::Ptr m_update_task;

--- a/launcher/RuntimeContext.h
+++ b/launcher/RuntimeContext.h
@@ -41,7 +41,7 @@ struct RuntimeContext {
         return javaRealArchitecture;
     }
 
-    void updateFromInstanceSettings(SettingsObjectPtr instanceSettings)
+    void updateFromInstanceSettings(SettingsObject* instanceSettings)
     {
         javaArchitecture = instanceSettings->get("JavaArchitecture").toString();
         javaRealArchitecture = instanceSettings->get("JavaRealArchitecture").toString();

--- a/launcher/Usable.h
+++ b/launcher/Usable.h
@@ -36,7 +36,7 @@ class Usable {
  */
 class UseLock {
    public:
-    UseLock(shared_qobject_ptr<Usable> usable) : m_usable(usable)
+    UseLock(Usable* usable) : m_usable(usable)
     {
         // this doesn't use shared pointer use count, because that wouldn't be correct. this count is separate.
         m_usable->incrementUses();
@@ -44,5 +44,5 @@ class UseLock {
     ~UseLock() { m_usable->decrementUses(); }
 
    private:
-    shared_qobject_ptr<Usable> m_usable;
+    Usable* m_usable;
 };

--- a/launcher/java/download/ManifestDownloadTask.cpp
+++ b/launcher/java/download/ManifestDownloadTask.cpp
@@ -41,7 +41,7 @@ void ManifestDownloadTask::executeTask()
     auto download = makeShared<NetJob>(QString("JRE::DownloadJava"), APPLICATION->network());
     auto files = std::make_shared<QByteArray>();
 
-    auto action = Net::Download::makeByteArray(m_url, files);
+    auto action = Net::Download::makeByteArray(m_url, files.get());
     if (!m_checksum_hash.isEmpty() && !m_checksum_type.isEmpty()) {
         auto hashType = QCryptographicHash::Algorithm::Sha1;
         if (m_checksum_type == "sha256") {

--- a/launcher/launch/LaunchTask.cpp
+++ b/launcher/launch/LaunchTask.cpp
@@ -51,14 +51,14 @@ void LaunchTask::init()
     m_instance->setRunning(true);
 }
 
-shared_qobject_ptr<LaunchTask> LaunchTask::create(MinecraftInstancePtr inst)
+std::unique_ptr<LaunchTask> LaunchTask::create(MinecraftInstance* inst)
 {
-    shared_qobject_ptr<LaunchTask> proc(new LaunchTask(inst));
-    proc->init();
-    return proc;
+    auto task = std::unique_ptr<LaunchTask>(new LaunchTask(inst));
+    task->init();
+    return task;
 }
 
-LaunchTask::LaunchTask(MinecraftInstancePtr instance) : m_instance(instance) {}
+LaunchTask::LaunchTask(MinecraftInstance* instance) : m_instance(instance) {}
 
 void LaunchTask::appendStep(shared_qobject_ptr<LaunchStep> step)
 {

--- a/launcher/launch/LaunchTask.h
+++ b/launcher/launch/LaunchTask.h
@@ -39,7 +39,6 @@
 #include <QObjectPtr.h>
 #include <minecraft/MinecraftInstance.h>
 #include <QProcess>
-#include "BaseInstance.h"
 #include "LaunchStep.h"
 #include "LogModel.h"
 #include "MessageLevel.h"
@@ -48,21 +47,21 @@
 class LaunchTask : public Task {
     Q_OBJECT
    protected:
-    explicit LaunchTask(MinecraftInstancePtr instance);
+    explicit LaunchTask(MinecraftInstance* instance);
     void init();
 
    public:
     enum State { NotStarted, Running, Waiting, Failed, Aborted, Finished };
 
    public: /* methods */
-    static shared_qobject_ptr<LaunchTask> create(MinecraftInstancePtr inst);
+    static std::unique_ptr<LaunchTask> create(MinecraftInstance* inst);
     virtual ~LaunchTask() = default;
 
     void appendStep(shared_qobject_ptr<LaunchStep> step);
     void prependStep(shared_qobject_ptr<LaunchStep> step);
     void setCensorFilter(QMap<QString, QString> filter);
 
-    MinecraftInstancePtr instance() { return m_instance; }
+    MinecraftInstance* instance() { return m_instance; }
 
     void setPid(qint64 pid) { m_pid = pid; }
 
@@ -119,7 +118,7 @@ class LaunchTask : public Task {
     bool parseXmlLogs(QString const& line, MessageLevel level);
 
    protected: /* data */
-    MinecraftInstancePtr m_instance;
+    MinecraftInstance* m_instance;
     shared_qobject_ptr<LogModel> m_logModel;
     QList<shared_qobject_ptr<LaunchStep>> m_steps;
     QMap<QString, QString> m_censorFilter;

--- a/launcher/minecraft/MinecraftInstance.h
+++ b/launcher/minecraft/MinecraftInstance.h
@@ -56,8 +56,8 @@ class PackProfile;
 class MinecraftInstance : public BaseInstance {
     Q_OBJECT
    public:
-    MinecraftInstance(SettingsObjectPtr globalSettings, SettingsObjectPtr settings, const QString& rootDir);
-    virtual ~MinecraftInstance() = default;
+    MinecraftInstance(SettingsObject* globalSettings, std::unique_ptr<SettingsObject> settings, const QString& rootDir);
+    virtual ~MinecraftInstance();
     virtual void saveNow() override;
 
     void loadSpecificSettings() override;
@@ -109,22 +109,22 @@ class MinecraftInstance : public BaseInstance {
     void updateRuntimeContext() override;
 
     //////  Profile management //////
-    std::shared_ptr<PackProfile> getPackProfile() const;
+    PackProfile* getPackProfile() const;
 
     //////  Mod Lists  //////
-    std::shared_ptr<ModFolderModel> loaderModList();
-    std::shared_ptr<ModFolderModel> coreModList();
-    std::shared_ptr<ModFolderModel> nilModList();
-    std::shared_ptr<ResourcePackFolderModel> resourcePackList();
-    std::shared_ptr<TexturePackFolderModel> texturePackList();
-    std::shared_ptr<ShaderPackFolderModel> shaderPackList();
-    std::shared_ptr<DataPackFolderModel> dataPackList();
-    QList<std::shared_ptr<ResourceFolderModel>> resourceLists();
-    std::shared_ptr<WorldList> worldList();
+    ModFolderModel* loaderModList();
+    ModFolderModel* coreModList();
+    ModFolderModel* nilModList();
+    ResourcePackFolderModel* resourcePackList();
+    TexturePackFolderModel* texturePackList();
+    ShaderPackFolderModel* shaderPackList();
+    DataPackFolderModel* dataPackList();
+    QList<ResourceFolderModel*> resourceLists();
+    WorldList* worldList();
 
     //////  Launch stuff //////
     QList<Task::Ptr> createUpdateTask() override;
-    shared_qobject_ptr<LaunchTask> createLaunchTask(AuthSessionPtr account, MinecraftTarget::Ptr targetToJoin) override;
+    LaunchTask* createLaunchTask(AuthSessionPtr account, MinecraftTarget::Ptr targetToJoin) override;
     QStringList extraArguments() override;
     QStringList verboseDescription(AuthSessionPtr session, MinecraftTarget::Ptr targetToJoin) override;
     QList<Mod*> getJarMods() const;
@@ -162,15 +162,13 @@ class MinecraftInstance : public BaseInstance {
     QMap<QString, QString> makeProfileVarMapping(std::shared_ptr<LaunchProfile> profile) const;
 
    protected:  // data
-    std::shared_ptr<PackProfile> m_components;
-    mutable std::shared_ptr<ModFolderModel> m_loader_mod_list;
-    mutable std::shared_ptr<ModFolderModel> m_core_mod_list;
-    mutable std::shared_ptr<ModFolderModel> m_nil_mod_list;
-    mutable std::shared_ptr<ResourcePackFolderModel> m_resource_pack_list;
-    mutable std::shared_ptr<ShaderPackFolderModel> m_shader_pack_list;
-    mutable std::shared_ptr<TexturePackFolderModel> m_texture_pack_list;
-    mutable std::shared_ptr<DataPackFolderModel> m_data_pack_list;
-    mutable std::shared_ptr<WorldList> m_world_list;
+    std::unique_ptr<PackProfile> m_components;
+    std::unique_ptr<ModFolderModel> m_loader_mod_list;
+    std::unique_ptr<ModFolderModel> m_core_mod_list;
+    std::unique_ptr<ModFolderModel> m_nil_mod_list;
+    std::unique_ptr<ResourcePackFolderModel> m_resource_pack_list;
+    std::unique_ptr<ShaderPackFolderModel> m_shader_pack_list;
+    std::unique_ptr<TexturePackFolderModel> m_texture_pack_list;
+    std::unique_ptr<DataPackFolderModel> m_data_pack_list;
+    std::unique_ptr<WorldList> m_world_list;
 };
-
-using MinecraftInstancePtr = std::shared_ptr<MinecraftInstance>;

--- a/launcher/minecraft/VanillaInstanceCreationTask.cpp
+++ b/launcher/minecraft/VanillaInstanceCreationTask.cpp
@@ -19,10 +19,10 @@ bool VanillaCreationTask::createInstance()
 {
     setStatus(tr("Creating instance from version %1").arg(m_version->name()));
 
-    auto instance_settings = std::make_shared<INISettingsObject>(FS::PathCombine(m_stagingPath, "instance.cfg"));
+    auto instance_settings = std::make_unique<INISettingsObject>(FS::PathCombine(m_stagingPath, "instance.cfg"));
     instance_settings->suspendSave();
     {
-        MinecraftInstance inst(m_globalSettings, instance_settings, m_stagingPath);
+        MinecraftInstance inst(m_globalSettings, std::move(instance_settings), m_stagingPath);
         auto components = inst.getPackProfile();
         components->buildingFromScratch();
         components->setComponentVersion("net.minecraft", m_version->descriptor(), true);
@@ -31,8 +31,9 @@ bool VanillaCreationTask::createInstance()
 
         inst.setName(name());
         inst.setIconKey(m_instIcon);
+
+        inst.settings()->resumeSave();
     }
-    instance_settings->resumeSave();
 
     return true;
 }

--- a/launcher/minecraft/VanillaInstanceCreationTask.cpp
+++ b/launcher/minecraft/VanillaInstanceCreationTask.cpp
@@ -19,21 +19,17 @@ bool VanillaCreationTask::createInstance()
 {
     setStatus(tr("Creating instance from version %1").arg(m_version->name()));
 
-    auto instance_settings = std::make_unique<INISettingsObject>(FS::PathCombine(m_stagingPath, "instance.cfg"));
-    instance_settings->suspendSave();
-    {
-        MinecraftInstance inst(m_globalSettings, std::move(instance_settings), m_stagingPath);
-        auto components = inst.getPackProfile();
-        components->buildingFromScratch();
-        components->setComponentVersion("net.minecraft", m_version->descriptor(), true);
-        if (m_using_loader)
-            components->setComponentVersion(m_loader, m_loader_version->descriptor());
+    MinecraftInstance inst(m_globalSettings, std::make_unique<INISettingsObject>(FS::PathCombine(m_stagingPath, "instance.cfg")), m_stagingPath);
+    SettingsObject::Lock lock(inst.settings());
 
-        inst.setName(name());
-        inst.setIconKey(m_instIcon);
+    auto components = inst.getPackProfile();
+    components->buildingFromScratch();
+    components->setComponentVersion("net.minecraft", m_version->descriptor(), true);
+    if (m_using_loader)
+        components->setComponentVersion(m_loader, m_loader_version->descriptor());
 
-        inst.settings()->resumeSave();
-    }
+    inst.setName(name());
+    inst.setIconKey(m_instIcon);
 
     return true;
 }

--- a/launcher/minecraft/auth/steps/EntitlementsStep.cpp
+++ b/launcher/minecraft/auth/steps/EntitlementsStep.cpp
@@ -32,8 +32,8 @@ void EntitlementsStep::perform()
                                            { "Authorization", QString("Bearer %1").arg(m_data->yggdrasilToken.token).toUtf8() } };
 
     m_response.reset(new QByteArray());
-    m_request = Net::Download::makeByteArray(url, m_response);
-    m_request->addHeaderProxy(new Net::RawHeaderProxy(headers));
+    m_request = Net::Download::makeByteArray(url, m_response.get());
+    m_request->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(headers));
 
     m_task.reset(new NetJob("EntitlementsStep", APPLICATION->network()));
     m_task->setAskRetry(false);

--- a/launcher/minecraft/auth/steps/EntitlementsStep.h
+++ b/launcher/minecraft/auth/steps/EntitlementsStep.h
@@ -22,7 +22,7 @@ class EntitlementsStep : public AuthStep {
 
    private:
     QString m_entitlements_request_id;
-    std::shared_ptr<QByteArray> m_response;
+    std::unique_ptr<QByteArray> m_response;
     Net::Download::Ptr m_request;
     NetJob::Ptr m_task;
 };

--- a/launcher/minecraft/auth/steps/GetSkinStep.cpp
+++ b/launcher/minecraft/auth/steps/GetSkinStep.cpp
@@ -17,7 +17,7 @@ void GetSkinStep::perform()
     QUrl url(m_data->minecraftProfile.skin.url);
 
     m_response.reset(new QByteArray());
-    m_request = Net::Download::makeByteArray(url, m_response);
+    m_request = Net::Download::makeByteArray(url, m_response.get());
 
     m_task.reset(new NetJob("GetSkinStep", APPLICATION->network()));
     m_task->setAskRetry(false);

--- a/launcher/minecraft/auth/steps/GetSkinStep.h
+++ b/launcher/minecraft/auth/steps/GetSkinStep.h
@@ -21,7 +21,7 @@ class GetSkinStep : public AuthStep {
     void onRequestDone();
 
    private:
-    std::shared_ptr<QByteArray> m_response;
+    std::unique_ptr<QByteArray> m_response;
     Net::Download::Ptr m_request;
     NetJob::Ptr m_task;
 };

--- a/launcher/minecraft/auth/steps/LauncherLoginStep.cpp
+++ b/launcher/minecraft/auth/steps/LauncherLoginStep.cpp
@@ -37,8 +37,8 @@ void LauncherLoginStep::perform()
     };
 
     m_response.reset(new QByteArray());
-    m_request = Net::Upload::makeByteArray(url, m_response, requestBody.toUtf8());
-    m_request->addHeaderProxy(new Net::RawHeaderProxy(headers));
+    m_request = Net::Upload::makeByteArray(url, m_response.get(), requestBody.toUtf8());
+    m_request->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(headers));
 
     m_task.reset(new NetJob("LauncherLoginStep", APPLICATION->network()));
     m_task->setAskRetry(false);

--- a/launcher/minecraft/auth/steps/LauncherLoginStep.h
+++ b/launcher/minecraft/auth/steps/LauncherLoginStep.h
@@ -21,7 +21,7 @@ class LauncherLoginStep : public AuthStep {
     void onRequestDone();
 
    private:
-    std::shared_ptr<QByteArray> m_response;
+    std::unique_ptr<QByteArray> m_response;
     Net::Upload::Ptr m_request;
     NetJob::Ptr m_task;
 };

--- a/launcher/minecraft/auth/steps/MSADeviceCodeStep.cpp
+++ b/launcher/minecraft/auth/steps/MSADeviceCodeStep.cpp
@@ -67,8 +67,8 @@ void MSADeviceCodeStep::perform()
         { "Accept", "application/json" },
     };
     m_response.reset(new QByteArray());
-    m_request = Net::Upload::makeByteArray(url, m_response, payload);
-    m_request->addHeaderProxy(new Net::RawHeaderProxy(headers));
+    m_request = Net::Upload::makeByteArray(url, m_response.get(), payload);
+    m_request->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(headers));
 
     m_task.reset(new NetJob("MSADeviceCodeStep", APPLICATION->network()));
     m_task->setAskRetry(false);
@@ -181,8 +181,8 @@ void MSADeviceCodeStep::authenticateUser()
         { "Accept", "application/json" },
     };
     m_response.reset(new QByteArray());
-    m_request = Net::Upload::makeByteArray(url, m_response, payload);
-    m_request->addHeaderProxy(new Net::RawHeaderProxy(headers));
+    m_request = Net::Upload::makeByteArray(url, m_response.get(), payload);
+    m_request->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(headers));
 
     connect(m_request.get(), &Task::finished, this, &MSADeviceCodeStep::authenticationFinished);
 

--- a/launcher/minecraft/auth/steps/MSADeviceCodeStep.h
+++ b/launcher/minecraft/auth/steps/MSADeviceCodeStep.h
@@ -72,7 +72,7 @@ class MSADeviceCodeStep : public AuthStep {
     QTimer m_pool_timer;
     QTimer m_expiration_timer;
 
-    std::shared_ptr<QByteArray> m_response;
+    std::unique_ptr<QByteArray> m_response;
     Net::Upload::Ptr m_request;
     NetJob::Ptr m_task;
 };

--- a/launcher/minecraft/auth/steps/MSAStep.cpp
+++ b/launcher/minecraft/auth/steps/MSAStep.cpp
@@ -107,7 +107,7 @@ MSAStep::MSAStep(AccountData* data, bool silent) : AuthStep(data), m_silent(sile
     m_oauth2.setAccessTokenUrl(QUrl("https://login.microsoftonline.com/consumers/oauth2/v2.0/token"));
     m_oauth2.setScope("XboxLive.SignIn XboxLive.offline_access");
     m_oauth2.setClientIdentifier(m_clientId);
-    m_oauth2.setNetworkAccessManager(APPLICATION->network().get());
+    m_oauth2.setNetworkAccessManager(APPLICATION->network());
 
     connect(&m_oauth2, &QOAuth2AuthorizationCodeFlow::granted, this, [this] {
         m_data->msaClientID = m_oauth2.clientIdentifier();

--- a/launcher/minecraft/auth/steps/MinecraftProfileStep.cpp
+++ b/launcher/minecraft/auth/steps/MinecraftProfileStep.cpp
@@ -22,8 +22,8 @@ void MinecraftProfileStep::perform()
                                            { "Authorization", QString("Bearer %1").arg(m_data->yggdrasilToken.token).toUtf8() } };
 
     m_response.reset(new QByteArray());
-    m_request = Net::Download::makeByteArray(url, m_response);
-    m_request->addHeaderProxy(new Net::RawHeaderProxy(headers));
+    m_request = Net::Download::makeByteArray(url, m_response.get());
+    m_request->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(headers));
 
     m_task.reset(new NetJob("MinecraftProfileStep", APPLICATION->network()));
     m_task->setAskRetry(false);

--- a/launcher/minecraft/auth/steps/MinecraftProfileStep.h
+++ b/launcher/minecraft/auth/steps/MinecraftProfileStep.h
@@ -21,7 +21,7 @@ class MinecraftProfileStep : public AuthStep {
     void onRequestDone();
 
    private:
-    std::shared_ptr<QByteArray> m_response;
+    std::unique_ptr<QByteArray> m_response;
     Net::Download::Ptr m_request;
     NetJob::Ptr m_task;
 };

--- a/launcher/minecraft/auth/steps/XboxAuthorizationStep.cpp
+++ b/launcher/minecraft/auth/steps/XboxAuthorizationStep.cpp
@@ -42,8 +42,8 @@ void XboxAuthorizationStep::perform()
         { "Accept", "application/json" },
     };
     m_response.reset(new QByteArray());
-    m_request = Net::Upload::makeByteArray(url, m_response, xbox_auth_data.toUtf8());
-    m_request->addHeaderProxy(new Net::RawHeaderProxy(headers));
+    m_request = Net::Upload::makeByteArray(url, m_response.get(), xbox_auth_data.toUtf8());
+    m_request->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(headers));
 
     m_task.reset(new NetJob("XboxAuthorizationStep", APPLICATION->network()));
     m_task->setAskRetry(false);

--- a/launcher/minecraft/auth/steps/XboxAuthorizationStep.h
+++ b/launcher/minecraft/auth/steps/XboxAuthorizationStep.h
@@ -28,7 +28,7 @@ class XboxAuthorizationStep : public AuthStep {
     QString m_relyingParty;
     QString m_authorizationKind;
 
-    std::shared_ptr<QByteArray> m_response;
+    std::unique_ptr<QByteArray> m_response;
     Net::Upload::Ptr m_request;
     NetJob::Ptr m_task;
 };

--- a/launcher/minecraft/auth/steps/XboxProfileStep.cpp
+++ b/launcher/minecraft/auth/steps/XboxProfileStep.cpp
@@ -34,8 +34,8 @@ void XboxProfileStep::perform()
     };
 
     m_response.reset(new QByteArray());
-    m_request = Net::Download::makeByteArray(url, m_response);
-    m_request->addHeaderProxy(new Net::RawHeaderProxy(headers));
+    m_request = Net::Download::makeByteArray(url, m_response.get());
+    m_request->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(headers));
 
     m_task.reset(new NetJob("XboxProfileStep", APPLICATION->network()));
     m_task->setAskRetry(false);

--- a/launcher/minecraft/auth/steps/XboxProfileStep.h
+++ b/launcher/minecraft/auth/steps/XboxProfileStep.h
@@ -21,7 +21,7 @@ class XboxProfileStep : public AuthStep {
     void onRequestDone();
 
    private:
-    std::shared_ptr<QByteArray> m_response;
+    std::unique_ptr<QByteArray> m_response;
     Net::Download::Ptr m_request;
     NetJob::Ptr m_task;
 };

--- a/launcher/minecraft/auth/steps/XboxUserStep.cpp
+++ b/launcher/minecraft/auth/steps/XboxUserStep.cpp
@@ -38,8 +38,8 @@ void XboxUserStep::perform()
         { "x-xbl-contract-version", "1" }
     };
     m_response.reset(new QByteArray());
-    m_request = Net::Upload::makeByteArray(url, m_response, xbox_auth_data.toUtf8());
-    m_request->addHeaderProxy(new Net::RawHeaderProxy(headers));
+    m_request = Net::Upload::makeByteArray(url, m_response.get(), xbox_auth_data.toUtf8());
+    m_request->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(headers));
 
     m_task.reset(new NetJob("XboxUserStep", APPLICATION->network()));
     m_task->setAskRetry(false);

--- a/launcher/minecraft/auth/steps/XboxUserStep.h
+++ b/launcher/minecraft/auth/steps/XboxUserStep.h
@@ -21,7 +21,7 @@ class XboxUserStep : public AuthStep {
     void onRequestDone();
 
    private:
-    std::shared_ptr<QByteArray> m_response;
+    std::unique_ptr<QByteArray> m_response;
     Net::Upload::Ptr m_request;
     NetJob::Ptr m_task;
 };

--- a/launcher/minecraft/launch/AutoInstallJava.h
+++ b/launcher/minecraft/launch/AutoInstallJava.h
@@ -59,7 +59,7 @@ class AutoInstallJava : public LaunchStep {
     void tryNextMajorJava();
 
    private:
-    MinecraftInstancePtr m_instance;
+    MinecraftInstance* m_instance;
     Task::Ptr m_current_task;
 
     qsizetype m_majorJavaVersionIndex = 0;

--- a/launcher/minecraft/launch/ClaimAccount.cpp
+++ b/launcher/minecraft/launch/ClaimAccount.cpp
@@ -15,7 +15,7 @@ ClaimAccount::ClaimAccount(LaunchTask* parent, AuthSessionPtr session) : LaunchS
 void ClaimAccount::executeTask()
 {
     if (m_account) {
-        lock.reset(new UseLock(m_account));
+        lock.reset(new UseLock(m_account.get()));
         emitSucceeded();
     }
 }

--- a/launcher/minecraft/launch/ScanModFolders.cpp
+++ b/launcher/minecraft/launch/ScanModFolders.cpp
@@ -45,19 +45,19 @@ void ScanModFolders::executeTask()
     auto m_inst = m_parent->instance();
 
     auto loaders = m_inst->loaderModList();
-    connect(loaders.get(), &ModFolderModel::updateFinished, this, &ScanModFolders::modsDone);
+    connect(loaders, &ModFolderModel::updateFinished, this, &ScanModFolders::modsDone);
     if (!loaders->update()) {
         m_modsDone = true;
     }
 
     auto cores = m_inst->coreModList();
-    connect(cores.get(), &ModFolderModel::updateFinished, this, &ScanModFolders::coreModsDone);
+    connect(cores, &ModFolderModel::updateFinished, this, &ScanModFolders::coreModsDone);
     if (!cores->update()) {
         m_coreModsDone = true;
     }
 
     auto nils = m_inst->nilModList();
-    connect(nils.get(), &ModFolderModel::updateFinished, this, &ScanModFolders::nilModsDone);
+    connect(nils, &ModFolderModel::updateFinished, this, &ScanModFolders::nilModsDone);
     if (!nils->update()) {
         m_nilModsDone = true;
     }

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -175,7 +175,7 @@ void ResourceFolderModel::installResourceWithFlameMetadata(QString path, ModPlat
         };
 
         auto response = std::make_shared<QByteArray>();
-        auto job = FlameAPI().getProject(vers.addonId.toString(), response);
+        auto job = FlameAPI().getProject(vers.addonId.toString(), response.get());
         connect(job.get(), &Task::failed, this, install);
         connect(job.get(), &Task::aborted, this, install);
         connect(job.get(), &Task::succeeded, [response, this, &vers, install, &pack] {

--- a/launcher/minecraft/mod/tasks/GetModDependenciesTask.cpp
+++ b/launcher/minecraft/mod/tasks/GetModDependenciesTask.cpp
@@ -135,7 +135,7 @@ Task::Ptr GetModDependenciesTask::getProjectInfoTask(std::shared_ptr<PackDepende
 {
     auto provider = pDep->pack->provider;
     auto responseInfo = std::make_shared<QByteArray>();
-    auto info = getAPI(provider)->getProject(pDep->pack->addonId.toString(), responseInfo);
+    auto info = getAPI(provider)->getProject(pDep->pack->addonId.toString(), responseInfo.get());
     connect(info.get(), &NetJob::succeeded, [this, responseInfo, provider, pDep] {
         QJsonParseError parse_error{};
         QJsonDocument doc = QJsonDocument::fromJson(*responseInfo, &parse_error);

--- a/launcher/minecraft/skins/CapeChange.cpp
+++ b/launcher/minecraft/skins/CapeChange.cpp
@@ -37,8 +37,7 @@
 #include "CapeChange.h"
 
 #include <memory>
-
-#include "net/ByteArraySink.h"
+#include <net/DummySink.h>
 #include "net/RawHeaderProxy.h"
 
 CapeChange::CapeChange(QString cape) : NetRequest(), m_capeId(cape)
@@ -62,7 +61,7 @@ CapeChange::Ptr CapeChange::make(QString token, QString capeId)
     auto up = makeShared<CapeChange>(capeId);
     up->m_url = QUrl("https://api.minecraftservices.com/minecraft/profile/capes/active");
     up->setObjectName(QString("BYTES:") + up->m_url.toString());
-    up->m_sink.reset(new Net::ByteArraySink(new QByteArray()));
+    up->m_sink.reset(new Net::DummySink());
     up->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(QList<Net::HeaderPair>{
         { "Authorization", QString("Bearer %1").arg(token).toLocal8Bit() },
     }));

--- a/launcher/minecraft/skins/CapeChange.cpp
+++ b/launcher/minecraft/skins/CapeChange.cpp
@@ -62,8 +62,8 @@ CapeChange::Ptr CapeChange::make(QString token, QString capeId)
     auto up = makeShared<CapeChange>(capeId);
     up->m_url = QUrl("https://api.minecraftservices.com/minecraft/profile/capes/active");
     up->setObjectName(QString("BYTES:") + up->m_url.toString());
-    up->m_sink.reset(new Net::ByteArraySink(std::make_shared<QByteArray>()));
-    up->addHeaderProxy(new Net::RawHeaderProxy(QList<Net::HeaderPair>{
+    up->m_sink.reset(new Net::ByteArraySink(new QByteArray()));
+    up->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(QList<Net::HeaderPair>{
         { "Authorization", QString("Bearer %1").arg(token).toLocal8Bit() },
     }));
     return up;

--- a/launcher/minecraft/skins/SkinDelete.cpp
+++ b/launcher/minecraft/skins/SkinDelete.cpp
@@ -36,7 +36,7 @@
 
 #include "SkinDelete.h"
 
-#include "net/ByteArraySink.h"
+#include <net/DummySink.h>
 #include "net/RawHeaderProxy.h"
 
 SkinDelete::SkinDelete() : NetRequest()
@@ -54,8 +54,8 @@ SkinDelete::Ptr SkinDelete::make(QString token)
 {
     auto up = makeShared<SkinDelete>();
     up->m_url = QUrl("https://api.minecraftservices.com/minecraft/profile/skins/active");
-    up->m_sink.reset(new Net::ByteArraySink(std::make_shared<QByteArray>()));
-    up->addHeaderProxy(new Net::RawHeaderProxy(QList<Net::HeaderPair>{
+    up->m_sink.reset(new Net::DummySink());
+    up->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(QList<Net::HeaderPair>{
         { "Authorization", QString("Bearer %1").arg(token).toLocal8Bit() },
     }));
     return up;

--- a/launcher/minecraft/skins/SkinUpload.cpp
+++ b/launcher/minecraft/skins/SkinUpload.cpp
@@ -39,7 +39,7 @@
 #include <QHttpMultiPart>
 
 #include "FileSystem.h"
-#include "net/ByteArraySink.h"
+#include "net/DummySink.h"
 #include "net/RawHeaderProxy.h"
 
 SkinUpload::SkinUpload(QString path, QString variant) : NetRequest(), m_path(path), m_variant(variant)
@@ -72,8 +72,8 @@ SkinUpload::Ptr SkinUpload::make(QString token, QString path, QString variant)
     auto up = makeShared<SkinUpload>(path, variant);
     up->m_url = QUrl("https://api.minecraftservices.com/minecraft/profile/skins");
     up->setObjectName(QString("BYTES:") + up->m_url.toString());
-    up->m_sink.reset(new Net::ByteArraySink(std::make_shared<QByteArray>()));
-    up->addHeaderProxy(new Net::RawHeaderProxy(QList<Net::HeaderPair>{
+    up->m_sink.reset(new Net::DummySink());
+    up->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(QList<Net::HeaderPair>{
         { "Authorization", QString("Bearer %1").arg(token).toLocal8Bit() },
     }));
     return up;

--- a/launcher/minecraft/update/LibrariesTask.cpp
+++ b/launcher/minecraft/update/LibrariesTask.cpp
@@ -31,7 +31,7 @@ void LibrariesTask::executeTask()
                 emitFailed(tr("Null jar is specified in the metadata, aborting."));
                 return false;
             }
-            auto dls = lib->getDownloads(inst->runtimeContext(), metacache.get(), errors, localPath);
+            auto dls = lib->getDownloads(inst->runtimeContext(), metacache, errors, localPath);
             for (auto dl : dls) {
                 downloadJob->addNetAction(dl);
             }

--- a/launcher/modplatform/CheckUpdateTask.h
+++ b/launcher/modplatform/CheckUpdateTask.h
@@ -14,12 +14,12 @@ class CheckUpdateTask : public Task {
     CheckUpdateTask(QList<Resource*>& resources,
                     std::list<Version>& mcVersions,
                     QList<ModPlatform::ModLoaderType> loadersList,
-                    std::shared_ptr<ResourceFolderModel> resourceModel)
+                    ResourceFolderModel* resourceModel)
         : Task()
         , m_resources(resources)
         , m_gameVersions(mcVersions)
         , m_loadersList(std::move(loadersList))
-        , m_resourceModel(std::move(resourceModel))
+        , m_resourceModel(resourceModel)
     {}
 
     struct Update {
@@ -71,7 +71,7 @@ class CheckUpdateTask : public Task {
     QList<Resource*>& m_resources;
     std::list<Version>& m_gameVersions;
     QList<ModPlatform::ModLoaderType> m_loadersList;
-    std::shared_ptr<ResourceFolderModel> m_resourceModel;
+    ResourceFolderModel* m_resourceModel;
 
     std::vector<Update> m_updates;
     QList<std::shared_ptr<GetModDependenciesTask::PackDependency>> m_deps;

--- a/launcher/modplatform/EnsureMetadataTask.cpp
+++ b/launcher/modplatform/EnsureMetadataTask.cpp
@@ -216,7 +216,7 @@ Task::Ptr EnsureMetadataTask::modrinthVersionsTask()
     auto hash_type = ModPlatform::ProviderCapabilities::hashType(ModPlatform::ResourceProvider::MODRINTH).first();
 
     auto response = std::make_shared<QByteArray>();
-    auto ver_task = modrinth_api.currentVersions(m_resources.keys(), hash_type, response);
+    auto ver_task = modrinth_api.currentVersions(m_resources.keys(), hash_type, response.get());
 
     // Prevents unfortunate timings when aborting the task
     if (!ver_task)
@@ -273,9 +273,9 @@ Task::Ptr EnsureMetadataTask::modrinthProjectsTask()
     if (addonIds.isEmpty()) {
         qWarning() << "No addonId found!";
     } else if (addonIds.size() == 1) {
-        proj_task = modrinth_api.getProject(*addonIds.keyBegin(), response);
+        proj_task = modrinth_api.getProject(*addonIds.keyBegin(), response.get());
     } else {
-        proj_task = modrinth_api.getProjects(addonIds.keys(), response);
+        proj_task = modrinth_api.getProjects(addonIds.keys(), response.get());
     }
 
     // Prevents unfortunate timings when aborting the task
@@ -348,7 +348,7 @@ Task::Ptr EnsureMetadataTask::flameVersionsTask()
         fingerprints.push_back(murmur.toUInt());
     }
 
-    auto ver_task = flame_api.matchFingerprints(fingerprints, response);
+    auto ver_task = flame_api.matchFingerprints(fingerprints, response.get());
 
     connect(ver_task.get(), &Task::succeeded, this, [this, response] {
         QJsonParseError parse_error{};
@@ -423,9 +423,9 @@ Task::Ptr EnsureMetadataTask::flameProjectsTask()
     if (addonIds.isEmpty()) {
         qWarning() << "No addonId found!";
     } else if (addonIds.size() == 1) {
-        proj_task = flame_api.getProject(*addonIds.keyBegin(), response);
+        proj_task = flame_api.getProject(*addonIds.keyBegin(), response.get());
     } else {
-        proj_task = flame_api.getProjects(addonIds.keys(), response);
+        proj_task = flame_api.getProjects(addonIds.keys(), response.get());
     }
 
     // Prevents unfortunate timings when aborting the task

--- a/launcher/modplatform/ResourceAPI.cpp
+++ b/launcher/modplatform/ResourceAPI.cpp
@@ -21,7 +21,7 @@ Task::Ptr ResourceAPI::searchProjects(SearchArgs&& args, Callback<QList<ModPlatf
     auto response = std::make_shared<QByteArray>();
     auto netJob = makeShared<NetJob>(QString("%1::Search").arg(debugName()), APPLICATION->network());
 
-    netJob->addNetAction(Net::ApiDownload::makeByteArray(QUrl(search_url), response));
+    netJob->addNetAction(Net::ApiDownload::makeByteArray(QUrl(search_url), response.get()));
 
     QObject::connect(netJob.get(), &NetJob::succeeded, [this, response, callbacks] {
         QJsonParseError parse_error{};
@@ -86,7 +86,7 @@ Task::Ptr ResourceAPI::getProjectVersions(VersionSearchArgs&& args, Callback<QVe
     auto netJob = makeShared<NetJob>(QString("%1::Versions").arg(args.pack->name), APPLICATION->network());
     auto response = std::make_shared<QByteArray>();
 
-    netJob->addNetAction(Net::ApiDownload::makeByteArray(versions_url, response));
+    netJob->addNetAction(Net::ApiDownload::makeByteArray(versions_url, response.get()));
 
     QObject::connect(netJob.get(), &NetJob::succeeded, [this, response, callbacks, args] {
         QJsonParseError parse_error{};
@@ -149,7 +149,7 @@ Task::Ptr ResourceAPI::getProjectVersions(VersionSearchArgs&& args, Callback<QVe
 Task::Ptr ResourceAPI::getProjectInfo(ProjectInfoArgs&& args, Callback<ModPlatform::IndexedPack::Ptr>&& callbacks) const
 {
     auto response = std::make_shared<QByteArray>();
-    auto job = getProject(args.pack->addonId.toString(), response);
+    auto job = getProject(args.pack->addonId.toString(), response.get());
 
     QObject::connect(job.get(), &NetJob::succeeded, [this, response, callbacks, args] {
         auto pack = args.pack;
@@ -206,7 +206,7 @@ Task::Ptr ResourceAPI::getDependencyVersion(DependencySearchArgs&& args, Callbac
     auto netJob = makeShared<NetJob>(QString("%1::Dependency").arg(args.dependency.addonId.toString()), APPLICATION->network());
     auto response = std::make_shared<QByteArray>();
 
-    netJob->addNetAction(Net::ApiDownload::makeByteArray(versions_url, response));
+    netJob->addNetAction(Net::ApiDownload::makeByteArray(versions_url, response.get()));
 
     QObject::connect(netJob.get(), &NetJob::succeeded, [this, response, callbacks, args] {
         QJsonParseError parse_error{};
@@ -284,7 +284,7 @@ QString ResourceAPI::mapMCVersionToModrinth(Version v) const
     return verStr;
 }
 
-Task::Ptr ResourceAPI::getProject(QString addonId, std::shared_ptr<QByteArray> response) const
+Task::Ptr ResourceAPI::getProject(QString addonId, QByteArray* response) const
 {
     auto project_url_optional = getInfoURL(addonId);
     if (!project_url_optional.has_value())

--- a/launcher/modplatform/ResourceAPI.h
+++ b/launcher/modplatform/ResourceAPI.h
@@ -112,8 +112,8 @@ class ResourceAPI {
    public slots:
     virtual Task::Ptr searchProjects(SearchArgs&&, Callback<QList<ModPlatform::IndexedPack::Ptr>>&&) const;
 
-    virtual Task::Ptr getProject(QString addonId, std::shared_ptr<QByteArray> response) const;
-    virtual Task::Ptr getProjects(QStringList addonIds, std::shared_ptr<QByteArray> response) const = 0;
+    virtual Task::Ptr getProject(QString addonId, QByteArray* response) const;
+    virtual Task::Ptr getProjects(QStringList addonIds, QByteArray* response) const = 0;
 
     virtual Task::Ptr getProjectInfo(ProjectInfoArgs&&, Callback<ModPlatform::IndexedPack::Ptr>&&) const;
     Task::Ptr getProjectVersions(VersionSearchArgs&& args, Callback<QVector<ModPlatform::IndexedVersion>>&& callbacks) const;

--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
@@ -988,10 +988,9 @@ void PackInstallTask::install()
     setStatus(tr("Installing modpack"));
 
     auto instanceConfigPath = FS::PathCombine(m_stagingPath, "instance.cfg");
-    auto instanceSettings = std::make_unique<INISettingsObject>(instanceConfigPath);
-    instanceSettings->suspendSave();
+    MinecraftInstance instance(m_globalSettings, std::make_unique<INISettingsObject>(instanceConfigPath), m_stagingPath);
+    SettingsObject::Lock lock(instance.settings());
 
-    MinecraftInstance instance(m_globalSettings, std::move(instanceSettings), m_stagingPath);
     auto components = instance.getPackProfile();
     components->buildingFromScratch();
 
@@ -1047,7 +1046,6 @@ void PackInstallTask::install()
     instance.setName(name());
     instance.setIconKey(m_instIcon);
     instance.setManagedPack("atlauncher", m_pack_safe_name, m_pack_name, m_version_name, m_version_name);
-    instance.settings()->resumeSave();
 
     jarmods.clear();
     emitSucceeded();

--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
@@ -87,7 +87,7 @@ void PackInstallTask::executeTask()
     NetJob::Ptr netJob{ new NetJob("ATLauncher::VersionFetch", APPLICATION->network()) };
     auto searchUrl =
         QString(BuildConfig.ATL_DOWNLOAD_SERVER_URL + "packs/%1/versions/%2/Configs.json").arg(m_pack_safe_name).arg(m_version_name);
-    netJob->addNetAction(Net::ApiDownload::makeByteArray(QUrl(searchUrl), response));
+    netJob->addNetAction(Net::ApiDownload::makeByteArray(QUrl(searchUrl), response.get()));
 
     connect(netJob.get(), &NetJob::succeeded, this, &PackInstallTask::onDownloadSucceeded);
     connect(netJob.get(), &NetJob::failed, this, &PackInstallTask::onDownloadFailed);
@@ -423,7 +423,7 @@ QString PackInstallTask::detectLibrary(const VersionLibrary& library)
     return "org.multimc.atlauncher:" + library.md5 + ":1";
 }
 
-bool PackInstallTask::createLibrariesComponent(QString instanceRoot, std::shared_ptr<PackProfile> profile)
+bool PackInstallTask::createLibrariesComponent(QString instanceRoot, PackProfile* profile)
 {
     if (m_version.libraries.isEmpty()) {
         return true;
@@ -532,11 +532,11 @@ bool PackInstallTask::createLibrariesComponent(QString instanceRoot, std::shared
     file.write(OneSixVersionFormat::versionFileToJson(f).toJson());
     file.close();
 
-    profile->appendComponent(ComponentPtr{ new Component(profile.get(), target_id, f) });
+    profile->appendComponent(ComponentPtr{ new Component(profile, target_id, f) });
     return true;
 }
 
-bool PackInstallTask::createPackComponent(QString instanceRoot, std::shared_ptr<PackProfile> profile)
+bool PackInstallTask::createPackComponent(QString instanceRoot, PackProfile* profile)
 {
     if (m_version.mainClass.mainClass.isEmpty() && m_version.extraArguments.arguments.isEmpty()) {
         return true;
@@ -621,7 +621,7 @@ bool PackInstallTask::createPackComponent(QString instanceRoot, std::shared_ptr<
     file.write(OneSixVersionFormat::versionFileToJson(f).toJson());
     file.close();
 
-    profile->appendComponent(ComponentPtr{ new Component(profile.get(), target_id, f) });
+    profile->appendComponent(ComponentPtr{ new Component(profile, target_id, f) });
     return true;
 }
 
@@ -988,10 +988,10 @@ void PackInstallTask::install()
     setStatus(tr("Installing modpack"));
 
     auto instanceConfigPath = FS::PathCombine(m_stagingPath, "instance.cfg");
-    auto instanceSettings = std::make_shared<INISettingsObject>(instanceConfigPath);
+    auto instanceSettings = std::make_unique<INISettingsObject>(instanceConfigPath);
     instanceSettings->suspendSave();
 
-    MinecraftInstance instance(m_globalSettings, instanceSettings, m_stagingPath);
+    MinecraftInstance instance(m_globalSettings, std::move(instanceSettings), m_stagingPath);
     auto components = instance.getPackProfile();
     components->buildingFromScratch();
 
@@ -1047,7 +1047,7 @@ void PackInstallTask::install()
     instance.setName(name());
     instance.setIconKey(m_instIcon);
     instance.setManagedPack("atlauncher", m_pack_safe_name, m_pack_name, m_version_name, m_version_name);
-    instanceSettings->resumeSave();
+    instance.settings()->resumeSave();
 
     jarmods.clear();
     emitSucceeded();

--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.h
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.h
@@ -107,8 +107,8 @@ class PackInstallTask : public InstanceTask {
     QString getVersionForLoader(QString uid);
     QString detectLibrary(const VersionLibrary& library);
 
-    bool createLibrariesComponent(QString instanceRoot, std::shared_ptr<PackProfile> profile);
-    bool createPackComponent(QString instanceRoot, std::shared_ptr<PackProfile> profile);
+    bool createLibrariesComponent(QString instanceRoot, PackProfile* profile);
+    bool createPackComponent(QString instanceRoot, PackProfile* profile);
 
     void deleteExistingFiles();
     void installConfigs();
@@ -125,7 +125,7 @@ class PackInstallTask : public InstanceTask {
     bool abortable = false;
 
     NetJob::Ptr jobPtr;
-    std::shared_ptr<QByteArray> response = std::make_shared<QByteArray>();
+    std::unique_ptr<QByteArray> response = std::make_unique<QByteArray>();
 
     InstallMode m_install_mode;
     QString m_pack_name;

--- a/launcher/modplatform/flame/FileResolvingTask.cpp
+++ b/launcher/modplatform/flame/FileResolvingTask.cpp
@@ -57,7 +57,7 @@ void Flame::FileResolvingTask::executeTask()
     for (auto file : m_manifest.files) {
         fileIds.push_back(QString::number(file.fileId));
     }
-    m_task = flameAPI.getFiles(fileIds, m_result);
+    m_task = flameAPI.getFiles(fileIds, m_result.get());
 
     auto step_progress = std::make_shared<TaskStepProgress>();
     connect(m_task.get(), &Task::finished, this, [this, step_progress]() {
@@ -154,7 +154,7 @@ void Flame::FileResolvingTask::netJobFinished()
         return;
     }
     m_result.reset(new QByteArray());
-    m_task = modrinthAPI.currentVersions(hashes, "sha1", m_result);
+    m_task = modrinthAPI.currentVersions(hashes, "sha1", m_result.get());
     (dynamic_cast<NetJob*>(m_task.get()))->setAskRetry(false);
     auto step_progress = std::make_shared<TaskStepProgress>();
     connect(m_task.get(), &Task::finished, this, [this, step_progress]() {
@@ -227,7 +227,7 @@ void Flame::FileResolvingTask::getFlameProjects()
         addonIds.push_back(QString::number(file.projectId));
     }
 
-    m_task = flameAPI.getProjects(addonIds, m_result);
+    m_task = flameAPI.getProjects(addonIds, m_result.get());
 
     auto step_progress = std::make_shared<TaskStepProgress>();
     connect(m_task.get(), &Task::succeeded, this, [this, step_progress] {

--- a/launcher/modplatform/flame/FileResolvingTask.h
+++ b/launcher/modplatform/flame/FileResolvingTask.h
@@ -43,7 +43,7 @@ class FileResolvingTask : public Task {
 
    private: /* data */
     Flame::Manifest m_manifest;
-    std::shared_ptr<QByteArray> m_result;
+    std::unique_ptr<QByteArray> m_result;
     Task::Ptr m_task;
 };
 }  // namespace Flame

--- a/launcher/modplatform/flame/FlameAPI.cpp
+++ b/launcher/modplatform/flame/FlameAPI.cpp
@@ -15,7 +15,7 @@
 #include "net/ApiUpload.h"
 #include "net/NetJob.h"
 
-Task::Ptr FlameAPI::matchFingerprints(const QList<uint>& fingerprints, std::shared_ptr<QByteArray> response)
+Task::Ptr FlameAPI::matchFingerprints(const QList<uint>& fingerprints, QByteArray* response)
 {
     auto netJob = makeShared<NetJob>(QString("Flame::MatchFingerprints"), APPLICATION->network());
 
@@ -45,7 +45,7 @@ QString FlameAPI::getModFileChangelog(int modId, int fileId)
     netJob->addNetAction(Net::ApiDownload::makeByteArray(
         QString(BuildConfig.FLAME_BASE_URL + "/mods/%1/files/%2/changelog")
             .arg(QString::fromStdString(std::to_string(modId)), QString::fromStdString(std::to_string(fileId))),
-        response));
+        response.get()));
 
     QObject::connect(netJob.get(), &NetJob::succeeded, [&netJob, response, &changelog] {
         QJsonParseError parse_error{};
@@ -78,7 +78,7 @@ QString FlameAPI::getModDescription(int modId)
     auto netJob = makeShared<NetJob>(QString("Flame::ModDescription"), APPLICATION->network());
     auto response = std::make_shared<QByteArray>();
     netJob->addNetAction(Net::ApiDownload::makeByteArray(
-        QString(BuildConfig.FLAME_BASE_URL + "/mods/%1/description").arg(QString::number(modId)), response));
+        QString(BuildConfig.FLAME_BASE_URL + "/mods/%1/description").arg(QString::number(modId)), response.get()));
 
     QObject::connect(netJob.get(), &NetJob::succeeded, [&netJob, response, &description] {
         QJsonParseError parse_error{};
@@ -103,7 +103,7 @@ QString FlameAPI::getModDescription(int modId)
     return description;
 }
 
-Task::Ptr FlameAPI::getProjects(QStringList addonIds, std::shared_ptr<QByteArray> response) const
+Task::Ptr FlameAPI::getProjects(QStringList addonIds, QByteArray* response) const
 {
     auto netJob = makeShared<NetJob>(QString("Flame::GetProjects"), APPLICATION->network());
 
@@ -125,7 +125,7 @@ Task::Ptr FlameAPI::getProjects(QStringList addonIds, std::shared_ptr<QByteArray
     return netJob;
 }
 
-Task::Ptr FlameAPI::getFiles(const QStringList& fileIds, std::shared_ptr<QByteArray> response) const
+Task::Ptr FlameAPI::getFiles(const QStringList& fileIds, QByteArray* response) const
 {
     auto netJob = makeShared<NetJob>(QString("Flame::GetFiles"), APPLICATION->network());
 
@@ -147,7 +147,7 @@ Task::Ptr FlameAPI::getFiles(const QStringList& fileIds, std::shared_ptr<QByteAr
     return netJob;
 }
 
-Task::Ptr FlameAPI::getFile(const QString& addonId, const QString& fileId, std::shared_ptr<QByteArray> response) const
+Task::Ptr FlameAPI::getFile(const QString& addonId, const QString& fileId, QByteArray* response) const
 {
     auto netJob = makeShared<NetJob>(QString("Flame::GetFile"), APPLICATION->network());
     netJob->addNetAction(
@@ -171,7 +171,7 @@ QList<ResourceAPI::SortingMethod> FlameAPI::getSortingMethods() const
              { 8, "GameVersion", QObject::tr("Sort by Game Version") } };
 }
 
-Task::Ptr FlameAPI::getCategories(std::shared_ptr<QByteArray> response, ModPlatform::ResourceType type)
+Task::Ptr FlameAPI::getCategories(QByteArray* response, ModPlatform::ResourceType type)
 {
     auto netJob = makeShared<NetJob>(QString("Flame::GetCategories"), APPLICATION->network());
     netJob->addNetAction(Net::ApiDownload::makeByteArray(
@@ -180,12 +180,12 @@ Task::Ptr FlameAPI::getCategories(std::shared_ptr<QByteArray> response, ModPlatf
     return netJob;
 }
 
-Task::Ptr FlameAPI::getModCategories(std::shared_ptr<QByteArray> response)
+Task::Ptr FlameAPI::getModCategories(QByteArray* response)
 {
     return getCategories(response, ModPlatform::ResourceType::Mod);
 }
 
-QList<ModPlatform::Category> FlameAPI::loadModCategories(std::shared_ptr<QByteArray> response)
+QList<ModPlatform::Category> FlameAPI::loadModCategories(QByteArray* response)
 {
     QList<ModPlatform::Category> categories;
     QJsonParseError parse_error{};

--- a/launcher/modplatform/flame/FlameAPI.h
+++ b/launcher/modplatform/flame/FlameAPI.h
@@ -23,14 +23,14 @@ class FlameAPI : public ResourceAPI {
                                                                 ModPlatform::ModLoaderTypes fallback,
                                                                 bool checkLoaders);
 
-    Task::Ptr getProjects(QStringList addonIds, std::shared_ptr<QByteArray> response) const override;
-    Task::Ptr matchFingerprints(const QList<uint>& fingerprints, std::shared_ptr<QByteArray> response);
-    Task::Ptr getFiles(const QStringList& fileIds, std::shared_ptr<QByteArray> response) const;
-    Task::Ptr getFile(const QString& addonId, const QString& fileId, std::shared_ptr<QByteArray> response) const;
+    Task::Ptr getProjects(QStringList addonIds, QByteArray* response) const override;
+    Task::Ptr matchFingerprints(const QList<uint>& fingerprints, QByteArray* response);
+    Task::Ptr getFiles(const QStringList& fileIds, QByteArray* response) const;
+    Task::Ptr getFile(const QString& addonId, const QString& fileId, QByteArray* response) const;
 
-    static Task::Ptr getCategories(std::shared_ptr<QByteArray> response, ModPlatform::ResourceType type);
-    static Task::Ptr getModCategories(std::shared_ptr<QByteArray> response);
-    static QList<ModPlatform::Category> loadModCategories(std::shared_ptr<QByteArray> response);
+    static Task::Ptr getCategories(QByteArray* response, ModPlatform::ResourceType type);
+    static Task::Ptr getModCategories(QByteArray* response);
+    static QList<ModPlatform::Category> loadModCategories(QByteArray* response);
 
     QList<ResourceAPI::SortingMethod> getSortingMethods() const override;
 

--- a/launcher/modplatform/flame/FlameCheckUpdate.cpp
+++ b/launcher/modplatform/flame/FlameCheckUpdate.cpp
@@ -53,16 +53,16 @@ void FlameCheckUpdate::executeTask()
             continue;
 
         auto response = std::make_shared<QByteArray>();
-        auto task = Net::ApiDownload::makeByteArray(versionsUrlOptional.value(), response);
+        auto task = Net::ApiDownload::makeByteArray(versionsUrlOptional.value(), response.get());
 
-        connect(task.get(), &Task::succeeded, this, [this, resource, response] { getLatestVersionCallback(resource, response); });
+        connect(task.get(), &Task::succeeded, this, [this, resource, response] { getLatestVersionCallback(resource, response.get()); });
         netJob->addNetAction(task);
     }
     m_task.reset(netJob);
     m_task->start();
 }
 
-void FlameCheckUpdate::getLatestVersionCallback(Resource* resource, std::shared_ptr<QByteArray> response)
+void FlameCheckUpdate::getLatestVersionCallback(Resource* resource, QByteArray* response)
 {
     QJsonParseError parse_error{};
     QJsonDocument doc = QJsonDocument::fromJson(*response, &parse_error);
@@ -146,9 +146,9 @@ void FlameCheckUpdate::collectBlockedMods()
         emitSucceeded();
         return;
     } else if (addonIds.size() == 1) {
-        projTask = api.getProject(*addonIds.begin(), response);
+        projTask = api.getProject(*addonIds.begin(), response.get());
     } else {
-        projTask = api.getProjects(addonIds, response);
+        projTask = api.getProjects(addonIds, response.get());
     }
 
     connect(projTask.get(), &Task::succeeded, this, [this, response, addonIds, quickSearch] {

--- a/launcher/modplatform/flame/FlameCheckUpdate.h
+++ b/launcher/modplatform/flame/FlameCheckUpdate.h
@@ -9,8 +9,8 @@ class FlameCheckUpdate : public CheckUpdateTask {
     FlameCheckUpdate(QList<Resource*>& resources,
                      std::list<Version>& mcVersions,
                      QList<ModPlatform::ModLoaderType> loadersList,
-                     std::shared_ptr<ResourceFolderModel> resourceModel)
-        : CheckUpdateTask(resources, mcVersions, std::move(loadersList), std::move(resourceModel))
+                     ResourceFolderModel* resourceModel)
+        : CheckUpdateTask(resources, mcVersions, std::move(loadersList), resourceModel)
     {}
 
    public slots:
@@ -19,7 +19,7 @@ class FlameCheckUpdate : public CheckUpdateTask {
    protected slots:
     void executeTask() override;
    private slots:
-    void getLatestVersionCallback(Resource* resource, std::shared_ptr<QByteArray> response);
+    void getLatestVersionCallback(Resource* resource, QByteArray* response);
     void collectBlockedMods();
 
    private:

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -91,7 +91,7 @@ bool FlameCreationTask::updateInstance()
     auto instance_list = APPLICATION->instances();
 
     // FIXME: How to handle situations when there's more than one install already for a given modpack?
-    InstancePtr inst;
+    BaseInstance* inst;
     if (auto original_id = originalInstanceID(); !original_id.isEmpty()) {
         inst = instance_list->getInstanceById(original_id);
         Q_ASSERT(inst);
@@ -185,7 +185,7 @@ bool FlameCreationTask::updateInstance()
         }
 
         auto raw_response = std::make_shared<QByteArray>();
-        auto job = api.getFiles(fileIds, raw_response);
+        auto job = api.getFiles(fileIds, raw_response.get());
 
         QEventLoop loop;
 
@@ -386,8 +386,8 @@ bool FlameCreationTask::createInstance()
     }
 
     QString configPath = FS::PathCombine(m_stagingPath, "instance.cfg");
-    auto instanceSettings = std::make_shared<INISettingsObject>(configPath);
-    MinecraftInstance instance(m_globalSettings, instanceSettings, m_stagingPath);
+    auto instanceSettings = std::make_unique<INISettingsObject>(configPath);
+    MinecraftInstance instance(m_globalSettings, std::move(instanceSettings), m_stagingPath);
     auto mcVersion = m_pack.minecraft.version;
 
     // Hack to correct some 'special sauce'...

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.h
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.h
@@ -52,7 +52,7 @@ class FlameCreationTask final : public InstanceCreationTask {
 
    public:
     FlameCreationTask(const QString& staging_path,
-                      SettingsObjectPtr global_settings,
+                      SettingsObject* global_settings,
                       QWidget* parent,
                       QString id,
                       QString version_id,
@@ -91,7 +91,7 @@ class FlameCreationTask final : public InstanceCreationTask {
 
     QList<std::pair<QString, QString>> m_otherResources;
 
-    std::optional<InstancePtr> m_instance;
+    std::optional<BaseInstance*> m_instance;
 
     QStringList m_selectedOptionalMods;
 };

--- a/launcher/modplatform/flame/FlamePackExportTask.cpp
+++ b/launcher/modplatform/flame/FlamePackExportTask.cpp
@@ -77,7 +77,7 @@ void FlamePackExportTask::collectFiles()
     resolvedFiles.clear();
 
     m_options.instance->loaderModList()->update();
-    connect(m_options.instance->loaderModList().get(), &ModFolderModel::updateFinished, this, &FlamePackExportTask::collectHashes);
+    connect(m_options.instance->loaderModList(), &ModFolderModel::updateFinished, this, &FlamePackExportTask::collectHashes);
 }
 
 void FlamePackExportTask::collectHashes()
@@ -174,7 +174,7 @@ void FlamePackExportTask::makeApiRequest()
         fingerprints.push_back(murmur.toUInt());
     }
 
-    task.reset(api.matchFingerprints(fingerprints, response));
+    task.reset(api.matchFingerprints(fingerprints, response.get()));
 
     connect(task.get(), &Task::succeeded, this, [this, response] {
         QJsonParseError parseError{};
@@ -252,9 +252,9 @@ void FlamePackExportTask::getProjectsInfo()
         buildZip();
         return;
     } else if (addonIds.size() == 1) {
-        projTask = api.getProject(*addonIds.begin(), response);
+        projTask = api.getProject(*addonIds.begin(), response.get());
     } else {
-        projTask = api.getProjects(addonIds, response);
+        projTask = api.getProjects(addonIds, response.get());
     }
 
     connect(projTask.get(), &Task::succeeded, this, [this, response, addonIds] {

--- a/launcher/modplatform/flame/FlamePackExportTask.h
+++ b/launcher/modplatform/flame/FlamePackExportTask.h
@@ -29,7 +29,7 @@ struct FlamePackExportOptions {
     QString version;
     QString author;
     bool optionalFiles;
-    MinecraftInstancePtr instance;
+    MinecraftInstance* instance;
     QString output;
     MMCZip::FilterFileFunction filter;
     int recommendedRAM;

--- a/launcher/modplatform/import_ftb/PackInstallTask.cpp
+++ b/launcher/modplatform/import_ftb/PackInstallTask.cpp
@@ -50,10 +50,11 @@ void PackInstallTask::copySettings()
 {
     setStatus(tr("Copying settings..."));
     progress(2, 2);
+
     QString instanceConfigPath = FS::PathCombine(m_stagingPath, "instance.cfg");
-    auto instanceSettings = std::make_unique<INISettingsObject>(instanceConfigPath);
-    instanceSettings->suspendSave();
-    MinecraftInstance instance(m_globalSettings, std::move(instanceSettings), m_stagingPath);
+    MinecraftInstance instance(m_globalSettings, std::make_unique<INISettingsObject>(instanceConfigPath), m_stagingPath);
+    SettingsObject::Lock lock(instance.settings());
+
     instance.settings()->set("InstanceType", "OneSix");
     instance.settings()->set("totalTimePlayed", m_pack.totalPlayTime / 1000);
 
@@ -108,7 +109,6 @@ void PackInstallTask::copySettings()
     if (m_instIcon == "default")
         m_instIcon = "ftb_logo";
     instance.setIconKey(m_instIcon);
-    instance.settings()->resumeSave();
 
     emitSucceeded();
 }

--- a/launcher/modplatform/import_ftb/PackInstallTask.cpp
+++ b/launcher/modplatform/import_ftb/PackInstallTask.cpp
@@ -51,9 +51,9 @@ void PackInstallTask::copySettings()
     setStatus(tr("Copying settings..."));
     progress(2, 2);
     QString instanceConfigPath = FS::PathCombine(m_stagingPath, "instance.cfg");
-    auto instanceSettings = std::make_shared<INISettingsObject>(instanceConfigPath);
+    auto instanceSettings = std::make_unique<INISettingsObject>(instanceConfigPath);
     instanceSettings->suspendSave();
-    MinecraftInstance instance(m_globalSettings, instanceSettings, m_stagingPath);
+    MinecraftInstance instance(m_globalSettings, std::move(instanceSettings), m_stagingPath);
     instance.settings()->set("InstanceType", "OneSix");
     instance.settings()->set("totalTimePlayed", m_pack.totalPlayTime / 1000);
 
@@ -108,7 +108,7 @@ void PackInstallTask::copySettings()
     if (m_instIcon == "default")
         m_instIcon = "ftb_logo";
     instance.setIconKey(m_instIcon);
-    instanceSettings->resumeSave();
+    instance.settings()->resumeSave();
 
     emitSucceeded();
 }

--- a/launcher/modplatform/legacy_ftb/PackFetchTask.cpp
+++ b/launcher/modplatform/legacy_ftb/PackFetchTask.cpp
@@ -53,11 +53,11 @@ void PackFetchTask::fetch()
 
     QUrl publicPacksUrl = QUrl(BuildConfig.LEGACY_FTB_CDN_BASE_URL + "static/modpacks.xml");
     qDebug() << "Downloading public version info from" << publicPacksUrl.toString();
-    jobPtr->addNetAction(Net::ApiDownload::makeByteArray(publicPacksUrl, publicModpacksXmlFileData));
+    jobPtr->addNetAction(Net::ApiDownload::makeByteArray(publicPacksUrl, publicModpacksXmlFileData.get()));
 
     QUrl thirdPartyUrl = QUrl(BuildConfig.LEGACY_FTB_CDN_BASE_URL + "static/thirdparty.xml");
     qDebug() << "Downloading thirdparty version info from" << thirdPartyUrl.toString();
-    jobPtr->addNetAction(Net::Download::makeByteArray(thirdPartyUrl, thirdPartyModpacksXmlFileData));
+    jobPtr->addNetAction(Net::Download::makeByteArray(thirdPartyUrl, thirdPartyModpacksXmlFileData.get()));
 
     connect(jobPtr.get(), &NetJob::succeeded, this, &PackFetchTask::fileDownloadFinished);
     connect(jobPtr.get(), &NetJob::failed, this, &PackFetchTask::fileDownloadFailed);
@@ -73,7 +73,7 @@ void PackFetchTask::fetchPrivate(const QStringList& toFetch)
     for (auto& packCode : toFetch) {
         auto data = std::make_shared<QByteArray>();
         NetJob* job = new NetJob("Fetching private pack", m_network);
-        job->addNetAction(Net::ApiDownload::makeByteArray(privatePackBaseUrl.arg(packCode), data));
+        job->addNetAction(Net::ApiDownload::makeByteArray(privatePackBaseUrl.arg(packCode), data.get()));
         job->setAskRetry(false);
 
         connect(job, &NetJob::succeeded, this, [this, job, data, packCode] {

--- a/launcher/modplatform/legacy_ftb/PackFetchTask.h
+++ b/launcher/modplatform/legacy_ftb/PackFetchTask.h
@@ -13,18 +13,18 @@ class PackFetchTask : public QObject {
     Q_OBJECT
 
    public:
-    PackFetchTask(shared_qobject_ptr<QNetworkAccessManager> network) : QObject(nullptr), m_network(network) {};
+    PackFetchTask(QNetworkAccessManager* network) : QObject(nullptr), m_network(network) {};
     virtual ~PackFetchTask() = default;
 
     void fetch();
     void fetchPrivate(const QStringList& toFetch);
 
    private:
-    shared_qobject_ptr<QNetworkAccessManager> m_network;
+    QNetworkAccessManager* m_network;
     NetJob::Ptr jobPtr;
 
-    std::shared_ptr<QByteArray> publicModpacksXmlFileData = std::make_shared<QByteArray>();
-    std::shared_ptr<QByteArray> thirdPartyModpacksXmlFileData = std::make_shared<QByteArray>();
+    std::unique_ptr<QByteArray> publicModpacksXmlFileData = std::make_unique<QByteArray>();
+    std::unique_ptr<QByteArray> thirdPartyModpacksXmlFileData = std::make_unique<QByteArray>();
 
     bool parseAndAddPacks(QByteArray& data, PackType packType, ModpackList& list);
     ModpackList publicPacks;

--- a/launcher/modplatform/legacy_ftb/PackInstallTask.cpp
+++ b/launcher/modplatform/legacy_ftb/PackInstallTask.cpp
@@ -52,7 +52,7 @@
 
 namespace LegacyFTB {
 
-PackInstallTask::PackInstallTask(shared_qobject_ptr<QNetworkAccessManager> network, const Modpack& pack, QString version)
+PackInstallTask::PackInstallTask(QNetworkAccessManager* network, const Modpack& pack, QString version)
 {
     m_pack = pack;
     m_version = version;
@@ -133,10 +133,10 @@ void PackInstallTask::install()
     }
 
     QString instanceConfigPath = FS::PathCombine(m_stagingPath, "instance.cfg");
-    auto instanceSettings = std::make_shared<INISettingsObject>(instanceConfigPath);
+    auto instanceSettings = std::make_unique<INISettingsObject>(instanceConfigPath);
     instanceSettings->suspendSave();
 
-    MinecraftInstance instance(m_globalSettings, instanceSettings, m_stagingPath);
+    MinecraftInstance instance(m_globalSettings, std::move(instanceSettings), m_stagingPath);
     auto components = instance.getPackProfile();
     components->buildingFromScratch();
     components->setComponentVersion("net.minecraft", m_pack.mcVersion, true);
@@ -204,7 +204,7 @@ void PackInstallTask::install()
         m_instIcon = "ftb_logo";
     }
     instance.setIconKey(m_instIcon);
-    instanceSettings->resumeSave();
+    instance.settings()->resumeSave();
 
     emitSucceeded();
 }

--- a/launcher/modplatform/legacy_ftb/PackInstallTask.cpp
+++ b/launcher/modplatform/legacy_ftb/PackInstallTask.cpp
@@ -133,10 +133,9 @@ void PackInstallTask::install()
     }
 
     QString instanceConfigPath = FS::PathCombine(m_stagingPath, "instance.cfg");
-    auto instanceSettings = std::make_unique<INISettingsObject>(instanceConfigPath);
-    instanceSettings->suspendSave();
+    MinecraftInstance instance(m_globalSettings, std::make_unique<INISettingsObject>(instanceConfigPath), m_stagingPath);
+    SettingsObject::Lock lock(instance.settings());
 
-    MinecraftInstance instance(m_globalSettings, std::move(instanceSettings), m_stagingPath);
     auto components = instance.getPackProfile();
     components->buildingFromScratch();
     components->setComponentVersion("net.minecraft", m_pack.mcVersion, true);
@@ -204,7 +203,6 @@ void PackInstallTask::install()
         m_instIcon = "ftb_logo";
     }
     instance.setIconKey(m_instIcon);
-    instance.settings()->resumeSave();
 
     emitSucceeded();
 }

--- a/launcher/modplatform/legacy_ftb/PackInstallTask.h
+++ b/launcher/modplatform/legacy_ftb/PackInstallTask.h
@@ -14,7 +14,7 @@ class PackInstallTask : public InstanceTask {
     Q_OBJECT
 
    public:
-    explicit PackInstallTask(shared_qobject_ptr<QNetworkAccessManager> network, const Modpack& pack, QString version);
+    explicit PackInstallTask(QNetworkAccessManager* network, const Modpack& pack, QString version);
     virtual ~PackInstallTask() {}
 
     bool canAbort() const override { return true; }
@@ -35,7 +35,7 @@ class PackInstallTask : public InstanceTask {
     void onUnzipCanceled();
 
    private: /* data */
-    shared_qobject_ptr<QNetworkAccessManager> m_network;
+    QNetworkAccessManager* m_network;
     bool abortable = false;
     QFuture<std::optional<QStringList>> m_extractFuture;
     QFutureWatcher<std::optional<QStringList>> m_extractFutureWatcher;

--- a/launcher/modplatform/modrinth/ModrinthAPI.cpp
+++ b/launcher/modplatform/modrinth/ModrinthAPI.cpp
@@ -11,7 +11,7 @@
 #include "net/NetJob.h"
 #include "net/Upload.h"
 
-Task::Ptr ModrinthAPI::currentVersion(QString hash, QString hash_format, std::shared_ptr<QByteArray> response)
+Task::Ptr ModrinthAPI::currentVersion(QString hash, QString hash_format, QByteArray* response)
 {
     auto netJob = makeShared<NetJob>(QString("Modrinth::GetCurrentVersion"), APPLICATION->network());
 
@@ -21,7 +21,7 @@ Task::Ptr ModrinthAPI::currentVersion(QString hash, QString hash_format, std::sh
     return netJob;
 }
 
-Task::Ptr ModrinthAPI::currentVersions(const QStringList& hashes, QString hash_format, std::shared_ptr<QByteArray> response)
+Task::Ptr ModrinthAPI::currentVersions(const QStringList& hashes, QString hash_format, QByteArray* response)
 {
     auto netJob = makeShared<NetJob>(QString("Modrinth::GetCurrentVersions"), APPLICATION->network());
 
@@ -42,7 +42,7 @@ Task::Ptr ModrinthAPI::latestVersion(QString hash,
                                      QString hash_format,
                                      std::optional<std::list<Version>> mcVersions,
                                      std::optional<ModPlatform::ModLoaderTypes> loaders,
-                                     std::shared_ptr<QByteArray> response)
+                                     QByteArray* response)
 {
     auto netJob = makeShared<NetJob>(QString("Modrinth::GetLatestVersion"), APPLICATION->network());
 
@@ -72,7 +72,7 @@ Task::Ptr ModrinthAPI::latestVersions(const QStringList& hashes,
                                       QString hash_format,
                                       std::optional<std::list<Version>> mcVersions,
                                       std::optional<ModPlatform::ModLoaderTypes> loaders,
-                                      std::shared_ptr<QByteArray> response)
+                                      QByteArray* response)
 {
     auto netJob = makeShared<NetJob>(QString("Modrinth::GetLatestVersions"), APPLICATION->network());
 
@@ -101,7 +101,7 @@ Task::Ptr ModrinthAPI::latestVersions(const QStringList& hashes,
     return netJob;
 }
 
-Task::Ptr ModrinthAPI::getProjects(QStringList addonIds, std::shared_ptr<QByteArray> response) const
+Task::Ptr ModrinthAPI::getProjects(QStringList addonIds, QByteArray* response) const
 {
     auto netJob = makeShared<NetJob>(QString("Modrinth::GetProjects"), APPLICATION->network());
     auto searchUrl = getMultipleModInfoURL(addonIds);
@@ -121,7 +121,7 @@ QList<ResourceAPI::SortingMethod> ModrinthAPI::getSortingMethods() const
              { 5, "updated", QObject::tr("Sort by Last Updated") } };
 }
 
-Task::Ptr ModrinthAPI::getModCategories(std::shared_ptr<QByteArray> response)
+Task::Ptr ModrinthAPI::getModCategories(QByteArray* response)
 {
     auto netJob = makeShared<NetJob>(QString("Modrinth::GetCategories"), APPLICATION->network());
     netJob->addNetAction(Net::ApiDownload::makeByteArray(QUrl(BuildConfig.MODRINTH_PROD_URL + "/tag/category"), response));
@@ -129,7 +129,7 @@ Task::Ptr ModrinthAPI::getModCategories(std::shared_ptr<QByteArray> response)
     return netJob;
 }
 
-QList<ModPlatform::Category> ModrinthAPI::loadCategories(std::shared_ptr<QByteArray> response, QString projectType)
+QList<ModPlatform::Category> ModrinthAPI::loadCategories(QByteArray* response, QString projectType)
 {
     QList<ModPlatform::Category> categories;
     QJsonParseError parse_error{};
@@ -159,7 +159,7 @@ QList<ModPlatform::Category> ModrinthAPI::loadCategories(std::shared_ptr<QByteAr
     return categories;
 }
 
-QList<ModPlatform::Category> ModrinthAPI::loadModCategories(std::shared_ptr<QByteArray> response)
+QList<ModPlatform::Category> ModrinthAPI::loadModCategories(QByteArray* response)
 {
     return loadCategories(response, "mod");
 };

--- a/launcher/modplatform/modrinth/ModrinthAPI.h
+++ b/launcher/modplatform/modrinth/ModrinthAPI.h
@@ -14,27 +14,27 @@
 
 class ModrinthAPI : public ResourceAPI {
    public:
-    Task::Ptr currentVersion(QString hash, QString hash_format, std::shared_ptr<QByteArray> response);
+    Task::Ptr currentVersion(QString hash, QString hash_format, QByteArray* response);
 
-    Task::Ptr currentVersions(const QStringList& hashes, QString hash_format, std::shared_ptr<QByteArray> response);
+    Task::Ptr currentVersions(const QStringList& hashes, QString hash_format, QByteArray* response);
 
     Task::Ptr latestVersion(QString hash,
                             QString hash_format,
                             std::optional<std::list<Version>> mcVersions,
                             std::optional<ModPlatform::ModLoaderTypes> loaders,
-                            std::shared_ptr<QByteArray> response);
+                            QByteArray* response);
 
     Task::Ptr latestVersions(const QStringList& hashes,
                              QString hash_format,
                              std::optional<std::list<Version>> mcVersions,
                              std::optional<ModPlatform::ModLoaderTypes> loaders,
-                             std::shared_ptr<QByteArray> response);
+                             QByteArray* response);
 
-    Task::Ptr getProjects(QStringList addonIds, std::shared_ptr<QByteArray> response) const override;
+    Task::Ptr getProjects(QStringList addonIds, QByteArray* response) const override;
 
-    static Task::Ptr getModCategories(std::shared_ptr<QByteArray> response);
-    static QList<ModPlatform::Category> loadCategories(std::shared_ptr<QByteArray> response, QString projectType);
-    static QList<ModPlatform::Category> loadModCategories(std::shared_ptr<QByteArray> response);
+    static Task::Ptr getModCategories(QByteArray* response);
+    static QList<ModPlatform::Category> loadCategories(QByteArray* response, QString projectType);
+    static QList<ModPlatform::Category> loadModCategories(QByteArray* response);
 
    public:
     auto getSortingMethods() const -> QList<ResourceAPI::SortingMethod> override;

--- a/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
+++ b/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
@@ -18,8 +18,8 @@ static ModrinthAPI api;
 ModrinthCheckUpdate::ModrinthCheckUpdate(QList<Resource*>& resources,
                                          std::list<Version>& mcVersions,
                                          QList<ModPlatform::ModLoaderType> loadersList,
-                                         std::shared_ptr<ResourceFolderModel> resourceModel)
-    : CheckUpdateTask(resources, mcVersions, std::move(loadersList), std::move(resourceModel))
+                                         ResourceFolderModel* resourceModel)
+    : CheckUpdateTask(resources, mcVersions, std::move(loadersList), resourceModel)
     , m_hashType(ModPlatform::ProviderCapabilities::hashType(ModPlatform::ResourceProvider::MODRINTH).first())
 {
     if (!m_loadersList.isEmpty()) {  // this is for mods so append all the other posible loaders to the initial list
@@ -97,9 +97,9 @@ void ModrinthCheckUpdate::getUpdateModsForLoader(std::optional<ModPlatform::ModL
     } else {
         hashes = m_mappings.keys();
     }
-    auto job = api.latestVersions(hashes, m_hashType, m_gameVersions, loader, response);
+    auto job = api.latestVersions(hashes, m_hashType, m_gameVersions, loader, response.get());
 
-    connect(job.get(), &Task::succeeded, this, [this, response, loader] { checkVersionsResponse(response, loader); });
+    connect(job.get(), &Task::succeeded, this, [this, response, loader] { checkVersionsResponse(response.get(), loader); });
 
     connect(job.get(), &Task::failed, this, &ModrinthCheckUpdate::checkNextLoader);
 
@@ -108,7 +108,7 @@ void ModrinthCheckUpdate::getUpdateModsForLoader(std::optional<ModPlatform::ModL
     job->start();
 }
 
-void ModrinthCheckUpdate::checkVersionsResponse(std::shared_ptr<QByteArray> response, std::optional<ModPlatform::ModLoaderTypes> loader)
+void ModrinthCheckUpdate::checkVersionsResponse(QByteArray* response, std::optional<ModPlatform::ModLoaderTypes> loader)
 {
     setStatus(tr("Parsing the API response from Modrinth..."));
     setProgress(m_progress + 1, m_progressTotal);

--- a/launcher/modplatform/modrinth/ModrinthCheckUpdate.h
+++ b/launcher/modplatform/modrinth/ModrinthCheckUpdate.h
@@ -9,7 +9,7 @@ class ModrinthCheckUpdate : public CheckUpdateTask {
     ModrinthCheckUpdate(QList<Resource*>& resources,
                         std::list<Version>& mcVersions,
                         QList<ModPlatform::ModLoaderType> loadersList,
-                        std::shared_ptr<ResourceFolderModel> resourceModel);
+                        ResourceFolderModel* resourceModel);
 
    public slots:
     bool abort() override;
@@ -17,7 +17,7 @@ class ModrinthCheckUpdate : public CheckUpdateTask {
    protected slots:
     void executeTask() override;
     void getUpdateModsForLoader(std::optional<ModPlatform::ModLoaderTypes> loader = {}, bool forceModLoaderCheck = false);
-    void checkVersionsResponse(std::shared_ptr<QByteArray> response, std::optional<ModPlatform::ModLoaderTypes> loader);
+    void checkVersionsResponse(QByteArray* response, std::optional<ModPlatform::ModLoaderTypes> loader);
     void checkNextLoader();
 
    private:

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
@@ -43,7 +43,7 @@ bool ModrinthCreationTask::updateInstance()
     auto instance_list = APPLICATION->instances();
 
     // FIXME: How to handle situations when there's more than one install already for a given modpack?
-    InstancePtr inst;
+    BaseInstance* inst;
     if (auto original_id = originalInstanceID(); !original_id.isEmpty()) {
         inst = instance_list->getInstanceById(original_id);
         Q_ASSERT(inst);
@@ -212,8 +212,8 @@ bool ModrinthCreationTask::createInstance()
     }
 
     QString configPath = FS::PathCombine(m_stagingPath, "instance.cfg");
-    auto instanceSettings = std::make_shared<INISettingsObject>(configPath);
-    MinecraftInstance instance(m_globalSettings, instanceSettings, m_stagingPath);
+    auto instanceSettings = std::make_unique<INISettingsObject>(configPath);
+    MinecraftInstance instance(m_globalSettings, std::move(instanceSettings), m_stagingPath);
 
     auto components = instance.getPackProfile();
     components->buildingFromScratch();

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.h
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.h
@@ -25,7 +25,7 @@ class ModrinthCreationTask final : public InstanceCreationTask {
 
    public:
     ModrinthCreationTask(QString staging_path,
-                         SettingsObjectPtr global_settings,
+                         SettingsObject* global_settings,
                          QWidget* parent,
                          QString id,
                          QString version_id = {},
@@ -55,7 +55,7 @@ class ModrinthCreationTask final : public InstanceCreationTask {
     std::vector<File> m_files;
     Task::Ptr m_task;
 
-    std::optional<InstancePtr> m_instance;
+    std::optional<BaseInstance*> m_instance;
 
     QString m_root_path = "minecraft";
 };

--- a/launcher/modplatform/modrinth/ModrinthPackExportTask.h
+++ b/launcher/modplatform/modrinth/ModrinthPackExportTask.h
@@ -34,7 +34,7 @@ class ModrinthPackExportTask : public Task {
                            const QString& version,
                            const QString& summary,
                            bool optionalFiles,
-                           InstancePtr instance,
+                           BaseInstance* instance,
                            const QString& output,
                            MMCZip::FilterFileFunction filter);
 
@@ -55,7 +55,7 @@ class ModrinthPackExportTask : public Task {
     // inputs
     const QString name, version, summary;
     const bool optionalFiles;
-    const InstancePtr instance;
+    const BaseInstance* instance;
     MinecraftInstance* mcInstance;
     const QDir gameRoot;
     const QString output;
@@ -70,7 +70,7 @@ class ModrinthPackExportTask : public Task {
     void collectFiles();
     void collectHashes();
     void makeApiRequest();
-    void parseApiResponse(std::shared_ptr<QByteArray> response);
+    void parseApiResponse(QByteArray* response);
     void buildZip();
 
     QByteArray generateIndex();

--- a/launcher/modplatform/technic/SolderPackInstallTask.cpp
+++ b/launcher/modplatform/technic/SolderPackInstallTask.cpp
@@ -45,7 +45,7 @@
 #include "net/ApiDownload.h"
 #include "net/ChecksumValidator.h"
 
-Technic::SolderPackInstallTask::SolderPackInstallTask(shared_qobject_ptr<QNetworkAccessManager> network,
+Technic::SolderPackInstallTask::SolderPackInstallTask(QNetworkAccessManager* network,
                                                       const QUrl& solderUrl,
                                                       const QString& pack,
                                                       const QString& version,
@@ -72,7 +72,7 @@ void Technic::SolderPackInstallTask::executeTask()
 
     m_filesNetJob.reset(new NetJob(tr("Resolving modpack files"), m_network));
     auto sourceUrl = QString("%1/modpack/%2/%3").arg(m_solderUrl.toString(), m_pack, m_version);
-    m_filesNetJob->addNetAction(Net::ApiDownload::makeByteArray(sourceUrl, m_response));
+    m_filesNetJob->addNetAction(Net::ApiDownload::makeByteArray(sourceUrl, m_response.get()));
 
     auto job = m_filesNetJob.get();
     connect(job, &NetJob::succeeded, this, &Technic::SolderPackInstallTask::fileListSucceeded);

--- a/launcher/modplatform/technic/SolderPackInstallTask.h
+++ b/launcher/modplatform/technic/SolderPackInstallTask.h
@@ -46,7 +46,7 @@ namespace Technic {
 class SolderPackInstallTask : public InstanceTask {
     Q_OBJECT
    public:
-    explicit SolderPackInstallTask(shared_qobject_ptr<QNetworkAccessManager> network,
+    explicit SolderPackInstallTask(QNetworkAccessManager* network,
                                    const QUrl& solderUrl,
                                    const QString& pack,
                                    const QString& version,
@@ -71,14 +71,14 @@ class SolderPackInstallTask : public InstanceTask {
    private:
     bool m_abortable = false;
 
-    shared_qobject_ptr<QNetworkAccessManager> m_network;
+    QNetworkAccessManager* m_network;
 
     NetJob::Ptr m_filesNetJob;
     QUrl m_solderUrl;
     QString m_pack;
     QString m_version;
     QString m_minecraftVersion;
-    std::shared_ptr<QByteArray> m_response = std::make_shared<QByteArray>();
+    std::unique_ptr<QByteArray> m_response = std::make_unique<QByteArray>();
     QTemporaryDir m_outputDir;
     int m_modCount;
     QFuture<bool> m_extractFuture;

--- a/launcher/modplatform/technic/TechnicPackProcessor.cpp
+++ b/launcher/modplatform/technic/TechnicPackProcessor.cpp
@@ -24,7 +24,7 @@
 #include <memory>
 #include "archive/ArchiveReader.h"
 
-void Technic::TechnicPackProcessor::run(SettingsObjectPtr globalSettings,
+void Technic::TechnicPackProcessor::run(SettingsObject* globalSettings,
                                         const QString& instName,
                                         const QString& instIcon,
                                         const QString& stagingPath,
@@ -33,8 +33,8 @@ void Technic::TechnicPackProcessor::run(SettingsObjectPtr globalSettings,
 {
     QString minecraftPath = FS::PathCombine(stagingPath, "minecraft");
     QString configPath = FS::PathCombine(stagingPath, "instance.cfg");
-    auto instanceSettings = std::make_shared<INISettingsObject>(configPath);
-    MinecraftInstance instance(globalSettings, instanceSettings, stagingPath);
+    auto instanceSettings = std::make_unique<INISettingsObject>(configPath);
+    MinecraftInstance instance(globalSettings, std::move(instanceSettings), stagingPath);
 
     instance.setName(instName);
 

--- a/launcher/modplatform/technic/TechnicPackProcessor.h
+++ b/launcher/modplatform/technic/TechnicPackProcessor.h
@@ -28,7 +28,7 @@ class TechnicPackProcessor : public QObject {
     void failed(QString reason);
 
    public:
-    void run(SettingsObjectPtr globalSettings,
+    void run(SettingsObject* globalSettings,
              const QString& instName,
              const QString& instIcon,
              const QString& stagingPath,

--- a/launcher/net/ApiDownload.cpp
+++ b/launcher/net/ApiDownload.cpp
@@ -25,21 +25,21 @@ namespace Net {
 Download::Ptr ApiDownload::makeCached(QUrl url, MetaEntryPtr entry, Download::Options options)
 {
     auto dl = Download::makeCached(url, entry, options);
-    dl->addHeaderProxy(new ApiHeaderProxy());
+    dl->addHeaderProxy(std::make_unique<ApiHeaderProxy>());
     return dl;
 }
 
-Download::Ptr ApiDownload::makeByteArray(QUrl url, std::shared_ptr<QByteArray> output, Download::Options options)
+Download::Ptr ApiDownload::makeByteArray(QUrl url, QByteArray* output, Download::Options options)
 {
     auto dl = Download::makeByteArray(url, output, options);
-    dl->addHeaderProxy(new ApiHeaderProxy());
+    dl->addHeaderProxy(std::make_unique<ApiHeaderProxy>());
     return dl;
 }
 
 Download::Ptr ApiDownload::makeFile(QUrl url, QString path, Download::Options options)
 {
     auto dl = Download::makeFile(url, path, options);
-    dl->addHeaderProxy(new ApiHeaderProxy());
+    dl->addHeaderProxy(std::make_unique<ApiHeaderProxy>());
     return dl;
 }
 

--- a/launcher/net/ApiUpload.cpp
+++ b/launcher/net/ApiUpload.cpp
@@ -22,10 +22,10 @@
 
 namespace Net {
 
-Upload::Ptr ApiUpload::makeByteArray(QUrl url, std::shared_ptr<QByteArray> output, QByteArray m_post_data)
+Upload::Ptr ApiUpload::makeByteArray(QUrl url, QByteArray* output, QByteArray m_post_data)
 {
     auto up = Upload::makeByteArray(url, output, m_post_data);
-    up->addHeaderProxy(new ApiHeaderProxy());
+    up->addHeaderProxy(std::make_unique<ApiHeaderProxy>());
     return up;
 }
 

--- a/launcher/net/ApiUpload.h
+++ b/launcher/net/ApiUpload.h
@@ -24,7 +24,7 @@
 namespace Net {
 
 namespace ApiUpload {
-Upload::Ptr makeByteArray(QUrl url, std::shared_ptr<QByteArray> output, QByteArray m_post_data);
+Upload::Ptr makeByteArray(QUrl url, QByteArray* output, QByteArray m_post_data);
 };
 
 }  // namespace Net

--- a/launcher/net/ByteArraySink.h
+++ b/launcher/net/ByteArraySink.h
@@ -45,7 +45,7 @@ namespace Net {
  */
 class ByteArraySink : public Sink {
    public:
-    ByteArraySink(std::shared_ptr<QByteArray> output) : m_output(output) {};
+    ByteArraySink(QByteArray* output) : m_output(output) {}
 
     virtual ~ByteArraySink() = default;
 
@@ -92,6 +92,6 @@ class ByteArraySink : public Sink {
     auto hasLocalData() -> bool override { return false; }
 
    protected:
-    std::shared_ptr<QByteArray> m_output;
+    QByteArray* m_output;
 };
 }  // namespace Net

--- a/launcher/net/Download.cpp
+++ b/launcher/net/Download.cpp
@@ -63,7 +63,7 @@ auto Download::makeCached(QUrl url, MetaEntryPtr entry, Options options) -> Down
 }
 #endif
 
-auto Download::makeByteArray(QUrl url, std::shared_ptr<QByteArray> output, Options options) -> Download::Ptr
+auto Download::makeByteArray(QUrl url, QByteArray* output, Options options) -> Download::Ptr
 {
     auto dl = makeShared<Download>();
     dl->m_url = url;

--- a/launcher/net/Download.h
+++ b/launcher/net/Download.h
@@ -54,7 +54,7 @@ class Download : public NetRequest {
     static auto makeCached(QUrl url, MetaEntryPtr entry, Options options = Option::NoOptions) -> Download::Ptr;
 #endif
 
-    static auto makeByteArray(QUrl url, std::shared_ptr<QByteArray> output, Options options = Option::NoOptions) -> Download::Ptr;
+    static auto makeByteArray(QUrl url, QByteArray* output, Options options = Option::NoOptions) -> Download::Ptr;
     static auto makeFile(QUrl url, QString path, Options options = Option::NoOptions) -> Download::Ptr;
 
    protected:

--- a/launcher/net/DummySink.h
+++ b/launcher/net/DummySink.h
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
  *  Prism Launcher - Minecraft Launcher
- *  Copyright (C) 2023 Rachel Powers <508861+Ryex@users.noreply.github.com>
+ *  Copyright (c) 2025 Octol1ttle <l1ttleofficial@outlook.com>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -14,19 +14,21 @@
  *
  *  You should have received a copy of the GNU General Public License
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- *
  */
 
 #pragma once
 
-#include "Download.h"
-
 namespace Net {
 
-namespace ApiDownload {
-Download::Ptr makeCached(QUrl url, MetaEntryPtr entry, Download::Options options = Download::Option::NoOptions);
-Download::Ptr makeByteArray(QUrl url, QByteArray* output, Download::Options options = Download::Option::NoOptions);
-Download::Ptr makeFile(QUrl url, QString path, Download::Options options = Download::Option::NoOptions);
-};  // namespace ApiDownload
+class DummySink : public Sink {
+   public:
+    explicit DummySink() {}
+    ~DummySink() override {}
+    auto init(QNetworkRequest& request) -> Task::State override { return Task::State::Running; }
+    auto write(QByteArray& data) -> Task::State override { return Task::State::Succeeded; }
+    auto abort() -> Task::State override { return Task::State::AbortedByUser; }
+    auto finalize(QNetworkReply& reply) -> Task::State override { return Task::State::Succeeded; }
+    auto hasLocalData() -> bool override { return false; }
+};
 
-}  // namespace Net
+} // namespace Net

--- a/launcher/net/NetJob.cpp
+++ b/launcher/net/NetJob.cpp
@@ -44,7 +44,7 @@
 #include "ui/dialogs/CustomMessageBox.h"
 #endif
 
-NetJob::NetJob(QString job_name, shared_qobject_ptr<QNetworkAccessManager> network, int max_concurrent)
+NetJob::NetJob(QString job_name, QNetworkAccessManager* network, int max_concurrent)
     : ConcurrentTask(job_name), m_network(network)
 {
 #if defined(LAUNCHER_APPLICATION)

--- a/launcher/net/NetJob.h
+++ b/launcher/net/NetJob.h
@@ -50,9 +50,10 @@ class NetJob : public ConcurrentTask {
     Q_OBJECT
 
    public:
+    // TODO: delete
     using Ptr = shared_qobject_ptr<NetJob>;
 
-    explicit NetJob(QString job_name, shared_qobject_ptr<QNetworkAccessManager> network, int max_concurrent = -1);
+    explicit NetJob(QString job_name, QNetworkAccessManager* network, int max_concurrent = -1);
     ~NetJob() override = default;
 
     auto size() const -> int;
@@ -77,7 +78,7 @@ class NetJob : public ConcurrentTask {
     bool isOnline();
 
    private:
-    shared_qobject_ptr<QNetworkAccessManager> m_network;
+    QNetworkAccessManager* m_network;
 
     int m_try = 1;
     bool m_ask_retry = true;

--- a/launcher/net/NetRequest.h
+++ b/launcher/net/NetRequest.h
@@ -68,8 +68,8 @@ class NetRequest : public Task {
     auto abort() -> bool override;
     auto canAbort() const -> bool override { return true; }
 
-    void setNetwork(shared_qobject_ptr<QNetworkAccessManager> network) { m_network = network; }
-    void addHeaderProxy(Net::HeaderProxy* proxy) { m_headerProxies.push_back(std::shared_ptr<Net::HeaderProxy>(proxy)); }
+    void setNetwork(QNetworkAccessManager* network) { m_network = network; }
+    void addHeaderProxy(std::unique_ptr<Net::HeaderProxy> proxy) { m_headerProxies.push_back(std::move(proxy)); }
 
     QUrl url() const;
     void setUrl(QUrl url) { m_url = url; }
@@ -100,15 +100,15 @@ class NetRequest : public Task {
     std::chrono::time_point<std::chrono::steady_clock> m_last_progress_time;
     qint64 m_last_progress_bytes;
 
-    shared_qobject_ptr<QNetworkAccessManager> m_network;
+    QNetworkAccessManager* m_network;
 
     /// the network reply
-    unique_qobject_ptr<QNetworkReply> m_reply;
+    std::unique_ptr<QNetworkReply> m_reply;
     QByteArray m_errorResponse;
 
     /// source URL
     QUrl m_url;
-    std::vector<std::shared_ptr<Net::HeaderProxy>> m_headerProxies;
+    std::vector<std::unique_ptr<Net::HeaderProxy>> m_headerProxies;
 };
 }  // namespace Net
 

--- a/launcher/net/PasteUpload.cpp
+++ b/launcher/net/PasteUpload.cpp
@@ -214,5 +214,5 @@ PasteUpload::PasteUpload(const QString& log, QString url, PasteType pasteType) :
     else
         m_url = m_baseUrl + base.endpointPath;
 
-    m_sink.reset(new Sink(this));
+    m_sink.reset(new Sink(this, m_output.get()));
 }

--- a/launcher/net/PasteUpload.h
+++ b/launcher/net/PasteUpload.h
@@ -71,7 +71,7 @@ class PasteUpload : public Net::NetRequest {
 
     class Sink : public Net::ByteArraySink {
        public:
-        Sink(PasteUpload* p) : Net::ByteArraySink(std::make_shared<QByteArray>()), m_d(p) {};
+        Sink(PasteUpload* p, QByteArray* output) : Net::ByteArraySink(output), m_d(p) {};
         virtual ~Sink() = default;
 
        public:
@@ -93,4 +93,5 @@ class PasteUpload : public Net::NetRequest {
     QString m_pasteLink;
     QString m_baseUrl;
     const PasteType m_paste_type;
+    std::unique_ptr<QByteArray> m_output = std::make_unique<QByteArray>();
 };

--- a/launcher/net/Upload.cpp
+++ b/launcher/net/Upload.cpp
@@ -51,7 +51,7 @@ QNetworkReply* Upload::getReply(QNetworkRequest& request)
     return m_network->post(request, m_post_data);
 }
 
-Upload::Ptr Upload::makeByteArray(QUrl url, std::shared_ptr<QByteArray> output, QByteArray m_post_data)
+Upload::Ptr Upload::makeByteArray(QUrl url, QByteArray* output, QByteArray m_post_data)
 {
     auto up = makeShared<Upload>();
     up->m_url = std::move(url);

--- a/launcher/net/Upload.h
+++ b/launcher/net/Upload.h
@@ -47,7 +47,7 @@ class Upload : public NetRequest {
     using Ptr = shared_qobject_ptr<Upload>;
     explicit Upload() : NetRequest() { logCat = taskUploadLogC; };
 
-    static Upload::Ptr makeByteArray(QUrl url, std::shared_ptr<QByteArray> output, QByteArray m_post_data);
+    static Upload::Ptr makeByteArray(QUrl url, QByteArray* output, QByteArray m_post_data);
 
    protected:
     virtual QNetworkReply* getReply(QNetworkRequest&) override;

--- a/launcher/news/NewsChecker.cpp
+++ b/launcher/news/NewsChecker.cpp
@@ -40,7 +40,7 @@
 
 #include <QDebug>
 
-NewsChecker::NewsChecker(shared_qobject_ptr<QNetworkAccessManager> network, const QString& feedUrl)
+NewsChecker::NewsChecker(QNetworkAccessManager* network, const QString& feedUrl)
 {
     m_network = network;
     m_feedUrl = feedUrl;
@@ -57,7 +57,7 @@ void NewsChecker::reloadNews()
     qDebug() << "Reloading news.";
 
     NetJob::Ptr job{ new NetJob("News RSS Feed", m_network) };
-    job->addNetAction(Net::Download::makeByteArray(m_feedUrl, newsData));
+    job->addNetAction(Net::Download::makeByteArray(m_feedUrl, newsData.get()));
     job->setAskRetry(false);
     connect(job.get(), &NetJob::succeeded, this, &NewsChecker::rssDownloadFinished);
     connect(job.get(), &NetJob::failed, this, &NewsChecker::rssDownloadFailed);

--- a/launcher/news/NewsChecker.h
+++ b/launcher/news/NewsChecker.h
@@ -29,7 +29,7 @@ class NewsChecker : public QObject {
     /*!
      * Constructs a news reader to read from the given RSS feed URL.
      */
-    NewsChecker(shared_qobject_ptr<QNetworkAccessManager> network, const QString& feedUrl);
+    NewsChecker(QNetworkAccessManager* network, const QString& feedUrl);
 
     /*!
      * Returns the error message for the last time the news was loaded.
@@ -84,7 +84,7 @@ class NewsChecker : public QObject {
     //! True if news has been loaded.
     bool m_loadedNews;
 
-    std::shared_ptr<QByteArray> newsData = std::make_shared<QByteArray>();
+    std::unique_ptr<QByteArray> newsData = std::make_unique<QByteArray>();
 
     /*!
      * Gets the error message that was given last time the news was loaded.
@@ -92,7 +92,7 @@ class NewsChecker : public QObject {
      */
     QString m_lastLoadError;
 
-    shared_qobject_ptr<QNetworkAccessManager> m_network;
+    QNetworkAccessManager* m_network;
 
    protected slots:
     /// Emits newsLoaded() and sets m_lastLoadError to empty string.

--- a/launcher/screenshots/ImgurAlbumCreation.cpp
+++ b/launcher/screenshots/ImgurAlbumCreation.cpp
@@ -54,7 +54,7 @@ Net::NetRequest::Ptr ImgurAlbumCreation::make(std::shared_ptr<ImgurAlbumCreation
     up->m_url = BuildConfig.IMGUR_BASE_URL + "album";
     up->m_sink.reset(new Sink(output));
     up->m_screenshots = screenshots;
-    up->addHeaderProxy(new Net::RawHeaderProxy(
+    up->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(
         QList<Net::HeaderPair>{ { "Content-Type", "application/x-www-form-urlencoded" },
                                 { "Authorization", QString("Client-ID %1").arg(BuildConfig.IMGUR_CLIENT_ID).toUtf8() },
                                 { "Accept", "application/json" } }));

--- a/launcher/screenshots/ImgurUpload.cpp
+++ b/launcher/screenshots/ImgurUpload.cpp
@@ -120,7 +120,7 @@ Net::NetRequest::Ptr ImgurUpload::make(ScreenShot::Ptr m_shot)
     auto up = makeShared<ImgurUpload>(m_shot->m_file);
     up->m_url = std::move(BuildConfig.IMGUR_BASE_URL + "image");
     up->m_sink.reset(new Sink(m_shot));
-    up->addHeaderProxy(new Net::RawHeaderProxy(QList<Net::HeaderPair>{
+    up->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(QList<Net::HeaderPair>{
         { "Authorization", QString("Client-ID %1").arg(BuildConfig.IMGUR_CLIENT_ID).toUtf8() }, { "Accept", "application/json" } }));
     return up;
 }

--- a/launcher/settings/SettingsObject.h
+++ b/launcher/settings/SettingsObject.h
@@ -30,9 +30,6 @@
 class Setting;
 class SettingsObject;
 
-using SettingsObjectPtr = std::shared_ptr<SettingsObject>;
-using SettingsObjectWeakPtr = std::weak_ptr<SettingsObject>;
-
 /*!
  * \brief The SettingsObject handles communicating settings between the application and a
  *settings file.
@@ -50,11 +47,11 @@ class SettingsObject : public QObject {
    public:
     class Lock {
        public:
-        Lock(SettingsObjectPtr locked) : m_locked(locked) { m_locked->suspendSave(); }
+        Lock(SettingsObject* locked) : m_locked(locked) { m_locked->suspendSave(); }
         ~Lock() { m_locked->resumeSave(); }
 
        private:
-        SettingsObjectPtr m_locked;
+        SettingsObject* m_locked;
     };
 
    public:

--- a/launcher/tools/BaseExternalTool.cpp
+++ b/launcher/tools/BaseExternalTool.cpp
@@ -9,13 +9,13 @@
 
 #include "BaseInstance.h"
 
-BaseExternalTool::BaseExternalTool(SettingsObjectPtr settings, InstancePtr instance, QObject* parent)
+BaseExternalTool::BaseExternalTool(SettingsObject* settings, BaseInstance* instance, QObject* parent)
     : QObject(parent), m_instance(instance), globalSettings(settings)
 {}
 
 BaseExternalTool::~BaseExternalTool() {}
 
-BaseDetachedTool::BaseDetachedTool(SettingsObjectPtr settings, InstancePtr instance, QObject* parent)
+BaseDetachedTool::BaseDetachedTool(SettingsObject* settings, BaseInstance* instance, QObject* parent)
     : BaseExternalTool(settings, instance, parent)
 {}
 
@@ -26,7 +26,7 @@ void BaseDetachedTool::run()
 
 BaseExternalToolFactory::~BaseExternalToolFactory() {}
 
-BaseDetachedTool* BaseDetachedToolFactory::createDetachedTool(InstancePtr instance, QObject* parent)
+BaseDetachedTool* BaseDetachedToolFactory::createDetachedTool(BaseInstance* instance, QObject* parent)
 {
     return qobject_cast<BaseDetachedTool*>(createTool(instance, parent));
 }

--- a/launcher/tools/BaseExternalTool.h
+++ b/launcher/tools/BaseExternalTool.h
@@ -10,18 +10,18 @@ class QProcess;
 class BaseExternalTool : public QObject {
     Q_OBJECT
    public:
-    explicit BaseExternalTool(SettingsObjectPtr settings, InstancePtr instance, QObject* parent = 0);
+    explicit BaseExternalTool(SettingsObject* settings, BaseInstance* instance, QObject* parent = 0);
     virtual ~BaseExternalTool();
 
    protected:
-    InstancePtr m_instance;
-    SettingsObjectPtr globalSettings;
+    BaseInstance* m_instance;
+    SettingsObject* globalSettings;
 };
 
 class BaseDetachedTool : public BaseExternalTool {
     Q_OBJECT
    public:
-    explicit BaseDetachedTool(SettingsObjectPtr settings, InstancePtr instance, QObject* parent = 0);
+    explicit BaseDetachedTool(SettingsObject* settings, BaseInstance* instance, QObject* parent = 0);
 
    public slots:
     void run();
@@ -36,18 +36,18 @@ class BaseExternalToolFactory {
 
     virtual QString name() const = 0;
 
-    virtual void registerSettings(SettingsObjectPtr settings) = 0;
+    virtual void registerSettings(SettingsObject* settings) = 0;
 
-    virtual BaseExternalTool* createTool(InstancePtr instance, QObject* parent = 0) = 0;
+    virtual BaseExternalTool* createTool(BaseInstance* instance, QObject* parent = 0) = 0;
 
     virtual bool check(QString* error) = 0;
     virtual bool check(const QString& path, QString* error) = 0;
 
    protected:
-    SettingsObjectPtr globalSettings;
+    SettingsObject* globalSettings;
 };
 
 class BaseDetachedToolFactory : public BaseExternalToolFactory {
    public:
-    virtual BaseDetachedTool* createDetachedTool(InstancePtr instance, QObject* parent = 0);
+    virtual BaseDetachedTool* createDetachedTool(BaseInstance* instance, QObject* parent = 0);
 };

--- a/launcher/tools/BaseProfiler.cpp
+++ b/launcher/tools/BaseProfiler.cpp
@@ -3,10 +3,10 @@
 
 #include <QProcess>
 
-BaseProfiler::BaseProfiler(SettingsObjectPtr settings, InstancePtr instance, QObject* parent) : BaseExternalTool(settings, instance, parent)
+BaseProfiler::BaseProfiler(SettingsObject* settings, BaseInstance* instance, QObject* parent) : BaseExternalTool(settings, instance, parent)
 {}
 
-void BaseProfiler::beginProfiling(shared_qobject_ptr<LaunchTask> process)
+void BaseProfiler::beginProfiling(LaunchTask* process)
 {
     beginProfilingImpl(process);
 }
@@ -27,7 +27,7 @@ void BaseProfiler::abortProfilingImpl()
     emit abortLaunch(tr("Profiler aborted"));
 }
 
-BaseProfiler* BaseProfilerFactory::createProfiler(InstancePtr instance, QObject* parent)
+BaseProfiler* BaseProfilerFactory::createProfiler(BaseInstance* instance, QObject* parent)
 {
     return qobject_cast<BaseProfiler*>(createTool(instance, parent));
 }

--- a/launcher/tools/BaseProfiler.h
+++ b/launcher/tools/BaseProfiler.h
@@ -11,16 +11,16 @@ class QProcess;
 class BaseProfiler : public BaseExternalTool {
     Q_OBJECT
    public:
-    explicit BaseProfiler(SettingsObjectPtr settings, InstancePtr instance, QObject* parent = 0);
+    explicit BaseProfiler(SettingsObject* settings, BaseInstance* instance, QObject* parent = 0);
 
    public slots:
-    void beginProfiling(shared_qobject_ptr<LaunchTask> process);
+    void beginProfiling(LaunchTask* process);
     void abortProfiling();
 
    protected:
     QProcess* m_profilerProcess;
 
-    virtual void beginProfilingImpl(shared_qobject_ptr<LaunchTask> process) = 0;
+    virtual void beginProfilingImpl(LaunchTask* process) = 0;
     virtual void abortProfilingImpl();
 
    signals:
@@ -30,5 +30,5 @@ class BaseProfiler : public BaseExternalTool {
 
 class BaseProfilerFactory : public BaseExternalToolFactory {
    public:
-    virtual BaseProfiler* createProfiler(InstancePtr instance, QObject* parent = 0);
+    virtual BaseProfiler* createProfiler(BaseInstance* instance, QObject* parent = 0);
 };

--- a/launcher/tools/GenericProfiler.cpp
+++ b/launcher/tools/GenericProfiler.cpp
@@ -24,22 +24,22 @@
 class GenericProfiler : public BaseProfiler {
     Q_OBJECT
    public:
-    GenericProfiler(SettingsObjectPtr settings, InstancePtr instance, QObject* parent = 0);
+    GenericProfiler(SettingsObject* settings, BaseInstance* instance, QObject* parent = 0);
 
    protected:
-    void beginProfilingImpl(shared_qobject_ptr<LaunchTask> process);
+    void beginProfilingImpl(LaunchTask* process);
 };
 
-GenericProfiler::GenericProfiler(SettingsObjectPtr settings, InstancePtr instance, QObject* parent)
+GenericProfiler::GenericProfiler(SettingsObject* settings, BaseInstance* instance, QObject* parent)
     : BaseProfiler(settings, instance, parent)
 {}
 
-void GenericProfiler::beginProfilingImpl(shared_qobject_ptr<LaunchTask> process)
+void GenericProfiler::beginProfilingImpl(LaunchTask* process)
 {
     emit readyToLaunch(tr("Started process: %1").arg(process->pid()));
 }
 
-BaseExternalTool* GenericProfilerFactory::createTool(InstancePtr instance, QObject* parent)
+BaseExternalTool* GenericProfilerFactory::createTool(BaseInstance* instance, QObject* parent)
 {
     return new GenericProfiler(globalSettings, instance, parent);
 }

--- a/launcher/tools/GenericProfiler.h
+++ b/launcher/tools/GenericProfiler.h
@@ -22,8 +22,8 @@
 class GenericProfilerFactory : public BaseProfilerFactory {
    public:
     QString name() const override { return "Generic"; }
-    void registerSettings([[maybe_unused]] SettingsObjectPtr settings) override {};
-    BaseExternalTool* createTool(InstancePtr instance, QObject* parent = 0) override;
+    void registerSettings([[maybe_unused]] SettingsObject* settings) override {};
+    BaseExternalTool* createTool(BaseInstance* instance, QObject* parent = 0) override;
     bool check([[maybe_unused]] QString* error) override { return true; };
     bool check([[maybe_unused]] const QString& path, [[maybe_unused]] QString* error) override { return true; };
 };

--- a/launcher/tools/JProfiler.cpp
+++ b/launcher/tools/JProfiler.cpp
@@ -9,20 +9,20 @@
 class JProfiler : public BaseProfiler {
     Q_OBJECT
    public:
-    JProfiler(SettingsObjectPtr settings, InstancePtr instance, QObject* parent = 0);
+    JProfiler(SettingsObject* settings, BaseInstance* instance, QObject* parent = 0);
 
    private slots:
     void profilerStarted();
     void profilerFinished(int exit, QProcess::ExitStatus status);
 
    protected:
-    void beginProfilingImpl(shared_qobject_ptr<LaunchTask> process);
+    void beginProfilingImpl(LaunchTask* process);
 
    private:
     int listeningPort = 0;
 };
 
-JProfiler::JProfiler(SettingsObjectPtr settings, InstancePtr instance, QObject* parent) : BaseProfiler(settings, instance, parent) {}
+JProfiler::JProfiler(SettingsObject* settings, BaseInstance* instance, QObject* parent) : BaseProfiler(settings, instance, parent) {}
 
 void JProfiler::profilerStarted()
 {
@@ -40,7 +40,7 @@ void JProfiler::profilerFinished([[maybe_unused]] int exit, QProcess::ExitStatus
     }
 }
 
-void JProfiler::beginProfilingImpl(shared_qobject_ptr<LaunchTask> process)
+void JProfiler::beginProfilingImpl(LaunchTask* process)
 {
     listeningPort = globalSettings->get("JProfilerPort").toInt();
     QProcess* profiler = new QProcess(this);
@@ -63,14 +63,14 @@ void JProfiler::beginProfilingImpl(shared_qobject_ptr<LaunchTask> process)
     profiler->start();
 }
 
-void JProfilerFactory::registerSettings(SettingsObjectPtr settings)
+void JProfilerFactory::registerSettings(SettingsObject* settings)
 {
     settings->registerSetting("JProfilerPath");
     settings->registerSetting("JProfilerPort", 42042);
     globalSettings = settings;
 }
 
-BaseExternalTool* JProfilerFactory::createTool(InstancePtr instance, QObject* parent)
+BaseExternalTool* JProfilerFactory::createTool(BaseInstance* instance, QObject* parent)
 {
     return new JProfiler(globalSettings, instance, parent);
 }

--- a/launcher/tools/JProfiler.h
+++ b/launcher/tools/JProfiler.h
@@ -5,8 +5,8 @@
 class JProfilerFactory : public BaseProfilerFactory {
    public:
     QString name() const override { return "JProfiler"; }
-    void registerSettings(SettingsObjectPtr settings) override;
-    BaseExternalTool* createTool(InstancePtr instance, QObject* parent = 0) override;
+    void registerSettings(SettingsObject* settings) override;
+    BaseExternalTool* createTool(BaseInstance* instance, QObject* parent = 0) override;
     bool check(QString* error) override;
     bool check(const QString& path, QString* error) override;
 };

--- a/launcher/tools/JVisualVM.cpp
+++ b/launcher/tools/JVisualVM.cpp
@@ -10,17 +10,17 @@
 class JVisualVM : public BaseProfiler {
     Q_OBJECT
    public:
-    JVisualVM(SettingsObjectPtr settings, InstancePtr instance, QObject* parent = 0);
+    JVisualVM(SettingsObject* settings, BaseInstance* instance, QObject* parent = 0);
 
    private slots:
     void profilerStarted();
     void profilerFinished(int exit, QProcess::ExitStatus status);
 
    protected:
-    void beginProfilingImpl(shared_qobject_ptr<LaunchTask> process);
+    void beginProfilingImpl(LaunchTask* process);
 };
 
-JVisualVM::JVisualVM(SettingsObjectPtr settings, InstancePtr instance, QObject* parent) : BaseProfiler(settings, instance, parent) {}
+JVisualVM::JVisualVM(SettingsObject* settings, BaseInstance* instance, QObject* parent) : BaseProfiler(settings, instance, parent) {}
 
 void JVisualVM::profilerStarted()
 {
@@ -38,7 +38,7 @@ void JVisualVM::profilerFinished([[maybe_unused]] int exit, QProcess::ExitStatus
     }
 }
 
-void JVisualVM::beginProfilingImpl(shared_qobject_ptr<LaunchTask> process)
+void JVisualVM::beginProfilingImpl(LaunchTask* process)
 {
     QProcess* profiler = new QProcess(this);
     QStringList profilerArgs = { "--openpid", QString::number(process->pid()) };
@@ -54,7 +54,7 @@ void JVisualVM::beginProfilingImpl(shared_qobject_ptr<LaunchTask> process)
     m_profilerProcess = profiler;
 }
 
-void JVisualVMFactory::registerSettings(SettingsObjectPtr settings)
+void JVisualVMFactory::registerSettings(SettingsObject* settings)
 {
     QString defaultValue = QStandardPaths::findExecutable("jvisualvm");
     if (defaultValue.isNull()) {
@@ -64,7 +64,7 @@ void JVisualVMFactory::registerSettings(SettingsObjectPtr settings)
     globalSettings = settings;
 }
 
-BaseExternalTool* JVisualVMFactory::createTool(InstancePtr instance, QObject* parent)
+BaseExternalTool* JVisualVMFactory::createTool(BaseInstance* instance, QObject* parent)
 {
     return new JVisualVM(globalSettings, instance, parent);
 }

--- a/launcher/tools/JVisualVM.h
+++ b/launcher/tools/JVisualVM.h
@@ -5,8 +5,8 @@
 class JVisualVMFactory : public BaseProfilerFactory {
    public:
     QString name() const override { return "VisualVM"; }
-    void registerSettings(SettingsObjectPtr settings) override;
-    BaseExternalTool* createTool(InstancePtr instance, QObject* parent = 0) override;
+    void registerSettings(SettingsObject* settings) override;
+    BaseExternalTool* createTool(BaseInstance* instance, QObject* parent = 0) override;
     bool check(QString* error) override;
     bool check(const QString& path, QString* error) override;
 };

--- a/launcher/tools/MCEditTool.cpp
+++ b/launcher/tools/MCEditTool.cpp
@@ -8,7 +8,7 @@
 #include "minecraft/MinecraftInstance.h"
 #include "settings/SettingsObject.h"
 
-MCEditTool::MCEditTool(SettingsObjectPtr settings)
+MCEditTool::MCEditTool(SettingsObject* settings)
 {
     settings->registerSetting("MCEditPath");
     m_settings = settings;

--- a/launcher/tools/MCEditTool.h
+++ b/launcher/tools/MCEditTool.h
@@ -5,12 +5,12 @@
 
 class MCEditTool {
    public:
-    MCEditTool(SettingsObjectPtr settings);
+    MCEditTool(SettingsObject* settings);
     void setPath(QString& path);
     QString path() const;
     bool check(const QString& toolPath, QString& error);
     QString getProgramPath();
 
    private:
-    SettingsObjectPtr m_settings;
+    SettingsObject* m_settings;
 };

--- a/launcher/ui/InstanceWindow.cpp
+++ b/launcher/ui/InstanceWindow.cpp
@@ -49,7 +49,7 @@
 
 #include "icons/IconList.h"
 
-InstanceWindow::InstanceWindow(InstancePtr instance, QWidget* parent) : QMainWindow(parent), m_instance(instance)
+InstanceWindow::InstanceWindow(BaseInstance* instance, QWidget* parent) : QMainWindow(parent), m_instance(instance)
 {
     setAttribute(Qt::WA_DeleteOnClose);
 
@@ -109,7 +109,7 @@ InstanceWindow::InstanceWindow(InstancePtr instance, QWidget* parent) : QMainWin
 
         m_container->addButtons(horizontalLayout);
 
-        connect(m_instance.get(), &BaseInstance::profilerChanged, this, &InstanceWindow::updateButtons);
+        connect(m_instance, &BaseInstance::profilerChanged, this, &InstanceWindow::updateButtons);
         connect(APPLICATION, &Application::globalSettingsApplied, this, &InstanceWindow::updateButtons);
     }
 
@@ -125,13 +125,13 @@ InstanceWindow::InstanceWindow(InstancePtr instance, QWidget* parent) : QMainWin
     {
         auto launchTask = m_instance->getLaunchTask();
         instanceLaunchTaskChanged(launchTask);
-        connect(m_instance.get(), &BaseInstance::launchTaskChanged, this, &InstanceWindow::instanceLaunchTaskChanged);
-        connect(m_instance.get(), &BaseInstance::runningStatusChanged, this, &InstanceWindow::runningStateChanged);
+        connect(m_instance, &BaseInstance::launchTaskChanged, this, &InstanceWindow::instanceLaunchTaskChanged);
+        connect(m_instance, &BaseInstance::runningStatusChanged, this, &InstanceWindow::runningStateChanged);
     }
 
     // set up instance destruction detection
     {
-        connect(m_instance.get(), &BaseInstance::statusChanged, this, &InstanceWindow::on_instanceStatusChanged);
+        connect(m_instance, &BaseInstance::statusChanged, this, &InstanceWindow::on_instanceStatusChanged);
     }
 
     // add ourself as the modpack page's instance window
@@ -164,7 +164,7 @@ void InstanceWindow::updateButtons()
     m_launchButton->setMenu(launchMenu);
 }
 
-void InstanceWindow::instanceLaunchTaskChanged(shared_qobject_ptr<LaunchTask> proc)
+void InstanceWindow::instanceLaunchTaskChanged(LaunchTask* proc)
 {
     m_proc = proc;
 }

--- a/launcher/ui/InstanceWindow.h
+++ b/launcher/ui/InstanceWindow.h
@@ -53,7 +53,7 @@ class InstanceWindow : public QMainWindow, public BasePageContainer {
     Q_OBJECT
 
    public:
-    explicit InstanceWindow(InstancePtr proc, QWidget* parent = 0);
+    explicit InstanceWindow(BaseInstance* proc, QWidget* parent = 0);
     virtual ~InstanceWindow() = default;
 
     bool selectPage(QString pageId) override;
@@ -72,7 +72,7 @@ class InstanceWindow : public QMainWindow, public BasePageContainer {
     void isClosing();
 
    private slots:
-    void instanceLaunchTaskChanged(shared_qobject_ptr<LaunchTask> proc);
+    void instanceLaunchTaskChanged(LaunchTask* proc);
     void runningStateChanged(bool running);
     void on_instanceStatusChanged(BaseInstance::Status, BaseInstance::Status newStatus);
 
@@ -83,8 +83,8 @@ class InstanceWindow : public QMainWindow, public BasePageContainer {
     void updateButtons();
 
    private:
-    shared_qobject_ptr<LaunchTask> m_proc;
-    InstancePtr m_instance;
+    LaunchTask* m_proc;
+    BaseInstance* m_instance;
     bool m_doNotSave = false;
     PageContainer* m_container = nullptr;
     QPushButton* m_closeButton = nullptr;

--- a/launcher/ui/MainWindow.h
+++ b/launcher/ui/MainWindow.h
@@ -220,7 +220,7 @@ class MainWindow : public QMainWindow {
     void retranslateUi();
 
     void addInstance(const QString& url = QString(), const QMap<QString, QString>& extra_info = {});
-    void activateInstance(InstancePtr instance);
+    void activateInstance(BaseInstance* instance);
     void setCatBackground(bool enabled);
     void updateInstanceToolIcon(QString new_icon);
     void setSelectedInstanceById(const QString& id);
@@ -247,7 +247,7 @@ class MainWindow : public QMainWindow {
 
     unique_qobject_ptr<NewsChecker> m_newsChecker;
 
-    InstancePtr m_selectedInstance;
+    BaseInstance* m_selectedInstance = nullptr;
     QString m_currentInstIcon;
 
     // managed by the application object

--- a/launcher/ui/dialogs/CopyInstanceDialog.cpp
+++ b/launcher/ui/dialogs/CopyInstanceDialog.cpp
@@ -51,7 +51,7 @@
 #include "InstanceList.h"
 #include "icons/IconList.h"
 
-CopyInstanceDialog::CopyInstanceDialog(InstancePtr original, QWidget* parent)
+CopyInstanceDialog::CopyInstanceDialog(BaseInstance* original, QWidget* parent)
     : QDialog(parent), ui(new Ui::CopyInstanceDialog), m_original(original)
 {
     ui->setupUi(this);

--- a/launcher/ui/dialogs/CopyInstanceDialog.h
+++ b/launcher/ui/dialogs/CopyInstanceDialog.h
@@ -30,7 +30,7 @@ class CopyInstanceDialog : public QDialog {
     Q_OBJECT
 
    public:
-    explicit CopyInstanceDialog(InstancePtr original, QWidget* parent = 0);
+    explicit CopyInstanceDialog(BaseInstance* original, QWidget* parent = 0);
     ~CopyInstanceDialog();
 
     void updateDialogState();
@@ -71,7 +71,7 @@ class CopyInstanceDialog : public QDialog {
     /* data */
     Ui::CopyInstanceDialog* ui;
     QString InstIconKey;
-    InstancePtr m_original;
+    BaseInstance* m_original;
     InstanceCopyPrefs m_selectedOptions;
     bool m_cloneSupported = false;
     bool m_linkSupported = false;

--- a/launcher/ui/dialogs/CreateShortcutDialog.cpp
+++ b/launcher/ui/dialogs/CreateShortcutDialog.cpp
@@ -55,7 +55,7 @@
 #include "minecraft/WorldList.h"
 #include "minecraft/auth/AccountList.h"
 
-CreateShortcutDialog::CreateShortcutDialog(InstancePtr instance, QWidget* parent)
+CreateShortcutDialog::CreateShortcutDialog(BaseInstance* instance, QWidget* parent)
     : QDialog(parent), ui(new Ui::CreateShortcutDialog), m_instance(instance)
 {
     ui->setupUi(this);
@@ -64,7 +64,7 @@ CreateShortcutDialog::CreateShortcutDialog(InstancePtr instance, QWidget* parent
     ui->iconButton->setIcon(APPLICATION->icons()->getIcon(InstIconKey));
     ui->instNameTextBox->setPlaceholderText(instance->name());
 
-    auto mInst = std::dynamic_pointer_cast<MinecraftInstance>(instance);
+    auto mInst = dynamic_cast<MinecraftInstance*>(instance);
     m_QuickJoinSupported = mInst && mInst->traits().contains("feature:is_quick_play_singleplayer");
     auto worldList = mInst->worldList();
     worldList->update();
@@ -212,7 +212,7 @@ void CreateShortcutDialog::createShortcut()
     if (ui->overrideAccountCheckbox->isChecked())
         extraArgs.append({ "--profile", ui->accountSelectionBox->currentData().toString() });
 
-    ShortcutUtils::Shortcut args{ m_instance.get(), name, targetString, this, extraArgs, InstIconKey, target };
+    ShortcutUtils::Shortcut args{ m_instance, name, targetString, this, extraArgs, InstIconKey, target };
     if (target == ShortcutTarget::Desktop)
         ShortcutUtils::createInstanceShortcutOnDesktop(args);
     else if (target == ShortcutTarget::Applications)

--- a/launcher/ui/dialogs/CreateShortcutDialog.h
+++ b/launcher/ui/dialogs/CreateShortcutDialog.h
@@ -28,7 +28,7 @@ class CreateShortcutDialog : public QDialog {
     Q_OBJECT
 
    public:
-    explicit CreateShortcutDialog(InstancePtr instance, QWidget* parent = nullptr);
+    explicit CreateShortcutDialog(BaseInstance* instance, QWidget* parent = nullptr);
     ~CreateShortcutDialog();
 
     void createShortcut();
@@ -51,7 +51,7 @@ class CreateShortcutDialog : public QDialog {
     // Data
     Ui::CreateShortcutDialog* ui;
     QString InstIconKey;
-    InstancePtr m_instance;
+    BaseInstance* m_instance;
     bool m_QuickJoinSupported = false;
 
     // Functions

--- a/launcher/ui/dialogs/ExportInstanceDialog.cpp
+++ b/launcher/ui/dialogs/ExportInstanceDialog.cpp
@@ -60,7 +60,7 @@
 #include "Application.h"
 #include "SeparatorPrefixTree.h"
 
-ExportInstanceDialog::ExportInstanceDialog(InstancePtr instance, QWidget* parent)
+ExportInstanceDialog::ExportInstanceDialog(BaseInstance* instance, QWidget* parent)
     : QDialog(parent), m_ui(new Ui::ExportInstanceDialog), m_instance(instance)
 {
     m_ui->setupUi(this);
@@ -98,7 +98,7 @@ ExportInstanceDialog::~ExportInstanceDialog()
 }
 
 /// Save icon to instance's folder is needed
-void SaveIcon(InstancePtr m_instance)
+void SaveIcon(BaseInstance* m_instance)
 {
     auto iconKey = m_instance->iconKey();
     auto iconList = APPLICATION->icons();

--- a/launcher/ui/dialogs/ExportInstanceDialog.h
+++ b/launcher/ui/dialogs/ExportInstanceDialog.h
@@ -43,7 +43,6 @@
 #include "FileIgnoreProxy.h"
 
 class BaseInstance;
-using InstancePtr = std::shared_ptr<BaseInstance>;
 
 namespace Ui {
 class ExportInstanceDialog;
@@ -53,7 +52,7 @@ class ExportInstanceDialog : public QDialog {
     Q_OBJECT
 
    public:
-    explicit ExportInstanceDialog(InstancePtr instance, QWidget* parent = 0);
+    explicit ExportInstanceDialog(BaseInstance* instance, QWidget* parent = 0);
     ~ExportInstanceDialog();
 
     virtual void done(int result);
@@ -64,7 +63,7 @@ class ExportInstanceDialog : public QDialog {
 
    private:
     Ui::ExportInstanceDialog* m_ui;
-    InstancePtr m_instance;
+    BaseInstance* m_instance;
     FileIgnoreProxy* m_proxyModel;
     FastFileIconProvider m_icons;
 

--- a/launcher/ui/dialogs/ExportPackDialog.cpp
+++ b/launcher/ui/dialogs/ExportPackDialog.cpp
@@ -33,7 +33,7 @@
 #include "MMCZip.h"
 #include "modplatform/modrinth/ModrinthPackExportTask.h"
 
-ExportPackDialog::ExportPackDialog(MinecraftInstancePtr instance, QWidget* parent, ModPlatform::ResourceProvider provider)
+ExportPackDialog::ExportPackDialog(MinecraftInstance* instance, QWidget* parent, ModPlatform::ResourceProvider provider)
     : QDialog(parent), m_instance(instance), m_ui(new Ui::ExportPackDialog), m_provider(provider)
 {
     Q_ASSERT(m_provider == ModPlatform::ResourceProvider::MODRINTH || m_provider == ModPlatform::ResourceProvider::FLAME);
@@ -101,23 +101,20 @@ ExportPackDialog::ExportPackDialog(MinecraftInstancePtr instance, QWidget* paren
 
     const QDir::Filters filter(QDir::AllEntries | QDir::NoDotAndDotDot | QDir::AllDirs | QDir::Hidden);
 
-    MinecraftInstance* mcInstance = dynamic_cast<MinecraftInstance*>(instance.get());
-    if (mcInstance) {
-        for (auto resourceModel : mcInstance->resourceLists()) {
-            if (resourceModel == nullptr) {
-                continue;
-            }
-
-            if (!resourceModel->indexDir().exists()) {
-                continue;
-            }
-
-            if (resourceModel->dir() == resourceModel->indexDir()) {
-                continue;
-            }
-
-            m_proxy->ignoreFilesWithPath().insert(instanceRoot.relativeFilePath(resourceModel->indexDir().absolutePath()));
+    for (auto resourceModel : instance->resourceLists()) {
+        if (resourceModel == nullptr) {
+            continue;
         }
+
+        if (!resourceModel->indexDir().exists()) {
+            continue;
+        }
+
+        if (resourceModel->dir() == resourceModel->indexDir()) {
+            continue;
+        }
+
+        m_proxy->ignoreFilesWithPath().insert(instanceRoot.relativeFilePath(resourceModel->indexDir().absolutePath()));
     }
 
     m_ui->files->setModel(m_proxy);

--- a/launcher/ui/dialogs/ExportPackDialog.h
+++ b/launcher/ui/dialogs/ExportPackDialog.h
@@ -33,7 +33,7 @@ class ExportPackDialog : public QDialog {
     Q_OBJECT
 
    public:
-    explicit ExportPackDialog(MinecraftInstancePtr instance,
+    explicit ExportPackDialog(MinecraftInstance* instance,
                               QWidget* parent = nullptr,
                               ModPlatform::ResourceProvider provider = ModPlatform::ResourceProvider::MODRINTH);
     ~ExportPackDialog();
@@ -45,7 +45,7 @@ class ExportPackDialog : public QDialog {
     QString ignoreFileName();
 
    private:
-    const MinecraftInstancePtr m_instance;
+    MinecraftInstance* m_instance;
     Ui::ExportPackDialog* m_ui;
     FileIgnoreProxy* m_proxy;
     FastFileIconProvider m_icons;

--- a/launcher/ui/dialogs/IconPickerDialog.cpp
+++ b/launcher/ui/dialogs/IconPickerDialog.cpp
@@ -40,7 +40,7 @@ IconPickerDialog::IconPickerDialog(QWidget* parent) : QDialog(parent), ui(new Ui
     ui->verticalLayout->insertWidget(0, searchBar);
 
     proxyModel = new QSortFilterProxyModel(this);
-    proxyModel->setSourceModel(APPLICATION->icons().get());
+    proxyModel->setSourceModel(APPLICATION->icons());
     proxyModel->setFilterCaseSensitivity(Qt::CaseInsensitive);
     ui->iconView->setModel(proxyModel);
 
@@ -88,7 +88,7 @@ IconPickerDialog::IconPickerDialog(QWidget* parent) : QDialog(parent), ui(new Ui
     connect(buttonFolder, &QPushButton::clicked, this, &IconPickerDialog::openFolder);
     connect(searchBar, &QLineEdit::textChanged, this, &IconPickerDialog::filterIcons);
     // Prevent incorrect indices from e.g. filesystem changes
-    connect(APPLICATION->icons().get(), &IconList::iconUpdated, this, [this]() { proxyModel->invalidate(); });
+    connect(APPLICATION->icons(), &IconList::iconUpdated, this, [this]() { proxyModel->invalidate(); });
 }
 
 bool IconPickerDialog::eventFilter(QObject* obj, QEvent* evt)

--- a/launcher/ui/dialogs/ImportResourceDialog.cpp
+++ b/launcher/ui/dialogs/ImportResourceDialog.cpp
@@ -35,7 +35,7 @@ ImportResourceDialog::ImportResourceDialog(QString file_path, ModPlatform::Resou
     contentsWidget->setItemDelegate(new ListViewDelegate());
 
     proxyModel = new InstanceProxyModel(this);
-    proxyModel->setSourceModel(APPLICATION->instances().get());
+    proxyModel->setSourceModel(APPLICATION->instances());
     proxyModel->sort(0);
     contentsWidget->setModel(proxyModel);
 

--- a/launcher/ui/dialogs/InstallLoaderDialog.cpp
+++ b/launcher/ui/dialogs/InstallLoaderDialog.cpp
@@ -37,7 +37,7 @@ class InstallLoaderPage : public VersionSelectWidget, public BasePage {
                       const QString& iconName,
                       const QString& name,
                       const Version& oldestVersion,
-                      const std::shared_ptr<PackProfile> profile)
+                      PackProfile* profile)
         : VersionSelectWidget(nullptr), uid(id), iconName(iconName), name(name)
     {
         const QString minecraftVersion = profile->getComponentVersion("net.minecraft");
@@ -88,8 +88,8 @@ static InstallLoaderPage* pageCast(BasePage* page)
     return result;
 }
 
-InstallLoaderDialog::InstallLoaderDialog(std::shared_ptr<PackProfile> profile, const QString& uid, QWidget* parent)
-    : QDialog(parent), profile(std::move(profile)), container(new PageContainer(this, QString(), this)), buttons(new QDialogButtonBox(this))
+InstallLoaderDialog::InstallLoaderDialog(PackProfile* profile, const QString& uid, QWidget* parent)
+    : QDialog(parent), profile(profile), container(new PageContainer(this, QString(), this)), buttons(new QDialogButtonBox(this))
 {
     auto layout = new QVBoxLayout(this);
     layout->setContentsMargins(0, 0, 0, 0);

--- a/launcher/ui/dialogs/InstallLoaderDialog.h
+++ b/launcher/ui/dialogs/InstallLoaderDialog.h
@@ -30,7 +30,7 @@ class InstallLoaderDialog final : public QDialog, protected BasePageProvider {
     Q_OBJECT
 
    public:
-    explicit InstallLoaderDialog(std::shared_ptr<PackProfile> instance, const QString& uid = QString(), QWidget* parent = nullptr);
+    explicit InstallLoaderDialog(PackProfile* instance, const QString& uid = QString(), QWidget* parent = nullptr);
 
     QList<BasePage*> getPages() override;
     QString dialogTitle() override;
@@ -39,7 +39,7 @@ class InstallLoaderDialog final : public QDialog, protected BasePageProvider {
     void done(int result) override;
 
    private:
-    std::shared_ptr<PackProfile> profile;
+    PackProfile* profile;
     PageContainer* container;
     QDialogButtonBox* buttons;
 };

--- a/launcher/ui/dialogs/ProfileSelectDialog.h
+++ b/launcher/ui/dialogs/ProfileSelectDialog.h
@@ -76,7 +76,7 @@ class ProfileSelectDialog : public QDialog {
     void on_buttonBox_rejected();
 
    protected:
-    shared_qobject_ptr<AccountList> m_accounts;
+    AccountList* m_accounts;
 
     //! The account that was selected when the user clicked OK.
     MinecraftAccountPtr m_selected;

--- a/launcher/ui/dialogs/ProfileSetupDialog.cpp
+++ b/launcher/ui/dialogs/ProfileSetupDialog.cpp
@@ -162,8 +162,8 @@ void ProfileSetupDialog::checkName(const QString& name)
     m_check_response.reset(new QByteArray());
     if (m_check_task)
         disconnect(m_check_task.get(), nullptr, this, nullptr);
-    m_check_task = Net::Download::makeByteArray(url, m_check_response);
-    m_check_task->addHeaderProxy(new Net::RawHeaderProxy(headers));
+    m_check_task = Net::Download::makeByteArray(url, m_check_response.get());
+    m_check_task->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(headers));
 
     connect(m_check_task.get(), &Task::finished, this, &ProfileSetupDialog::checkFinished);
 
@@ -206,8 +206,8 @@ void ProfileSetupDialog::setupProfile(const QString& profileName)
                                            { "Authorization", QString("Bearer %1").arg(m_accountToSetup->accessToken()).toUtf8() } };
 
     m_profile_response.reset(new QByteArray());
-    m_profile_task = Net::Upload::makeByteArray(url, m_profile_response, payloadTemplate.arg(profileName).toUtf8());
-    m_profile_task->addHeaderProxy(new Net::RawHeaderProxy(headers));
+    m_profile_task = Net::Upload::makeByteArray(url, m_profile_response.get(), payloadTemplate.arg(profileName).toUtf8());
+    m_profile_task->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(headers));
 
     connect(m_profile_task.get(), &Task::finished, this, &ProfileSetupDialog::setupProfileFinished);
 

--- a/launcher/ui/dialogs/ProfileSetupDialog.h
+++ b/launcher/ui/dialogs/ProfileSetupDialog.h
@@ -70,9 +70,9 @@ class ProfileSetupDialog : public QDialog {
 
     QTimer checkStartTimer;
 
-    std::shared_ptr<QByteArray> m_check_response;
+    std::unique_ptr<QByteArray> m_check_response;
     Net::Download::Ptr m_check_task;
 
-    std::shared_ptr<QByteArray> m_profile_response;
+    std::unique_ptr<QByteArray> m_profile_response;
     Net::Upload::Ptr m_profile_task;
 };

--- a/launcher/ui/dialogs/ResourceDownloadDialog.cpp
+++ b/launcher/ui/dialogs/ResourceDownloadDialog.cpp
@@ -49,7 +49,7 @@
 
 namespace ResourceDownload {
 
-ResourceDownloadDialog::ResourceDownloadDialog(QWidget* parent, const std::shared_ptr<ResourceFolderModel> base_model)
+ResourceDownloadDialog::ResourceDownloadDialog(QWidget* parent, ResourceFolderModel* base_model)
     : QDialog(parent)
     , m_base_model(base_model)
     , m_buttons(QDialogButtonBox::Help | QDialogButtonBox::Ok | QDialogButtonBox::Cancel)
@@ -269,7 +269,7 @@ void ResourceDownloadDialog::selectedPageChanged(BasePage* previous, BasePage* s
     result->setSearchTerm(prev_page->getSearchTerm());
 }
 
-ModDownloadDialog::ModDownloadDialog(QWidget* parent, const std::shared_ptr<ModFolderModel>& mods, BaseInstance* instance)
+ModDownloadDialog::ModDownloadDialog(QWidget* parent, ModFolderModel* mods, BaseInstance* instance)
     : ResourceDownloadDialog(parent, mods), m_instance(instance)
 {
     setWindowTitle(dialogTitle());
@@ -298,7 +298,7 @@ QList<BasePage*> ModDownloadDialog::getPages()
 GetModDependenciesTask::Ptr ModDownloadDialog::getModDependenciesTask()
 {
     if (!APPLICATION->settings()->get("ModDependenciesDisabled").toBool()) {  // dependencies
-        if (auto model = dynamic_cast<ModFolderModel*>(getBaseModel().get()); model) {
+        if (auto model = dynamic_cast<ModFolderModel*>(getBaseModel()); model) {
             QList<std::shared_ptr<GetModDependenciesTask::PackDependency>> selectedVers;
             for (auto& selected : getTasks()) {
                 selectedVers.append(std::make_shared<GetModDependenciesTask::PackDependency>(selected->getPack(), selected->getVersion()));
@@ -311,7 +311,7 @@ GetModDependenciesTask::Ptr ModDownloadDialog::getModDependenciesTask()
 }
 
 ResourcePackDownloadDialog::ResourcePackDownloadDialog(QWidget* parent,
-                                                       const std::shared_ptr<ResourcePackFolderModel>& resource_packs,
+                                                       ResourcePackFolderModel* resource_packs,
                                                        BaseInstance* instance)
     : ResourceDownloadDialog(parent, resource_packs), m_instance(instance)
 {
@@ -336,7 +336,7 @@ QList<BasePage*> ResourcePackDownloadDialog::getPages()
 }
 
 TexturePackDownloadDialog::TexturePackDownloadDialog(QWidget* parent,
-                                                     const std::shared_ptr<TexturePackFolderModel>& resource_packs,
+                                                     TexturePackFolderModel* resource_packs,
                                                      BaseInstance* instance)
     : ResourceDownloadDialog(parent, resource_packs), m_instance(instance)
 {
@@ -361,7 +361,7 @@ QList<BasePage*> TexturePackDownloadDialog::getPages()
 }
 
 ShaderPackDownloadDialog::ShaderPackDownloadDialog(QWidget* parent,
-                                                   const std::shared_ptr<ShaderPackFolderModel>& shaders,
+                                                   ShaderPackFolderModel* shaders,
                                                    BaseInstance* instance)
     : ResourceDownloadDialog(parent, shaders), m_instance(instance)
 {
@@ -401,7 +401,7 @@ void ResourceDownloadDialog::setResourceMetadata(const std::shared_ptr<Metadata:
 }
 
 DataPackDownloadDialog::DataPackDownloadDialog(QWidget* parent,
-                                               const std::shared_ptr<DataPackFolderModel>& data_packs,
+                                               DataPackFolderModel* data_packs,
                                                BaseInstance* instance)
     : ResourceDownloadDialog(parent, data_packs), m_instance(instance)
 {

--- a/launcher/ui/dialogs/ResourceDownloadDialog.h
+++ b/launcher/ui/dialogs/ResourceDownloadDialog.h
@@ -51,7 +51,7 @@ class ResourceDownloadDialog : public QDialog, public BasePageProvider {
    public:
     using DownloadTaskPtr = shared_qobject_ptr<ResourceDownloadTask>;
 
-    ResourceDownloadDialog(QWidget* parent, std::shared_ptr<ResourceFolderModel> base_model);
+    ResourceDownloadDialog(QWidget* parent, ResourceFolderModel* base_model);
 
     void initializeContainer();
     void connectButtons();
@@ -68,7 +68,7 @@ class ResourceDownloadDialog : public QDialog, public BasePageProvider {
     void removeResource(const QString&);
 
     const QList<DownloadTaskPtr> getTasks();
-    const std::shared_ptr<ResourceFolderModel> getBaseModel() const { return m_base_model; }
+    ResourceFolderModel* getBaseModel() const { return m_base_model; }
 
     void setResourceMetadata(const std::shared_ptr<Metadata::ModStruct>& meta);
 
@@ -88,7 +88,7 @@ class ResourceDownloadDialog : public QDialog, public BasePageProvider {
     virtual GetModDependenciesTask::Ptr getModDependenciesTask() { return nullptr; }
 
    protected:
-    const std::shared_ptr<ResourceFolderModel> m_base_model;
+    ResourceFolderModel* m_base_model;
 
     PageContainer* m_container = nullptr;
 
@@ -100,7 +100,7 @@ class ModDownloadDialog final : public ResourceDownloadDialog {
     Q_OBJECT
 
    public:
-    explicit ModDownloadDialog(QWidget* parent, const std::shared_ptr<ModFolderModel>& mods, BaseInstance* instance);
+    explicit ModDownloadDialog(QWidget* parent, ModFolderModel* mods, BaseInstance* instance);
     ~ModDownloadDialog() override = default;
 
     //: String that gets appended to the mod download dialog title ("Download " + resourcesString())
@@ -119,7 +119,7 @@ class ResourcePackDownloadDialog final : public ResourceDownloadDialog {
 
    public:
     explicit ResourcePackDownloadDialog(QWidget* parent,
-                                        const std::shared_ptr<ResourcePackFolderModel>& resource_packs,
+                                        ResourcePackFolderModel* resource_packs,
                                         BaseInstance* instance);
     ~ResourcePackDownloadDialog() override = default;
 
@@ -138,7 +138,7 @@ class TexturePackDownloadDialog final : public ResourceDownloadDialog {
 
    public:
     explicit TexturePackDownloadDialog(QWidget* parent,
-                                       const std::shared_ptr<TexturePackFolderModel>& resource_packs,
+                                       TexturePackFolderModel* resource_packs,
                                        BaseInstance* instance);
     ~TexturePackDownloadDialog() override = default;
 
@@ -156,7 +156,7 @@ class ShaderPackDownloadDialog final : public ResourceDownloadDialog {
     Q_OBJECT
 
    public:
-    explicit ShaderPackDownloadDialog(QWidget* parent, const std::shared_ptr<ShaderPackFolderModel>& shader_packs, BaseInstance* instance);
+    explicit ShaderPackDownloadDialog(QWidget* parent, ShaderPackFolderModel* shader_packs, BaseInstance* instance);
     ~ShaderPackDownloadDialog() override = default;
 
     //: String that gets appended to the shader pack download dialog title ("Download " + resourcesString())
@@ -173,7 +173,7 @@ class DataPackDownloadDialog final : public ResourceDownloadDialog {
     Q_OBJECT
 
    public:
-    explicit DataPackDownloadDialog(QWidget* parent, const std::shared_ptr<DataPackFolderModel>& data_packs, BaseInstance* instance);
+    explicit DataPackDownloadDialog(QWidget* parent, DataPackFolderModel* data_packs, BaseInstance* instance);
     ~DataPackDownloadDialog() override = default;
 
     //: String that gets appended to the data pack download dialog title ("Download " + resourcesString())

--- a/launcher/ui/dialogs/ResourceUpdateDialog.cpp
+++ b/launcher/ui/dialogs/ResourceUpdateDialog.cpp
@@ -36,7 +36,7 @@ static std::list<Version> mcVersions(BaseInstance* inst)
 
 ResourceUpdateDialog::ResourceUpdateDialog(QWidget* parent,
                                            BaseInstance* instance,
-                                           const std::shared_ptr<ResourceFolderModel> resourceModel,
+                                           ResourceFolderModel* resourceModel,
                                            QList<Resource*>& searchFor,
                                            bool includeDeps,
                                            QList<ModPlatform::ModLoaderType> loadersList)
@@ -188,7 +188,7 @@ void ResourceUpdateDialog::checkCandidates()
     }
 
     if (m_includeDeps && !APPLICATION->settings()->get("ModDependenciesDisabled").toBool()) {  // dependencies
-        auto* mod_model = dynamic_cast<ModFolderModel*>(m_resourceModel.get());
+        auto* mod_model = dynamic_cast<ModFolderModel*>(m_resourceModel);
 
         if (mod_model != nullptr) {
             auto depTask = makeShared<GetModDependenciesTask>(m_instance, mod_model, selectedVers);

--- a/launcher/ui/dialogs/ResourceUpdateDialog.h
+++ b/launcher/ui/dialogs/ResourceUpdateDialog.h
@@ -18,7 +18,7 @@ class ResourceUpdateDialog final : public ReviewMessageBox {
    public:
     explicit ResourceUpdateDialog(QWidget* parent,
                                   BaseInstance* instance,
-                                  std::shared_ptr<ResourceFolderModel> resourceModel,
+                                  ResourceFolderModel* resourceModel,
                                   QList<Resource*>& searchFor,
                                   bool includeDeps,
                                   QList<ModPlatform::ModLoaderType> loadersList = {});
@@ -48,7 +48,7 @@ class ResourceUpdateDialog final : public ReviewMessageBox {
     shared_qobject_ptr<ModrinthCheckUpdate> m_modrinthCheckTask;
     shared_qobject_ptr<FlameCheckUpdate> m_flameCheckTask;
 
-    const std::shared_ptr<ResourceFolderModel> m_resourceModel;
+    ResourceFolderModel* m_resourceModel;
 
     QList<Resource*>& m_candidates;
     QList<Resource*> m_modrinthToUpdate;

--- a/launcher/ui/dialogs/skins/SkinManageDialog.cpp
+++ b/launcher/ui/dialogs/skins/SkinManageDialog.cpp
@@ -476,8 +476,8 @@ void SkinManageDialog::on_userBtn_clicked()
     auto uuidLoop = makeShared<WaitTask>();
     auto profileLoop = makeShared<WaitTask>();
 
-    auto getUUID = Net::Download::makeByteArray("https://api.minecraftservices.com/minecraft/profile/lookup/name/" + user, uuidOut);
-    auto getProfile = Net::Download::makeByteArray(QUrl(), profileOut);
+    auto getUUID = Net::Download::makeByteArray("https://api.minecraftservices.com/minecraft/profile/lookup/name/" + user, uuidOut.get());
+    auto getProfile = Net::Download::makeByteArray(QUrl(), profileOut.get());
     auto downloadSkin = Net::Download::makeFile(QUrl(), path);
 
     QString failReason;

--- a/launcher/ui/instanceview/InstanceView.cpp
+++ b/launcher/ui/instanceview/InstanceView.cpp
@@ -642,7 +642,7 @@ void InstanceView::dropEvent(QDropEvent* event)
                 return;
             }
             auto instanceId = QString::fromUtf8(mimedata->data("application/x-instanceid"));
-            auto instanceList = APPLICATION->instances().get();
+            auto instanceList = APPLICATION->instances();
             instanceList->setInstanceGroup(instanceId, group->text);
             event->setDropAction(Qt::MoveAction);
             event->accept();

--- a/launcher/ui/pages/global/AccountListPage.cpp
+++ b/launcher/ui/pages/global/AccountListPage.cpp
@@ -61,7 +61,7 @@ AccountListPage::AccountListPage(QWidget* parent) : QMainWindow(parent), ui(new 
 
     m_accounts = APPLICATION->accounts();
 
-    ui->listView->setModel(m_accounts.get());
+    ui->listView->setModel(m_accounts);
     ui->listView->header()->setSectionResizeMode(AccountList::VListColumns::ProfileNameColumn, QHeaderView::Stretch);
     ui->listView->header()->setSectionResizeMode(AccountList::VListColumns::NameColumn, QHeaderView::Stretch);
     ui->listView->header()->setSectionResizeMode(AccountList::VListColumns::TypeColumn, QHeaderView::ResizeToContents);
@@ -78,9 +78,9 @@ AccountListPage::AccountListPage(QWidget* parent) : QMainWindow(parent), ui(new 
     connect(ui->listView, &VersionListView::activated, this,
             [this](const QModelIndex& index) { m_accounts->setDefaultAccount(m_accounts->at(index.row())); });
 
-    connect(m_accounts.get(), &AccountList::listChanged, this, &AccountListPage::listChanged);
-    connect(m_accounts.get(), &AccountList::listActivityChanged, this, &AccountListPage::listChanged);
-    connect(m_accounts.get(), &AccountList::defaultAccountChanged, this, &AccountListPage::listChanged);
+    connect(m_accounts, &AccountList::listChanged, this, &AccountListPage::listChanged);
+    connect(m_accounts, &AccountList::listActivityChanged, this, &AccountListPage::listChanged);
+    connect(m_accounts, &AccountList::defaultAccountChanged, this, &AccountListPage::listChanged);
 
     updateButtonStates();
 

--- a/launcher/ui/pages/global/AccountListPage.h
+++ b/launcher/ui/pages/global/AccountListPage.h
@@ -88,6 +88,6 @@ class AccountListPage : public QMainWindow, public BasePage {
    private:
     void changeEvent(QEvent* event) override;
     QMenu* createPopupMenu() override;
-    shared_qobject_ptr<AccountList> m_accounts;
+    AccountList* m_accounts;
     Ui::AccountListPage* ui;
 };

--- a/launcher/ui/pages/instance/DataPackPage.cpp
+++ b/launcher/ui/pages/instance/DataPackPage.cpp
@@ -25,7 +25,7 @@
 #include "ui/dialogs/ResourceDownloadDialog.h"
 #include "ui/dialogs/ResourceUpdateDialog.h"
 
-DataPackPage::DataPackPage(BaseInstance* instance, std::shared_ptr<DataPackFolderModel> model, QWidget* parent)
+DataPackPage::DataPackPage(BaseInstance* instance, DataPackFolderModel* model, QWidget* parent)
     : ExternalResourcesPage(instance, model, parent), m_model(model)
 {
     ui->actionDownloadItem->setText(tr("Download Packs"));

--- a/launcher/ui/pages/instance/DataPackPage.h
+++ b/launcher/ui/pages/instance/DataPackPage.h
@@ -26,7 +26,7 @@
 class DataPackPage : public ExternalResourcesPage {
     Q_OBJECT
    public:
-    explicit DataPackPage(BaseInstance* instance, std::shared_ptr<DataPackFolderModel> model, QWidget* parent = nullptr);
+    explicit DataPackPage(BaseInstance* instance, DataPackFolderModel* model, QWidget* parent = nullptr);
 
     QString displayName() const override { return QObject::tr("Data Packs"); }
     QIcon icon() const override { return QIcon::fromTheme("datapacks"); }
@@ -43,7 +43,7 @@ class DataPackPage : public ExternalResourcesPage {
     void changeDataPackVersion();
 
    private:
-    std::shared_ptr<DataPackFolderModel> m_model;
+    DataPackFolderModel* m_model;
     QPointer<ResourceDownload::DataPackDownloadDialog> m_downloadDialog;
 };
 

--- a/launcher/ui/pages/instance/ExternalResourcesPage.cpp
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.cpp
@@ -47,7 +47,7 @@
 #include <QMenu>
 #include <algorithm>
 
-ExternalResourcesPage::ExternalResourcesPage(BaseInstance* instance, std::shared_ptr<ResourceFolderModel> model, QWidget* parent)
+ExternalResourcesPage::ExternalResourcesPage(BaseInstance* instance, ResourceFolderModel* model, QWidget* parent)
     : QMainWindow(parent), m_instance(instance), ui(new Ui::ExternalResourcesPage), m_model(model)
 {
     ui->setupUi(this);
@@ -58,7 +58,7 @@ ExternalResourcesPage::ExternalResourcesPage(BaseInstance* instance, std::shared
     m_filterModel->setDynamicSortFilter(true);
     m_filterModel->setFilterCaseSensitivity(Qt::CaseInsensitive);
     m_filterModel->setSortCaseSensitivity(Qt::CaseInsensitive);
-    m_filterModel->setSourceModel(m_model.get());
+    m_filterModel->setSourceModel(m_model);
     m_filterModel->setFilterKeyColumn(-1);
     ui->treeView->setModel(m_filterModel);
     // must come after setModel
@@ -98,12 +98,12 @@ ExternalResourcesPage::ExternalResourcesPage(BaseInstance* instance, std::shared
     };
 
     connect(selection_model, &QItemSelectionModel::selectionChanged, this, updateExtra);
-    connect(model.get(), &ResourceFolderModel::updateFinished, this, updateExtra);
-    connect(model.get(), &ResourceFolderModel::parseFinished, this, updateExtra);
+    connect(model, &ResourceFolderModel::updateFinished, this, updateExtra);
+    connect(model, &ResourceFolderModel::parseFinished, this, updateExtra);
 
     connect(selection_model, &QItemSelectionModel::selectionChanged, this, [this] { updateActions(); });
-    connect(m_model.get(), &ResourceFolderModel::rowsInserted, this, [this] { updateActions(); });
-    connect(m_model.get(), &ResourceFolderModel::rowsRemoved, this, [this] { updateActions(); });
+    connect(m_model, &ResourceFolderModel::rowsInserted, this, [this] { updateActions(); });
+    connect(m_model, &ResourceFolderModel::rowsRemoved, this, [this] { updateActions(); });
 
     auto viewHeader = ui->treeView->header();
     viewHeader->setContextMenuPolicy(Qt::CustomContextMenu);

--- a/launcher/ui/pages/instance/ExternalResourcesPage.h
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.h
@@ -20,7 +20,7 @@ class ExternalResourcesPage : public QMainWindow, public BasePage {
     Q_OBJECT
 
    public:
-    explicit ExternalResourcesPage(BaseInstance* instance, std::shared_ptr<ResourceFolderModel> model, QWidget* parent = nullptr);
+    explicit ExternalResourcesPage(BaseInstance* instance, ResourceFolderModel* model, QWidget* parent = nullptr);
     virtual ~ExternalResourcesPage();
 
     virtual QString displayName() const override = 0;
@@ -68,7 +68,7 @@ class ExternalResourcesPage : public QMainWindow, public BasePage {
     BaseInstance* m_instance = nullptr;
 
     Ui::ExternalResourcesPage* ui = nullptr;
-    std::shared_ptr<ResourceFolderModel> m_model;
+    ResourceFolderModel* m_model;
     QSortFilterProxyModel* m_filterModel = nullptr;
 
     QString m_fileSelectionFilter;

--- a/launcher/ui/pages/instance/InstanceSettingsPage.h
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.h
@@ -44,8 +44,8 @@ class InstanceSettingsPage : public MinecraftSettingsWidget, public BasePage {
     Q_OBJECT
 
    public:
-    explicit InstanceSettingsPage(MinecraftInstancePtr instance, QWidget* parent = nullptr)
-        : MinecraftSettingsWidget(std::move(instance), parent)
+    explicit InstanceSettingsPage(MinecraftInstance* instance, QWidget* parent = nullptr)
+        : MinecraftSettingsWidget(instance, parent)
     {
         connect(APPLICATION, &Application::globalSettingsAboutToOpen, this, &InstanceSettingsPage::saveSettings);
         connect(APPLICATION, &Application::globalSettingsApplied, this, &InstanceSettingsPage::loadSettings);

--- a/launcher/ui/pages/instance/LogPage.cpp
+++ b/launcher/ui/pages/instance/LogPage.cpp
@@ -128,7 +128,7 @@ QModelIndex LogFormatProxyModel::find(const QModelIndex& start, const QString& v
     return QModelIndex();
 }
 
-LogPage::LogPage(InstancePtr instance, QWidget* parent) : QWidget(parent), ui(new Ui::LogPage), m_instance(instance)
+LogPage::LogPage(BaseInstance* instance, QWidget* parent) : QWidget(parent), ui(new Ui::LogPage), m_instance(instance)
 {
     ui->setupUi(this);
 
@@ -153,7 +153,7 @@ LogPage::LogPage(InstancePtr instance, QWidget* parent) : QWidget(parent), ui(ne
         if (launchTask) {
             setInstanceLaunchTaskChanged(launchTask, true);
         }
-        connect(m_instance.get(), &BaseInstance::launchTaskChanged, this, &LogPage::onInstanceLaunchTaskChanged);
+        connect(m_instance, &BaseInstance::launchTaskChanged, this, &LogPage::onInstanceLaunchTaskChanged);
     }
 
     auto findShortcut = new QShortcut(QKeySequence(QKeySequence::Find), this);
@@ -203,7 +203,7 @@ void LogPage::UIToModelState()
     m_model->suspend(ui->trackLogCheckbox->checkState() != Qt::Checked);
 }
 
-void LogPage::setInstanceLaunchTaskChanged(shared_qobject_ptr<LaunchTask> proc, bool initial)
+void LogPage::setInstanceLaunchTaskChanged(LaunchTask* proc, bool initial)
 {
     m_process = proc;
     if (m_process) {
@@ -220,7 +220,7 @@ void LogPage::setInstanceLaunchTaskChanged(shared_qobject_ptr<LaunchTask> proc, 
     }
 }
 
-void LogPage::onInstanceLaunchTaskChanged(shared_qobject_ptr<LaunchTask> proc)
+void LogPage::onInstanceLaunchTaskChanged(LaunchTask* proc)
 {
     setInstanceLaunchTaskChanged(proc, false);
 }

--- a/launcher/ui/pages/instance/LogPage.h
+++ b/launcher/ui/pages/instance/LogPage.h
@@ -63,7 +63,7 @@ class LogPage : public QWidget, public BasePage {
     Q_OBJECT
 
    public:
-    explicit LogPage(InstancePtr instance, QWidget* parent = 0);
+    explicit LogPage(BaseInstance* instance, QWidget* parent = 0);
     virtual ~LogPage();
     virtual QString displayName() const override { return tr("Minecraft Log"); }
     virtual QIcon icon() const override { return QIcon::fromTheme("log"); }
@@ -88,17 +88,17 @@ class LogPage : public QWidget, public BasePage {
     void findNextActivated();
     void findPreviousActivated();
 
-    void onInstanceLaunchTaskChanged(shared_qobject_ptr<LaunchTask> proc);
+    void onInstanceLaunchTaskChanged(LaunchTask* proc);
 
    private:
     void modelStateToUI();
     void UIToModelState();
-    void setInstanceLaunchTaskChanged(shared_qobject_ptr<LaunchTask> proc, bool initial);
+    void setInstanceLaunchTaskChanged(LaunchTask* proc, bool initial);
 
    private:
     Ui::LogPage* ui;
-    InstancePtr m_instance;
-    shared_qobject_ptr<LaunchTask> m_process;
+    BaseInstance* m_instance;
+    LaunchTask* m_process;
 
     LogFormatProxyModel* m_proxy;
     shared_qobject_ptr<LogModel> m_model;

--- a/launcher/ui/pages/instance/ModFolderPage.cpp
+++ b/launcher/ui/pages/instance/ModFolderPage.cpp
@@ -66,7 +66,7 @@
 #include "tasks/Task.h"
 #include "ui/dialogs/ProgressDialog.h"
 
-ModFolderPage::ModFolderPage(BaseInstance* inst, std::shared_ptr<ModFolderModel> model, QWidget* parent)
+ModFolderPage::ModFolderPage(BaseInstance* inst, ModFolderModel* model, QWidget* parent)
     : ExternalResourcesPage(inst, model, parent), m_model(model)
 {
     ui->actionDownloadItem->setText(tr("Download Mods"));
@@ -341,7 +341,7 @@ void ModFolderPage::exportModMetadata()
     dlg.exec();
 }
 
-CoreModFolderPage::CoreModFolderPage(BaseInstance* inst, std::shared_ptr<ModFolderModel> mods, QWidget* parent)
+CoreModFolderPage::CoreModFolderPage(BaseInstance* inst, ModFolderModel* mods, QWidget* parent)
     : ModFolderPage(inst, mods, parent)
 {
     auto mcInst = dynamic_cast<MinecraftInstance*>(m_instance);
@@ -381,7 +381,7 @@ bool CoreModFolderPage::shouldDisplay() const
     return false;
 }
 
-NilModFolderPage::NilModFolderPage(BaseInstance* inst, std::shared_ptr<ModFolderModel> mods, QWidget* parent)
+NilModFolderPage::NilModFolderPage(BaseInstance* inst, ModFolderModel* mods, QWidget* parent)
     : ModFolderPage(inst, mods, parent)
 {}
 

--- a/launcher/ui/pages/instance/ModFolderPage.h
+++ b/launcher/ui/pages/instance/ModFolderPage.h
@@ -48,7 +48,7 @@ class ModFolderPage : public ExternalResourcesPage {
     inline bool handleNoModLoader();
 
    public:
-    explicit ModFolderPage(BaseInstance* inst, std::shared_ptr<ModFolderModel> model, QWidget* parent = nullptr);
+    explicit ModFolderPage(BaseInstance* inst, ModFolderModel* model, QWidget* parent = nullptr);
     virtual ~ModFolderPage() = default;
 
     void setFilter(const QString& filter) { m_fileSelectionFilter = filter; }
@@ -74,14 +74,14 @@ class ModFolderPage : public ExternalResourcesPage {
     void changeModVersion();
 
    protected:
-    std::shared_ptr<ModFolderModel> m_model;
+    ModFolderModel* m_model;
     QPointer<ResourceDownload::ModDownloadDialog> m_downloadDialog;
 };
 
 class CoreModFolderPage : public ModFolderPage {
     Q_OBJECT
    public:
-    explicit CoreModFolderPage(BaseInstance* inst, std::shared_ptr<ModFolderModel> mods, QWidget* parent = 0);
+    explicit CoreModFolderPage(BaseInstance* inst, ModFolderModel* mods, QWidget* parent = 0);
     virtual ~CoreModFolderPage() = default;
 
     virtual QString displayName() const override { return tr("Core Mods"); }
@@ -95,7 +95,7 @@ class CoreModFolderPage : public ModFolderPage {
 class NilModFolderPage : public ModFolderPage {
     Q_OBJECT
    public:
-    explicit NilModFolderPage(BaseInstance* inst, std::shared_ptr<ModFolderModel> mods, QWidget* parent = 0);
+    explicit NilModFolderPage(BaseInstance* inst, ModFolderModel* mods, QWidget* parent = 0);
     virtual ~NilModFolderPage() = default;
 
     virtual QString displayName() const override { return tr("Nilmods"); }

--- a/launcher/ui/pages/instance/OtherLogsPage.cpp
+++ b/launcher/ui/pages/instance/OtherLogsPage.cpp
@@ -50,7 +50,7 @@
 #include <QShortcut>
 #include <QUrl>
 
-OtherLogsPage::OtherLogsPage(QString id, QString displayName, QString helpPage, InstancePtr instance, QWidget* parent)
+OtherLogsPage::OtherLogsPage(QString id, QString displayName, QString helpPage, BaseInstance* instance, QWidget* parent)
     : QWidget(parent)
     , m_id(id)
     , m_displayName(displayName)
@@ -64,10 +64,10 @@ OtherLogsPage::OtherLogsPage(QString id, QString displayName, QString helpPage, 
 
     m_proxy = new LogFormatProxyModel(this);
     if (m_instance) {
-        m_model.reset(new LogModel(this));
+        m_model = new LogModel(this);
         ui->trackLogCheckbox->hide();
     } else {
-        m_model = APPLICATION->logModel;
+        m_model = APPLICATION->logModel.get();
     }
 
     // set up fonts in the log proxy
@@ -90,7 +90,7 @@ OtherLogsPage::OtherLogsPage(QString id, QString displayName, QString helpPage, 
     } else {
         modelStateToUI();
     }
-    m_proxy->setSourceModel(m_model.get());
+    m_proxy->setSourceModel(m_model);
 
     connect(&m_watcher, &QFileSystemWatcher::directoryChanged, this, &OtherLogsPage::populateSelectLogBox);
 
@@ -243,8 +243,8 @@ void OtherLogsPage::reload()
         if (m_instance) {
             setControlsEnabled(false);
         } else {
-            m_model = APPLICATION->logModel;
-            m_proxy->setSourceModel(m_model.get());
+            m_model = APPLICATION->logModel.get();
+            m_proxy->setSourceModel(m_model);
             ui->text->setModel(m_proxy);
             ui->text->scrollToBottom();
             UIToModelState();
@@ -299,7 +299,7 @@ void OtherLogsPage::reload()
         ui->text->clear();
         ui->text->setModel(nullptr);
         if (!m_instance) {
-            m_model.reset(new LogModel(this));
+            m_model = new LogModel(this);
             m_model->setMaxLines(getConsoleMaxLines(APPLICATION->settings()));
             m_model->setStopOnOverflow(shouldStopOnConsoleOverflow(APPLICATION->settings()));
             m_model->setOverflowMessage(tr("Cannot display this log since the log length surpassed %1 lines.").arg(m_model->getMaxLines()));
@@ -338,7 +338,7 @@ void OtherLogsPage::reload()
             ui->text->setModel(m_proxy);
             ui->text->scrollToBottom();
         } else {
-            m_proxy->setSourceModel(m_model.get());
+            m_proxy->setSourceModel(m_model);
             ui->text->setModel(m_proxy);
             ui->text->scrollToBottom();
             UIToModelState();

--- a/launcher/ui/pages/instance/OtherLogsPage.h
+++ b/launcher/ui/pages/instance/OtherLogsPage.h
@@ -52,7 +52,7 @@ class OtherLogsPage : public QWidget, public BasePage {
     Q_OBJECT
 
    public:
-    explicit OtherLogsPage(QString id, QString displayName, QString helpPage, InstancePtr instance = nullptr, QWidget* parent = 0);
+    explicit OtherLogsPage(QString id, QString displayName, QString helpPage, BaseInstance* instance = nullptr, QWidget* parent = 0);
     ~OtherLogsPage();
 
     QString id() const override { return m_id; }
@@ -97,7 +97,7 @@ class OtherLogsPage : public QWidget, public BasePage {
     QString m_helpPage;
 
     Ui::OtherLogsPage* ui;
-    InstancePtr m_instance;
+    BaseInstance* m_instance;
     /** Path to display log paths relative to. */
     QString m_basePath;
     QStringList m_logSearchPaths;
@@ -105,5 +105,5 @@ class OtherLogsPage : public QWidget, public BasePage {
     QFileSystemWatcher m_watcher;
 
     LogFormatProxyModel* m_proxy;
-    shared_qobject_ptr<LogModel> m_model;
+    LogModel* m_model;
 };

--- a/launcher/ui/pages/instance/ResourcePackPage.cpp
+++ b/launcher/ui/pages/instance/ResourcePackPage.cpp
@@ -42,7 +42,7 @@
 #include "ui/dialogs/ResourceDownloadDialog.h"
 #include "ui/dialogs/ResourceUpdateDialog.h"
 
-ResourcePackPage::ResourcePackPage(MinecraftInstance* instance, std::shared_ptr<ResourcePackFolderModel> model, QWidget* parent)
+ResourcePackPage::ResourcePackPage(MinecraftInstance* instance, ResourcePackFolderModel* model, QWidget* parent)
     : ExternalResourcesPage(instance, model, parent), m_model(model)
 {
     ui->actionDownloadItem->setText(tr("Download Packs"));

--- a/launcher/ui/pages/instance/ResourcePackPage.h
+++ b/launcher/ui/pages/instance/ResourcePackPage.h
@@ -48,7 +48,7 @@
 class ResourcePackPage : public ExternalResourcesPage {
     Q_OBJECT
    public:
-    explicit ResourcePackPage(MinecraftInstance* instance, std::shared_ptr<ResourcePackFolderModel> model, QWidget* parent = 0);
+    explicit ResourcePackPage(MinecraftInstance* instance, ResourcePackFolderModel* model, QWidget* parent = 0);
 
     QString displayName() const override { return tr("Resource Packs"); }
     QIcon icon() const override { return QIcon::fromTheme("resourcepacks"); }
@@ -71,6 +71,6 @@ class ResourcePackPage : public ExternalResourcesPage {
     void changeResourcePackVersion();
 
    protected:
-    std::shared_ptr<ResourcePackFolderModel> m_model;
+    ResourcePackFolderModel* m_model;
     QPointer<ResourceDownload::ResourceDownloadDialog> m_downloadDialog;
 };

--- a/launcher/ui/pages/instance/ServersPage.cpp
+++ b/launcher/ui/pages/instance/ServersPage.cpp
@@ -548,7 +548,7 @@ class ServersModel : public QAbstractListModel {
     ConcurrentTask::Ptr m_currentQueryTask = nullptr;
 };
 
-ServersPage::ServersPage(InstancePtr inst, QWidget* parent) : QMainWindow(parent), ui(new Ui::ServersPage)
+ServersPage::ServersPage(BaseInstance* inst, QWidget* parent) : QMainWindow(parent), ui(new Ui::ServersPage)
 {
     ui->setupUi(this);
     m_inst = inst;
@@ -568,7 +568,7 @@ ServersPage::ServersPage(InstancePtr inst, QWidget* parent) : QMainWindow(parent
 
     auto selectionModel = ui->serversView->selectionModel();
     connect(selectionModel, &QItemSelectionModel::currentChanged, this, &ServersPage::currentChanged);
-    connect(m_inst.get(), &MinecraftInstance::runningStatusChanged, this, &ServersPage::runningStateChanged);
+    connect(m_inst, &MinecraftInstance::runningStatusChanged, this, &ServersPage::runningStateChanged);
     connect(ui->nameLine, &QLineEdit::textEdited, this, &ServersPage::nameEdited);
     connect(ui->addressLine, &QLineEdit::textEdited, this, &ServersPage::addressEdited);
     connect(ui->resourceComboBox, &QComboBox::currentIndexChanged, this, &ServersPage::resourceIndexChanged);

--- a/launcher/ui/pages/instance/ServersPage.h
+++ b/launcher/ui/pages/instance/ServersPage.h
@@ -56,7 +56,7 @@ class ServersPage : public QMainWindow, public BasePage {
     Q_OBJECT
 
    public:
-    explicit ServersPage(InstancePtr inst, QWidget* parent = 0);
+    explicit ServersPage(BaseInstance* inst, QWidget* parent = 0);
     virtual ~ServersPage();
 
     void openedImpl() override;
@@ -100,7 +100,7 @@ class ServersPage : public QMainWindow, public BasePage {
     bool m_locked = true;
     Ui::ServersPage* ui = nullptr;
     ServersModel* m_model = nullptr;
-    InstancePtr m_inst = nullptr;
+    BaseInstance* m_inst = nullptr;
 
     std::shared_ptr<Setting> m_wide_bar_setting = nullptr;
 };

--- a/launcher/ui/pages/instance/ShaderPackPage.cpp
+++ b/launcher/ui/pages/instance/ShaderPackPage.cpp
@@ -47,7 +47,7 @@
 #include "ui/dialogs/ResourceDownloadDialog.h"
 #include "ui/dialogs/ResourceUpdateDialog.h"
 
-ShaderPackPage::ShaderPackPage(MinecraftInstance* instance, std::shared_ptr<ShaderPackFolderModel> model, QWidget* parent)
+ShaderPackPage::ShaderPackPage(MinecraftInstance* instance, ShaderPackFolderModel* model, QWidget* parent)
     : ExternalResourcesPage(instance, model, parent), m_model(model)
 {
     ui->actionDownloadItem->setText(tr("Download Packs"));

--- a/launcher/ui/pages/instance/ShaderPackPage.h
+++ b/launcher/ui/pages/instance/ShaderPackPage.h
@@ -44,7 +44,7 @@
 class ShaderPackPage : public ExternalResourcesPage {
     Q_OBJECT
    public:
-    explicit ShaderPackPage(MinecraftInstance* instance, std::shared_ptr<ShaderPackFolderModel> model, QWidget* parent = nullptr);
+    explicit ShaderPackPage(MinecraftInstance* instance, ShaderPackFolderModel* model, QWidget* parent = nullptr);
     ~ShaderPackPage() override = default;
 
     QString displayName() const override { return tr("Shader Packs"); }
@@ -62,6 +62,6 @@ class ShaderPackPage : public ExternalResourcesPage {
     void changeShaderPackVersion();
 
    private:
-    std::shared_ptr<ShaderPackFolderModel> m_model;
+    ShaderPackFolderModel* m_model;
     QPointer<ResourceDownload::ShaderPackDownloadDialog> m_downloadDialog;
 };

--- a/launcher/ui/pages/instance/TexturePackPage.cpp
+++ b/launcher/ui/pages/instance/TexturePackPage.cpp
@@ -46,7 +46,7 @@
 #include "ui/dialogs/ResourceDownloadDialog.h"
 #include "ui/dialogs/ResourceUpdateDialog.h"
 
-TexturePackPage::TexturePackPage(MinecraftInstance* instance, std::shared_ptr<TexturePackFolderModel> model, QWidget* parent)
+TexturePackPage::TexturePackPage(MinecraftInstance* instance, TexturePackFolderModel* model, QWidget* parent)
     : ExternalResourcesPage(instance, model, parent), m_model(model)
 {
     ui->actionDownloadItem->setText(tr("Download Packs"));

--- a/launcher/ui/pages/instance/TexturePackPage.h
+++ b/launcher/ui/pages/instance/TexturePackPage.h
@@ -48,7 +48,7 @@
 class TexturePackPage : public ExternalResourcesPage {
     Q_OBJECT
    public:
-    explicit TexturePackPage(MinecraftInstance* instance, std::shared_ptr<TexturePackFolderModel> model, QWidget* parent = nullptr);
+    explicit TexturePackPage(MinecraftInstance* instance, TexturePackFolderModel* model, QWidget* parent = nullptr);
 
     QString displayName() const override { return tr("Texture packs"); }
     QIcon icon() const override { return QIcon::fromTheme("resourcepacks"); }
@@ -66,6 +66,6 @@ class TexturePackPage : public ExternalResourcesPage {
     void changeTexturePackVersion();
 
    private:
-    std::shared_ptr<TexturePackFolderModel> m_model;
+    TexturePackFolderModel* m_model;
     QPointer<ResourceDownload::TexturePackDownloadDialog> m_downloadDialog;
 };

--- a/launcher/ui/pages/instance/VersionPage.cpp
+++ b/launcher/ui/pages/instance/VersionPage.cpp
@@ -151,7 +151,7 @@ VersionPage::VersionPage(MinecraftInstance* inst, QWidget* parent) : QMainWindow
     reloadPackProfile();
 
     auto proxy = new IconProxy(ui->packageView);
-    proxy->setSourceModel(m_profile.get());
+    proxy->setSourceModel(m_profile);
 
     m_filterModel = new QSortFilterProxyModel(this);
     m_filterModel->setDynamicSortFilter(true);
@@ -168,7 +168,7 @@ VersionPage::VersionPage(MinecraftInstance* inst, QWidget* parent) : QMainWindow
     auto smodel = ui->packageView->selectionModel();
     connect(smodel, &QItemSelectionModel::currentChanged, this, &VersionPage::versionCurrent);
     connect(smodel, &QItemSelectionModel::currentChanged, this, &VersionPage::packageCurrent);
-    connect(m_profile.get(), &PackProfile::minecraftChanged, this, &VersionPage::updateVersionControls);
+    connect(m_profile, &PackProfile::minecraftChanged, this, &VersionPage::updateVersionControls);
     updateVersionControls();
     preselect(0);
     connect(ui->packageView, &ModListView::customContextMenuRequested, this, &VersionPage::showContextMenu);

--- a/launcher/ui/pages/instance/VersionPage.h
+++ b/launcher/ui/pages/instance/VersionPage.h
@@ -105,7 +105,7 @@ class VersionPage : public QMainWindow, public BasePage {
    private:
     Ui::VersionPage* ui;
     QSortFilterProxyModel* m_filterModel;
-    std::shared_ptr<PackProfile> m_profile;
+    PackProfile* m_profile;
     MinecraftInstance* m_inst;
     int currentIdx = 0;
 

--- a/launcher/ui/pages/instance/WorldListPage.h
+++ b/launcher/ui/pages/instance/WorldListPage.h
@@ -52,7 +52,7 @@ class WorldListPage : public QMainWindow, public BasePage {
     Q_OBJECT
 
    public:
-    explicit WorldListPage(MinecraftInstancePtr inst, std::shared_ptr<WorldList> worlds, QWidget* parent = 0);
+    explicit WorldListPage(MinecraftInstance* inst, WorldList* worlds, QWidget* parent = 0);
     virtual ~WorldListPage();
 
     virtual QString displayName() const override { return tr("Worlds"); }
@@ -71,7 +71,7 @@ class WorldListPage : public QMainWindow, public BasePage {
     QMenu* createPopupMenu() override;
 
    protected:
-    MinecraftInstancePtr m_inst;
+    MinecraftInstance* m_inst;
 
    private:
     QModelIndex getSelectedWorld();
@@ -81,11 +81,12 @@ class WorldListPage : public QMainWindow, public BasePage {
 
    private:
     Ui::WorldListPage* ui;
-    std::shared_ptr<WorldList> m_worlds;
+    WorldList* m_worlds;
     unique_qobject_ptr<LoggedProcess> m_mceditProcess;
     bool m_mceditStarting = false;
 
     std::shared_ptr<Setting> m_wide_bar_setting = nullptr;
+    std::unique_ptr<DataPackFolderModel> m_datapackModel;
 
    private slots:
     void on_actionCopy_Seed_triggered();

--- a/launcher/ui/pages/modplatform/ImportPage.cpp
+++ b/launcher/ui/pages/modplatform/ImportPage.cpp
@@ -134,7 +134,7 @@ void ImportPage::updateState()
             auto array = std::make_shared<QByteArray>();
 
             auto api = FlameAPI();
-            auto job = api.getFile(addonId, fileId, array);
+            auto job = api.getFile(addonId, fileId, array.get());
 
             connect(job.get(), &NetJob::failed, this,
                     [this](QString reason) { CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show(); });

--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -114,7 +114,7 @@ QMap<QString, QString> ModPage::urlHandlers() const
 
 void ModPage::addResourceToPage(ModPlatform::IndexedPack::Ptr pack,
                                 ModPlatform::IndexedVersion& version,
-                                const std::shared_ptr<ResourceFolderModel> base_model)
+                                ResourceFolderModel* base_model)
 {
     bool is_indexed = !APPLICATION->settings()->get("ModMetadataDisabled").toBool();
     m_model->addPack(pack, version, base_model, is_indexed);

--- a/launcher/ui/pages/modplatform/ModPage.h
+++ b/launcher/ui/pages/modplatform/ModPage.h
@@ -49,7 +49,7 @@ class ModPage : public ResourcePage {
 
     QMap<QString, QString> urlHandlers() const override;
 
-    void addResourceToPage(ModPlatform::IndexedPack::Ptr, ModPlatform::IndexedVersion&, std::shared_ptr<ResourceFolderModel>) override;
+    void addResourceToPage(ModPlatform::IndexedPack::Ptr, ModPlatform::IndexedVersion&, ResourceFolderModel*) override;
 
     virtual std::unique_ptr<ModFilterWidget> createFilterWidget() = 0;
 

--- a/launcher/ui/pages/modplatform/ResourceModel.cpp
+++ b/launcher/ui/pages/modplatform/ResourceModel.cpp
@@ -471,7 +471,7 @@ void ResourceModel::infoRequestSucceeded(ModPlatform::IndexedPack::Ptr pack, con
 
 void ResourceModel::addPack(ModPlatform::IndexedPack::Ptr pack,
                             ModPlatform::IndexedVersion& version,
-                            const std::shared_ptr<ResourceFolderModel> packs,
+                            ResourceFolderModel* packs,
                             bool is_indexed)
 {
     version.is_currently_selected = true;

--- a/launcher/ui/pages/modplatform/ResourceModel.h
+++ b/launcher/ui/pages/modplatform/ResourceModel.h
@@ -93,7 +93,7 @@ class ResourceModel : public QAbstractListModel {
 
     void addPack(ModPlatform::IndexedPack::Ptr pack,
                  ModPlatform::IndexedVersion& version,
-                 std::shared_ptr<ResourceFolderModel> packs,
+                 ResourceFolderModel* packs,
                  bool is_indexed = false);
     void removePack(const QString& rem);
     QList<DownloadTaskPtr> selectedPacks() { return m_selected; }

--- a/launcher/ui/pages/modplatform/ResourcePage.cpp
+++ b/launcher/ui/pages/modplatform/ResourcePage.cpp
@@ -372,7 +372,7 @@ void ResourcePage::removeResourceFromDialog(const QString& pack_name)
 
 void ResourcePage::addResourceToPage(ModPlatform::IndexedPack::Ptr pack,
                                      ModPlatform::IndexedVersion& ver,
-                                     const std::shared_ptr<ResourceFolderModel> base_model)
+                                     ResourceFolderModel* base_model)
 {
     bool is_indexed = !APPLICATION->settings()->get("ModMetadataDisabled").toBool();
     m_model->addPack(pack, ver, base_model, is_indexed);

--- a/launcher/ui/pages/modplatform/ResourcePage.h
+++ b/launcher/ui/pages/modplatform/ResourcePage.h
@@ -78,7 +78,7 @@ class ResourcePage : public QWidget, public BasePage {
     void addResourceToDialog(ModPlatform::IndexedPack::Ptr, ModPlatform::IndexedVersion&);
     void removeResourceFromDialog(const QString& pack_name);
     virtual void removeResourceFromPage(const QString& name);
-    virtual void addResourceToPage(ModPlatform::IndexedPack::Ptr, ModPlatform::IndexedVersion&, std::shared_ptr<ResourceFolderModel>);
+    virtual void addResourceToPage(ModPlatform::IndexedPack::Ptr, ModPlatform::IndexedVersion&, ResourceFolderModel*);
 
     virtual void modelReset();
 

--- a/launcher/ui/pages/modplatform/ShaderPackPage.cpp
+++ b/launcher/ui/pages/modplatform/ShaderPackPage.cpp
@@ -44,7 +44,7 @@ QMap<QString, QString> ShaderPackResourcePage::urlHandlers() const
 
 void ShaderPackResourcePage::addResourceToPage(ModPlatform::IndexedPack::Ptr pack,
                                                ModPlatform::IndexedVersion& version,
-                                               const std::shared_ptr<ResourceFolderModel> base_model)
+                                               ResourceFolderModel* base_model)
 {
     bool is_indexed = !APPLICATION->settings()->get("ModMetadataDisabled").toBool();
     m_model->addPack(pack, version, base_model, is_indexed);

--- a/launcher/ui/pages/modplatform/ShaderPackPage.h
+++ b/launcher/ui/pages/modplatform/ShaderPackPage.h
@@ -39,7 +39,7 @@ class ShaderPackResourcePage : public ResourcePage {
 
     bool supportsFiltering() const override { return false; };
 
-    void addResourceToPage(ModPlatform::IndexedPack::Ptr, ModPlatform::IndexedVersion&, std::shared_ptr<ResourceFolderModel>) override;
+    void addResourceToPage(ModPlatform::IndexedPack::Ptr, ModPlatform::IndexedVersion&, ResourceFolderModel*) override;
 
     QMap<QString, QString> urlHandlers() const override;
 

--- a/launcher/ui/pages/modplatform/atlauncher/AtlListModel.cpp
+++ b/launcher/ui/pages/modplatform/atlauncher/AtlListModel.cpp
@@ -99,7 +99,7 @@ void ListModel::request()
 
     auto netJob = makeShared<NetJob>("Atl::Request", APPLICATION->network());
     auto url = QString(BuildConfig.ATL_DOWNLOAD_SERVER_URL + "launcher/json/packsnew.json");
-    netJob->addNetAction(Net::ApiDownload::makeByteArray(QUrl(url), response));
+    netJob->addNetAction(Net::ApiDownload::makeByteArray(QUrl(url), response.get()));
     jobPtr = netJob;
     jobPtr->start();
 

--- a/launcher/ui/pages/modplatform/atlauncher/AtlListModel.h
+++ b/launcher/ui/pages/modplatform/atlauncher/AtlListModel.h
@@ -61,7 +61,7 @@ class ListModel : public QAbstractListModel {
     QMap<QString, LogoCallback> waitingCallbacks;
 
     NetJob::Ptr jobPtr;
-    std::shared_ptr<QByteArray> response = std::make_shared<QByteArray>();
+    std::unique_ptr<QByteArray> response = std::make_unique<QByteArray>();
 };
 
 }  // namespace Atl

--- a/launcher/ui/pages/modplatform/atlauncher/AtlOptionalModDialog.cpp
+++ b/launcher/ui/pages/modplatform/atlauncher/AtlOptionalModDialog.cpp
@@ -159,7 +159,7 @@ void AtlOptionalModListModel::useShareCode(const QString& code)
 {
     m_jobPtr.reset(new NetJob("Atl::Request", APPLICATION->network()));
     auto url = QString(BuildConfig.ATL_API_BASE_URL + "share-codes/" + code);
-    m_jobPtr->addNetAction(Net::ApiDownload::makeByteArray(QUrl(url), m_response));
+    m_jobPtr->addNetAction(Net::ApiDownload::makeByteArray(QUrl(url), m_response.get()));
 
     connect(m_jobPtr.get(), &NetJob::succeeded, this, &AtlOptionalModListModel::shareCodeSuccess);
     connect(m_jobPtr.get(), &NetJob::failed, this, &AtlOptionalModListModel::shareCodeFailure);

--- a/launcher/ui/pages/modplatform/atlauncher/AtlOptionalModDialog.h
+++ b/launcher/ui/pages/modplatform/atlauncher/AtlOptionalModDialog.h
@@ -83,7 +83,7 @@ class AtlOptionalModListModel : public QAbstractListModel {
 
    private:
     NetJob::Ptr m_jobPtr;
-    std::shared_ptr<QByteArray> m_response = std::make_shared<QByteArray>();
+    std::unique_ptr<QByteArray> m_response = std::make_unique<QByteArray>();
 
     ATLauncher::PackVersion m_version;
     QList<ATLauncher::VersionMod> m_mods;

--- a/launcher/ui/pages/modplatform/flame/FlamePage.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.cpp
@@ -330,9 +330,9 @@ void FlamePage::createFilterWidget()
 
     connect(m_filterWidget.get(), &ModFilterWidget::filterChanged, this, &FlamePage::triggerSearch);
     auto response = std::make_shared<QByteArray>();
-    m_categoriesTask = FlameAPI::getCategories(response, ModPlatform::ResourceType::Modpack);
+    m_categoriesTask = FlameAPI::getCategories(response.get(), ModPlatform::ResourceType::Modpack);
     connect(m_categoriesTask.get(), &Task::succeeded, [this, response]() {
-        auto categories = FlameAPI::loadModCategories(response);
+        auto categories = FlameAPI::loadModCategories(response.get());
         m_filterWidget->setCategories(categories);
     });
     m_categoriesTask->start();

--- a/launcher/ui/pages/modplatform/flame/FlameResourcePages.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameResourcePages.cpp
@@ -248,9 +248,9 @@ std::unique_ptr<ModFilterWidget> FlameModPage::createFilterWidget()
 void FlameModPage::prepareProviderCategories()
 {
     auto response = std::make_shared<QByteArray>();
-    m_categoriesTask = FlameAPI::getModCategories(response);
+    m_categoriesTask = FlameAPI::getModCategories(response.get());
     connect(m_categoriesTask.get(), &Task::succeeded, [this, response]() {
-        auto categories = FlameAPI::loadModCategories(response);
+        auto categories = FlameAPI::loadModCategories(response.get());
         m_filter_widget->setCategories(categories);
     });
     m_categoriesTask->start();

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
@@ -372,9 +372,9 @@ void ModrinthPage::createFilterWidget()
 
     connect(m_filterWidget.get(), &ModFilterWidget::filterChanged, this, &ModrinthPage::triggerSearch);
     auto response = std::make_shared<QByteArray>();
-    m_categoriesTask = ModrinthAPI::getModCategories(response);
+    m_categoriesTask = ModrinthAPI::getModCategories(response.get());
     connect(m_categoriesTask.get(), &Task::succeeded, [this, response]() {
-        auto categories = ModrinthAPI::loadCategories(response, "modpack");
+        auto categories = ModrinthAPI::loadCategories(response.get(), "modpack");
         m_filterWidget->setCategories(categories);
     });
     m_categoriesTask->start();

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.cpp
@@ -166,9 +166,9 @@ std::unique_ptr<ModFilterWidget> ModrinthModPage::createFilterWidget()
 void ModrinthModPage::prepareProviderCategories()
 {
     auto response = std::make_shared<QByteArray>();
-    m_categoriesTask = ModrinthAPI::getModCategories(response);
+    m_categoriesTask = ModrinthAPI::getModCategories(response.get());
     connect(m_categoriesTask.get(), &Task::succeeded, [this, response]() {
-        auto categories = ModrinthAPI::loadModCategories(response);
+        auto categories = ModrinthAPI::loadModCategories(response.get());
         m_filter_widget->setCategories(categories);
     });
     m_categoriesTask->start();

--- a/launcher/ui/pages/modplatform/technic/TechnicModel.cpp
+++ b/launcher/ui/pages/modplatform/technic/TechnicModel.cpp
@@ -156,7 +156,7 @@ void Technic::ListModel::performSearch()
     if (!clientId.isEmpty()) {
         searchUrl += "?cid=" + clientId;
     }
-    netJob->addNetAction(Net::ApiDownload::makeByteArray(QUrl(searchUrl), response));
+    netJob->addNetAction(Net::ApiDownload::makeByteArray(QUrl(searchUrl), response.get()));
     jobPtr = netJob;
     jobPtr->start();
     connect(netJob.get(), &NetJob::succeeded, this, &ListModel::searchRequestFinished);

--- a/launcher/ui/pages/modplatform/technic/TechnicModel.h
+++ b/launcher/ui/pages/modplatform/technic/TechnicModel.h
@@ -86,7 +86,7 @@ class ListModel : public QAbstractListModel {
         Single,
     } searchMode = List;
     NetJob::Ptr jobPtr;
-    std::shared_ptr<QByteArray> response = std::make_shared<QByteArray>();
+    std::unique_ptr<QByteArray> response = std::make_unique<QByteArray>();
 };
 
 }  // namespace Technic

--- a/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
+++ b/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
@@ -163,7 +163,7 @@ void TechnicPage::suggestCurrent()
     auto netJob = makeShared<NetJob>(QString("Technic::PackMeta(%1)").arg(current.name), APPLICATION->network());
     QString slug = current.slug;
     netJob->addNetAction(Net::ApiDownload::makeByteArray(
-        QString("%1modpack/%2?build=%3").arg(BuildConfig.TECHNIC_API_BASE_URL, slug, BuildConfig.TECHNIC_API_BUILD), response));
+        QString("%1modpack/%2?build=%3").arg(BuildConfig.TECHNIC_API_BASE_URL, slug, BuildConfig.TECHNIC_API_BUILD), response.get()));
     connect(netJob.get(), &NetJob::succeeded, this, [this, slug] {
         jobPtr.reset();
 
@@ -260,7 +260,7 @@ void TechnicPage::metadataLoaded()
 
         auto netJob = makeShared<NetJob>(QString("Technic::SolderMeta(%1)").arg(current.name), APPLICATION->network());
         auto url = QString("%1/modpack/%2").arg(current.url, current.slug);
-        netJob->addNetAction(Net::ApiDownload::makeByteArray(QUrl(url), response));
+        netJob->addNetAction(Net::ApiDownload::makeByteArray(QUrl(url), response.get()));
 
         connect(netJob.get(), &NetJob::succeeded, this, &TechnicPage::onSolderLoaded);
         connect(jobPtr.get(), &NetJob::failed,

--- a/launcher/ui/pages/modplatform/technic/TechnicPage.h
+++ b/launcher/ui/pages/modplatform/technic/TechnicPage.h
@@ -95,7 +95,7 @@ class TechnicPage : public QWidget, public ModpackProviderBasePage {
     QString selectedVersion;
 
     NetJob::Ptr jobPtr;
-    std::shared_ptr<QByteArray> response = std::make_shared<QByteArray>();
+    std::unique_ptr<QByteArray> response = std::make_unique<QByteArray>();
 
     ProgressWidget m_fetch_progress;
 

--- a/launcher/ui/widgets/AppearanceWidget.cpp
+++ b/launcher/ui/widgets/AppearanceWidget.cpp
@@ -92,7 +92,7 @@ AppearanceWidget::~AppearanceWidget()
 
 void AppearanceWidget::applySettings()
 {
-    SettingsObjectPtr settings = APPLICATION->settings();
+    SettingsObject* settings = APPLICATION->settings();
     QString consoleFontFamily = m_ui->consoleFont->currentFont().family();
     settings->set("ConsoleFont", consoleFontFamily);
     settings->set("ConsoleFontSize", m_ui->fontSizeBox->value());
@@ -103,7 +103,7 @@ void AppearanceWidget::applySettings()
 
 void AppearanceWidget::loadSettings()
 {
-    SettingsObjectPtr settings = APPLICATION->settings();
+    SettingsObject* settings = APPLICATION->settings();
     QString fontFamily = settings->get("ConsoleFont").toString();
     QFont consoleFont(fontFamily);
     m_ui->consoleFont->setCurrentFont(consoleFont);
@@ -175,7 +175,7 @@ void AppearanceWidget::loadThemeSettings()
     m_ui->widgetStyleComboBox->clear();
     m_ui->catPackComboBox->clear();
 
-    const SettingsObjectPtr settings = APPLICATION->settings();
+    SettingsObject* settings = APPLICATION->settings();
 
     const QString currentIconTheme = settings->get("IconTheme").toString();
     const auto iconThemes = APPLICATION->themeManager()->getValidIconThemes();

--- a/launcher/ui/widgets/JavaSettingsWidget.cpp
+++ b/launcher/ui/widgets/JavaSettingsWidget.cpp
@@ -53,8 +53,8 @@
 
 #include "ui_JavaSettingsWidget.h"
 
-JavaSettingsWidget::JavaSettingsWidget(InstancePtr instance, QWidget* parent)
-    : QWidget(parent), m_instance(std::move(instance)), m_ui(new Ui::JavaSettingsWidget)
+JavaSettingsWidget::JavaSettingsWidget(BaseInstance* instance, QWidget* parent)
+    : QWidget(parent), m_instance(instance), m_ui(new Ui::JavaSettingsWidget)
 {
     m_ui->setupUi(this);
 
@@ -79,7 +79,7 @@ JavaSettingsWidget::JavaSettingsWidget(InstancePtr instance, QWidget* parent)
         m_ui->memoryGroupBox->setCheckable(true);
         m_ui->javaArgumentsGroupBox->setCheckable(true);
 
-        SettingsObjectPtr settings = m_instance->settings();
+        SettingsObject* settings = m_instance->settings();
 
         connect(settings->getSetting("OverrideJavaLocation").get(), &Setting::SettingChanged, m_ui->javaInstallationGroupBox,
                 [this, settings] { m_ui->javaInstallationGroupBox->setChecked(settings->get("OverrideJavaLocation").toBool()); });
@@ -87,7 +87,7 @@ JavaSettingsWidget::JavaSettingsWidget(InstancePtr instance, QWidget* parent)
                 [this, settings] { m_ui->javaPathTextBox->setText(settings->get("JavaPath").toString()); });
 
         connect(m_ui->javaDownloadBtn, &QPushButton::clicked, this, [this] {
-            auto javaDialog = new Java::InstallDialog({}, m_instance.get(), this);
+            auto javaDialog = new Java::InstallDialog({}, m_instance, this);
             javaDialog->exec();
         });
         connect(m_ui->javaPathTextBox, &QLineEdit::textChanged, [this](QString newValue) {
@@ -115,7 +115,7 @@ JavaSettingsWidget::~JavaSettingsWidget()
 
 void JavaSettingsWidget::loadSettings()
 {
-    SettingsObjectPtr settings;
+    SettingsObject* settings;
 
     if (m_instance != nullptr)
         settings = m_instance->settings();
@@ -158,7 +158,7 @@ void JavaSettingsWidget::loadSettings()
 
 void JavaSettingsWidget::saveSettings()
 {
-    SettingsObjectPtr settings;
+    SettingsObject* settings;
 
     if (m_instance != nullptr)
         settings = m_instance->settings();
@@ -265,7 +265,7 @@ void JavaSettingsWidget::onJavaAutodetect()
         return;
     }
 
-    VersionSelectDialog versionDialog(APPLICATION->javalist().get(), tr("Select a Java version"), this, true);
+    VersionSelectDialog versionDialog(APPLICATION->javalist(), tr("Select a Java version"), this, true);
     versionDialog.setResizeOn(2);
     versionDialog.exec();
 

--- a/launcher/ui/widgets/JavaSettingsWidget.h
+++ b/launcher/ui/widgets/JavaSettingsWidget.h
@@ -48,8 +48,8 @@ class JavaSettingsWidget : public QWidget {
     Q_OBJECT
 
    public:
-    explicit JavaSettingsWidget(QWidget* parent = nullptr) : JavaSettingsWidget(nullptr, nullptr) {}
-    explicit JavaSettingsWidget(InstancePtr instance, QWidget* parent = nullptr);
+    explicit JavaSettingsWidget(QWidget* parent = nullptr) : JavaSettingsWidget(nullptr, parent) {}
+    explicit JavaSettingsWidget(BaseInstance* instance, QWidget* parent = nullptr);
     ~JavaSettingsWidget() override;
 
     void loadSettings();
@@ -62,7 +62,7 @@ class JavaSettingsWidget : public QWidget {
     void updateThresholds();
 
    private:
-    InstancePtr m_instance;
+    BaseInstance* m_instance;
     Ui::JavaSettingsWidget* m_ui;
     unique_qobject_ptr<JavaCommon::TestCheck> m_checker;
 };

--- a/launcher/ui/widgets/JavaWizardWidget.cpp
+++ b/launcher/ui/widgets/JavaWizardWidget.cpp
@@ -185,7 +185,7 @@ void JavaWizardWidget::setupUi()
 
 void JavaWizardWidget::initialize()
 {
-    m_versionWidget->initialize(APPLICATION->javalist().get());
+    m_versionWidget->initialize(APPLICATION->javalist());
     m_versionWidget->selectSearch();
     m_versionWidget->setResizeOn(2);
     auto s = APPLICATION->settings();

--- a/launcher/ui/widgets/LanguageSelectionWidget.cpp
+++ b/launcher/ui/widgets/LanguageSelectionWidget.cpp
@@ -40,7 +40,7 @@ LanguageSelectionWidget::LanguageSelectionWidget(QWidget* parent) : QWidget(pare
 
     auto translations = APPLICATION->translations();
     auto index = translations->selectedIndex();
-    languageView->setModel(translations.get());
+    languageView->setModel(translations);
     languageView->setCurrentIndex(index);
     languageView->header()->setSectionResizeMode(QHeaderView::ResizeToContents);
     languageView->header()->setSectionResizeMode(0, QHeaderView::Stretch);

--- a/launcher/ui/widgets/MinecraftSettingsWidget.cpp
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.cpp
@@ -48,7 +48,7 @@
 #include "minecraft/auth/AccountList.h"
 #include "settings/Setting.h"
 
-MinecraftSettingsWidget::MinecraftSettingsWidget(MinecraftInstancePtr instance, QWidget* parent)
+MinecraftSettingsWidget::MinecraftSettingsWidget(MinecraftInstance* instance, QWidget* parent)
     : QWidget(parent), m_instance(std::move(instance)), m_ui(new Ui::MinecraftSettingsWidget)
 {
     m_ui->setupUi(this);
@@ -154,7 +154,7 @@ MinecraftSettingsWidget::~MinecraftSettingsWidget()
 
 void MinecraftSettingsWidget::loadSettings()
 {
-    SettingsObjectPtr settings;
+    SettingsObject* settings;
 
     if (m_instance != nullptr)
         settings = m_instance->settings();
@@ -297,7 +297,7 @@ void MinecraftSettingsWidget::loadSettings()
 
 void MinecraftSettingsWidget::saveSettings()
 {
-    SettingsObjectPtr settings;
+    SettingsObject* settings;
 
     if (m_instance != nullptr)
         settings = m_instance->settings();

--- a/launcher/ui/widgets/MinecraftSettingsWidget.h
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.h
@@ -46,7 +46,7 @@ class MinecraftSettingsWidget;
 
 class MinecraftSettingsWidget : public QWidget {
    public:
-    MinecraftSettingsWidget(MinecraftInstancePtr instance, QWidget* parent = nullptr);
+    MinecraftSettingsWidget(MinecraftInstance* instance, QWidget* parent = nullptr);
     ~MinecraftSettingsWidget() override;
 
     void loadSettings();
@@ -61,7 +61,7 @@ class MinecraftSettingsWidget : public QWidget {
     void saveDataPacksPath();
     void selectDataPacksFolder();
 
-    MinecraftInstancePtr m_instance;
+    MinecraftInstance* m_instance;
     Ui::MinecraftSettingsWidget* m_ui;
     JavaSettingsWidget* m_javaSettings = nullptr;
     bool m_quickPlaySingleplayer = false;

--- a/launcher/updater/prismupdater/PrismUpdater.h
+++ b/launcher/updater/prismupdater/PrismUpdater.h
@@ -128,7 +128,7 @@ class PrismUpdaterApp : public QApplication {
     GitHubRelease m_install_release;
 
     Status m_status = Status::Starting;
-    shared_qobject_ptr<QNetworkAccessManager> m_network;
+    std::unique_ptr<QNetworkAccessManager> m_network;
     QString m_current_url;
     Task::Ptr m_current_task;
     QList<GitHubRelease> m_releases;


### PR DESCRIPTION
An object held by a shared pointer does not have a clear lifetime or ownership. Each shared pointer has ownership and extends the lifetime of the object by means of reference counting, breaking the principle of least responsibility. Something as simple as a `LogPage` has ownership over the entire `MinecraftInstance`.

Shared pointers also have a performance overhead. One may argue the overhead is not noticeable, but shared pointers are used *everywhere* in the codebase, they have become normalized to the point that multiple aliases exist just to not write out `std::shared_ptr` all the time

This PR is one in a series, designated to explicitly define ownership through migrating all shared pointers to single-ownership pointers (`std::unique_ptr`, `gsl::owner`) and non owning pointers (`Class*`)