### PR TITLE
Check that mouse press is inside view rectangle of CheckComboBox

### DIFF
--- a/launcher/ui/widgets/CheckComboBox.cpp
+++ b/launcher/ui/widgets/CheckComboBox.cpp
@@ -138,7 +138,7 @@ bool CheckComboBox::eventFilter(QObject* receiver, QEvent* event)
         }
         case QEvent::MouseButtonPress: {
             auto ev = static_cast<QMouseEvent*>(event);
-            m_containerMousePress = ev && view()->indexAt(ev->pos()).isValid();
+            m_containerMousePress = ev && view()->indexAt(ev->pos()).isValid() && view()->rect().contains(ev->pos());
             break;
         }
         case QEvent::Wheel:


### PR DESCRIPTION
Closes #4651 

`view()->indexAt` doesn't care about the view's geometry, it acts as if the list isn't cut off by anything, so whether the click falls within the view's geometry has to be checked manually