### PR TITLE
Update build instructions links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,7 @@ The translation effort for Prism Launcher is hosted on [Weblate](https://hosted.
 
 ## Building
 
-If you want to build Prism Launcher yourself, check the build instructions:
-
-- [Windows](https://prismlauncher.org/wiki/development/build-instructions/windows/)
-- [Linux](https://prismlauncher.org/wiki/development/build-instructions/linux/)
-- [MacOS](https://prismlauncher.org/wiki/development/build-instructions/macos/)
-- [OpenBSD](https://prismlauncher.org/wiki/development/build-instructions/openbsd/)
+If you want to build Prism Launcher yourself, check the [build instructions](https://prismlauncher.org/wiki/development/build-instructions).
 
 ## Sponsors & Partners
 


### PR DESCRIPTION
It appears the wiki no longer has separate pages for build instructions per platform, and now instead uses platform tabs on instruction blocks.

This change updates the README to now correctly link to the build instructions page, rather than trying to link to platform-specific sub-pages that no longer exist.