### PR TITLE
fix curseforge import

### DIFF
--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -150,22 +150,17 @@ void InstanceImportTask::processZipPack()
             extractDir.cd("minecraft");
             m_modpackType = ModpackType::Technic;
             stop = true;
-        } else {
-            QFileInfo fileInfo(fileName);
-            if (fileInfo.fileName() == "instance.cfg") {
-                qDebug() << "MultiMC:" << true;
-                m_modpackType = ModpackType::MultiMC;
-                root = cleanPath(fileInfo.path());
-                stop = true;
-                return true;
-            }
-            if (fileInfo.fileName() == "manifest.json") {
-                qDebug() << "Flame:" << true;
-                m_modpackType = ModpackType::Flame;
-                root = cleanPath(fileInfo.path());
-                stop = true;
-                return true;
-            }
+        } else if (fileName == "manifest.json") {
+            qDebug() << "Flame:" << true;
+            m_modpackType = ModpackType::Flame;
+            stop = true;
+            return true;
+        } else if (QFileInfo fileInfo(fileName); fileInfo.fileName() == "instance.cfg") {
+            qDebug() << "MultiMC:" << true;
+            m_modpackType = ModpackType::MultiMC;
+            root = cleanPath(fileInfo.path());
+            stop = true;
+            return true;
         }
         QCoreApplication::processEvents();
         return true;


### PR DESCRIPTION
fixes #4698

this happened because somewhere inside there was a `manifest.json` file that was detected before the root one so droped the recursive stuff for curseforge and only look at the root level fo the json file