### PR TITLE
fix modrinth environments filter

### DIFF
--- a/launcher/ui/pages/modplatform/ModModel.cpp
+++ b/launcher/ui/pages/modplatform/ModModel.cpp
@@ -106,8 +106,8 @@ QVariant ModModel::getInstalledPackVersion(ModPlatform::IndexedPack::Ptr pack) c
 
 bool checkSide(ModPlatform::Side filter, ModPlatform::Side value)
 {
-    return filter == ModPlatform::Side::NoSide || value == ModPlatform::Side::NoSide || filter == ModPlatform::Side::UniversalSide ||
-           value == ModPlatform::Side::UniversalSide || filter == value;
+    return (filter != ModPlatform::Side::ClientSide && filter != ModPlatform::Side::ServerSide) ||
+           (value != ModPlatform::Side::ClientSide && value != ModPlatform::Side::ServerSide) || filter == value;
 }
 
 bool ModModel::checkFilters(ModPlatform::IndexedPack::Ptr pack)


### PR DESCRIPTION
fixes #4630
reversed the conditions to check for side because somewhere the mod side is no initilized(easier to check one line than search where it is not initialized)

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
