### PR TITLE
fix jpg icons

### DIFF
--- a/launcher/icons/IconList.cpp
+++ b/launcher/icons/IconList.cpp
@@ -40,6 +40,7 @@
 #include <QFileSystemWatcher>
 #include <QMap>
 #include <QMimeData>
+#include <QPixmap>
 #include <QSet>
 #include <QUrl>
 #include "icons/IconUtils.h"
@@ -217,7 +218,13 @@ void IconList::fileChanged(const QString& path)
     int idx = getIconIndex(key);
     if (idx == -1)
         return;
-    QIcon icon(path);
+    QIcon icon;
+    // special handling for jpg and jpeg to go through pixmap to keep the size constant
+    if (path.endsWith(".jpg") || path.endsWith(".jpeg")) {
+        icon.addPixmap(QPixmap(path));
+    } else {
+        icon.addFile(path);
+    }
     if (icon.availableSizes().empty())
         return;
 
@@ -395,7 +402,14 @@ bool IconList::addThemeIcon(const QString& key)
 bool IconList::addIcon(const QString& key, const QString& name, const QString& path, const IconType type)
 {
     // replace the icon even? is the input valid?
-    QIcon icon(path);
+    QIcon icon;
+    // special handling for jpg and jpeg to go through pixmap to keep the size constant
+    if (path.endsWith(".jpg") || path.endsWith(".jpeg")) {
+        icon.addPixmap(QPixmap(path));
+    } else {
+        icon.addFile(path);
+    }
+
     if (icon.isNull())
         return false;
     auto iter = m_nameIndex.find(key);


### PR DESCRIPTION
fixes #4686 and fixes #4666
Forces jpg and jpeg to go through QPixmap first then to Icon. The original behaivior used the QIcon internal engine to build the QPixmap causing some inconsitencies.

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
