### PR TITLE
Fix shaderpacks folder being hidden

### DIFF
--- a/launcher/minecraft/mod/tasks/LocalResourceUpdateTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalResourceUpdateTask.cpp
@@ -35,7 +35,13 @@ LocalResourceUpdateTask::LocalResourceUpdateTask(QDir index_dir, ModPlatform::In
     }
 
 #ifdef Q_OS_WIN32
-    SetFileAttributesW(index_dir.path().toStdWString().c_str(), FILE_ATTRIBUTE_HIDDEN | FILE_ATTRIBUTE_NOT_CONTENT_INDEXED);
+    std::wstring wpath = index_dir.path().toStdWString();
+    if (index_dir.dirName().startsWith('.')) {
+        SetFileAttributesW(wpath.c_str(), FILE_ATTRIBUTE_HIDDEN | FILE_ATTRIBUTE_NOT_CONTENT_INDEXED);
+    } else {
+        // fix shaderpacks folder being hidden by Prism Launcher 10.0.1
+        SetFileAttributesW(wpath.c_str(), FILE_ATTRIBUTE_NORMAL);
+    }
 #endif
 }
 


### PR DESCRIPTION
Arguably a bit hacky but at least this ensures consistency with Linux (which is basically our main platform :trollface:)
(passing down a boolean is probably worse in terms of tech debt so...)
Fixes https://github.com/PrismLauncher/PrismLauncher/issues/4703