### PR TITLE
Fix environment variables always being discarded and custom commands always being overriden

### DIFF
--- a/launcher/ui/widgets/CustomCommands.cpp
+++ b/launcher/ui/widgets/CustomCommands.cpp
@@ -65,8 +65,6 @@ void CustomCommands::retranslate()
 
 bool CustomCommands::checked() const
 {
-    if (!ui->overrideCheckBox->isVisible())
-        return true;
     return ui->overrideCheckBox->isChecked();
 }
 

--- a/launcher/ui/widgets/EnvironmentVariables.cpp
+++ b/launcher/ui/widgets/EnvironmentVariables.cpp
@@ -96,8 +96,6 @@ void EnvironmentVariables::retranslate()
 
 bool EnvironmentVariables::override() const
 {
-    if (!ui->overrideCheckBox->isVisible())
-        return false;
     return ui->overrideCheckBox->isChecked();
 }
 


### PR DESCRIPTION
Fixes #4660.

setVisible is called with m_instance != nullptr
The bug was caused as isVisible returns false if the tab is not active anyway

The call sites of checked() and override() check for m_instance == nullptr anyway so these if statements are not needed:
https://github.com/PrismLauncher/PrismLauncher/blob/develop/launcher/ui/widgets/MinecraftSettingsWidget.cpp#L349
https://github.com/PrismLauncher/PrismLauncher/blob/develop/launcher/ui/widgets/MinecraftSettingsWidget.cpp#L365

I don't know why one of them returns true and the other false but when the code was working properly this return would never be read