### PR TITLE
Network: log server response on error

### DIFF
--- a/launcher/net/NetRequest.h
+++ b/launcher/net/NetRequest.h
@@ -104,6 +104,7 @@ class NetRequest : public Task {
 
     /// the network reply
     unique_qobject_ptr<QNetworkReply> m_reply;
+    QByteArray m_errorResponse;
 
     /// source URL
     QUrl m_url;


### PR DESCRIPTION
Example (artificially created):
```
     7.026 C: [launcher.task.net.upload] "{7fde84b0-1a6f-41a1-980d-567c1926fe88}" Failed "https://api.modrinth.com/v2/version_files" with error QNetworkReply::ProtocolInvalidOperationError (Net::NetRequest::downloadError:172)
     7.026 C: [launcher.task.net.upload] "{7fde84b0-1a6f-41a1-980d-567c1926fe88}" HTTP status: 400 "Error transferring https://api.modrinth.com/v2/version_files - server replied with status code 400" (Net::NetRequest::downloadError:174)
     7.026 C: [launcher.task.net.upload] "{7fde84b0-1a6f-41a1-980d-567c1926fe88}" Response from server: "{\"error\":\"invalid_input\",\"description\":\"Error while validating input: Json deserialize error: missing field `hashes` at line 3 column 1\"}" (Net::NetRequest::downloadError:177)
```