### PR TITLE
Fix for Prism failing to recognize some shader pack ZIP archives added manually by the user

### DIFF
--- a/launcher/minecraft/mod/tasks/LocalShaderPackParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalShaderPackParseTask.cpp
@@ -79,13 +79,13 @@ bool processZIP(ShaderPack& pack, ProcessingLevel level)
       // there are multiple, the first one is picked.
       bool isShaderPresent = false;
       for (QString f: files) {
-	if (zip.exists(f + "/shaders"))
-	  isShaderPresent = true;
+        if (zip.exists(f + "/shaders"))
+          isShaderPresent = true;
       }
-      
+     
       if (!isShaderPresent)
-	// assets dir does not exist.
-	return false;
+        // assets dir does not exist.
+        return false;
       
     }
     pack.setPackFormat(ShaderPackFormat::VALID);

--- a/launcher/minecraft/mod/tasks/LocalShaderPackParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalShaderPackParseTask.cpp
@@ -65,30 +65,29 @@ bool processZIP(ShaderPack& pack, ProcessingLevel level)
         return false;  // can't open zip file
 
     if (!zip.exists("/shaders")) {
-      // assets dir does not exists at zip root, but shader packs
-      // will sometimes be a zip file containing a folder with the
-      // actual contents in it. This happens
-      // e.g. when the shader pack is downloaded as code
-      // from Github. so other than "/shaders", we
-      // could also check for a "shaders" folder one level deep.
+        // assets dir does not exists at zip root, but shader packs
+        // will sometimes be a zip file containing a folder with the
+        // actual contents in it. This happens
+        // e.g. when the shader pack is downloaded as code
+        // from Github. so other than "/shaders", we
+        // could also check for a "shaders" folder one level deep.
 
-      QStringList files = zip.getFiles();
+        QStringList files = zip.getFiles();
 
-      // the assumption here is that there is just one
-      // folder with the "shader" subfolder. In case
-      // there are multiple, the first one is picked.
-      bool isShaderPresent = false;
-      for (QString f : files) {
-        if (f.contains("/shaders/", Qt::CaseInsensitive)) {
-	  isShaderPresent = true;
-	  break;
-	}
-      }
-     
-      if (!isShaderPresent)
-        // assets dir does not exist.
-        return false;
-      
+        // the assumption here is that there is just one
+        // folder with the "shader" subfolder. In case
+        // there are multiple, the first one is picked.
+        bool isShaderPresent = false;
+        for (QString f : files) {
+            if (f.contains("/shaders/", Qt::CaseInsensitive)) {
+                isShaderPresent = true;
+                break;
+            }
+        }
+
+        if (!isShaderPresent)
+            // assets dir does not exist.
+            return false;
     }
     pack.setPackFormat(ShaderPackFormat::VALID);
 

--- a/launcher/minecraft/mod/tasks/LocalShaderPackParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalShaderPackParseTask.cpp
@@ -78,7 +78,7 @@ bool processZIP(ShaderPack& pack, ProcessingLevel level)
       // folder with the "shader" subfolder. In case
       // there are multiple, the first one is picked.
       bool isShaderPresent = false;
-      for (QString f: files) {
+      for (QString f : files) {
         if (zip.exists(f + "/shaders"))
           isShaderPresent = true;
       }

--- a/launcher/minecraft/mod/tasks/LocalShaderPackParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalShaderPackParseTask.cpp
@@ -79,8 +79,10 @@ bool processZIP(ShaderPack& pack, ProcessingLevel level)
       // there are multiple, the first one is picked.
       bool isShaderPresent = false;
       for (QString f : files) {
-        if (zip.exists(f + "/shaders"))
-          isShaderPresent = true;
+        if (zip.exists(f + "/shaders")) {
+	  isShaderPresent = true;
+	  break;
+	}
       }
      
       if (!isShaderPresent)

--- a/launcher/minecraft/mod/tasks/LocalShaderPackParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalShaderPackParseTask.cpp
@@ -79,7 +79,7 @@ bool processZIP(ShaderPack& pack, ProcessingLevel level)
       // there are multiple, the first one is picked.
       bool isShaderPresent = false;
       for (QString f : files) {
-        if (zip.exists(f + "/shaders")) {
+        if (f.contains("/shaders/", Qt::CaseInsensitive)) {
 	  isShaderPresent = true;
 	  break;
 	}


### PR DESCRIPTION
This PR adds support for manually adding shader packs as ZIP archives containing the contents in a sub-folder.

This happens, for instance, when downloading ZIP archives of github repos, for example [this one](https://github.com/sixthsurge/photon/tree/voxy-support) (the branch of the photon shaders with voxy support enabled).

Since Iris itself recognizes the shader pack properly, it makes sense to me that Prism should recognize and manage it, and before this PR no entry appeared in the shader list in Prism and no error message was given to the user to indicate what went wrong.

This solution may be not perfect, because this way a zip archive of shader pack folders will be misunderstood as a single shader pack. I'm not sure how Iris handles that, but it's probably not a good idea. However i do think that, at that point, it's sort of the user's responsibility to not manually add ZIP archives without first seeing what's in them.
