### PR TITLE
Don't set BUILD_TIMESTAMP if it's hardcoded

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,8 +273,12 @@ message(STATUS "Git commit: ${Launcher_GIT_COMMIT}")
 message(STATUS "Git tag: ${Launcher_GIT_TAG}")
 message(STATUS "Git refspec: ${Launcher_GIT_REFSPEC}")
 
-string(TIMESTAMP TODAY "%Y-%m-%d")
-set(Launcher_BUILD_TIMESTAMP "${TODAY}")
+if(DEFINED ENV{SOURCE_DATE_EPOCH})
+    set(Launcher_BUILD_TIMESTAMP "")
+else()
+    string(TIMESTAMP TODAY "%Y-%m-%d")
+    set(Launcher_BUILD_TIMESTAMP "${TODAY}")
+endif()
 
 ################################ 3rd Party Libs ################################
 


### PR DESCRIPTION
I don't have a lot of experience with CMake, but I think this should work

- #4661

Note: The build date label is hidden when the string is empty

https://github.com/PrismLauncher/PrismLauncher/blob/c3bcfec5e4b003b0d9cd0eb2b6aff46372ad3f76/launcher/ui/dialogs/AboutDialog.cpp#L107-L110