### PR TITLE
IconList: Make sure we always set new path

### DIFF
--- a/launcher/icons/IconList.cpp
+++ b/launcher/icons/IconList.cpp
@@ -147,8 +147,7 @@ void IconList::directoryChanged(const QString& path)
 {
     QDir newDir(path);
     if (m_dir.absolutePath() != newDir.absolutePath()) {
-        if (!path.startsWith(m_dir.absolutePath()))
-            m_dir.setPath(path);
+        m_dir.setPath(path);
         m_dir.refresh();
         if (m_isWatching)
             stopWatching();


### PR DESCRIPTION
Closes #4664
Fixes https://github.com/PrismLauncher/PrismLauncher/commit/abbebff400a697023f159c2f00087031a470b577

The removed check would ignore any new path (as read from the config file or inputted by the user) that starts with the absolute path of the currently set icons directory.
On launch, if `IconsDir` is an absolute path, and pointing to a folder inside the CWD (the default for QDir), `IconsDir` would be discarded and the launcher would start scanning for icons in the CWD (usually the Prism data directory, which contains a ton of stuff like asset and instance files), causing the launcher to lock up until the scan is complete