### PR TITLE
Fix some modpacks not importing

### DIFF
--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -154,13 +154,11 @@ void InstanceImportTask::processZipPack()
             qDebug() << "Flame:" << true;
             m_modpackType = ModpackType::Flame;
             stop = true;
-            return true;
         } else if (QFileInfo fileInfo(fileName); fileInfo.fileName() == "instance.cfg") {
             qDebug() << "MultiMC:" << true;
             m_modpackType = ModpackType::MultiMC;
             root = cleanPath(fileInfo.path());
             stop = true;
-            return true;
         }
         QCoreApplication::processEvents();
         return true;

--- a/launcher/archive/ArchiveReader.cpp
+++ b/launcher/archive/ArchiveReader.cpp
@@ -151,7 +151,7 @@ bool ArchiveReader::File::writeFile(archive* out, QString targetFileName, bool n
     auto r = archive_write_finish_entry(out);
     if (r < ARCHIVE_OK)
         qCritical() << "Failed to finish writing entry:" << archive_error_string(out);
-    return (r > ARCHIVE_WARN);
+    return (r >= ARCHIVE_WARN);
 }
 
 bool ArchiveReader::parse(std::function<bool(File*, bool&)> doStuff)
@@ -180,6 +180,7 @@ bool ArchiveReader::parse(std::function<bool(File*, bool&)> doStuff)
     archive_read_close(a);
     return true;
 }
+
 bool ArchiveReader::parse(std::function<bool(File*)> doStuff)
 {
     return parse([doStuff](File* f, bool&) { return doStuff(f); });


### PR DESCRIPTION
this is the intended behavior to treat warnings as ok, because teoretically the file was extracted, even if the time of the file can't be set

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
