### PR TITLE
Allow opting out of pre-compiled headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,8 @@ set(Launcher_SUBREDDIT_URL "https://prismlauncher.org/reddit" CACHE STRING "URL 
 # Builds
 set(Launcher_QT_VERSION_MAJOR "6" CACHE STRING "Major Qt version to build against")
 
+option(Launcher_USE_PCH "Use precompiled headers where possible" ON)
+
 # Java downloader
 set(Launcher_ENABLE_JAVA_DOWNLOADER_DEFAULT ON)
 

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -1305,11 +1305,14 @@ include(CompilerWarnings)
 
 ######## Precompiled Headers ###########
 
-set(PRECOMPILED_HEADERS
-    include/base.pch.hpp
-    include/qtcore.pch.hpp
-    include/qtgui.pch.hpp
-)
+if(${Launcher_USE_PCH})
+    message(STATUS "Using precompiled headers for applicable launcher targets")
+    set(PRECOMPILED_HEADERS
+        include/base.pch.hpp
+        include/qtcore.pch.hpp
+        include/qtgui.pch.hpp
+    )
+endif()
 
 ####### Targets ########
 
@@ -1321,7 +1324,11 @@ set_project_warnings(Launcher_logic
     "${Launcher_GCC_WARNINGS}")
 target_include_directories(Launcher_logic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_definitions(Launcher_logic PUBLIC LAUNCHER_APPLICATION)
-target_precompile_headers(Launcher_logic PRIVATE ${PRECOMPILED_HEADERS})
+
+if(${Launcher_USE_PCH})
+    target_precompile_headers(Launcher_logic PRIVATE ${PRECOMPILED_HEADERS})
+endif()
+
 target_link_libraries(Launcher_logic
     systeminfo
     Launcher_murmur2
@@ -1403,7 +1410,11 @@ endif()
 target_link_libraries(Launcher_logic)
 
 add_executable(${Launcher_Name} MACOSX_BUNDLE WIN32 main.cpp ${LAUNCHER_RCS})
-target_precompile_headers(${Launcher_Name} REUSE_FROM Launcher_logic)
+
+if(${Launcher_USE_PCH})
+    target_precompile_headers(${Launcher_Name} REUSE_FROM Launcher_logic)
+endif()
+
 target_link_libraries(${Launcher_Name} Launcher_logic)
 
 if(DEFINED Launcher_APP_BINARY_NAME)
@@ -1435,7 +1446,11 @@ if(Launcher_BUILD_UPDATER)
     # Updater
     add_library(prism_updater_logic STATIC ${PRISMUPDATER_SOURCES} ${TASKS_SOURCES} ${PRISMUPDATER_UI})
     target_include_directories(prism_updater_logic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-    target_precompile_headers(prism_updater_logic PRIVATE ${PRECOMPILED_HEADERS})
+
+    if(${Launcher_USE_PCH})
+        target_precompile_headers(prism_updater_logic PRIVATE ${PRECOMPILED_HEADERS})
+    endif()
+
     target_link_libraries(prism_updater_logic
         ${ZLIB_LIBRARIES}
         systeminfo
@@ -1455,7 +1470,10 @@ if(Launcher_BUILD_UPDATER)
     add_executable("${Launcher_Name}_updater" WIN32 updater/prismupdater/updater_main.cpp)
     target_sources("${Launcher_Name}_updater" PRIVATE updater/prismupdater/updater.exe.manifest)
     target_link_libraries("${Launcher_Name}_updater" prism_updater_logic)
-    target_precompile_headers("${Launcher_Name}_updater" REUSE_FROM prism_updater_logic)
+
+    if(${Launcher_USE_PCH})
+        target_precompile_headers("${Launcher_Name}_updater" REUSE_FROM prism_updater_logic)
+    endif()
 
     if(DEFINED Launcher_APP_BINARY_NAME)
         set_target_properties("${Launcher_Name}_updater" PROPERTIES OUTPUT_NAME "${Launcher_APP_BINARY_NAME}_updater")
@@ -1486,7 +1504,10 @@ if(WIN32 OR (DEFINED Launcher_BUILD_FILELINKER AND Launcher_BUILD_FILELINKER))
     "${Launcher_GCC_WARNINGS}")
 
     target_include_directories(filelink_logic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-    target_precompile_headers(filelink_logic PRIVATE ${PRECOMPILED_HEADERS})
+
+    if(${Launcher_USE_PCH})
+        target_precompile_headers(filelink_logic PRIVATE ${PRECOMPILED_HEADERS})
+    endif()
 
     target_link_libraries(filelink_logic
         systeminfo
@@ -1499,9 +1520,11 @@ if(WIN32 OR (DEFINED Launcher_BUILD_FILELINKER AND Launcher_BUILD_FILELINKER))
     )
 
     add_executable("${Launcher_Name}_filelink" WIN32 filelink/filelink_main.cpp)
-
     target_sources("${Launcher_Name}_filelink" PRIVATE filelink/filelink.exe.manifest)
-    target_precompile_headers("${Launcher_Name}_filelink" REUSE_FROM filelink_logic)
+
+    if(${Launcher_USE_PCH})
+        target_precompile_headers("${Launcher_Name}_filelink" REUSE_FROM filelink_logic)
+    endif()
 
     # HACK: Fix manifest issues with Ninja in release mode (and only release mode) and MSVC
     # I have no idea why this works or why it's needed. UPDATE THIS IF YOU EDIT THE MANIFEST!!! -@getchoo

--- a/launcher/ui/widgets/JavaWizardWidget.cpp
+++ b/launcher/ui/widgets/JavaWizardWidget.cpp
@@ -1,5 +1,6 @@
 #include "JavaWizardWidget.h"
 
+#include <QCheckBox>
 #include <QFileDialog>
 #include <QGroupBox>
 #include <QLabel>

--- a/launcher/ui/widgets/JavaWizardWidget.h
+++ b/launcher/ui/widgets/JavaWizardWidget.h
@@ -6,6 +6,7 @@
 #include <java/JavaChecker.h>
 #include <QIcon>
 
+class QCheckBox;
 class QLineEdit;
 class VersionSelectWidget;
 class QSpinBox;


### PR DESCRIPTION
While pre-compiled headers seems to take the build down from `10:47.35` to `8:41.12` (sorry for the pointless data, I don't want to feel like I wasted time measuring how long it took) on my machine I was having some problems with incremental builds taking forever* with them enabled
*about 40 seconds longer, and having to wait `1:34.24` after editing a single cpp file is not much fun