### PR TITLE
Fix missing `#include <QCheckBox>` at JavaWizardWidget.cpp

### DIFF
--- a/launcher/ui/widgets/JavaWizardWidget.cpp
+++ b/launcher/ui/widgets/JavaWizardWidget.cpp
@@ -11,6 +11,7 @@
 #include <QSpinBox>
 #include <QToolButton>
 #include <QVBoxLayout>
+#include <QCheckBox>
 
 #include <sys.h>
 

--- a/launcher/ui/widgets/JavaWizardWidget.h
+++ b/launcher/ui/widgets/JavaWizardWidget.h
@@ -17,6 +17,7 @@ class QGridLayout;
 class QLabel;
 class QToolButton;
 class QSpacerItem;
+class QCheckBox;
 
 class JavaWizardWidget : public QWidget {
     Q_OBJECT


### PR DESCRIPTION
It was mistakenly removed in #4643
Link to downstream: https://github.com/gentoo/gentoo/pull/45375