### PR TITLE
Do not delete LaunchController before we're done using it

### DIFF
--- a/launcher/Application.h
+++ b/launcher/Application.h
@@ -221,8 +221,7 @@ class Application : public QApplication {
    private slots:
     void on_windowClose();
     void messageReceived(const QByteArray& message);
-    void controllerSucceeded();
-    void controllerFailed(const QString& error);
+    void controllerFinished();
     void setupWizardFinished(int status);
 
    private:


### PR DESCRIPTION
Closes #4806 
Supersedes #4809 

The activation of signal `LaunchController::failed` causes `Application` to delete said `LaunchController`. Then, the activation of signal `LaunchController::finished` causes heap-use-after-free

This PR connects the `Application` logic to `finished` instead, and unifies the code since it's almost fully copy-paste