### PR TITLE
Print custom environment variables during instance launch

### DIFF
--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -683,12 +683,7 @@ QProcessEnvironment MinecraftInstance::createEnvironment()
             env.insert(iter.key(), iter.value().toString());
     };
 
-    bool overrideEnv = settings()->get("OverrideEnv").toBool();
-
-    if (!overrideEnv)
-        insertEnv(APPLICATION->settings()->get("Env").toString());
-    else
-        insertEnv(settings()->get("Env").toString());
+    insertEnv(settings()->get("Env").toString());
     return env;
 }
 
@@ -1010,7 +1005,7 @@ QStringList MinecraftInstance::verboseDescription(AuthSessionPtr session, Minecr
     out << emptyLine;
 
     // environment variables
-    const QString env = settings->get("OverrideEnv").toBool() ? settings->get("Env").toString() : APPLICATION->settings()->get("Env").toString();
+    const QString env = settings->get("Env").toString();
     if (auto envMap = Json::toMap(env); !envMap.isEmpty()) {
         out << "Custom environment variables:";
         for (auto [key, value] : envMap.asKeyValueRange()) {

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -1008,6 +1008,17 @@ QStringList MinecraftInstance::verboseDescription(AuthSessionPtr session, Minecr
 
     out << "Launcher: " + getLauncher();
     out << emptyLine;
+
+    // environment variables
+    const QString env = settings->get("OverrideEnv").toBool() ? settings->get("Env").toString() : APPLICATION->settings()->get("Env").toString();
+    if (auto envMap = Json::toMap(env); !envMap.isEmpty()) {
+        out << "Custom environment variables:";
+        for (auto [key, value] : envMap.asKeyValueRange()) {
+            out << indent + key + "=" + value.toString();
+        }
+        out << emptyLine;
+    }
+
     return out;
 }
 

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -888,9 +888,13 @@ QString MinecraftInstance::createLaunchScript(AuthSessionPtr session, MinecraftT
 
 QStringList MinecraftInstance::verboseDescription(AuthSessionPtr session, MinecraftTarget::Ptr targetToJoin)
 {
+    constexpr auto indent = "  ";
+    constexpr auto emptyLine = "";
+
     QStringList out;
-    out << "Main Class:" << "  " + getMainClass() << "";
-    out << "Native path:" << "  " + getNativePath() << "";
+
+    out << "Main Class:" << indent + getMainClass() << emptyLine;
+    out << "Native path:" << indent + getNativePath() << emptyLine;
 
     auto profile = m_components->getProfile();
 
@@ -899,9 +903,9 @@ QStringList MinecraftInstance::verboseDescription(AuthSessionPtr session, Minecr
     if (alltraits.size()) {
         out << "Traits:";
         for (auto trait : alltraits) {
-            out << "traits " + trait;
+            out << indent + trait;
         }
-        out << "";
+        out << emptyLine;
     }
 
     // native libraries
@@ -913,7 +917,7 @@ QStringList MinecraftInstance::verboseDescription(AuthSessionPtr session, Minecr
             out << "Using system OpenAL.";
         if (nativeGLFW)
             out << "Using system GLFW.";
-        out << "";
+        out << emptyLine;
     }
 
     // libraries and class path.
@@ -924,20 +928,20 @@ QStringList MinecraftInstance::verboseDescription(AuthSessionPtr session, Minecr
         auto printLibFile = [&out](const QString& path) {
             QFileInfo info(path);
             if (info.exists()) {
-                out << "  " + path;
+                out << indent + path;
             } else {
-                out << "  " + path + " (missing)";
+                out << indent + path + " (missing)";
             }
         };
         for (auto file : jars) {
             printLibFile(file);
         }
-        out << "";
+        out << emptyLine;
         out << "Native libraries:";
         for (auto file : nativeJars) {
             printLibFile(file);
         }
-        out << "";
+        out << emptyLine;
     }
 
     // mods and core mods
@@ -962,7 +966,7 @@ QStringList MinecraftInstance::verboseDescription(AuthSessionPtr session, Minecr
                     out << u8"  [✘] " + mod->fileinfo().completeBaseName() + " (disabled)";
                 }
             }
-            out << "";
+            out << emptyLine;
         }
     };
 
@@ -977,19 +981,19 @@ QStringList MinecraftInstance::verboseDescription(AuthSessionPtr session, Minecr
             auto displayname = jarmod->displayName(runtimeContext());
             auto realname = jarmod->filename(runtimeContext());
             if (displayname != realname) {
-                out << "  " + displayname + " (" + realname + ")";
+                out << indent + displayname + " (" + realname + ")";
             } else {
-                out << "  " + realname;
+                out << indent + realname;
             }
         }
-        out << "";
+        out << emptyLine;
     }
 
     // minecraft arguments
     auto params = processMinecraftArgs(nullptr, targetToJoin);
     out << "Params:";
-    out << "  " + params.join(' ');
-    out << "";
+    out << indent + params.join(' ');
+    out << emptyLine;
 
     // window size
     QString windowParams;
@@ -1000,9 +1004,10 @@ QStringList MinecraftInstance::verboseDescription(AuthSessionPtr session, Minecr
         auto height = settings->get("MinecraftWinHeight").toInt();
         out << "Window size: " + QString::number(width) + " x " + QString::number(height);
     }
-    out << "";
+    out << emptyLine;
+
     out << "Launcher: " + getLauncher();
-    out << "";
+    out << emptyLine;
     return out;
 }
 


### PR DESCRIPTION
Closes #4432 (best effort, if the user modified their env vars outside the launcher we cannot log that without logging ALL environment variables)

This PR includes a minor refactor, review individual commits if necessary

<img width="437" height="223" alt="showcase" src="https://github.com/user-attachments/assets/4a24a89f-f927-47a8-983c-ebae04fce275" />
