### PR TITLE
refactor: replace std::list with std::vector

### DIFF
--- a/launcher/modplatform/CheckUpdateTask.h
+++ b/launcher/modplatform/CheckUpdateTask.h
@@ -12,7 +12,7 @@ class CheckUpdateTask : public Task {
 
    public:
     CheckUpdateTask(QList<Resource*>& resources,
-                    std::list<Version>& mcVersions,
+                    std::vector<Version>& mcVersions,
                     QList<ModPlatform::ModLoaderType> loadersList,
                     ResourceFolderModel* resourceModel)
         : Task(), m_resources(resources), m_gameVersions(mcVersions), m_loadersList(std::move(loadersList)), m_resourceModel(resourceModel)
@@ -65,7 +65,7 @@ class CheckUpdateTask : public Task {
 
    protected:
     QList<Resource*>& m_resources;
-    std::list<Version>& m_gameVersions;
+    std::vector<Version>& m_gameVersions;
     QList<ModPlatform::ModLoaderType> m_loadersList;
     ResourceFolderModel* m_resourceModel;
 

--- a/launcher/modplatform/ResourceAPI.cpp
+++ b/launcher/modplatform/ResourceAPI.cpp
@@ -262,7 +262,7 @@ Task::Ptr ResourceAPI::getDependencyVersion(DependencySearchArgs&& args, Callbac
     return netJob;
 }
 
-QString ResourceAPI::getGameVersionsString(std::list<Version> mcVersions) const
+QString ResourceAPI::getGameVersionsString(std::vector<Version> mcVersions) const
 {
     QString s;
     for (auto& ver : mcVersions) {

--- a/launcher/modplatform/ResourceAPI.h
+++ b/launcher/modplatform/ResourceAPI.h
@@ -81,7 +81,7 @@ class ResourceAPI {
         std::optional<QString> search;
         std::optional<SortingMethod> sorting;
         std::optional<ModPlatform::ModLoaderTypes> loaders;
-        std::optional<std::list<Version>> versions;
+        std::optional<std::vector<Version>> versions;
         std::optional<ModPlatform::Side> side;
         std::optional<QStringList> categoryIds;
         bool openSource;
@@ -90,7 +90,7 @@ class ResourceAPI {
     struct VersionSearchArgs {
         ModPlatform::IndexedPack::Ptr pack;
 
-        std::optional<std::list<Version>> mcVersions;
+        std::optional<std::vector<Version>> mcVersions;
         std::optional<ModPlatform::ModLoaderTypes> loaders;
         ModPlatform::ResourceType resourceType;
     };
@@ -124,7 +124,7 @@ class ResourceAPI {
 
     QString mapMCVersionToModrinth(Version v) const;
 
-    QString getGameVersionsString(std::list<Version> mcVersions) const;
+    QString getGameVersionsString(std::vector<Version> mcVersions) const;
 
    public:
     virtual auto getSearchURL(SearchArgs const& args) const -> std::optional<QString> = 0;

--- a/launcher/modplatform/flame/FlameCheckUpdate.h
+++ b/launcher/modplatform/flame/FlameCheckUpdate.h
@@ -7,7 +7,7 @@ class FlameCheckUpdate : public CheckUpdateTask {
 
    public:
     FlameCheckUpdate(QList<Resource*>& resources,
-                     std::list<Version>& mcVersions,
+                     std::vector<Version>& mcVersions,
                      QList<ModPlatform::ModLoaderType> loadersList,
                      ResourceFolderModel* resourceModel)
         : CheckUpdateTask(resources, mcVersions, std::move(loadersList), resourceModel)

--- a/launcher/modplatform/modrinth/ModrinthAPI.cpp
+++ b/launcher/modplatform/modrinth/ModrinthAPI.cpp
@@ -40,7 +40,7 @@ Task::Ptr ModrinthAPI::currentVersions(const QStringList& hashes, QString hash_f
 
 Task::Ptr ModrinthAPI::latestVersion(QString hash,
                                      QString hash_format,
-                                     std::optional<std::list<Version>> mcVersions,
+                                     std::optional<std::vector<Version>> mcVersions,
                                      std::optional<ModPlatform::ModLoaderTypes> loaders,
                                      QByteArray* response)
 {
@@ -70,7 +70,7 @@ Task::Ptr ModrinthAPI::latestVersion(QString hash,
 
 Task::Ptr ModrinthAPI::latestVersions(const QStringList& hashes,
                                       QString hash_format,
-                                      std::optional<std::list<Version>> mcVersions,
+                                      std::optional<std::vector<Version>> mcVersions,
                                       std::optional<ModPlatform::ModLoaderTypes> loaders,
                                       QByteArray* response)
 {

--- a/launcher/modplatform/modrinth/ModrinthAPI.h
+++ b/launcher/modplatform/modrinth/ModrinthAPI.h
@@ -20,13 +20,13 @@ class ModrinthAPI : public ResourceAPI {
 
     Task::Ptr latestVersion(QString hash,
                             QString hash_format,
-                            std::optional<std::list<Version>> mcVersions,
+                            std::optional<std::vector<Version>> mcVersions,
                             std::optional<ModPlatform::ModLoaderTypes> loaders,
                             QByteArray* response);
 
     Task::Ptr latestVersions(const QStringList& hashes,
                              QString hash_format,
-                             std::optional<std::list<Version>> mcVersions,
+                             std::optional<std::vector<Version>> mcVersions,
                              std::optional<ModPlatform::ModLoaderTypes> loaders,
                              QByteArray* response);
 
@@ -192,7 +192,7 @@ class ModrinthAPI : public ResourceAPI {
             .arg(BuildConfig.MODRINTH_PROD_URL, args.pack->addonId.toString(), get_arguments.isEmpty() ? "" : "?", get_arguments.join('&'));
     };
 
-    QString getGameVersionsArray(std::list<Version> mcVersions) const
+    QString getGameVersionsArray(std::vector<Version> mcVersions) const
     {
         QString s;
         for (auto& ver : mcVersions) {

--- a/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
+++ b/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
@@ -16,7 +16,7 @@
 static ModrinthAPI api;
 
 ModrinthCheckUpdate::ModrinthCheckUpdate(QList<Resource*>& resources,
-                                         std::list<Version>& mcVersions,
+                                         std::vector<Version>& mcVersions,
                                          QList<ModPlatform::ModLoaderType> loadersList,
                                          ResourceFolderModel* resourceModel)
     : CheckUpdateTask(resources, mcVersions, std::move(loadersList), resourceModel)

--- a/launcher/modplatform/modrinth/ModrinthCheckUpdate.h
+++ b/launcher/modplatform/modrinth/ModrinthCheckUpdate.h
@@ -7,7 +7,7 @@ class ModrinthCheckUpdate : public CheckUpdateTask {
 
    public:
     ModrinthCheckUpdate(QList<Resource*>& resources,
-                        std::list<Version>& mcVersions,
+                        std::vector<Version>& mcVersions,
                         QList<ModPlatform::ModLoaderType> loadersList,
                         ResourceFolderModel* resourceModel);
 

--- a/launcher/ui/dialogs/ResourceUpdateDialog.cpp
+++ b/launcher/ui/dialogs/ResourceUpdateDialog.cpp
@@ -29,7 +29,7 @@
 
 #include <optional>
 
-static std::list<Version> mcVersions(BaseInstance* inst)
+static std::vector<Version> mcVersions(BaseInstance* inst)
 {
     return { static_cast<MinecraftInstance*>(inst)->getPackProfile()->getComponent("net.minecraft")->getVersion() };
 }

--- a/launcher/ui/pages/modplatform/ModModel.cpp
+++ b/launcher/ui/pages/modplatform/ModModel.cpp
@@ -27,7 +27,7 @@ ResourceAPI::SearchArgs ModModel::createSearchArguments()
     Q_ASSERT(profile);
     Q_ASSERT(m_filter);
 
-    std::optional<std::list<Version>> versions{};
+    std::optional<std::vector<Version>> versions{};
     std::optional<QStringList> categories{};
     auto loaders = profile->getSupportedModLoaders();
 
@@ -55,7 +55,7 @@ ResourceAPI::VersionSearchArgs ModModel::createVersionsArguments(const QModelInd
     Q_ASSERT(profile);
     Q_ASSERT(m_filter);
 
-    std::optional<std::list<Version>> versions{};
+    std::optional<std::vector<Version>> versions{};
     auto loaders = profile->getSupportedModLoaders();
     if (!m_filter->versions.empty())
         versions = m_filter->versions;

--- a/launcher/ui/pages/modplatform/TexturePackModel.cpp
+++ b/launcher/ui/pages/modplatform/TexturePackModel.cpp
@@ -9,7 +9,7 @@
 #include "meta/Index.h"
 #include "meta/Version.h"
 
-static std::list<Version> s_availableVersions = {};
+static std::vector<Version> s_availableVersions = {};
 
 namespace ResourceDownload {
 TexturePackResourceModel::TexturePackResourceModel(BaseInstance const& inst, ResourceAPI* api, QString debugName, QString metaEntryBase)

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModel.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModel.h
@@ -98,7 +98,7 @@ class ModpackListModel : public QAbstractListModel {
    protected:
     void requestLogo(QString file, QString url);
 
-    inline auto getMineVersions() const -> std::list<Version>;
+    inline auto getMineVersions() const -> std::vector<Version>;
 
    protected:
     ModrinthPage* m_parent;

--- a/launcher/ui/widgets/ModFilterWidget.cpp
+++ b/launcher/ui/widgets/ModFilterWidget.cpp
@@ -243,7 +243,7 @@ void ModFilterWidget::prepareBasicFilter()
         ui->liteLoader->setChecked(loaders & ModPlatform::LiteLoader);
         m_filter->loaders = loaders;
         auto def = m_instance->getPackProfile()->getComponentVersion("net.minecraft");
-        m_filter->versions.emplace_front(def);
+        m_filter->versions.emplace_back(def);
         ui->versions->setCheckedItems({ def });
         ui->version->setCurrentIndex(ui->version->findText(def));
     } else {
@@ -263,7 +263,7 @@ void ModFilterWidget::onVersionFilterChanged(int)
 {
     auto versions = ui->versions->checkedItems();
     versions.sort();
-    std::list<Version> current_list;
+    std::vector<Version> current_list;
 
     for (const QString& version : versions)
         current_list.emplace_back(version);
@@ -385,7 +385,7 @@ void ModFilterWidget::onOpenSourceFilterChanged()
 
 void ModFilterWidget::onReleaseFilterChanged()
 {
-    std::list<ModPlatform::IndexedVersionType> releases;
+    std::vector<ModPlatform::IndexedVersionType> releases;
     if (ui->releaseCb->isChecked())
         releases.push_back(ModPlatform::IndexedVersionType::Release);
     if (ui->betaCb->isChecked())

--- a/launcher/ui/widgets/ModFilterWidget.h
+++ b/launcher/ui/widgets/ModFilterWidget.h
@@ -58,8 +58,8 @@ class ModFilterWidget : public QTabWidget {
     Q_OBJECT
    public:
     struct Filter {
-        std::list<Version> versions;
-        std::list<ModPlatform::IndexedVersionType> releases;
+        std::vector<Version> versions;
+        std::vector<ModPlatform::IndexedVersionType> releases;
         ModPlatform::ModLoaderTypes loaders;
         ModPlatform::Side side;
         bool hideInstalled;


### PR DESCRIPTION
There's no reason to use `std::list`, it's a doubly-linked list for O(1) insertion/removal in the middle of the container at the cost of memory and cache-friendliness. Prism doesn't need that functionality, the single incompatible `emplace_front` can be replaced with `emplace_back` with no behavior change as the list is guaranteed to be empty at the time of the operation