### PR TITLE
Add missing returns after task signal activation

### DIFF
--- a/launcher/ResourceDownloadTask.cpp
+++ b/launcher/ResourceDownloadTask.cpp
@@ -103,8 +103,8 @@ void ResourceDownloadTask::downloadSucceeded()
 
 void ResourceDownloadTask::downloadFailed(QString reason)
 {
-    emitFailed(reason);
     m_filesNetJob.reset();
+    emitFailed(reason);
 }
 
 void ResourceDownloadTask::downloadProgressChanged(qint64 current, qint64 total)

--- a/launcher/launch/LaunchTask.cpp
+++ b/launcher/launch/LaunchTask.cpp
@@ -76,6 +76,7 @@ void LaunchTask::executeTask()
     if (!m_steps.size()) {
         state = LaunchTask::Finished;
         emitSucceeded();
+        return;
     }
     state = LaunchTask::Running;
     onStepFinished();

--- a/launcher/launch/steps/LookupServerAddress.cpp
+++ b/launcher/launch/steps/LookupServerAddress.cpp
@@ -87,6 +87,6 @@ void LookupServerAddress::resolve(const QString& address, quint16 port)
     m_output->address = address;
     m_output->port = port;
 
-    emitSucceeded();
     m_dnsLookup->deleteLater();
+    emitSucceeded();
 }

--- a/launcher/minecraft/ComponentUpdateTask.cpp
+++ b/launcher/minecraft/ComponentUpdateTask.cpp
@@ -773,8 +773,9 @@ void ComponentUpdateTask::checkIfAllFinished()
                                          .arg(component->getName(), component->m_version));
             }
         }
+        d->remoteLoadStatusList.clear();
+
         auto allErrors = allErrorsList.join("\n");
         emitFailed(tr("Component metadata update task failed while downloading from remote server:\n%1").arg(allErrors));
-        d->remoteLoadStatusList.clear();
     }
 }

--- a/launcher/minecraft/auth/AuthFlow.cpp
+++ b/launcher/minecraft/auth/AuthFlow.cpp
@@ -151,8 +151,8 @@ bool AuthFlow::changeState(AccountTaskState newState, QString reason)
 }
 bool AuthFlow::abort()
 {
-    emitAborted();
     if (m_currentStep)
         m_currentStep->abort();
+    emitAborted();
     return true;
 }

--- a/launcher/minecraft/launch/AutoInstallJava.cpp
+++ b/launcher/minecraft/launch/AutoInstallJava.cpp
@@ -175,8 +175,8 @@ void AutoInstallJava::downloadJava(Meta::Version::Ptr version, QString javaName)
                     m_current_task = makeShared<Java::ArchiveDownloadTask>(java->url, final_path, java->checksumType, java->checksumHash);
                     break;
                 case Java::DownloadType::Unknown:
-                    emitFailed(tr("Could not determine Java download type!"));
                     deletePath();
+                    emitFailed(tr("Could not determine Java download type!"));
                     return;
             }
 #if defined(Q_OS_MACOS)

--- a/launcher/minecraft/launch/ExtractNatives.cpp
+++ b/launcher/minecraft/launch/ExtractNatives.cpp
@@ -75,6 +75,7 @@ void ExtractNatives::executeTask()
             const char* reason = QT_TR_NOOP("Couldn't extract native jar '%1' to destination '%2'");
             emit logLine(QString(reason).arg(source, outputPath), MessageLevel::Fatal);
             emitFailed(tr(reason).arg(source, outputPath));
+            return;
         }
     }
     emitSucceeded();

--- a/launcher/minecraft/launch/ModMinecraftJar.cpp
+++ b/launcher/minecraft/launch/ModMinecraftJar.cpp
@@ -51,11 +51,13 @@ void ModMinecraftJar::executeTask()
     // nuke obsolete stripped jar(s) if needed
     if (!FS::ensureFolderPathExists(m_inst->binRoot())) {
         emitFailed(tr("Couldn't create the bin folder for Minecraft.jar"));
+        return;
     }
 
     auto finalJarPath = QDir(m_inst->binRoot()).absoluteFilePath("minecraft.jar");
     if (!removeJar()) {
         emitFailed(tr("Couldn't remove stale jar file: %1").arg(finalJarPath));
+        return;
     }
 
     // create temporary modded jar, if needed

--- a/launcher/minecraft/mod/tasks/LocalResourceUpdateTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalResourceUpdateTask.cpp
@@ -32,6 +32,7 @@ LocalResourceUpdateTask::LocalResourceUpdateTask(QDir index_dir, ModPlatform::In
     // Ensure a '.index' folder exists in the mods folder, and create it if it does not
     if (!FS::ensureFolderPathExists(index_dir.path())) {
         emitFailed(QString("Unable to create index directory at %1!").arg(index_dir.absolutePath()));
+        return;
     }
 
 #ifdef Q_OS_WIN32

--- a/launcher/minecraft/update/AssetUpdateTask.cpp
+++ b/launcher/minecraft/update/AssetUpdateTask.cpp
@@ -68,6 +68,7 @@ void AssetUpdateTask::assetIndexFinished()
         auto entry = metacache->resolveEntry("asset_indexes", assets->id + ".json");
         metacache->evictEntry(entry);
         emitFailed(tr("Failed to read the assets index!"));
+        return;
     }
 
     auto job = index.getDownloadJob();

--- a/launcher/modplatform/helpers/HashUtils.cpp
+++ b/launcher/modplatform/helpers/HashUtils.cpp
@@ -145,8 +145,8 @@ void Hasher::executeTask()
         } else if (m_result = m_future.result(); m_result.isEmpty()) {
             emitFailed("Empty hash!");
         } else {
-            emitSucceeded();
             emit resultsReady(m_result);
+            emitSucceeded();
         }
     });
     m_watcher.setFuture(m_future);

--- a/launcher/modplatform/legacy_ftb/PackFetchTask.cpp
+++ b/launcher/modplatform/legacy_ftb/PackFetchTask.cpp
@@ -97,10 +97,10 @@ void PackFetchTask::fetchPrivate(const QStringList& toFetch)
         });
 
         connect(job, &NetJob::aborted, this, [this, job, data] {
-            emit aborted();
             job->deleteLater();
-
             data->clear();
+
+            emit aborted();
         });
 
         job->start();

--- a/launcher/modplatform/technic/SingleZipPackInstallTask.cpp
+++ b/launcher/modplatform/technic/SingleZipPackInstallTask.cpp
@@ -78,8 +78,8 @@ void Technic::SingleZipPackInstallTask::downloadSucceeded()
 void Technic::SingleZipPackInstallTask::downloadFailed(QString reason)
 {
     m_abortable = false;
-    emitFailed(reason);
     m_filesNetJob.reset();
+    emitFailed(reason);
 }
 
 void Technic::SingleZipPackInstallTask::downloadProgressChanged(qint64 current, qint64 total)

--- a/launcher/modplatform/technic/SolderPackInstallTask.cpp
+++ b/launcher/modplatform/technic/SolderPackInstallTask.cpp
@@ -98,8 +98,8 @@ void Technic::SolderPackInstallTask::fileListSucceeded()
     try {
         TechnicSolder::loadPackBuild(build, obj);
     } catch (const JSONValidationError& e) {
-        emitFailed(tr("Could not understand pack manifest:\n") + e.cause());
         m_filesNetJob.reset();
+        emitFailed(tr("Could not understand pack manifest:\n") + e.cause());
         return;
     }
 
@@ -159,8 +159,8 @@ void Technic::SolderPackInstallTask::downloadSucceeded()
 void Technic::SolderPackInstallTask::downloadFailed(QString reason)
 {
     m_abortable = false;
-    emitFailed(reason);
     m_filesNetJob.reset();
+    emitFailed(reason);
 }
 
 void Technic::SolderPackInstallTask::downloadProgressChanged(qint64 current, qint64 total)
@@ -171,8 +171,8 @@ void Technic::SolderPackInstallTask::downloadProgressChanged(qint64 current, qin
 
 void Technic::SolderPackInstallTask::downloadAborted()
 {
-    emitAborted();
     m_filesNetJob.reset();
+    emitAborted();
 }
 
 void Technic::SolderPackInstallTask::extractFinished()

--- a/launcher/tasks/SequentialTask.cpp
+++ b/launcher/tasks/SequentialTask.cpp
@@ -42,9 +42,9 @@ SequentialTask::SequentialTask(QString task_name) : ConcurrentTask(task_name, 1)
 
 void SequentialTask::subTaskFailed(Task::Ptr task, const QString& msg)
 {
-    emitFailed(msg);
     qWarning() << msg;
     ConcurrentTask::subTaskFailed(task, msg);
+    emitFailed(msg);
 }
 
 void SequentialTask::updateState()


### PR DESCRIPTION
In some changes, also moves the emission to the last statement to avoid unexpected behavior or use-after-free