### PR TITLE
ModrinthCheckUpdate: Don't send a request that is doomed to fail

### DIFF
--- a/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
+++ b/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
@@ -90,13 +90,19 @@ void ModrinthCheckUpdate::getUpdateModsForLoader(std::optional<ModPlatform::ModL
     QStringList hashes;
     if (forceModLoaderCheck && loader.has_value()) {
         for (auto hash : m_mappings.keys()) {
-            if (m_mappings[hash]->metadata()->loaders & loader.value()) {
+            if (m_mappings.value(hash)->metadata()->loaders & loader.value()) {
                 hashes.append(hash);
             }
         }
     } else {
         hashes = m_mappings.keys();
     }
+
+    if (hashes.isEmpty()) {
+        checkNextLoader();
+        return;
+    }
+
     auto job = api.latestVersions(hashes, m_hashType, m_gameVersions, loader, response.get());
 
     connect(job.get(), &Task::succeeded, this, [this, response, loader] { checkVersionsResponse(response.get(), loader); });


### PR DESCRIPTION
Closes #4678 
Closes #4818 (the original issue makes an incorrect assumption about the error they're encountering, but this PR fixes the error)

*check diff first*

Why would `hashes` be empty? When a mod supports multiple mod loaders, the launcher will consider all mod loaders when checking for updates. If a check for a loader succeeds, the hash will be erased from `m_mappings` and thus will not be available for checks for other mod loaders. So, when the launcher runs checks for other mod loaders, there may be no hashes to send.