### PR TITLE
MSAStep: Tighten isSchemeHandlerRegistered check

### DIFF
--- a/launcher/minecraft/auth/steps/MSAStep.cpp
+++ b/launcher/minecraft/auth/steps/MSAStep.cpp
@@ -56,13 +56,14 @@ bool isSchemeHandlerRegistered()
     process.waitForFinished();
     QString output = process.readAllStandardOutput().trimmed();
 
-    return output.contains(BuildConfig.LAUNCHER_APP_BINARY_NAME);
+    return output.contains(APPLICATION->desktopFileName());
 
 #elif defined(Q_OS_WIN)
     QString regPath = QString("HKEY_CURRENT_USER\\Software\\Classes\\%1").arg(BuildConfig.LAUNCHER_APP_BINARY_NAME);
     QSettings settings(regPath, QSettings::NativeFormat);
 
-    return settings.contains("shell/open/command/.");
+    const QString registeredRunCommand = settings.value("shell/open/command/.").toString().replace("\\", "/");
+    return registeredRunCommand.contains(QCoreApplication::applicationFilePath());
 #endif
     return true;
 }


### PR DESCRIPTION
Closes #4677 (on Windows only)

I didn't bother to attempt to fully fix this on Linux. To do that the launcher would have to find and parse out the desktop file, resolve the executable in the `Exec=` line (which could be discovered from `PATH` or symlinked) and finally compare it with the running file path. This is more code than I'm in the mood to do rn

If maintainers want it fixed on Linux too just leave a comment