### PR TITLE
[Backport release-10.x] ModrinthCheckUpdate: Don't send a request that is doomed to fail

### DIFF
--- a/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
+++ b/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
@@ -90,13 +90,19 @@ void ModrinthCheckUpdate::getUpdateModsForLoader(std::optional<ModPlatform::ModL
     QStringList hashes;
     if (forceModLoaderCheck && loader.has_value()) {
         for (auto hash : m_mappings.keys()) {
-            if (m_mappings[hash]->metadata()->loaders & loader.value()) {
+            if (m_mappings.value(hash)->metadata()->loaders & loader.value()) {
                 hashes.append(hash);
             }
         }
     } else {
         hashes = m_mappings.keys();
     }
+
+    if (hashes.isEmpty()) {
+        checkNextLoader();
+        return;
+    }
+
     auto job = api.latestVersions(hashes, m_hashType, m_gameVersions, loader, response);
 
     connect(job.get(), &Task::succeeded, this, [this, response, loader] { checkVersionsResponse(response, loader); });


### PR DESCRIPTION
Trial-based backport to `release-10.x`, triggered by a comment in #4840