### PR TITLE
MinecraftSettingsWidget: Swap window width/height spinboxes

### DIFF
--- a/launcher/ui/widgets/MinecraftSettingsWidget.ui
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.ui
@@ -110,7 +110,7 @@
                 </property>
                </widget>
               </item>
-              <item row="2" column="3">
+              <item row="2" column="1">
                <widget class="QSpinBox" name="windowWidthSpinBox">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -151,7 +151,7 @@
                 </property>
                </spacer>
               </item>
-              <item row="2" column="1">
+              <item row="2" column="3">
                <widget class="QSpinBox" name="windowHeightSpinBox">
                 <property name="sizePolicy">
                  <sizepolicy hsizetype="Maximum" vsizetype="Fixed">

--- a/launcher/ui/widgets/MinecraftSettingsWidget.ui
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.ui
@@ -82,7 +82,7 @@
               <item row="1" column="0" colspan="6">
                <widget class="QLabel" name="maximizedWarning">
                 <property name="toolTip">
-                 <string>The base game only supports resolution. In order to simulate the maximized behaviour the current implementation approximates the maximum display size.</string>
+                 <string>The base game only supports resolution. In order to simulate the maximized behavior the current implementation approximates the maximum display size.</string>
                 </property>
                 <property name="text">
                  <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600; color:#f5c211;&quot;&gt;Warning&lt;/span&gt;&lt;span style=&quot; color:#f5c211;&quot;&gt;: The maximized option may not be fully supported on all Minecraft versions.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>


### PR DESCRIPTION
happened to someone in a Discord support thread, no issue was made

<img width="819" height="211" alt="fix showcase" src="https://github.com/user-attachments/assets/ac05a502-8c5a-48c1-b27c-6f8b6d793c74" /> (left is develop, right is PR)
