### PR TITLE
Make Minecraft resource URL override consistent with other overrides

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -872,13 +872,13 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
                 m_settings->reset("MetaURLOverride");
 
             // Resource URL
-            m_settings->registerSetting("ResourceURL", BuildConfig.DEFAULT_RESOURCE_BASE);
+            m_settings->registerSetting({ "ResourceURLOverride", "ResourceURL" }, "");
 
-            QUrl resourceUrl(m_settings->get("ResourceURL").toString());
+            QUrl resourceUrl(m_settings->get("ResourceURLOverride").toString());
 
             // get rid of invalid resource urls
             if (!resourceUrl.isValid() || (resourceUrl.scheme() != "http" && resourceUrl.scheme() != "https"))
-                m_settings->reset("ResourceURL");
+                m_settings->reset("ResourceURLOverride");
         }
 
         m_settings->registerSetting("CloseAfterLaunch", false);

--- a/launcher/minecraft/AssetsUtils.cpp
+++ b/launcher/minecraft/AssetsUtils.cpp
@@ -52,6 +52,7 @@
 
 #include "Application.h"
 #include "net/NetRequest.h"
+#include "update/AssetUpdateTask.h"
 
 namespace {
 QSet<QString> collectPathsFromDir(QString dirPath)
@@ -298,7 +299,7 @@ QString AssetObject::getLocalPath()
 
 QUrl AssetObject::getUrl()
 {
-    auto resourceURL = APPLICATION->settings()->get("ResourceURL").toString();
+    auto resourceURL = AssetUpdateTask::resourceUrl();
     return resourceURL + getRelPath();
 }
 

--- a/launcher/minecraft/update/AssetUpdateTask.cpp
+++ b/launcher/minecraft/update/AssetUpdateTask.cpp
@@ -114,8 +114,8 @@ bool AssetUpdateTask::abort()
 
 QString AssetUpdateTask::resourceUrl()
 {
-    if (const QString override = APPLICATION->settings()->get("ResourceURLOverride").toString(); !override.isEmpty()) {
-        return override;
+    if (const QString urlOverride = APPLICATION->settings()->get("ResourceURLOverride").toString(); !urlOverride.isEmpty()) {
+        return urlOverride;
     }
 
     return BuildConfig.DEFAULT_RESOURCE_BASE;

--- a/launcher/minecraft/update/AssetUpdateTask.cpp
+++ b/launcher/minecraft/update/AssetUpdateTask.cpp
@@ -73,7 +73,7 @@ void AssetUpdateTask::assetIndexFinished()
 
     auto job = index.getDownloadJob();
     if (job) {
-        QString resourceURL = APPLICATION->settings()->get("ResourceURL").toString();
+        QString resourceURL = resourceUrl();
         QString source = tr("Mojang");
         if (resourceURL != BuildConfig.DEFAULT_RESOURCE_BASE) {
             source = QUrl(resourceURL).host();
@@ -110,4 +110,13 @@ bool AssetUpdateTask::abort()
         qWarning() << "Prematurely aborted AssetUpdateTask";
     }
     return true;
+}
+
+QString AssetUpdateTask::resourceUrl()
+{
+    if (const QString override = APPLICATION->settings()->get("ResourceURLOverride").toString(); !override.isEmpty()) {
+        return override;
+    }
+
+    return BuildConfig.DEFAULT_RESOURCE_BASE;
 }

--- a/launcher/minecraft/update/AssetUpdateTask.h
+++ b/launcher/minecraft/update/AssetUpdateTask.h
@@ -13,6 +13,9 @@ class AssetUpdateTask : public Task {
 
     bool canAbort() const override;
 
+   public:
+    static QString resourceUrl();
+
    private slots:
     void assetIndexFinished();
     void assetIndexFailed(QString reason);

--- a/launcher/ui/pages/global/APIPage.cpp
+++ b/launcher/ui/pages/global/APIPage.cpp
@@ -80,6 +80,7 @@ APIPage::APIPage(QWidget* parent) : QWidget(parent), ui(new Ui::APIPage)
     ui->msaClientID->setValidator(new QRegularExpressionValidator(s_validMSAClientID, ui->msaClientID));
 
     ui->metaURL->setPlaceholderText(BuildConfig.META_URL);
+    ui->resourceURL->setPlaceholderText(BuildConfig.DEFAULT_RESOURCE_BASE);
     ui->userAgentLineEdit->setPlaceholderText(BuildConfig.USER_AGENT);
 
     loadSettings();
@@ -136,7 +137,7 @@ void APIPage::loadSettings()
     ui->msaClientID->setText(msaClientID);
     QString metaURL = s->get("MetaURLOverride").toString();
     ui->metaURL->setText(metaURL);
-    QString resourceURL = s->get("ResourceURL").toString();
+    QString resourceURL = s->get("ResourceURLOverride").toString();
     ui->resourceURL->setText(resourceURL);
     QString flameKey = s->get("FlameKeyOverride").toString();
     ui->flameKey->setText(flameKey);
@@ -185,7 +186,7 @@ void APIPage::applySettings()
     }
 
     s->set("MetaURLOverride", metaURL.toString());
-    s->set("ResourceURL", resourceURL.toString());
+    s->set("ResourceURLOverride", resourceURL.toString());
     QString flameKey = ui->flameKey->text();
     s->set("FlameKeyOverride", flameKey);
     QString modrinthToken = ui->modrinthToken->text();


### PR DESCRIPTION
Some URL overrides are blank by default and the field acts as an override (use user-setting if not empty, otherwise the value from build config).
<img width="484" height="277" alt="изображение" src="https://github.com/user-attachments/assets/d3a2ac8b-2c28-4433-b2bb-98a6c086aff2" />

Minecraft resource URL is a weird exception to this: the default value *is* the build config value
<img width="674" height="107" alt="изображение" src="https://github.com/user-attachments/assets/bb3b129a-f4f9-4179-a99a-ff4e735a3775" />

With this PR, the experience is now consistent
<img width="480" height="125" alt="изображение" src="https://github.com/user-attachments/assets/cd21b507-934d-4d50-8d33-688a71e856ed" />

The legacy key for the setting has been retained as a synonym so that user overrides aren't erased after updating
