### PR TITLE
Actions: Use low-cost runner for simple workflows

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -19,7 +19,7 @@ jobs:
       actions: write # for korthout/backport-action to create PR with workflow changes
     name: Backport Pull Request
     if: github.repository_owner == 'PrismLauncher' && github.event.pull_request.merged == true && (github.event_name != 'labeled' || startsWith('backport', github.event.label.name))
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/blocked-prs.yml
+++ b/.github/workflows/blocked-prs.yml
@@ -17,7 +17,7 @@ on:
 jobs:
   blocked_status:
     name: Check Blocked Status
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
       - name: Generate token

--- a/.github/workflows/merge-blocking-pr.yml
+++ b/.github/workflows/merge-blocking-pr.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   update-blocked-status:
     name: Update Blocked Status
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     # a pr that was a `blocking:<id>` label was merged.
     # find the open pr's it was blocked by and trigger a refresh of their state

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
   winget:
     name: Winget
 
-    runs-on: windows-latest
+    runs-on: ubuntu-slim
 
     steps:
       - name: Publish on Winget

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
 
   create_release:
     needs: build_release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
   label:
     name: Label issues and PRs
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     permissions:
       issues: write

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   update-flake:
     if: github.repository == 'PrismLauncher/PrismLauncher'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
See https://github.blog/changelog/2026-01-22-1-vcpu-linux-runner-now-generally-available-in-github-actions/

All of the affected jobs take less than a few minutes to run and are I/O-bound, making them good candidates for the new low-cost runner type