### PR TITLE
Return to major.minor versioning scheme

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,12 +175,11 @@ set(Launcher_FMLLIBS_BASE_URL "https://files.prismlauncher.org/fmllibs/" CACHE S
 
 ######## Set version numbers ########
 set(Launcher_VERSION_MAJOR 10)
-set(Launcher_VERSION_MINOR 0)
-set(Launcher_VERSION_PATCH 2)
+set(Launcher_VERSION_MINOR 3)
 
-set(Launcher_VERSION_NAME "${Launcher_VERSION_MAJOR}.${Launcher_VERSION_MINOR}.${Launcher_VERSION_PATCH}")
-set(Launcher_VERSION_NAME4 "${Launcher_VERSION_MAJOR}.${Launcher_VERSION_MINOR}.${Launcher_VERSION_PATCH}.0")
-set(Launcher_VERSION_NAME4_COMMA "${Launcher_VERSION_MAJOR},${Launcher_VERSION_MINOR},${Launcher_VERSION_PATCH},0")
+set(Launcher_VERSION_NAME "${Launcher_VERSION_MAJOR}.${Launcher_VERSION_MINOR}")
+set(Launcher_VERSION_NAME4 "${Launcher_VERSION_MAJOR}.${Launcher_VERSION_MINOR}.0.0")
+set(Launcher_VERSION_NAME4_COMMA "${Launcher_VERSION_MAJOR},${Launcher_VERSION_MINOR},0,0")
 
 # Build platform.
 set(Launcher_BUILD_PLATFORM "unknown" CACHE STRING "A short string identifying the platform that this build was built for. Only used to display in the about dialog.")

--- a/buildconfig/BuildConfig.cpp.in
+++ b/buildconfig/BuildConfig.cpp.in
@@ -56,7 +56,6 @@ Config::Config()
     // Version information
     VERSION_MAJOR = @Launcher_VERSION_MAJOR@;
     VERSION_MINOR = @Launcher_VERSION_MINOR@;
-    VERSION_PATCH = @Launcher_VERSION_PATCH@;
 
     BUILD_PLATFORM = "@Launcher_BUILD_PLATFORM@";
     BUILD_ARTIFACT = "@Launcher_BUILD_ARTIFACT@";
@@ -126,7 +125,7 @@ Config::Config()
 
 QString Config::versionString() const
 {
-    return QString("%1.%2.%3").arg(VERSION_MAJOR).arg(VERSION_MINOR).arg(VERSION_PATCH);
+    return QString("%1.%2").arg(VERSION_MAJOR).arg(VERSION_MINOR);
 }
 
 QString Config::printableVersionString() const

--- a/buildconfig/BuildConfig.h
+++ b/buildconfig/BuildConfig.h
@@ -59,8 +59,6 @@ class Config {
     int VERSION_MAJOR;
     /// The minor version number.
     int VERSION_MINOR;
-    /// The patch version number.
-    int VERSION_PATCH;
 
     /**
      * The version channel

--- a/launcher/updater/prismupdater/PrismUpdater.cpp
+++ b/launcher/updater/prismupdater/PrismUpdater.cpp
@@ -353,10 +353,6 @@ PrismUpdaterApp::PrismUpdaterApp(int& argc, char** argv) : QApplication(argc, ar
         auto version_parts = version.split('.');
         m_prismVersionMajor = version_parts.takeFirst().toInt();
         m_prismVersionMinor = version_parts.takeFirst().toInt();
-        if (!version_parts.isEmpty())
-            m_prismVersionPatch = version_parts.takeFirst().toInt();
-        else
-            m_prismVersionPatch = 0;
     }
 
     m_allowPreRelease = parser.isSet("pre-release");
@@ -439,7 +435,6 @@ void PrismUpdaterApp::run()
         m_prismVersion = BuildConfig.printableVersionString();
         m_prismVersionMajor = BuildConfig.VERSION_MAJOR;
         m_prismVersionMinor = BuildConfig.VERSION_MINOR;
-        m_prismVersionPatch = BuildConfig.VERSION_PATCH;
         m_prsimVersionChannel = BuildConfig.VERSION_CHANNEL;
         m_prismGitCommit = BuildConfig.GIT_COMMIT;
     }
@@ -448,7 +443,6 @@ void PrismUpdaterApp::run()
     qDebug() << "Executable reports as:" << m_prismBinaryName << "version:" << m_prismVersion;
     qDebug() << "Version major:" << m_prismVersionMajor;
     qDebug() << "Version minor:" << m_prismVersionMinor;
-    qDebug() << "Version minor:" << m_prismVersionPatch;
     qDebug() << "Version channel:" << m_prsimVersionChannel;
     qDebug() << "Git Commit:" << m_prismGitCommit;
 
@@ -1132,10 +1126,6 @@ bool PrismUpdaterApp::loadPrismVersionFromExe(const QString& exe_path)
         return false;
     m_prismVersionMajor = version_parts.takeFirst().toInt();
     m_prismVersionMinor = version_parts.takeFirst().toInt();
-    if (!version_parts.isEmpty())
-        m_prismVersionPatch = version_parts.takeFirst().toInt();
-    else
-        m_prismVersionPatch = 0;
     m_prismGitCommit = lines.takeFirst().simplified();
     return true;
 }
@@ -1259,7 +1249,7 @@ GitHubRelease PrismUpdaterApp::getLatestRelease()
 
 bool PrismUpdaterApp::needUpdate(const GitHubRelease& release)
 {
-    auto current_ver = Version(QString("%1.%2.%3").arg(m_prismVersionMajor).arg(m_prismVersionMinor).arg(m_prismVersionPatch));
+    auto current_ver = Version(QString("%1.%2").arg(m_prismVersionMajor).arg(m_prismVersionMinor));
     return current_ver < release.version;
 }
 

--- a/launcher/updater/prismupdater/PrismUpdater.h
+++ b/launcher/updater/prismupdater/PrismUpdater.h
@@ -121,7 +121,6 @@ class PrismUpdaterApp : public QApplication {
     QString m_prismVersion;
     int m_prismVersionMajor = -1;
     int m_prismVersionMinor = -1;
-    int m_prismVersionPatch = -1;
     QString m_prsimVersionChannel;
     QString m_prismGitCommit;
 


### PR DESCRIPTION
We are considering returning to the previous versioning scheme due to the maintenance burden...

This PR reverts #3605, apart from the formatting changes and also bumps to 10.3

See also: https://github.com/PolyMC/PolyMC/pull/992 (we are really going back to the new versioning scheme when we switched to a versioning scheme more like the old one 😵‍💫)