### PR TITLE
feat: curseforge modpack downloading via binaryname:// uri

### DIFF
--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -941,10 +941,20 @@ void MainWindow::processURLs(QList<QUrl> urls)
         QUrl local_url;
         if (!url.isLocalFile()) {  // download the remote resource and identify
             QUrl dl_url;
-            if (url.scheme() == "curseforge") {
+            if (url.scheme() == "curseforge" || (url.scheme() == BuildConfig.LAUNCHER_APP_BINARY_NAME && url.host() == "install")) {
                 // need to find the download link for the modpack / resource
                 // format of url curseforge://install?addonId=IDHERE&fileId=IDHERE
+                // format of url binaryname://install?platform=curseforge&addonId=IDHERE&fileId=IDHERE
                 QUrlQuery query(url);
+                
+                // check if this is a binaryname:// url
+                if (url.scheme() == BuildConfig.LAUNCHER_APP_BINARY_NAME) {
+                    // check this is an curseforge platform request
+                    if (query.queryItemValue("platform").toLower() != "curseforge") {
+                        qDebug() << "Invalid mod distribution platform:" << query.queryItemValue("platform");
+                        continue;
+                    }
+                }
 
                 if (query.allQueryItemValues("addonId").isEmpty() || query.allQueryItemValues("fileId").isEmpty()) {
                     qDebug() << "Invalid curseforge link:" << url;


### PR DESCRIPTION
Hey!

I have contributed the ability to download CurseForge modpack via an URL Protocol. 

My reason for contributing this is because I want to embed an button on my server's website which allows users to download a modpack from Prism. Prism Launcher supports ``curseforge://`` URI at the moment, but it might get overwritten by CurseForge launcher which will lead users to the wrong launcher. This addition would be great and benefit websites that want to offer dedicated download buttons for both CurseForge and Prism Launcher modpacks.

This is my first ever contribution and I'm willing to recieve any feedback or code review notes :)

Cheers!