### PR TITLE
Fix typo for loader mods help page

### DIFF
--- a/launcher/ui/pages/instance/ModFolderPage.h
+++ b/launcher/ui/pages/instance/ModFolderPage.h
@@ -56,7 +56,7 @@ class ModFolderPage : public ExternalResourcesPage {
     virtual QString displayName() const override { return tr("Mods"); }
     virtual QIcon icon() const override { return QIcon::fromTheme("loadermods"); }
     virtual QString id() const override { return "mods"; }
-    virtual QString helpPage() const override { return "Loader-mods"; }
+    virtual QString helpPage() const override { return "loader-mods"; }
 
     virtual bool shouldDisplay() const override;
 


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->

This PR fixes a typo I noticed when I misclicked the help button on the loader mods help page.
Before it redirected you to https://prismlauncher.org/wiki/help-pages/Loader-mods/ (capital L in loader, it should be lowercase.)