### PR TITLE
Remove double spaces in logging

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -686,7 +686,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         QString resolvedDefaultMonospace = consoleFontInfo.family();
         QFont resolvedFont(resolvedDefaultMonospace);
         qDebug().nospace() << "Detected default console font: " << resolvedDefaultMonospace
-                 << ", substitutions: " << resolvedFont.substitutions().join(',');
+                           << ", substitutions: " << resolvedFont.substitutions().join(',');
 
         m_settings->registerSetting("ConsoleFont", resolvedDefaultMonospace);
         m_settings->registerSetting("ConsoleFontSize", defaultSize);

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -603,25 +603,25 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
 
     {
         qInfo() << qPrintable(BuildConfig.LAUNCHER_DISPLAYNAME + ", " + QString(BuildConfig.LAUNCHER_COPYRIGHT).replace("\n", ", "));
-        qInfo() << "Version                    : " << BuildConfig.printableVersionString();
-        qInfo() << "Platform                   : " << BuildConfig.BUILD_PLATFORM;
-        qInfo() << "Git commit                 : " << BuildConfig.GIT_COMMIT;
-        qInfo() << "Git refspec                : " << BuildConfig.GIT_REFSPEC;
-        qInfo() << "Compiled for               : " << BuildConfig.systemID();
-        qInfo() << "Compiled by                : " << BuildConfig.compilerID();
-        qInfo() << "Build Artifact             : " << BuildConfig.BUILD_ARTIFACT;
-        qInfo() << "Updates Enabled           : " << (updaterEnabled() ? "Yes" : "No");
+        qInfo() << "Version                    :" << BuildConfig.printableVersionString();
+        qInfo() << "Platform                   :" << BuildConfig.BUILD_PLATFORM;
+        qInfo() << "Git commit                 :" << BuildConfig.GIT_COMMIT;
+        qInfo() << "Git refspec                :" << BuildConfig.GIT_REFSPEC;
+        qInfo() << "Compiled for               :" << BuildConfig.systemID();
+        qInfo() << "Compiled by                :" << BuildConfig.compilerID();
+        qInfo() << "Build Artifact             :" << BuildConfig.BUILD_ARTIFACT;
+        qInfo() << "Updates Enabled            :" << (updaterEnabled() ? "Yes" : "No");
         if (adjustedBy.size()) {
-            qInfo() << "Work dir before adjustment : " << origcwdPath;
-            qInfo() << "Work dir after adjustment  : " << QDir::currentPath();
-            qInfo() << "Adjusted by                : " << adjustedBy;
+            qInfo() << "Work dir before adjustment :" << origcwdPath;
+            qInfo() << "Work dir after adjustment  :" << QDir::currentPath();
+            qInfo() << "Adjusted by                :" << adjustedBy;
         } else {
-            qInfo() << "Work dir                   : " << QDir::currentPath();
+            qInfo() << "Work dir                   :" << QDir::currentPath();
         }
-        qInfo() << "Binary path                : " << binPath;
-        qInfo() << "Application root path      : " << m_rootPath;
+        qInfo() << "Binary path                :" << binPath;
+        qInfo() << "Application root path      :" << m_rootPath;
         if (!m_instanceIdToLaunch.isEmpty()) {
-            qInfo() << "ID of instance to launch   : " << m_instanceIdToLaunch;
+            qInfo() << "ID of instance to launch   :" << m_instanceIdToLaunch;
         }
         if (!m_serverToJoin.isEmpty()) {
             qInfo() << "Address of server to join  :" << m_serverToJoin;
@@ -685,8 +685,8 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         QFontInfo consoleFontInfo(consoleFont);
         QString resolvedDefaultMonospace = consoleFontInfo.family();
         QFont resolvedFont(resolvedDefaultMonospace);
-        qDebug() << "Detected default console font:" << resolvedDefaultMonospace
-                 << ", substitutions:" << resolvedFont.substitutions().join(',');
+        qDebug().nospace() << "Detected default console font: " << resolvedDefaultMonospace
+                 << ", substitutions: " << resolvedFont.substitutions().join(',');
 
         m_settings->registerSetting("ConsoleFont", resolvedDefaultMonospace);
         m_settings->registerSetting("ConsoleFontSize", defaultSize);
@@ -985,7 +985,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         // instance path: check for problems with '!' in instance path and warn the user in the log
         // and remember that we have to show him a dialog when the gui starts (if it does so)
         QString instDir = m_settings->get("InstanceDir").toString();
-        qInfo() << "Instance path              : " << instDir;
+        qInfo() << "Instance path              :" << instDir;
         if (FS::checkProblemticPathJava(QDir(instDir))) {
             qWarning() << "Your instance path contains \'!\' and this is known to cause java problems!";
         }

--- a/launcher/FileSystem.cpp
+++ b/launcher/FileSystem.cpp
@@ -432,7 +432,7 @@ void create_link::make_link_list(const QString& offset)
             link_file(src, "");
         } else {
             if (m_debug)
-                qDebug() << "linking recursively:" << src << "to" << dst << ", max_depth:" << m_max_depth;
+                qDebug().nospace() << "linking recursively: " << src << " to " << dst << ", max_depth: " << m_max_depth;
             QDir src_dir(src);
             QDirIterator source_it(src, QDir::Filter::Files | QDir::Filter::Hidden, QDirIterator::Subdirectories);
 
@@ -1100,17 +1100,17 @@ QString createShortcut(QString destination, QString target, QStringList args, QS
             hres = ppf->Save(wsz, TRUE);
             if (FAILED(hres)) {
                 qWarning() << "IPresistFile->Save() failed";
-                qWarning() << "hres = " << hres;
+                qWarning() << "hres =" << hres;
             }
             ppf->Release();
         } else {
             qWarning() << "Failed to query IPersistFile interface from IShellLink instance";
-            qWarning() << "hres = " << hres;
+            qWarning() << "hres =" << hres;
         }
         psl->Release();
     } else {
         qWarning() << "Failed to create IShellLink instance";
-        qWarning() << "hres = " << hres;
+        qWarning() << "hres =" << hres;
     }
 
     // go away COM, nobody likes you
@@ -1399,14 +1399,14 @@ bool win_ioctl_clone(const std::wstring& src_path, const std::wstring& dst_path,
     ULONG fs_flags;
     if (!GetVolumeInformationByHandleW(hSourceFile, nullptr, 0, nullptr, nullptr, &fs_flags, nullptr, 0)) {
         ec = std::error_code(GetLastError(), std::system_category());
-        qDebug() << "Failed to get Filesystem information for " << src_path.c_str();
+        qDebug() << "Failed to get Filesystem information for" << src_path.c_str();
         CloseHandle(hSourceFile);
         return false;
     }
     if (!(fs_flags & FILE_SUPPORTS_BLOCK_REFCOUNTING)) {
         SetLastError(ERROR_NOT_CAPABLE);
         ec = std::error_code(GetLastError(), std::system_category());
-        qWarning() << "Filesystem at " << src_path.c_str() << " does not support reflink";
+        qWarning() << "Filesystem at" << src_path.c_str() << "does not support reflink";
         CloseHandle(hSourceFile);
         return false;
     }

--- a/launcher/InstanceCreationTask.cpp
+++ b/launcher/InstanceCreationTask.cpp
@@ -25,7 +25,7 @@ void InstanceCreationTask::executeTask()
 
         qWarning() << "Instance creation failed!";
         if (!m_error_message.isEmpty()) {
-            qWarning() << "Reason: " << m_error_message;
+            qWarning() << "Reason:" << m_error_message;
             emitFailed(tr("Error while creating new instance:\n%1").arg(m_error_message));
         } else {
             emitFailed(tr("Error while creating new instance."));

--- a/launcher/MMCZip.cpp
+++ b/launcher/MMCZip.cpp
@@ -56,18 +56,18 @@ bool mergeZipFiles(ArchiveWriter& into, QFileInfo from, QSet<QString>& contained
     return r.parse([&into, &contained, &filter, from](ArchiveReader::File* f) {
         auto filename = f->filename();
         if (filter && !filter(filename)) {
-            qDebug() << "Skipping file " << filename << " from " << from.fileName() << " - filtered";
+            qDebug() << "Skipping file" << filename << "from" << from.fileName() << "- filtered";
             f->skip();
             return true;
         }
         if (contained.contains(filename)) {
-            qDebug() << "Skipping already contained file " << filename << " from " << from.fileName();
+            qDebug() << "Skipping already contained file" << filename << "from" << from.fileName();
             f->skip();
             return true;
         }
         contained.insert(filename);
         if (!into.addFile(f)) {
-            qCritical() << "Failed to copy data of " << filename << " into the jar";
+            qCritical() << "Failed to copy data of" << filename << "into the jar";
             return false;
         }
         return true;
@@ -149,7 +149,7 @@ bool createModdedJar(QString sourceJarPath, QString targetJarPath, const QList<M
                 qCritical() << "Failed to add" << mod->fileinfo().fileName() << "to the jar.";
                 return false;
             }
-            qDebug() << "Adding folder " << filename.fileName() << " from " << filename.absoluteFilePath();
+            qDebug() << "Adding folder" << filename.fileName() << "from" << filename.absoluteFilePath();
         } else {
             // Make sure we do not continue launching when something is missing or undefined...
             zipOut.close();
@@ -321,7 +321,7 @@ bool collectFileListRecursively(const QString& rootDir, const QString& subDir, Q
     for (const auto& e : entries) {
         if (excludeFilter && excludeFilter(e)) {
             QString relativeFilePath = rootDirectory.relativeFilePath(e.absoluteFilePath());
-            qDebug() << "Skipping file " << relativeFilePath;
+            qDebug() << "Skipping file" << relativeFilePath;
             continue;
         }
 

--- a/launcher/archive/ArchiveReader.cpp
+++ b/launcher/archive/ArchiveReader.cpp
@@ -57,7 +57,7 @@ QByteArray ArchiveReader::File::readAll(int* outStatus)
         data.append(static_cast<const char*>(buff), static_cast<qsizetype>(size));
     }
     if (status != ARCHIVE_EOF && status != ARCHIVE_OK) {
-        qWarning() << "libarchive read error: " << archive_error_string(m_archive.get());
+        qWarning() << "libarchive read error:" << archive_error_string(m_archive.get());
     }
     if (outStatus) {
         *outStatus = status;

--- a/launcher/archive/ArchiveWriter.cpp
+++ b/launcher/archive/ArchiveWriter.cpp
@@ -167,14 +167,14 @@ bool ArchiveWriter::addFile(const QString& fileName, const QString& fileDest)
     }
 
     if (archive_write_header(m_archive, entry) != ARCHIVE_OK) {
-        qCritical() << "Failed to write header for: " << fileDest << "-" << archive_error_string(m_archive);
+        qCritical() << "Failed to write header for:" << fileDest << "-" << archive_error_string(m_archive);
         return false;
     }
 
     if (fileInfo.isFile() && !fileInfo.isSymLink()) {
         QFile file(fileInfo.absoluteFilePath());
         if (!file.open(QIODevice::ReadOnly)) {
-            qCritical() << "Failed to open file: " << fileInfo.filePath();
+            qCritical() << "Failed to open file:" << fileInfo.filePath();
             return false;
         }
 
@@ -185,12 +185,12 @@ bool ArchiveWriter::addFile(const QString& fileName, const QString& fileDest)
         while (!file.atEnd()) {
             auto bytesRead = file.read(buffer.data(), chunkSize);
             if (bytesRead < 0) {
-                qCritical() << "Read error in file: " << fileInfo.filePath();
+                qCritical() << "Read error in file:" << fileInfo.filePath();
                 return false;
             }
 
             if (archive_write_data(m_archive, buffer.constData(), bytesRead) < 0) {
-                qCritical() << "Write error in archive for: " << fileDest;
+                qCritical() << "Write error in archive for:" << fileDest;
                 return false;
             }
         }
@@ -216,12 +216,12 @@ bool ArchiveWriter::addFile(const QString& fileDest, const QByteArray& data)
     archive_entry_set_size(entry, data.size());
 
     if (archive_write_header(m_archive, entry) != ARCHIVE_OK) {
-        qCritical() << "Failed to write header for: " << fileDest << "-" << archive_error_string(m_archive);
+        qCritical() << "Failed to write header for:" << fileDest << "-" << archive_error_string(m_archive);
         return false;
     }
 
     if (archive_write_data(m_archive, data.constData(), data.size()) < 0) {
-        qCritical() << "Write error in archive for: " << fileDest << "-" << archive_error_string(m_archive);
+        qCritical() << "Write error in archive for:" << fileDest << "-" << archive_error_string(m_archive);
         return false;
     }
     return true;

--- a/launcher/filelink/FileLink.cpp
+++ b/launcher/filelink/FileLink.cpp
@@ -115,7 +115,7 @@ void FileLinkApp::joinServer(QString server)
                 qDebug() << ("The connection was closed by the peer. ");
                 break;
             default:
-                qDebug() << "The following error occurred: " << socket.errorString();
+                qDebug() << "The following error occurred:" << socket.errorString();
         }
     });
 

--- a/launcher/icons/IconList.cpp
+++ b/launcher/icons/IconList.cpp
@@ -169,7 +169,7 @@ void IconList::directoryChanged(const QString& path)
     QSet<QString> toAdd = newSet - currentSet;
 
     for (const QString& removedPath : toRemove) {
-        qDebug() << "Removing icon " << removedPath;
+        qDebug() << "Removing icon" << removedPath;
         QFileInfo removedFile(removedPath);
         QString relativePath = m_dir.relativeFilePath(removedFile.absoluteFilePath());
         QString key = QFileInfo(relativePath).completeBaseName();
@@ -191,7 +191,7 @@ void IconList::directoryChanged(const QString& path)
     }
 
     for (const QString& addedPath : toAdd) {
-        qDebug() << "Adding icon " << addedPath;
+        qDebug() << "Adding icon" << addedPath;
 
         QFileInfo addfile(addedPath);
         QString relativePath = m_dir.relativeFilePath(addfile.absoluteFilePath());
@@ -209,7 +209,7 @@ void IconList::directoryChanged(const QString& path)
 
 void IconList::fileChanged(const QString& path)
 {
-    qDebug() << "Checking icon " << path;
+    qDebug() << "Checking icon" << path;
     QFileInfo checkfile(path);
     if (!checkfile.exists())
         return;
@@ -246,9 +246,9 @@ void IconList::startWatching()
     FS::ensureFolderPathExists(abs_path);
     m_isWatching = addPathRecursively(abs_path);
     if (m_isWatching) {
-        qDebug() << "Started watching " << abs_path;
+        qDebug() << "Started watching" << abs_path;
     } else {
-        qDebug() << "Failed to start watching " << abs_path;
+        qDebug() << "Failed to start watching" << abs_path;
     }
 }
 

--- a/launcher/java/download/ManifestDownloadTask.cpp
+++ b/launcher/java/download/ManifestDownloadTask.cpp
@@ -61,7 +61,7 @@ void ManifestDownloadTask::executeTask()
         QJsonParseError parse_error{};
         QJsonDocument doc = QJsonDocument::fromJson(*files, &parse_error);
         if (parse_error.error != QJsonParseError::NoError) {
-            qWarning() << "Error while parsing JSON response at " << parse_error.offset << ". Reason: " << parse_error.errorString();
+            qWarning() << "Error while parsing JSON response at" << parse_error.offset << "reason:" << parse_error.errorString();
             qWarning() << *files;
             emitFailed(parse_error.errorString());
             return;

--- a/launcher/minecraft/Component.cpp
+++ b/launcher/minecraft/Component.cpp
@@ -479,6 +479,7 @@ void Component::clearUpdateAction()
 
 QDebug operator<<(QDebug d, const Component& comp)
 {
-    d << "Component(" << comp.m_uid << " : " << comp.m_cachedVersion << ")";
+    QDebugStateSaver saver(d);
+    d.nospace() << "Component(" << comp.m_uid << " : " << comp.m_cachedVersion << ")";
     return d;
 }

--- a/launcher/minecraft/ComponentUpdateTask.cpp
+++ b/launcher/minecraft/ComponentUpdateTask.cpp
@@ -521,7 +521,7 @@ void ComponentUpdateTask::resolveDependencies(bool checkOnly)
         // change a version of something that exists
         for (auto& change : toChange) {
             // FIXME: this should not work directly with the component list
-            qCDebug(instanceProfileResolveC) << "Setting version of " << change.uid << "to" << change.equalsVersion;
+            qCDebug(instanceProfileResolveC) << "Setting version of" << change.uid << "to" << change.equalsVersion;
             auto component = componentIndex[change.uid];
             component->setVersion(change.equalsVersion);
         }
@@ -744,7 +744,7 @@ void ComponentUpdateTask::remoteLoadFailed(size_t taskIndex, const QString& msg)
         qCWarning(instanceProfileResolveC) << "Got multiple results from remote load task" << taskIndex;
         return;
     }
-    qCDebug(instanceProfileResolveC) << "Remote task" << taskIndex << "failed: " << msg;
+    qCDebug(instanceProfileResolveC) << "Remote task" << taskIndex << "failed:" << msg;
     d->remoteLoadSuccessful = false;
     taskSlot.succeeded = false;
     taskSlot.finished = true;

--- a/launcher/minecraft/PackProfile.cpp
+++ b/launcher/minecraft/PackProfile.cpp
@@ -366,7 +366,7 @@ void PackProfile::updateSucceeded()
 
 void PackProfile::updateFailed(const QString& error)
 {
-    qCDebug(instanceProfileC) << d->m_instance->name() << "|" << "Component list update/resolve task failed " << "Reason:" << error;
+    qCDebug(instanceProfileC) << d->m_instance->name() << "|" << "Component list update/resolve task failed. Reason:" << error;
     d->m_updateTask.reset();
     invalidateLaunchProfile();
 }
@@ -954,7 +954,7 @@ std::shared_ptr<LaunchProfile> PackProfile::getProfile() const
             }
             d->m_profile = profile;
         } catch (const Exception& error) {
-            qCWarning(instanceProfileC) << d->m_instance->name() << "|" << "Couldn't apply profile patches because: " << error.cause();
+            qCWarning(instanceProfileC) << d->m_instance->name() << "|" << "Couldn't apply profile patches because:" << error.cause();
         }
     }
     return d->m_profile;

--- a/launcher/minecraft/ProfileUtils.cpp
+++ b/launcher/minecraft/ProfileUtils.cpp
@@ -55,7 +55,7 @@ bool readOverrideOrders(QString path, PatchOrder& order)
         return false;
     }
     if (!orderFile.open(QFile::ReadOnly)) {
-        qCritical() << "Couldn't open" << orderFile.fileName() << " for reading:" << orderFile.errorString();
+        qCritical() << "Couldn't open" << orderFile.fileName() << "for reading:" << orderFile.errorString();
         qWarning() << "Ignoring overridden order";
         return false;
     }

--- a/launcher/minecraft/World.cpp
+++ b/launcher/minecraft/World.cpp
@@ -405,7 +405,7 @@ void World::loadFromLevelDat(QByteArray data)
     try {
         valPtr = &levelData->at("Data");
     } catch (const std::out_of_range& e) {
-        qWarning() << "Unable to read NBT tags from " << m_folderName << ":" << e.what();
+        qWarning().nospace() << "Unable to read NBT tags from " << m_folderName << ": " << e.what();
         m_isValid = false;
         return;
     }

--- a/launcher/minecraft/WorldList.cpp
+++ b/launcher/minecraft/WorldList.cpp
@@ -64,9 +64,9 @@ void WorldList::startWatching()
     update();
     m_isWatching = m_watcher->addPath(m_dir.absolutePath());
     if (m_isWatching) {
-        qDebug() << "Started watching " << m_dir.absolutePath();
+        qDebug() << "Started watching" << m_dir.absolutePath();
     } else {
-        qDebug() << "Failed to start watching " << m_dir.absolutePath();
+        qDebug() << "Failed to start watching" << m_dir.absolutePath();
     }
 }
 
@@ -77,9 +77,9 @@ void WorldList::stopWatching()
     }
     m_isWatching = !m_watcher->removePath(m_dir.absolutePath());
     if (!m_isWatching) {
-        qDebug() << "Stopped watching " << m_dir.absolutePath();
+        qDebug() << "Stopped watching" << m_dir.absolutePath();
     } else {
-        qDebug() << "Failed to stop watching " << m_dir.absolutePath();
+        qDebug() << "Failed to stop watching" << m_dir.absolutePath();
     }
 }
 
@@ -351,7 +351,7 @@ Qt::DropActions WorldList::supportedDropActions() const
 
 void WorldList::installWorld(QFileInfo filename)
 {
-    qDebug() << "installing: " << filename.absoluteFilePath();
+    qDebug() << "installing:" << filename.absoluteFilePath();
     World w(filename);
     if (!w.isValid()) {
         return;

--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -612,7 +612,7 @@ void AccountList::fillQueue()
     if (m_defaultAccount && m_defaultAccount->shouldRefresh()) {
         auto idToRefresh = m_defaultAccount->internalId();
         m_refreshQueue.push_back(idToRefresh);
-        qDebug() << "AccountList: Queued default account with internal ID " << idToRefresh << " to refresh first";
+        qDebug() << "AccountList: Queued default account with internal ID" << idToRefresh << "to refresh first";
     }
 
     for (int i = 0; i < count(); i++) {
@@ -636,7 +636,7 @@ void AccountList::requestRefresh(QString accountId)
         m_refreshQueue.removeAt(index);
     }
     m_refreshQueue.push_front(accountId);
-    qDebug() << "AccountList: Pushed account with internal ID " << accountId << " to the front of the queue";
+    qDebug() << "AccountList: Pushed account with internal ID" << accountId << "to the front of the queue";
     if (!isActive()) {
         tryNext();
     }
@@ -648,7 +648,7 @@ void AccountList::queueRefresh(QString accountId)
         return;
     }
     m_refreshQueue.push_back(accountId);
-    qDebug() << "AccountList: Queued account with internal ID " << accountId << " to refresh";
+    qDebug() << "AccountList: Queued account with internal ID" << accountId << "to refresh";
 }
 
 void AccountList::tryNext()
@@ -664,13 +664,13 @@ void AccountList::tryNext()
                     connect(m_currentTask.get(), &Task::succeeded, this, &AccountList::authSucceeded);
                     connect(m_currentTask.get(), &Task::failed, this, &AccountList::authFailed);
                     m_currentTask->start();
-                    qDebug() << "RefreshSchedule: Processing account " << account->accountDisplayString() << " with internal ID "
+                    qDebug() << "RefreshSchedule: Processing account" << account->accountDisplayString() << "with internal ID"
                              << accountId;
                     return;
                 }
             }
         }
-        qDebug() << "RefreshSchedule: Account with with internal ID " << accountId << " not found.";
+        qDebug() << "RefreshSchedule: Account with internal ID" << accountId << "not found.";
     }
     // if we get here, no account needed refreshing. Schedule refresh in an hour.
     m_refreshTimer->start(1000 * 3600);
@@ -685,7 +685,7 @@ void AccountList::authSucceeded()
 
 void AccountList::authFailed(QString reason)
 {
-    qDebug() << "RefreshSchedule: Background account refresh failed: " << reason;
+    qDebug() << "RefreshSchedule: Background account refresh failed:" << reason;
     m_currentTask.reset();
     m_nextTimer->start(1000 * 20);
 }

--- a/launcher/minecraft/auth/Parsers.cpp
+++ b/launcher/minecraft/auth/Parsers.cpp
@@ -86,7 +86,7 @@ bool parseXTokenResponse(QByteArray& data, Token& output, QString name)
     QJsonParseError jsonError;
     QJsonDocument doc = QJsonDocument::fromJson(data, &jsonError);
     if (jsonError.error) {
-        qWarning() << "Failed to parse response from user.auth.xboxlive.com as JSON: " << jsonError.errorString();
+        qWarning() << "Failed to parse response from user.auth.xboxlive.com as JSON:" << jsonError.errorString();
         return false;
     }
 
@@ -123,7 +123,7 @@ bool parseXTokenResponse(QByteArray& data, Token& output, QString name)
         for (auto iter = obj_.begin(); iter != obj_.end(); iter++) {
             QString claim;
             if (!getString(obj_.value(iter.key()), claim)) {
-                qWarning() << "display claim " << iter.key() << " is not a string...";
+                qWarning() << "display claim" << iter.key() << "is not a string...";
                 return false;
             }
             output.extra[iter.key()] = claim;
@@ -148,7 +148,7 @@ bool parseMinecraftProfile(QByteArray& data, MinecraftProfile& output)
     QJsonParseError jsonError;
     QJsonDocument doc = QJsonDocument::fromJson(data, &jsonError);
     if (jsonError.error) {
-        qWarning() << "Failed to parse response from user.auth.xboxlive.com as JSON: " << jsonError.errorString();
+        qWarning() << "Failed to parse response from user.auth.xboxlive.com as JSON:" << jsonError.errorString();
         return false;
     }
 
@@ -290,7 +290,7 @@ bool parseMinecraftProfileMojang(QByteArray& data, MinecraftProfile& output)
     QJsonParseError jsonError;
     QJsonDocument doc = QJsonDocument::fromJson(data, &jsonError);
     if (jsonError.error) {
-        qWarning() << "Failed to parse response as JSON: " << jsonError.errorString();
+        qWarning() << "Failed to parse response as JSON:" << jsonError.errorString();
         return false;
     }
 
@@ -331,7 +331,7 @@ bool parseMinecraftProfileMojang(QByteArray& data, MinecraftProfile& output)
 
     doc = QJsonDocument::fromJson(texturePayload, &jsonError);
     if (jsonError.error) {
-        qWarning() << "Failed to parse response as JSON: " << jsonError.errorString();
+        qWarning() << "Failed to parse response as JSON:" << jsonError.errorString();
         return false;
     }
 
@@ -400,7 +400,7 @@ bool parseMinecraftEntitlements(QByteArray& data, MinecraftEntitlement& output)
     QJsonParseError jsonError;
     QJsonDocument doc = QJsonDocument::fromJson(data, &jsonError);
     if (jsonError.error) {
-        qWarning() << "Failed to parse response from user.auth.xboxlive.com as JSON: " << jsonError.errorString();
+        qWarning() << "Failed to parse response from user.auth.xboxlive.com as JSON:" << jsonError.errorString();
         return false;
     }
 
@@ -463,7 +463,7 @@ bool parseMojangResponse(QByteArray& data, Token& output)
     qCDebug(authCredentials()) << data;
     QJsonDocument doc = QJsonDocument::fromJson(data, &jsonError);
     if (jsonError.error) {
-        qWarning() << "Failed to parse response from api.minecraftservices.com/launcher/login as JSON: " << jsonError.errorString();
+        qWarning() << "Failed to parse response from api.minecraftservices.com/launcher/login as JSON:" << jsonError.errorString();
         return false;
     }
 

--- a/launcher/minecraft/auth/steps/MSADeviceCodeStep.cpp
+++ b/launcher/minecraft/auth/steps/MSADeviceCodeStep.cpp
@@ -120,12 +120,13 @@ void MSADeviceCodeStep::deviceAuthorizationFinished()
         return;
     }
     if (!m_request->wasSuccessful() || m_request->error() != QNetworkReply::NoError) {
+        qWarning() << "Device authorization failed:" << *m_response;
         emit finished(AccountTaskState::STATE_FAILED_HARD, tr("Failed to retrieve device authorization"));
-        qDebug() << *m_response;
         return;
     }
 
     if (rsp.device_code.isEmpty() || rsp.user_code.isEmpty() || rsp.verification_uri.isEmpty() || rsp.expires_in == 0) {
+        qWarning() << "Device authorization failed: required fields missing";
         emit finished(AccountTaskState::STATE_FAILED_HARD, tr("Device authorization failed: required fields missing"));
         return;
     }

--- a/launcher/minecraft/auth/steps/MinecraftProfileStep.cpp
+++ b/launcher/minecraft/auth/steps/MinecraftProfileStep.cpp
@@ -44,9 +44,9 @@ void MinecraftProfileStep::onRequestDone()
     }
     if (m_request->error() != QNetworkReply::NoError) {
         qWarning() << "Error getting profile:";
-        qWarning() << " HTTP Status:        " << m_request->replyStatusCode();
-        qWarning() << " Internal error no.: " << m_request->error();
-        qWarning() << " Error string:       " << m_request->errorString();
+        qWarning() << " HTTP Status       :" << m_request->replyStatusCode();
+        qWarning() << " Internal error no.:" << m_request->error();
+        qWarning() << " Error string      :" << m_request->errorString();
 
         qWarning() << " Response:";
         qWarning() << QString::fromUtf8(*m_response);

--- a/launcher/minecraft/auth/steps/XboxAuthorizationStep.cpp
+++ b/launcher/minecraft/auth/steps/XboxAuthorizationStep.cpp
@@ -52,7 +52,7 @@ void XboxAuthorizationStep::perform()
     connect(m_task.get(), &Task::finished, this, &XboxAuthorizationStep::onRequestDone);
 
     m_task->start();
-    qDebug() << "Getting authorization token for " << m_relyingParty;
+    qDebug() << "Getting authorization token for" << m_relyingParty;
 }
 
 void XboxAuthorizationStep::onRequestDone()
@@ -99,7 +99,7 @@ bool XboxAuthorizationStep::processSTSError()
         QJsonParseError jsonError;
         QJsonDocument doc = QJsonDocument::fromJson(*m_response, &jsonError);
         if (jsonError.error) {
-            qWarning() << "Cannot parse error XSTS response as JSON: " << jsonError.errorString();
+            qWarning() << "Cannot parse error XSTS response as JSON:" << jsonError.errorString();
             emit finished(AccountTaskState::STATE_FAILED_SOFT,
                           tr("Cannot parse %1 authorization error response as JSON: %2").arg(m_authorizationKind, jsonError.errorString()));
             return true;

--- a/launcher/minecraft/auth/steps/XboxProfileStep.cpp
+++ b/launcher/minecraft/auth/steps/XboxProfileStep.cpp
@@ -60,7 +60,7 @@ void XboxProfileStep::onRequestDone()
         return;
     }
 
-    qCDebug(authCredentials()) << "Xbox profile: " << *m_response;
+    qCDebug(authCredentials()) << "Xbox profile:" << *m_response;
 
     emit finished(AccountTaskState::STATE_WORKING, tr("Got Xbox profile"));
 }

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -64,9 +64,9 @@ bool ResourceFolderModel::startWatching(const QStringList& paths)
     auto couldnt_be_watched = m_watcher.addPaths(paths);
     for (auto path : paths) {
         if (couldnt_be_watched.contains(path))
-            qDebug() << "Failed to start watching " << path;
+            qDebug() << "Failed to start watching" << path;
         else
-            qDebug() << "Started watching " << path;
+            qDebug() << "Started watching" << path;
     }
 
     update();
@@ -83,9 +83,9 @@ bool ResourceFolderModel::stopWatching(const QStringList& paths)
     auto couldnt_be_stopped = m_watcher.removePaths(paths);
     for (auto path : paths) {
         if (couldnt_be_stopped.contains(path))
-            qDebug() << "Failed to stop watching " << path;
+            qDebug() << "Failed to stop watching" << path;
         else
-            qDebug() << "Stopped watching " << path;
+            qDebug() << "Stopped watching" << path;
     }
 
     m_is_watching = !m_is_watching;
@@ -102,7 +102,7 @@ bool ResourceFolderModel::installResource(QString original_path)
         qWarning() << "Caught attempt to install non-existing file or file-like object:" << original_path;
         return false;
     }
-    qDebug() << "Installing: " << file_info.absoluteFilePath();
+    qDebug() << "Installing:" << file_info.absoluteFilePath();
 
     Resource resource(file_info);
     if (!resource.valid()) {
@@ -185,8 +185,8 @@ void ResourceFolderModel::installResourceWithFlameMetadata(QString path, ModPlat
             QJsonParseError parse_error{};
             QJsonDocument doc = QJsonDocument::fromJson(*response, &parse_error);
             if (parse_error.error != QJsonParseError::NoError) {
-                qWarning() << "Error while parsing JSON response for mod info at " << parse_error.offset
-                           << " reason: " << parse_error.errorString();
+                qWarning() << "Error while parsing JSON response for mod info at" << parse_error.offset
+                           << "reason:" << parse_error.errorString();
                 qDebug() << *response;
                 return;
             }
@@ -195,7 +195,7 @@ void ResourceFolderModel::installResourceWithFlameMetadata(QString path, ModPlat
                 FlameMod::loadIndexedPack(pack, obj);
             } catch (const JSONValidationError& e) {
                 qDebug() << doc;
-                qWarning() << "Error while reading mod info: " << e.cause();
+                qWarning() << "Error while reading mod info:" << e.cause();
             }
             LocalResourceUpdateTask update_metadata(indexDir(), pack, vers);
             connect(&update_metadata, &Task::finished, this, install);

--- a/launcher/minecraft/mod/tasks/GetModDependenciesTask.cpp
+++ b/launcher/minecraft/mod/tasks/GetModDependenciesTask.cpp
@@ -141,8 +141,8 @@ Task::Ptr GetModDependenciesTask::getProjectInfoTask(std::shared_ptr<PackDepende
         QJsonDocument doc = QJsonDocument::fromJson(*responseInfo, &parse_error);
         if (parse_error.error != QJsonParseError::NoError) {
             removePack(pDep->pack->addonId);
-            qWarning() << "Error while parsing JSON response for mod info at " << parse_error.offset
-                       << " reason: " << parse_error.errorString();
+            qWarning() << "Error while parsing JSON response for mod info at" << parse_error.offset
+                       << "reason:" << parse_error.errorString();
             qDebug() << *responseInfo;
             return;
         }
@@ -154,7 +154,7 @@ Task::Ptr GetModDependenciesTask::getProjectInfoTask(std::shared_ptr<PackDepende
         } catch (const JSONValidationError& e) {
             removePack(pDep->pack->addonId);
             qDebug() << doc;
-            qWarning() << "Error while reading mod info: " << e.cause();
+            qWarning() << "Error while reading mod info:" << e.cause();
         }
     });
     return info;

--- a/launcher/minecraft/mod/tasks/LocalDataPackParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalDataPackParseTask.cpp
@@ -180,7 +180,7 @@ bool processMCMeta(DataPack* pack, QByteArray&& raw_data)
         pack->setPackFormat(pack_obj["pack_format"].toInt());
         pack->setDescription(DataPackUtils::processComponent(pack_obj.value("description")));
     } catch (Json::JsonException& e) {
-        qWarning() << "JsonException: " << e.what() << e.cause();
+        qWarning() << "JsonException:" << e.what() << e.cause();
         return false;
     }
     return true;

--- a/launcher/minecraft/skins/SkinList.cpp
+++ b/launcher/minecraft/skins/SkinList.cpp
@@ -45,9 +45,9 @@ void SkinList::startWatching()
     update();
     m_isWatching = m_watcher->addPath(m_dir.absolutePath());
     if (m_isWatching) {
-        qDebug() << "Started watching " << m_dir.absolutePath();
+        qDebug() << "Started watching" << m_dir.absolutePath();
     } else {
-        qDebug() << "Failed to start watching " << m_dir.absolutePath();
+        qDebug() << "Failed to start watching" << m_dir.absolutePath();
     }
 }
 
@@ -59,9 +59,9 @@ void SkinList::stopWatching()
     }
     m_isWatching = !m_watcher->removePath(m_dir.absolutePath());
     if (!m_isWatching) {
-        qDebug() << "Stopped watching " << m_dir.absolutePath();
+        qDebug() << "Stopped watching" << m_dir.absolutePath();
     } else {
-        qDebug() << "Failed to stop watching " << m_dir.absolutePath();
+        qDebug() << "Failed to stop watching" << m_dir.absolutePath();
     }
 }
 
@@ -167,7 +167,7 @@ void SkinList::directoryChanged(const QString& path)
 
 void SkinList::fileChanged(const QString& path)
 {
-    qDebug() << "Checking " << path;
+    qDebug() << "Checking" << path;
     QFileInfo checkfile(path);
     if (!checkfile.exists())
         return;

--- a/launcher/minecraft/update/AssetUpdateTask.cpp
+++ b/launcher/minecraft/update/AssetUpdateTask.cpp
@@ -43,7 +43,7 @@ void AssetUpdateTask::executeTask()
     connect(downloadJob.get(), &NetJob::progress, this, &AssetUpdateTask::progress);
     connect(downloadJob.get(), &NetJob::stepProgress, this, &AssetUpdateTask::propagateStepProgress);
 
-    qDebug() << m_inst->name() << ": Starting asset index download";
+    qDebug() << "Starting asset index download for" << m_inst->name();
     downloadJob->start();
 }
 
@@ -55,7 +55,7 @@ bool AssetUpdateTask::canAbort() const
 void AssetUpdateTask::assetIndexFinished()
 {
     AssetsIndex index;
-    qDebug() << m_inst->name() << ": Finished asset index download";
+    qDebug() << "Finished asset index download for" << m_inst->name();
 
     auto components = m_inst->getPackProfile();
     auto profile = components->getProfile();

--- a/launcher/modplatform/EnsureMetadataTask.cpp
+++ b/launcher/modplatform/EnsureMetadataTask.cpp
@@ -226,8 +226,8 @@ Task::Ptr EnsureMetadataTask::modrinthVersionsTask()
         QJsonParseError parse_error{};
         QJsonDocument doc = QJsonDocument::fromJson(*response, &parse_error);
         if (parse_error.error != QJsonParseError::NoError) {
-            qWarning() << "Error while parsing JSON response from Modrinth::CurrentVersions at " << parse_error.offset
-                       << " reason: " << parse_error.errorString();
+            qWarning() << "Error while parsing JSON response from Modrinth::CurrentVersions at" << parse_error.offset
+                       << "reason:" << parse_error.errorString();
             qWarning() << *response;
 
             failed(parse_error.errorString());
@@ -286,8 +286,8 @@ Task::Ptr EnsureMetadataTask::modrinthProjectsTask()
         QJsonParseError parse_error{};
         auto doc = QJsonDocument::fromJson(*response, &parse_error);
         if (parse_error.error != QJsonParseError::NoError) {
-            qWarning() << "Error while parsing JSON response from Modrinth projects task at " << parse_error.offset
-                       << " reason: " << parse_error.errorString();
+            qWarning() << "Error while parsing JSON response from Modrinth projects task at" << parse_error.offset
+                       << "reason:" << parse_error.errorString();
             qWarning() << *response;
             return;
         }
@@ -354,8 +354,8 @@ Task::Ptr EnsureMetadataTask::flameVersionsTask()
         QJsonParseError parse_error{};
         QJsonDocument doc = QJsonDocument::fromJson(*response, &parse_error);
         if (parse_error.error != QJsonParseError::NoError) {
-            qWarning() << "Error while parsing JSON response from Modrinth::CurrentVersions at " << parse_error.offset
-                       << " reason: " << parse_error.errorString();
+            qWarning() << "Error while parsing JSON response from Flame::CurrentVersions at" << parse_error.offset
+                       << "reason:" << parse_error.errorString();
             qWarning() << *response;
 
             failed(parse_error.errorString());
@@ -436,8 +436,8 @@ Task::Ptr EnsureMetadataTask::flameProjectsTask()
         QJsonParseError parse_error{};
         auto doc = QJsonDocument::fromJson(*response, &parse_error);
         if (parse_error.error != QJsonParseError::NoError) {
-            qWarning() << "Error while parsing JSON response from Modrinth projects task at " << parse_error.offset
-                       << " reason: " << parse_error.errorString();
+            qWarning() << "Error while parsing JSON response from Flame projects task at" << parse_error.offset
+                       << "reason:" << parse_error.errorString();
             qWarning() << *response;
             return;
         }

--- a/launcher/modplatform/ResourceAPI.cpp
+++ b/launcher/modplatform/ResourceAPI.cpp
@@ -27,8 +27,8 @@ Task::Ptr ResourceAPI::searchProjects(SearchArgs&& args, Callback<QList<ModPlatf
         QJsonParseError parse_error{};
         QJsonDocument doc = QJsonDocument::fromJson(*response, &parse_error);
         if (parse_error.error != QJsonParseError::NoError) {
-            qWarning() << "Error while parsing JSON response from " << debugName() << " at " << parse_error.offset
-                       << " reason: " << parse_error.errorString();
+            qWarning() << "Error while parsing JSON response from" << debugName() << "at" << parse_error.offset
+                       << "reason:" << parse_error.errorString();
             qWarning() << *response;
 
             callbacks.on_fail(parse_error.errorString(), -1);
@@ -47,7 +47,7 @@ Task::Ptr ResourceAPI::searchProjects(SearchArgs&& args, Callback<QList<ModPlatf
                 loadIndexedPack(*pack, packObj);
                 newList << pack;
             } catch (const JSONValidationError& e) {
-                qWarning() << "Error while loading resource from " << debugName() << ": " << e.cause();
+                qWarning().nospace() << "Error while loading resource from " << debugName() << ": " << e.cause();
                 continue;
             }
         }
@@ -92,8 +92,8 @@ Task::Ptr ResourceAPI::getProjectVersions(VersionSearchArgs&& args, Callback<QVe
         QJsonParseError parse_error{};
         QJsonDocument doc = QJsonDocument::fromJson(*response, &parse_error);
         if (parse_error.error != QJsonParseError::NoError) {
-            qWarning() << "Error while parsing JSON response for getting versions at " << parse_error.offset
-                       << " reason: " << parse_error.errorString();
+            qWarning() << "Error while parsing JSON response for getting versions at" << parse_error.offset
+                       << "reason:" << parse_error.errorString();
             qWarning() << *response;
             return;
         }
@@ -120,7 +120,7 @@ Task::Ptr ResourceAPI::getProjectVersions(VersionSearchArgs&& args, Callback<QVe
             std::sort(unsortedVersions.begin(), unsortedVersions.end(), orderSortPredicate);
         } catch (const JSONValidationError& e) {
             qDebug() << doc;
-            qWarning() << "Error while reading " << debugName() << " resource version: " << e.cause();
+            qWarning() << "Error while reading" << debugName() << "resource version:" << e.cause();
         }
 
         callbacks.on_succeed(unsortedVersions);
@@ -156,8 +156,8 @@ Task::Ptr ResourceAPI::getProjectInfo(ProjectInfoArgs&& args, Callback<ModPlatfo
         QJsonParseError parse_error{};
         QJsonDocument doc = QJsonDocument::fromJson(*response, &parse_error);
         if (parse_error.error != QJsonParseError::NoError) {
-            qWarning() << "Error while parsing JSON response for mod info at " << parse_error.offset
-                       << " reason: " << parse_error.errorString();
+            qWarning() << "Error while parsing JSON response for mod info at" << parse_error.offset
+                       << "reason:" << parse_error.errorString();
             qWarning() << *response;
             return;
         }
@@ -169,7 +169,7 @@ Task::Ptr ResourceAPI::getProjectInfo(ProjectInfoArgs&& args, Callback<ModPlatfo
             loadExtraPackInfo(*pack, obj);
         } catch (const JSONValidationError& e) {
             qDebug() << doc;
-            qWarning() << "Error while reading " << debugName() << " resource info: " << e.cause();
+            qWarning() << "Error while reading" << debugName() << "resource info:" << e.cause();
         }
         callbacks.on_succeed(pack);
     });
@@ -212,8 +212,8 @@ Task::Ptr ResourceAPI::getDependencyVersion(DependencySearchArgs&& args, Callbac
         QJsonParseError parse_error{};
         QJsonDocument doc = QJsonDocument::fromJson(*response, &parse_error);
         if (parse_error.error != QJsonParseError::NoError) {
-            qWarning() << "Error while parsing JSON response for getting versions at " << parse_error.offset
-                       << " reason: " << parse_error.errorString();
+            qWarning() << "Error while parsing JSON response for getting dependency version at" << parse_error.offset
+                       << "reason:" << parse_error.errorString();
             qWarning() << *response;
             return;
         }

--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
@@ -83,7 +83,7 @@ bool PackInstallTask::abort()
 
 void PackInstallTask::executeTask()
 {
-    qDebug() << "PackInstallTask::executeTask: " << QThread::currentThreadId();
+    qDebug() << "PackInstallTask::executeTask:" << QThread::currentThreadId();
     NetJob::Ptr netJob{ new NetJob("ATLauncher::VersionFetch", APPLICATION->network()) };
     auto searchUrl =
         QString(BuildConfig.ATL_DOWNLOAD_SERVER_URL + "packs/%1/versions/%2/Configs.json").arg(m_pack_safe_name).arg(m_version_name);
@@ -99,14 +99,14 @@ void PackInstallTask::executeTask()
 
 void PackInstallTask::onDownloadSucceeded()
 {
-    qDebug() << "PackInstallTask::onDownloadSucceeded: " << QThread::currentThreadId();
+    qDebug() << "PackInstallTask::onDownloadSucceeded:" << QThread::currentThreadId();
     jobPtr.reset();
 
     QJsonParseError parse_error{};
     QJsonDocument doc = QJsonDocument::fromJson(*response, &parse_error);
     if (parse_error.error != QJsonParseError::NoError) {
-        qWarning() << "Error while parsing JSON response from ATLauncher at " << parse_error.offset
-                   << " reason: " << parse_error.errorString();
+        qWarning() << "Error while parsing JSON response from ATLauncher at" << parse_error.offset
+                   << "reason:" << parse_error.errorString();
         qWarning() << *response.get();
         return;
     }
@@ -166,7 +166,7 @@ void PackInstallTask::onDownloadSucceeded()
 
 void PackInstallTask::onDownloadFailed(QString reason)
 {
-    qDebug() << "PackInstallTask::onDownloadFailed: " << QThread::currentThreadId();
+    qDebug() << "PackInstallTask::onDownloadFailed:" << QThread::currentThreadId();
     jobPtr.reset();
     emitFailed(reason);
 }
@@ -627,7 +627,7 @@ bool PackInstallTask::createPackComponent(QString instanceRoot, PackProfile* pro
 
 void PackInstallTask::installConfigs()
 {
-    qDebug() << "PackInstallTask::installConfigs: " << QThread::currentThreadId();
+    qDebug() << "PackInstallTask::installConfigs:" << QThread::currentThreadId();
     setStatus(tr("Downloading configs..."));
     jobPtr.reset(new NetJob(tr("Config download"), APPLICATION->network()));
 
@@ -669,7 +669,7 @@ void PackInstallTask::installConfigs()
 
 void PackInstallTask::extractConfigs()
 {
-    qDebug() << "PackInstallTask::extractConfigs: " << QThread::currentThreadId();
+    qDebug() << "PackInstallTask::extractConfigs:" << QThread::currentThreadId();
     setStatus(tr("Extracting configs..."));
 
     QDir extractDir(m_stagingPath);
@@ -682,7 +682,7 @@ void PackInstallTask::extractConfigs()
 
 void PackInstallTask::downloadMods()
 {
-    qDebug() << "PackInstallTask::installMods: " << QThread::currentThreadId();
+    qDebug() << "PackInstallTask::installMods:" << QThread::currentThreadId();
 
     QList<ATLauncher::VersionMod> optionalMods;
     for (const auto& mod : m_version.mods) {
@@ -819,7 +819,7 @@ void PackInstallTask::downloadMods()
         message_dialog.setModal(true);
 
         if (message_dialog.exec()) {
-            qDebug() << "Post dialog blocked mods list: " << mods;
+            qDebug() << "Post dialog blocked mods list:" << mods;
             for (auto blocked : mods) {
                 if (!blocked.matched) {
                     qDebug() << blocked.name << "was not matched to a local file, skipping copy";
@@ -883,7 +883,7 @@ void PackInstallTask::onModsDownloaded()
 {
     abortable = false;
 
-    qDebug() << "PackInstallTask::onModsDownloaded: " << QThread::currentThreadId();
+    qDebug() << "PackInstallTask::onModsDownloaded:" << QThread::currentThreadId();
     jobPtr.reset();
 
     if (!modsToExtract.empty() || !modsToDecomp.empty() || !modsToCopy.empty()) {
@@ -899,7 +899,7 @@ void PackInstallTask::onModsDownloaded()
 
 void PackInstallTask::onModsExtracted()
 {
-    qDebug() << "PackInstallTask::onModsExtracted: " << QThread::currentThreadId();
+    qDebug() << "PackInstallTask::onModsExtracted:" << QThread::currentThreadId();
     if (m_modExtractFuture.result()) {
         install();
     } else {
@@ -911,7 +911,7 @@ bool PackInstallTask::extractMods(const QMap<QString, VersionMod>& toExtract,
                                   const QMap<QString, VersionMod>& toDecomp,
                                   const QMap<QString, QString>& toCopy)
 {
-    qDebug() << "PackInstallTask::extractMods: " << QThread::currentThreadId();
+    qDebug() << "PackInstallTask::extractMods:" << QThread::currentThreadId();
 
     setStatus(tr("Extracting mods..."));
     for (auto iter = toExtract.begin(); iter != toExtract.end(); iter++) {
@@ -984,7 +984,7 @@ bool PackInstallTask::extractMods(const QMap<QString, VersionMod>& toExtract,
 
 void PackInstallTask::install()
 {
-    qDebug() << "PackInstallTask::install: " << QThread::currentThreadId();
+    qDebug() << "PackInstallTask::install:" << QThread::currentThreadId();
     setStatus(tr("Installing modpack"));
 
     auto instanceConfigPath = FS::PathCombine(m_stagingPath, "instance.cfg");

--- a/launcher/modplatform/flame/FileResolvingTask.cpp
+++ b/launcher/modplatform/flame/FileResolvingTask.cpp
@@ -163,8 +163,8 @@ void Flame::FileResolvingTask::netJobFinished()
         QJsonParseError parse_error{};
         QJsonDocument doc = QJsonDocument::fromJson(*m_result, &parse_error);
         if (parse_error.error != QJsonParseError::NoError) {
-            qWarning() << "Error while parsing JSON response from Modrinth::CurrentVersions at " << parse_error.offset
-                       << " reason: " << parse_error.errorString();
+            qWarning() << "Error while parsing JSON response from Modrinth::CurrentVersions at" << parse_error.offset
+                       << "reason:" << parse_error.errorString();
             qWarning() << *m_result;
 
             getFlameProjects();
@@ -186,7 +186,7 @@ void Flame::FileResolvingTask::netJobFinished()
                         // let the user download it manually.
                         if (!file.loaders || hasSingleModLoaderSelected(file.loaders)) {
                             out.version.downloadUrl = file.downloadUrl;
-                            qDebug() << "Found alternative on modrinth " << out.version.fileName;
+                            qDebug() << "Found alternative on modrinth" << out.version.fileName;
                         }
                     } catch (Json::JsonException& e) {
                         qDebug() << e.cause();
@@ -234,8 +234,8 @@ void Flame::FileResolvingTask::getFlameProjects()
         QJsonParseError parse_error{};
         auto doc = QJsonDocument::fromJson(*m_result, &parse_error);
         if (parse_error.error != QJsonParseError::NoError) {
-            qWarning() << "Error while parsing JSON response from Modrinth projects task at " << parse_error.offset
-                       << " reason: " << parse_error.errorString();
+            qWarning() << "Error while parsing JSON response from Modrinth projects task at" << parse_error.offset
+                       << "reason:" << parse_error.errorString();
             qWarning() << *m_result;
             return;
         }

--- a/launcher/modplatform/flame/FlameAPI.cpp
+++ b/launcher/modplatform/flame/FlameAPI.cpp
@@ -51,8 +51,8 @@ QString FlameAPI::getModFileChangelog(int modId, int fileId)
         QJsonParseError parse_error{};
         QJsonDocument doc = QJsonDocument::fromJson(*response, &parse_error);
         if (parse_error.error != QJsonParseError::NoError) {
-            qWarning() << "Error while parsing JSON response from Flame::FileChangelog at " << parse_error.offset
-                       << " reason: " << parse_error.errorString();
+            qWarning() << "Error while parsing JSON response from Flame::FileChangelog at" << parse_error.offset
+                       << "reason:" << parse_error.errorString();
             qWarning() << *response;
 
             netJob->failed(parse_error.errorString());
@@ -84,8 +84,8 @@ QString FlameAPI::getModDescription(int modId)
         QJsonParseError parse_error{};
         QJsonDocument doc = QJsonDocument::fromJson(*response, &parse_error);
         if (parse_error.error != QJsonParseError::NoError) {
-            qWarning() << "Error while parsing JSON response from Flame::ModDescription at " << parse_error.offset
-                       << " reason: " << parse_error.errorString();
+            qWarning() << "Error while parsing JSON response from Flame::ModDescription at" << parse_error.offset
+                       << "reason:" << parse_error.errorString();
             qWarning() << *response;
 
             netJob->failed(parse_error.errorString());
@@ -191,8 +191,8 @@ QList<ModPlatform::Category> FlameAPI::loadModCategories(QByteArray* response)
     QJsonParseError parse_error{};
     QJsonDocument doc = QJsonDocument::fromJson(*response, &parse_error);
     if (parse_error.error != QJsonParseError::NoError) {
-        qWarning() << "Error while parsing JSON response from categories at " << parse_error.offset
-                   << " reason: " << parse_error.errorString();
+        qWarning() << "Error while parsing JSON response from categories at" << parse_error.offset
+                   << "reason:" << parse_error.errorString();
         qWarning() << *response;
         return categories;
     }

--- a/launcher/modplatform/flame/FlameCheckUpdate.cpp
+++ b/launcher/modplatform/flame/FlameCheckUpdate.cpp
@@ -67,8 +67,8 @@ void FlameCheckUpdate::getLatestVersionCallback(Resource* resource, QByteArray* 
     QJsonParseError parse_error{};
     QJsonDocument doc = QJsonDocument::fromJson(*response, &parse_error);
     if (parse_error.error != QJsonParseError::NoError) {
-        qWarning() << "Error while parsing JSON response from latest mod version at " << parse_error.offset
-                   << " reason: " << parse_error.errorString();
+        qWarning() << "Error while parsing JSON response from latest mod version at" << parse_error.offset
+                   << "reason:" << parse_error.errorString();
         qWarning() << *response;
         return;
     }
@@ -155,8 +155,8 @@ void FlameCheckUpdate::collectBlockedMods()
         QJsonParseError parse_error{};
         auto doc = QJsonDocument::fromJson(*response, &parse_error);
         if (parse_error.error != QJsonParseError::NoError) {
-            qWarning() << "Error while parsing JSON response from Flame projects task at " << parse_error.offset
-                       << " reason: " << parse_error.errorString();
+            qWarning() << "Error while parsing JSON response from Flame projects task at" << parse_error.offset
+                       << "reason:" << parse_error.errorString();
             qWarning() << *response;
             return;
         }

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -194,8 +194,8 @@ bool FlameCreationTask::updateInstance()
             QJsonParseError parse_error{};
             auto doc = QJsonDocument::fromJson(*raw_response, &parse_error);
             if (parse_error.error != QJsonParseError::NoError) {
-                qWarning() << "Error while parsing JSON response from Flame files task at " << parse_error.offset
-                           << " reason: " << parse_error.errorString();
+                qWarning() << "Error while parsing JSON response from Flame files task at" << parse_error.offset
+                           << "reason:" << parse_error.errorString();
                 qWarning() << *raw_response;
                 return;
             }
@@ -235,7 +235,7 @@ bool FlameCreationTask::updateInstance()
                 }
             }
         });
-        connect(job.get(), &Task::failed, this, [](QString reason) { qCritical() << "Failed to get files: " << reason; });
+        connect(job.get(), &Task::failed, this, [](QString reason) { qCritical() << "Failed to get files:" << reason; });
         connect(job.get(), &Task::finished, &loop, &QEventLoop::quit);
 
         m_processUpdateFileInfoJob = job;
@@ -551,7 +551,7 @@ void FlameCreationTask::idResolverSucceeded(QEventLoop& loop)
         message_dialog.setModal(true);
 
         if (message_dialog.exec()) {
-            qDebug() << "Post dialog blocked mods list: " << blocked_mods;
+            qDebug() << "Post dialog blocked mods list:" << blocked_mods;
             copyBlockedMods(blocked_mods);
             setupDownloadJob(loop);
         } else {

--- a/launcher/modplatform/flame/FlamePackExportTask.cpp
+++ b/launcher/modplatform/flame/FlamePackExportTask.cpp
@@ -180,8 +180,8 @@ void FlamePackExportTask::makeApiRequest()
         QJsonParseError parseError{};
         QJsonDocument doc = QJsonDocument::fromJson(*response, &parseError);
         if (parseError.error != QJsonParseError::NoError) {
-            qWarning() << "Error while parsing JSON response from CurseForge::CurrentVersions at " << parseError.offset
-                       << " reason: " << parseError.errorString();
+            qWarning() << "Error while parsing JSON response from CurseForge::CurrentVersions at" << parseError.offset
+                       << "reason:" << parseError.errorString();
             qWarning() << *response;
 
             emitFailed(parseError.errorString());
@@ -261,8 +261,8 @@ void FlamePackExportTask::getProjectsInfo()
         QJsonParseError parseError{};
         auto doc = QJsonDocument::fromJson(*response, &parseError);
         if (parseError.error != QJsonParseError::NoError) {
-            qWarning() << "Error while parsing JSON response from CurseForge projects task at " << parseError.offset
-                       << " reason: " << parseError.errorString();
+            qWarning() << "Error while parsing JSON response from CurseForge projects task at" << parseError.offset
+                       << "reason:" << parseError.errorString();
             qWarning() << *response;
             emitFailed(parseError.errorString());
             return;

--- a/launcher/modplatform/import_ftb/PackHelpers.cpp
+++ b/launcher/modplatform/import_ftb/PackHelpers.cpp
@@ -93,7 +93,7 @@ Modpack parseDirectory(QString path)
             }
         }
     } catch (const Exception& e) {
-        qDebug() << "Couldn't load ftb instance json: " << e.cause();
+        qDebug() << "Couldn't load ftb instance json:" << e.cause();
         return {};
     }
     if (!modpack.loaderType.has_value()) {
@@ -147,7 +147,7 @@ void legacyInstanceParsing(QString path, std::optional<ModPlatform::ModLoaderTyp
             }
         }
     } catch (const Exception& e) {
-        qDebug() << "Couldn't load ftb version json: " << e.cause();
+        qDebug() << "Couldn't load ftb version json:" << e.cause();
         return;
     }
 }

--- a/launcher/modplatform/legacy_ftb/PackFetchTask.cpp
+++ b/launcher/modplatform/legacy_ftb/PackFetchTask.cpp
@@ -173,7 +173,7 @@ bool PackFetchTask::parseAndAddPacks(QByteArray& data, PackType packType, Modpac
                 qWarning() << "Added current version to oldVersions because oldVersions was empty! (" + modpack.name + ")";
             } else {
                 modpack.broken = true;
-                qWarning() << "Broken pack:" << modpack.name << " => No valid version!";
+                qWarning() << "Broken pack:" << modpack.name << "=> No valid version!";
             }
         }
 

--- a/launcher/modplatform/modrinth/ModrinthAPI.cpp
+++ b/launcher/modplatform/modrinth/ModrinthAPI.cpp
@@ -135,8 +135,8 @@ QList<ModPlatform::Category> ModrinthAPI::loadCategories(QByteArray* response, Q
     QJsonParseError parse_error{};
     QJsonDocument doc = QJsonDocument::fromJson(*response, &parse_error);
     if (parse_error.error != QJsonParseError::NoError) {
-        qWarning() << "Error while parsing JSON response from categories at " << parse_error.offset
-                   << " reason: " << parse_error.errorString();
+        qWarning() << "Error while parsing JSON response from categories at" << parse_error.offset
+                   << "reason:" << parse_error.errorString();
         qWarning() << *response;
         return categories;
     }

--- a/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
+++ b/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
@@ -122,8 +122,8 @@ void ModrinthCheckUpdate::checkVersionsResponse(QByteArray* response, std::optio
     QJsonParseError parse_error{};
     QJsonDocument doc = QJsonDocument::fromJson(*response, &parse_error);
     if (parse_error.error != QJsonParseError::NoError) {
-        qWarning() << "Error while parsing JSON response from ModrinthCheckUpdate at " << parse_error.offset
-                   << " reason: " << parse_error.errorString();
+        qWarning() << "Error while parsing JSON response from ModrinthCheckUpdate at" << parse_error.offset
+                   << "reason:" << parse_error.errorString();
         qWarning() << *response;
 
         emitFailed(parse_error.errorString());
@@ -142,7 +142,7 @@ void ModrinthCheckUpdate::checkVersionsResponse(QByteArray* response, std::optio
             // If the returned project is empty, but we have Modrinth metadata,
             // it means this specific version is not available
             if (project_obj.isEmpty()) {
-                qDebug() << "Mod " << m_mappings.find(hash).value()->name() << " got an empty response." << "Hash: " << hash;
+                qDebug() << "Mod" << m_mappings.find(hash).value()->name() << "got an empty response. Hash:" << hash;
                 ++iter;
                 continue;
             }

--- a/launcher/modplatform/packwiz/Packwiz.cpp
+++ b/launcher/modplatform/packwiz/Packwiz.cpp
@@ -50,7 +50,7 @@ auto getRealIndexName(const QDir& index_dir, QString normalized_fname, bool shou
 
         if (should_find_match && !QString::compare(normalized_fname, real_fname, Qt::CaseSensitive)) {
             qCritical() << "Could not find a match for a valid metadata file!";
-            qCritical() << "File: " << normalized_fname;
+            qCritical() << "File:" << normalized_fname;
             return {};
         }
     }
@@ -251,14 +251,14 @@ auto V1::getIndexForMod(const QDir& index_dir, QString slug) -> Mod
         table = toml::parse_file(StringUtils::toStdString(index_dir.absoluteFilePath(real_fname)));
     } catch (const toml::parse_error& err) {
         qWarning() << QString("Could not open file %1!").arg(normalized_fname);
-        qWarning() << "Reason: " << QString(err.what());
+        qWarning() << "Reason:" << QString(err.what());
         return {};
     }
 #else
     toml::parse_result result = toml::parse_file(StringUtils::toStdString(index_dir.absoluteFilePath(real_fname)));
     if (!result) {
         qWarning() << QString("Could not open file %1!").arg(normalized_fname);
-        qWarning() << "Reason: " << result.error().description();
+        qWarning() << "Reason:" << result.error().description();
         return {};
     }
     table = result.table();

--- a/launcher/modplatform/technic/SolderPackInstallTask.cpp
+++ b/launcher/modplatform/technic/SolderPackInstallTask.cpp
@@ -88,7 +88,7 @@ void Technic::SolderPackInstallTask::fileListSucceeded()
     QJsonParseError parse_error{};
     QJsonDocument doc = QJsonDocument::fromJson(*m_response, &parse_error);
     if (parse_error.error != QJsonParseError::NoError) {
-        qWarning() << "Error while parsing JSON response from Solder at " << parse_error.offset << " reason: " << parse_error.errorString();
+        qWarning() << "Error while parsing JSON response from Solder at" << parse_error.offset << "reason:" << parse_error.errorString();
         qWarning() << *m_response;
         return;
     }

--- a/launcher/net/FileSink.cpp
+++ b/launcher/net/FileSink.cpp
@@ -116,7 +116,7 @@ Task::State FileSink::finalize(QNetworkReply& reply)
 
         // nothing went wrong...
         if (!m_output_file->commit()) {
-            qCCritical(taskNetLogC) << "Failed to commit changes to " << m_filename;
+            qCCritical(taskNetLogC) << "Failed to commit changes to" << m_filename;
             m_output_file->cancelWriting();
             m_fail_reason = "Failed to commit changes";
             return Task::State::Failed;

--- a/launcher/net/HttpMetaCache.cpp
+++ b/launcher/net/HttpMetaCache.cpp
@@ -144,12 +144,12 @@ auto HttpMetaCache::resolveEntry(QString base, QString resource_path, QString ex
 auto HttpMetaCache::updateEntry(MetaEntryPtr stale_entry) -> bool
 {
     if (!m_entries.contains(stale_entry->m_baseId)) {
-        qCCritical(taskHttpMetaCacheLogC) << "Cannot add entry with unknown base: " << stale_entry->m_baseId.toLocal8Bit();
+        qCCritical(taskHttpMetaCacheLogC) << "Cannot add entry with unknown base:" << stale_entry->m_baseId.toLocal8Bit();
         return false;
     }
 
     if (stale_entry->m_stale) {
-        qCCritical(taskHttpMetaCacheLogC) << "Cannot add stale entry: " << stale_entry->getFullPath().toLocal8Bit();
+        qCCritical(taskHttpMetaCacheLogC) << "Cannot add stale entry:" << stale_entry->getFullPath().toLocal8Bit();
         return false;
     }
 

--- a/launcher/net/NetRequest.cpp
+++ b/launcher/net/NetRequest.cpp
@@ -75,12 +75,12 @@ void NetRequest::executeTask()
     m_state = m_sink->init(request);
     switch (m_state) {
         case State::Succeeded:
-            qCDebug(logCat) << getUid().toString() << "Request cache hit " << m_url.toString();
+            qCDebug(logCat) << getUid().toString() << "Request cache hit" << m_url.toString();
             emit succeeded();
             emit finished();
             return;
         case State::Running:
-            qCDebug(logCat) << getUid().toString() << "Running " << m_url.toString();
+            qCDebug(logCat) << getUid().toString() << "Running" << m_url.toString();
             break;
         case State::Inactive:
         case State::Failed:
@@ -159,7 +159,7 @@ void NetRequest::onProgress(qint64 bytesReceived, qint64 bytesTotal)
 void NetRequest::downloadError(QNetworkReply::NetworkError error)
 {
     if (error == QNetworkReply::OperationCanceledError) {
-        qCCritical(logCat) << getUid().toString() << "Aborted " << m_url.toString();
+        qCCritical(logCat) << getUid().toString() << "Aborted" << m_url.toString();
         m_state = State::Failed;
     } else {
         if (m_options & Option::AcceptLocalFiles) {
@@ -182,7 +182,7 @@ void NetRequest::sslErrors(const QList<QSslError>& errors)
 {
     int i = 1;
     for (auto error : errors) {
-        qCCritical(logCat) << getUid().toString() << "Request" << m_url.toString() << "SSL Error #" << i << " : " << error.errorString();
+        qCCritical(logCat).nospace() << getUid().toString() << " Request " << m_url.toString() << " SSL Error #" << i << ": " << error.errorString();
         auto cert = error.certificate();
         qCCritical(logCat) << getUid().toString() << "Certificate in question:\n" << cert.toText();
         i++;
@@ -237,7 +237,7 @@ auto NetRequest::handleRedirect() -> bool
     }
 
     m_url = QUrl(redirect.toString());
-    qCDebug(logCat) << getUid().toString() << "Following redirect to " << m_url.toString();
+    qCDebug(logCat) << getUid().toString() << "Following redirect to" << m_url.toString();
     executeTask();
 
     return true;
@@ -318,7 +318,7 @@ void NetRequest::downloadReadyRead()
         }
         // qDebug() << "Request" << m_url.toString() << "gained" << data.size() << "bytes";
     } else {
-        qCCritical(logCat) << getUid().toString() << "Cannot write download data! illegal status " << m_status;
+        qCCritical(logCat) << getUid().toString() << "Cannot write download data! illegal status" << m_status;
     }
 }
 

--- a/launcher/tasks/Task.cpp
+++ b/launcher/tasks/Task.cpp
@@ -113,12 +113,12 @@ void Task::emitFailed(QString reason)
 {
     // Don't fail twice.
     if (ASSERT_NEVER(!isRunning())) {
-        qCCritical(taskLogC) << "Task" << describe() << "failed while not running!!!!: " << reason;
+        qCCritical(taskLogC) << "Task" << describe() << "failed while not running!!!!:" << reason;
         return;
     }
     m_state = State::Failed;
     m_failReason = reason;
-    qCCritical(taskLogC) << "Task" << describe() << "failed: " << reason;
+    qCCritical(taskLogC) << "Task" << describe() << "failed:" << reason;
     emit failed(reason);
     emit finished();
 }

--- a/launcher/translations/POTranslator.cpp
+++ b/launcher/translations/POTranslator.cpp
@@ -253,7 +253,7 @@ void POTranslatorPrivate::reload()
                 mode = Mode::MessageString;
             }
         } else {
-            qDebug() << "I did not understand line: " << lineNumber << ":" << QString::fromUtf8(line);
+            qDebug() << "I did not understand line:" << lineNumber << ":" << QString::fromUtf8(line);
         }
         lineNumber++;
     }

--- a/launcher/ui/dialogs/BlockedModsDialog.cpp
+++ b/launcher/ui/dialogs/BlockedModsDialog.cpp
@@ -58,7 +58,7 @@ BlockedModsDialog::BlockedModsDialog(QWidget* parent, const QString& title, cons
 
     connect(&m_watcher, &QFileSystemWatcher::directoryChanged, this, &BlockedModsDialog::directoryChanged);
 
-    qDebug() << "[Blocked Mods Dialog] Mods List: " << mods;
+    qDebug() << "[Blocked Mods Dialog] Mods List:" << mods;
 
     // defer setup of file system watchers until after the dialog is shown
     // this allows OS (namely macOS) permission prompts to show after the relevant dialog appears
@@ -184,7 +184,7 @@ void BlockedModsDialog::update()
 /// @param path the path to the changed directory
 void BlockedModsDialog::directoryChanged(QString path)
 {
-    qDebug() << "[Blocked Mods Dialog] Directory changed: " << path;
+    qDebug() << "[Blocked Mods Dialog] Directory changed:" << path;
     validateMatchedMods();
     scanPath(path, true);
 }
@@ -269,10 +269,10 @@ void BlockedModsDialog::buildHashTask(QString path)
 {
     auto hash_task = Hashing::createHasher(path, m_hashType);
 
-    qDebug() << "[Blocked Mods Dialog] Creating Hash task for path: " << path;
+    qDebug() << "[Blocked Mods Dialog] Creating Hash task for path:" << path;
 
     connect(hash_task.get(), &Task::succeeded, this, [this, hash_task, path] { checkMatchHash(hash_task->getResult(), path); });
-    connect(hash_task.get(), &Task::failed, this, [path] { qDebug() << "Failed to hash path: " << path; });
+    connect(hash_task.get(), &Task::failed, this, [path] { qDebug() << "Failed to hash path:" << path; });
 
     m_hashingTask->addTask(hash_task);
 }
@@ -285,7 +285,7 @@ void BlockedModsDialog::checkMatchHash(QString hash, QString path)
 {
     bool match = false;
 
-    qDebug() << "[Blocked Mods Dialog] Checking for match on hash: " << hash << "| From path:" << path;
+    qDebug() << "[Blocked Mods Dialog] Checking for match on hash:" << hash << "| From path:" << path;
 
     auto downloadDir = QFileInfo(APPLICATION->settings()->get("DownloadsDir").toString()).absoluteFilePath();
     auto moveFiles = APPLICATION->settings()->get("MoveModsFromDownloadsDir").toBool();

--- a/launcher/ui/dialogs/ResourceUpdateDialog.cpp
+++ b/launcher/ui/dialogs/ResourceUpdateDialog.cpp
@@ -163,7 +163,7 @@ void ResourceUpdateDialog::checkCandidates()
             const auto& reason = std::get<1>(failed);
             const auto& recover_url = std::get<2>(failed);
 
-            qDebug() << mod->name() << " failed to check for updates!";
+            qDebug() << mod->name() << "failed to check for updates!";
 
             text += tr("Mod name: %1").arg(mod->name()) + "<br>";
             if (!reason.isEmpty())

--- a/launcher/ui/dialogs/skins/SkinManageDialog.cpp
+++ b/launcher/ui/dialogs/skins/SkinManageDialog.cpp
@@ -504,8 +504,8 @@ void SkinManageDialog::on_userBtn_clicked()
             QJsonParseError parse_error{};
             QJsonDocument doc = QJsonDocument::fromJson(*uuidOut, &parse_error);
             if (parse_error.error != QJsonParseError::NoError) {
-                qWarning() << "Error while parsing JSON response from Minecraft skin service at " << parse_error.offset
-                           << " reason: " << parse_error.errorString();
+                qWarning() << "Error while parsing JSON response from Minecraft skin service at" << parse_error.offset
+                           << "reason:" << parse_error.errorString();
                 failReason = tr("failed to parse get user UUID response");
                 uuidLoop->quit();
                 return;

--- a/launcher/ui/instanceview/AccessibleInstanceView.cpp
+++ b/launcher/ui/instanceview/AccessibleInstanceView.cpp
@@ -55,7 +55,7 @@ QAccessibleInterface* AccessibleInstanceView::cellAt(int row, int column) const
 
     QModelIndex index = view()->model()->index(row, column, view()->rootIndex());
     if (Q_UNLIKELY(!index.isValid())) {
-        qWarning() << "AccessibleInstanceView::cellAt: invalid index: " << index << " for " << view();
+        qWarning() << "AccessibleInstanceView::cellAt: invalid index:" << index << "for" << view();
         return 0;
     }
 
@@ -531,7 +531,7 @@ void AccessibleInstanceView::modelChange(QAccessibleTableModelChangeEvent* event
 AccessibleInstanceViewItem::AccessibleInstanceViewItem(QAbstractItemView* view_, const QModelIndex& index_) : view(view_), m_index(index_)
 {
     if (Q_UNLIKELY(!index_.isValid()))
-        qWarning() << "AccessibleInstanceViewItem::AccessibleInstanceViewItem with invalid index: " << index_;
+        qWarning() << "AccessibleInstanceViewItem::AccessibleInstanceViewItem with invalid index:" << index_;
 }
 
 void* AccessibleInstanceViewItem::interface_cast(QAccessible::InterfaceType t)

--- a/launcher/ui/java/VersionList.cpp
+++ b/launcher/ui/java/VersionList.cpp
@@ -118,7 +118,7 @@ void VersionList::sortVersions()
                      [versionStr](Java::MetadataPtr val) { return val->runtimeOS == versionStr; });
         std::sort(m_vlist.begin(), m_vlist.end(), sortJavas);
     } else {
-        qWarning() << "No Java versions found for your operating system." << SysInfo::currentSystem() << " " << SysInfo::useQTForArch();
+        qWarning() << "No Java versions found for your operating system:" << SysInfo::currentSystem() << SysInfo::useQTForArch();
     }
     endResetModel();
 }

--- a/launcher/ui/pages/instance/McClient.cpp
+++ b/launcher/ui/pages/instance/McClient.cpp
@@ -59,7 +59,7 @@ void McClient::readRawResponse()
 
     if (m_responseReadState == 1 && m_resp.size() >= m_wantedRespLength) {
         if (m_resp.size() > m_wantedRespLength) {
-            qDebug() << "Warning: Packet length doesn't match actual packet size (" << m_wantedRespLength << " expected vs "
+            qDebug().nospace() << "Warning: Packet length doesn't match actual packet size (" << m_wantedRespLength << " expected vs "
                      << m_resp.size() << " received)";
         }
         parseResponse();

--- a/launcher/ui/pages/instance/ScreenshotsPage.cpp
+++ b/launcher/ui/pages/instance/ScreenshotsPage.cpp
@@ -100,7 +100,7 @@ class ThumbnailRunnable : public QRunnable {
         QImage image(m_path);
         if (image.isNull()) {
             m_resultEmitter.emitResultsFailed(m_path);
-            qDebug() << "Error loading screenshot: " + m_path + ". Perhaps too large?";
+            qDebug() << "Error loading screenshot (perhaps too large?):" + m_path;
             return;
         }
         QImage small;

--- a/launcher/ui/pages/instance/ServerPingTask.cpp
+++ b/launcher/ui/pages/instance/ServerPingTask.cpp
@@ -18,19 +18,19 @@ unsigned getOnlinePlayers(QJsonObject data)
 
 void ServerPingTask::executeTask()
 {
-    qDebug() << "Querying status of " << QString("%1:%2").arg(m_domain).arg(m_port);
+    qDebug() << "Querying status of" << QString("%1:%2").arg(m_domain).arg(m_port);
 
     // Resolve the actual IP and port for the server
     McResolver* resolver = new McResolver(nullptr, m_domain, m_port);
     connect(resolver, &McResolver::succeeded, this, [this](QString ip, int port) {
-        qDebug() << "Resolved Address for" << m_domain << ": " << ip << ":" << port;
+        qDebug().nospace().noquote() << "Resolved address for " << m_domain << ": " << ip << ":" << port;
 
         // Now that we have the IP and port, query the server
         McClient* client = new McClient(nullptr, m_domain, ip, port);
 
         connect(client, &McClient::succeeded, this, [this](QJsonObject data) {
             m_outputOnlinePlayers = getOnlinePlayers(data);
-            qDebug() << "Online players: " << m_outputOnlinePlayers;
+            qDebug() << "Online players:" << m_outputOnlinePlayers;
             emitSucceeded();
         });
         connect(client, &McClient::failed, this, [this](QString error) { emitFailed(error); });

--- a/launcher/ui/pages/modplatform/atlauncher/AtlListModel.cpp
+++ b/launcher/ui/pages/modplatform/atlauncher/AtlListModel.cpp
@@ -114,7 +114,7 @@ void ListModel::requestFinished()
     QJsonParseError parse_error;
     QJsonDocument doc = QJsonDocument::fromJson(*response, &parse_error);
     if (parse_error.error != QJsonParseError::NoError) {
-        qWarning() << "Error while parsing JSON response from ATL at " << parse_error.offset << " reason: " << parse_error.errorString();
+        qWarning() << "Error while parsing JSON response from ATL at" << parse_error.offset << "reason:" << parse_error.errorString();
         qWarning() << *response;
         return;
     }
@@ -131,7 +131,7 @@ void ListModel::requestFinished()
             ATLauncher::loadIndexedPack(pack, packObj);
         } catch (const JSONValidationError& e) {
             qDebug() << QString::fromUtf8(*response);
-            qWarning() << "Error while reading pack manifest from ATLauncher: " << e.cause();
+            qWarning() << "Error while reading pack manifest from ATLauncher:" << e.cause();
             return;
         }
 

--- a/launcher/ui/pages/modplatform/atlauncher/AtlOptionalModDialog.cpp
+++ b/launcher/ui/pages/modplatform/atlauncher/AtlOptionalModDialog.cpp
@@ -174,7 +174,7 @@ void AtlOptionalModListModel::shareCodeSuccess()
     QJsonParseError parse_error{};
     auto doc = QJsonDocument::fromJson(*m_response, &parse_error);
     if (parse_error.error != QJsonParseError::NoError) {
-        qWarning() << "Error while parsing JSON response from ATL at " << parse_error.offset << " reason: " << parse_error.errorString();
+        qWarning() << "Error while parsing JSON response from ATL at" << parse_error.offset << "reason:" << parse_error.errorString();
         qWarning() << *m_response;
         return;
     }
@@ -185,7 +185,7 @@ void AtlOptionalModListModel::shareCodeSuccess()
         ATLauncher::loadShareCodeResponse(response, obj);
     } catch (const JSONValidationError& e) {
         qDebug() << QString::fromUtf8(*m_response);
-        qWarning() << "Error while reading response from ATLauncher: " << e.cause();
+        qWarning() << "Error while reading response from ATLauncher:" << e.cause();
         return;
     }
 

--- a/launcher/ui/pages/modplatform/import_ftb/ListModel.cpp
+++ b/launcher/ui/pages/modplatform/import_ftb/ListModel.cpp
@@ -54,7 +54,7 @@ QString getDynamicPath()
         auto doc = Json::requireDocument(FS::read(settingsPath));
         return Json::requireString(Json::requireObject(doc), "instanceLocation");
     } catch (const Exception& e) {
-        qCritical() << "Could not read ftb settings file: " << e.cause();
+        qCritical() << "Could not read ftb settings file:" << e.cause();
     }
     return {};
 }

--- a/launcher/ui/pages/modplatform/technic/TechnicModel.cpp
+++ b/launcher/ui/pages/modplatform/technic/TechnicModel.cpp
@@ -170,8 +170,8 @@ void Technic::ListModel::searchRequestFinished()
     QJsonParseError parse_error;
     QJsonDocument doc = QJsonDocument::fromJson(*response, &parse_error);
     if (parse_error.error != QJsonParseError::NoError) {
-        qWarning() << "Error while parsing JSON response from Technic at " << parse_error.offset
-                   << " reason: " << parse_error.errorString();
+        qWarning() << "Error while parsing JSON response from Technic at" << parse_error.offset
+                   << "reason:" << parse_error.errorString();
         qWarning() << *response;
         return;
     }

--- a/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
+++ b/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
@@ -175,8 +175,8 @@ void TechnicPage::suggestCurrent()
         QJsonDocument doc = QJsonDocument::fromJson(*response, &parse_error);
         QJsonObject obj = doc.object();
         if (parse_error.error != QJsonParseError::NoError) {
-            qWarning() << "Error while parsing JSON response from Technic at " << parse_error.offset
-                       << " reason: " << parse_error.errorString();
+            qWarning() << "Error while parsing JSON response from Technic at" << parse_error.offset
+                       << "reason:" << parse_error.errorString();
             qWarning() << *response;
             return;
         }
@@ -309,7 +309,7 @@ void TechnicPage::onSolderLoaded()
     QJsonParseError parse_error{};
     auto doc = QJsonDocument::fromJson(*response, &parse_error);
     if (parse_error.error != QJsonParseError::NoError) {
-        qWarning() << "Error while parsing JSON response from Solder at " << parse_error.offset << " reason: " << parse_error.errorString();
+        qWarning() << "Error while parsing JSON response from Solder at" << parse_error.offset << "reason:" << parse_error.errorString();
         qWarning() << *response;
         fallback();
         return;

--- a/launcher/ui/themes/CustomTheme.cpp
+++ b/launcher/ui/themes/CustomTheme.cpp
@@ -100,7 +100,7 @@ CustomTheme::CustomTheme(ITheme* baseTheme, QFileInfo& fileInfo, bool isManifest
         // themeDebugLog << "Theme Path: " << path;
 
         if (!FS::ensureFilePathExists(path)) {
-            themeWarningLog() << m_name << " Theme file path doesn't exist!";
+            themeWarningLog().nospace() << m_name << ": Theme file path doesn't exist!";
             m_palette = baseTheme->colorScheme();
             m_styleSheet = baseTheme->appStyleSheet();
             return;
@@ -256,7 +256,7 @@ bool CustomTheme::read(const QString& path, bool& hasCustomLogColors)
                 readAndSetLogColor(MessageLevel::Fatal, true, "Fatal");
             }
         } catch (const Exception& e) {
-            themeWarningLog() << "Couldn't load theme json: " << e.cause();
+            themeWarningLog() << "Couldn't load theme json:" << e.cause();
             return false;
         }
     } else {

--- a/launcher/ui/themes/ThemeManager.cpp
+++ b/launcher/ui/themes/ThemeManager.cpp
@@ -114,7 +114,7 @@ void ThemeManager::initializeIcons()
 
     if (!m_iconThemeFolder.mkpath("."))
         themeWarningLog() << "Couldn't create icon theme folder";
-    themeDebugLog() << "Icon Theme Folder Path: " << m_iconThemeFolder.absolutePath();
+    themeDebugLog() << "Icon Theme Folder Path:" << m_iconThemeFolder.absolutePath();
 
     QDirIterator directoryIterator(m_iconThemeFolder.path(), QDir::Dirs | QDir::NoDotAndDotDot);
     while (directoryIterator.hasNext()) {
@@ -154,7 +154,7 @@ void ThemeManager::initializeWidgets()
 
     if (!m_applicationThemeFolder.mkpath("."))
         themeWarningLog() << "Couldn't create theme folder";
-    themeDebugLog() << "Theme Folder Path: " << m_applicationThemeFolder.absolutePath();
+    themeDebugLog() << "Theme Folder Path:" << m_applicationThemeFolder.absolutePath();
 
     QDirIterator directoryIterator(m_applicationThemeFolder.path(), QDir::Dirs | QDir::NoDotAndDotDot);
     while (directoryIterator.hasNext()) {

--- a/launcher/ui/widgets/VariableSizedImageObject.cpp
+++ b/launcher/ui/widgets/VariableSizedImageObject.cpp
@@ -169,7 +169,7 @@ void VariableSizedImageObject::loadImage(QTextDocument* doc, std::shared_ptr<Ima
         loadImage(image);
     });
     connect(job, &NetJob::failed, this, [this, full_entry_path, source_url, loadImage](QString reason) {
-        qWarning() << "Failed resource at:" << full_entry_path << " because:" << reason;
+        qWarning() << "Failed resource at:" << full_entry_path << "because:" << reason;
         // If we flushed, don't proceed.
         if (!m_fetching_images.contains(source_url))
             return;

--- a/launcher/updater/prismupdater/PrismUpdater.cpp
+++ b/launcher/updater/prismupdater/PrismUpdater.cpp
@@ -272,23 +272,23 @@ PrismUpdaterApp::PrismUpdaterApp(int& argc, char** argv) : QApplication(argc, ar
     {  // log debug program info
         qDebug() << qPrintable(BuildConfig.LAUNCHER_DISPLAYNAME + " Updater, " +
                                QString(BuildConfig.LAUNCHER_COPYRIGHT).replace("\n", ", "));
-        qDebug() << "Version                    : " << BuildConfig.printableVersionString();
-        qDebug() << "Git commit                 : " << BuildConfig.GIT_COMMIT;
-        qDebug() << "Git refspec                : " << BuildConfig.GIT_REFSPEC;
-        qDebug() << "Compiled for               : " << BuildConfig.systemID();
-        qDebug() << "Compiled by                : " << BuildConfig.compilerID();
-        qDebug() << "Build Artifact             : " << BuildConfig.BUILD_ARTIFACT;
+        qDebug() << "Version                    :" << BuildConfig.printableVersionString();
+        qDebug() << "Git commit                 :" << BuildConfig.GIT_COMMIT;
+        qDebug() << "Git refspec                :" << BuildConfig.GIT_REFSPEC;
+        qDebug() << "Compiled for               :" << BuildConfig.systemID();
+        qDebug() << "Compiled by                :" << BuildConfig.compilerID();
+        qDebug() << "Build Artifact             :" << BuildConfig.BUILD_ARTIFACT;
         if (adjustedBy.size()) {
-            qDebug() << "Data dir before adjustment : " << origCwdPath;
-            qDebug() << "Data dir after adjustment  : " << m_dataPath;
-            qDebug() << "Adjusted by                : " << adjustedBy;
+            qDebug() << "Data dir before adjustment :" << origCwdPath;
+            qDebug() << "Data dir after adjustment  :" << m_dataPath;
+            qDebug() << "Adjusted by                :" << adjustedBy;
         } else {
-            qDebug() << "Data dir                   : " << QDir::currentPath();
+            qDebug() << "Data dir                   :" << QDir::currentPath();
         }
-        qDebug() << "Work dir                   : " << QDir::currentPath();
-        qDebug() << "Binary path                : " << binPath;
-        qDebug() << "Application root path      : " << m_rootPath;
-        qDebug() << "Portable install           : " << m_isPortable;
+        qDebug() << "Work dir                   :" << QDir::currentPath();
+        qDebug() << "Binary path                :" << binPath;
+        qDebug() << "Application root path      :" << m_rootPath;
+        qDebug() << "Portable install           :" << m_isPortable;
         qDebug() << "<> Paths set.";
     }
 
@@ -427,7 +427,7 @@ void PrismUpdaterApp::showFatalErrorMessage(const QString& title, const QString&
 void PrismUpdaterApp::run()
 {
     qDebug() << "found" << m_releases.length() << "releases on github";
-    qDebug() << "loading exe at " << m_prismExecutable;
+    qDebug() << "loading exe at" << m_prismExecutable;
 
     if (m_printOnly) {
         printReleases();

--- a/tests/Library_test.cpp
+++ b/tests/Library_test.cpp
@@ -49,7 +49,7 @@ class LibraryTest : public QObject {
     {
         QFile jsonFile(path);
         if (!jsonFile.open(QIODevice::ReadOnly)) {
-            qCritical() << "Failed to open file '" << jsonFile.fileName() << "' for reading!";
+            qCritical() << "Failed to open file" << jsonFile.fileName() << "for reading!";
             return LibraryPtr();
         }
         auto data = jsonFile.readAll();

--- a/tests/Version_test.cpp
+++ b/tests/Version_test.cpp
@@ -156,7 +156,7 @@ class VersionTest : public QObject {
                 continue;
             }
 
-            qCritical() << "Unexpected separator in the test vector: ";
+            qCritical() << "Unexpected separator in the test vector:";
             qCritical() << line;
 
             QVERIFY(0 != 0);


### PR DESCRIPTION
Qt automatically adds quotes and spaces when using `qDebug`/`qInfo`/etc. unless `nospace()`/`noquote()` are called