### PR TITLE
[Backport release-10.x] Abort launch when there are libraries missing

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -264,6 +264,8 @@ set(MINECRAFT_SOURCES
     minecraft/launch/ClaimAccount.h
     minecraft/launch/CreateGameFolders.cpp
     minecraft/launch/CreateGameFolders.h
+    minecraft/launch/EnsureOfflineLibraries.cpp
+    minecraft/launch/EnsureOfflineLibraries.h
     minecraft/launch/ModMinecraftJar.cpp
     minecraft/launch/ModMinecraftJar.h
     minecraft/launch/ExtractNatives.cpp

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -94,6 +94,8 @@
 #include <QStandardPaths>
 #include <QWindow>
 
+#include "launch/EnsureOfflineLibraries.h"
+
 #ifdef Q_OS_LINUX
 #include "MangoHud.h"
 #endif
@@ -919,21 +921,13 @@ QStringList MinecraftInstance::verboseDescription(AuthSessionPtr session, Minecr
         out << "Libraries:";
         QStringList jars, nativeJars;
         profile->getLibraryFiles(runtimeContext(), jars, nativeJars, getLocalLibraryPath(), binRoot());
-        auto printLibFile = [&out](const QString& path) {
-            QFileInfo info(path);
-            if (info.exists()) {
-                out << "  " + path;
-            } else {
-                out << "  " + path + " (missing)";
-            }
-        };
         for (auto file : jars) {
-            printLibFile(file);
+            out << "  " + file;
         }
         out << "";
         out << "Native libraries:";
         for (auto file : nativeJars) {
-            printLibFile(file);
+            out << "  " + file;
         }
         out << "";
     }
@@ -1172,6 +1166,8 @@ shared_qobject_ptr<LaunchTask> MinecraftInstance::createLaunchTask(AuthSessionPt
         for (auto t : createUpdateTask()) {
             process->appendStep(makeShared<TaskStepWrapper>(pptr, t));
         }
+    } else {
+        process->appendStep(makeShared<EnsureOfflineLibraries>(pptr, this));
     }
 
     // if there are any jar mods

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -69,8 +69,8 @@
 #include "minecraft/launch/VerifyJavaInstall.h"
 
 #include "minecraft/update/AssetUpdateTask.h"
+#include "minecraft/update/FMLLibrariesTask.h"
 #include "minecraft/update/FoldersTask.h"
-#include "minecraft/update/LegacyFMLLibrariesTask.h"
 #include "minecraft/update/LibrariesTask.h"
 
 #include "java/JavaUtils.h"

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -40,13 +40,6 @@
 #include "BuildConfig.h"
 #include "Json.h"
 #include "QObjectPtr.h"
-#include "minecraft/launch/AutoInstallJava.h"
-#include "minecraft/launch/CreateGameFolders.h"
-#include "minecraft/launch/ExtractNatives.h"
-#include "minecraft/launch/PrintInstanceInfo.h"
-#include "minecraft/update/AssetUpdateTask.h"
-#include "minecraft/update/FMLLibrariesTask.h"
-#include "minecraft/update/LibrariesTask.h"
 #include "settings/Setting.h"
 #include "settings/SettingsObject.h"
 
@@ -63,12 +56,22 @@
 #include "launch/steps/QuitAfterGameStop.h"
 #include "launch/steps/TextPrint.h"
 
+#include "minecraft/launch/AutoInstallJava.h"
 #include "minecraft/launch/ClaimAccount.h"
+#include "minecraft/launch/CreateGameFolders.h"
+#include "minecraft/launch/EnsureOfflineLibraries.h"
+#include "minecraft/launch/ExtractNatives.h"
 #include "minecraft/launch/LauncherPartLaunch.h"
 #include "minecraft/launch/ModMinecraftJar.h"
+#include "minecraft/launch/PrintInstanceInfo.h"
 #include "minecraft/launch/ReconstructAssets.h"
 #include "minecraft/launch/ScanModFolders.h"
 #include "minecraft/launch/VerifyJavaInstall.h"
+
+#include "minecraft/update/AssetUpdateTask.h"
+#include "minecraft/update/FoldersTask.h"
+#include "minecraft/update/LegacyFMLLibrariesTask.h"
+#include "minecraft/update/LibrariesTask.h"
 
 #include "java/JavaUtils.h"
 
@@ -84,7 +87,6 @@
 #include "AssetsUtils.h"
 #include "MinecraftLoadAndCheck.h"
 #include "PackProfile.h"
-#include "minecraft/update/FoldersTask.h"
 
 #include "tools/BaseProfiler.h"
 
@@ -93,8 +95,6 @@
 #include <QScreen>
 #include <QStandardPaths>
 #include <QWindow>
-
-#include "launch/EnsureOfflineLibraries.h"
 
 #ifdef Q_OS_LINUX
 #include "MangoHud.h"

--- a/launcher/minecraft/launch/EnsureOfflineLibraries.cpp
+++ b/launcher/minecraft/launch/EnsureOfflineLibraries.cpp
@@ -30,10 +30,9 @@ void EnsureOfflineLibraries::executeTask()
     profile->getLibraryFiles(m_instance->runtimeContext(), allJars, allJars, m_instance->getLocalLibraryPath(), m_instance->binRoot());
     for (const auto& jar : allJars) {
         if (!QFileInfo::exists(jar)) {
-            emit logLine(
-                tr("This instance cannot be launched in offline mode because libraries have not been downloaded yet. Please try again in "
-                   "online mode with a working Internet connection"),
-                MessageLevel::Fatal);
+            emit logLine(tr("This instance cannot be launched because some libraries are missing or have not been downloaded yet. Please "
+                            "try again in online mode with a working Internet connection"),
+                         MessageLevel::Fatal);
             emitFailed("Required libraries are missing");
             return;
         }

--- a/launcher/minecraft/launch/EnsureOfflineLibraries.cpp
+++ b/launcher/minecraft/launch/EnsureOfflineLibraries.cpp
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2026 Octol1ttle <l1ttleofficial@outlook.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "EnsureOfflineLibraries.h"
+
+#include "minecraft/PackProfile.h"
+
+EnsureOfflineLibraries::EnsureOfflineLibraries(LaunchTask* parent, MinecraftInstance* instance) : LaunchStep(parent), m_instance(instance)
+{}
+
+void EnsureOfflineLibraries::executeTask()
+{
+    const auto profile = m_instance->getPackProfile()->getProfile();
+    QStringList allJars;
+    profile->getLibraryFiles(m_instance->runtimeContext(), allJars, allJars, m_instance->getLocalLibraryPath(), m_instance->binRoot());
+    for (const auto& jar : allJars) {
+        if (!QFileInfo::exists(jar)) {
+            emit logLine(
+                tr("This instance cannot be launched in offline mode because libraries have not been downloaded yet. Please try again in "
+                   "online mode with a working Internet connection"),
+                MessageLevel::Fatal);
+            emitFailed("Required libraries are missing");
+            return;
+        }
+    }
+
+    emitSucceeded();
+}

--- a/launcher/minecraft/launch/EnsureOfflineLibraries.h
+++ b/launcher/minecraft/launch/EnsureOfflineLibraries.h
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2026 Octol1ttle <l1ttleofficial@outlook.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "launch/LaunchStep.h"
+#include "minecraft/MinecraftInstance.h"
+
+class EnsureOfflineLibraries : public LaunchStep {
+    Q_OBJECT
+
+   public:
+    explicit EnsureOfflineLibraries(LaunchTask* parent, MinecraftInstance* instance);
+    ~EnsureOfflineLibraries() override = default;
+
+    void executeTask() override;
+    bool canAbort() const override { return false; }
+
+   private:
+    MinecraftInstance* m_instance;
+};


### PR DESCRIPTION
Trial-based backport to `release-10.x`, triggered by a comment in #4899