### PR TITLE
[Backport release-10.x] update to qt 6.10.2, build codeql on the qt version we still want to support, sign DLLs on windows

### DIFF
--- a/.github/actions/package/windows/action.yml
+++ b/.github/actions/package/windows/action.yml
@@ -69,7 +69,7 @@ runs:
 
     - name: Sign executables
       if: ${{ env.CI_HAS_ACCESS_TO_AZURE != '' && inputs.azure-client-id != '' }}
-      uses: azure/trusted-signing-action@v0
+      uses: azure/artifact-signing-action@v1
       with:
         endpoint: https://eus.codesigning.azure.net/
         trusted-signing-account-name: PrismLauncher
@@ -79,8 +79,8 @@ runs:
         files-folder-recurse: true
         files-folder-depth: 2
         # recommended in https://github.com/Azure/artifact-signing-action#timestamping-1
-        timestamp-rfc3161: 'http://timestamp.acs.microsoft.com'
-        timestamp-digest: 'SHA256'
+        timestamp-rfc3161: "http://timestamp.acs.microsoft.com"
+        timestamp-digest: "SHA256"
         # TODO(@getchoo): Is this all really needed???
         # https://github.com/Azure/trusted-signing-action/blob/fc390cf8ed0f14e248a542af1d838388a47c7a7c/docs/OIDC.md
         exclude-environment-credential: true
@@ -142,7 +142,7 @@ runs:
 
     - name: Sign installer
       if: ${{ env.CI_HAS_ACCESS_TO_AZURE != '' && inputs.azure-client-id != '' }}
-      uses: azure/trusted-signing-action@v0
+      uses: azure/artifact-signing-action@v1
       with:
         endpoint: https://eus.codesigning.azure.net/
         trusted-signing-account-name: PrismLauncher
@@ -152,8 +152,8 @@ runs:
           ${{ github.workspace }}\PrismLauncher-Setup.exe
 
         # recommended in https://github.com/Azure/artifact-signing-action#timestamping-1
-        timestamp-rfc3161: 'http://timestamp.acs.microsoft.com'
-        timestamp-digest: 'SHA256'
+        timestamp-rfc3161: "http://timestamp.acs.microsoft.com"
+        timestamp-digest: "SHA256"
         # TODO(@getchoo): Is this all really needed???
         # https://github.com/Azure/trusted-signing-action/blob/fc390cf8ed0f14e248a542af1d838388a47c7a7c/docs/OIDC.md
         exclude-environment-credential: true

--- a/.github/actions/package/windows/action.yml
+++ b/.github/actions/package/windows/action.yml
@@ -74,12 +74,13 @@ runs:
         endpoint: https://eus.codesigning.azure.net/
         trusted-signing-account-name: PrismLauncher
         certificate-profile-name: PrismLauncher
-
-        files: |
-          ${{ github.workspace }}\install\prismlauncher.exe
-          ${{ github.workspace }}\install\prismlauncher_filelink.exe
-          ${{ github.workspace }}\install\prismlauncher_updater.exe
-
+        files-folder: ${{ github.workspace }}\install\
+        files-folder-filter: dll,exe
+        files-folder-recurse: true
+        files-folder-depth: 2
+        # recommended in https://github.com/Azure/artifact-signing-action#timestamping-1
+        timestamp-rfc3161: 'http://timestamp.acs.microsoft.com'
+        timestamp-digest: 'SHA256'
         # TODO(@getchoo): Is this all really needed???
         # https://github.com/Azure/trusted-signing-action/blob/fc390cf8ed0f14e248a542af1d838388a47c7a7c/docs/OIDC.md
         exclude-environment-credential: true
@@ -150,6 +151,9 @@ runs:
         files: |
           ${{ github.workspace }}\PrismLauncher-Setup.exe
 
+        # recommended in https://github.com/Azure/artifact-signing-action#timestamping-1
+        timestamp-rfc3161: 'http://timestamp.acs.microsoft.com'
+        timestamp-digest: 'SHA256'
         # TODO(@getchoo): Is this all really needed???
         # https://github.com/Azure/trusted-signing-action/blob/fc390cf8ed0f14e248a542af1d838388a47c7a7c/docs/OIDC.md
         exclude-environment-credential: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,12 +91,12 @@ jobs:
           - os: ubuntu-24.04
             artifact-name: Linux
             cmake-preset: linux
-            qt-version: 6.10.1
+            qt-version: 6.10.2
 
           - os: ubuntu-24.04-arm
             artifact-name: Linux-aarch64
             cmake-preset: linux
-            qt-version: 6.10.1
+            qt-version: 6.10.2
 
           - os: windows-2022
             artifact-name: Windows-MinGW-w64
@@ -115,13 +115,13 @@ jobs:
             cmake-preset: windows_msvc
             # TODO(@getchoo): This is the default in setup-dependencies/windows. Why isn't it working?!?!
             vcvars-arch: amd64
-            qt-version: 6.10.1
+            qt-version: 6.10.2
 
           - os: windows-11-arm
             artifact-name: Windows-MSVC-arm64
             cmake-preset: windows_msvc
             vcvars-arch: arm64
-            qt-version: 6.10.1
+            qt-version: 6.10.2
 
           - os: macos-26
             artifact-name: macOS

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -79,12 +79,16 @@ jobs:
         uses: ./.github/actions/setup-dependencies
         with:
           build-type: Debug
-          qt-version: 6.10.1
+          qt-version: 6.4.3
 
       - name: Configure and Build
         run: |
           cmake --preset linux
           cmake --build --preset linux --config Debug
+
+      - name: Run tests
+        run: |
+          ctest --preset linux --build-config Debug
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,7 +283,7 @@ set(Launcher_BUILD_TIMESTAMP "${TODAY}")
 # Find the required Qt parts
 if(Launcher_QT_VERSION_MAJOR EQUAL 6)
     set(QT_VERSION_MAJOR 6)
-    find_package(Qt6 REQUIRED COMPONENTS Core CoreTools Widgets Concurrent Network Test Xml NetworkAuth OpenGL)
+    find_package(Qt6 6.4 REQUIRED COMPONENTS Core CoreTools Widgets Concurrent Network Test Xml NetworkAuth OpenGL)
     find_package(Qt6 COMPONENTS DBus)
     list(APPEND Launcher_QT_DBUS Qt6::DBus)
 else()


### PR DESCRIPTION
Trial-based backport to `release-10.x`, triggered by a comment in #4909