### PR TITLE
feat: Auto handle Http 429 Too Many Requests with retry

### DIFF
--- a/launcher/minecraft/auth/steps/EntitlementsStep.cpp
+++ b/launcher/minecraft/auth/steps/EntitlementsStep.cpp
@@ -34,6 +34,7 @@ void EntitlementsStep::perform()
     m_response.reset(new QByteArray());
     m_request = Net::Download::makeByteArray(url, m_response.get());
     m_request->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(headers));
+    m_request->enableAutoRetry(true);
 
     m_task.reset(new NetJob("EntitlementsStep", APPLICATION->network()));
     m_task->setAskRetry(false);

--- a/launcher/minecraft/auth/steps/GetSkinStep.cpp
+++ b/launcher/minecraft/auth/steps/GetSkinStep.cpp
@@ -18,6 +18,7 @@ void GetSkinStep::perform()
 
     m_response.reset(new QByteArray());
     m_request = Net::Download::makeByteArray(url, m_response.get());
+    m_request->enableAutoRetry(true);
 
     m_task.reset(new NetJob("GetSkinStep", APPLICATION->network()));
     m_task->setAskRetry(false);

--- a/launcher/minecraft/auth/steps/LauncherLoginStep.cpp
+++ b/launcher/minecraft/auth/steps/LauncherLoginStep.cpp
@@ -39,6 +39,7 @@ void LauncherLoginStep::perform()
     m_response.reset(new QByteArray());
     m_request = Net::Upload::makeByteArray(url, m_response.get(), requestBody.toUtf8());
     m_request->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(headers));
+    m_request->enableAutoRetry(true);
 
     m_task.reset(new NetJob("LauncherLoginStep", APPLICATION->network()));
     m_task->setAskRetry(false);

--- a/launcher/minecraft/auth/steps/MSADeviceCodeStep.cpp
+++ b/launcher/minecraft/auth/steps/MSADeviceCodeStep.cpp
@@ -69,6 +69,7 @@ void MSADeviceCodeStep::perform()
     m_response.reset(new QByteArray());
     m_request = Net::Upload::makeByteArray(url, m_response.get(), payload);
     m_request->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(headers));
+    m_request->enableAutoRetry(true);
 
     m_task.reset(new NetJob("MSADeviceCodeStep", APPLICATION->network()));
     m_task->setAskRetry(false);

--- a/launcher/minecraft/auth/steps/MinecraftProfileStep.cpp
+++ b/launcher/minecraft/auth/steps/MinecraftProfileStep.cpp
@@ -24,6 +24,7 @@ void MinecraftProfileStep::perform()
     m_response.reset(new QByteArray());
     m_request = Net::Download::makeByteArray(url, m_response.get());
     m_request->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(headers));
+    m_request->enableAutoRetry(true);
 
     m_task.reset(new NetJob("MinecraftProfileStep", APPLICATION->network()));
     m_task->setAskRetry(false);

--- a/launcher/minecraft/auth/steps/XboxAuthorizationStep.cpp
+++ b/launcher/minecraft/auth/steps/XboxAuthorizationStep.cpp
@@ -45,6 +45,7 @@ void XboxAuthorizationStep::perform()
     m_response.reset(new QByteArray());
     m_request = Net::Upload::makeByteArray(url, m_response.get(), xbox_auth_data.toUtf8());
     m_request->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(headers));
+    m_request->enableAutoRetry(true);
 
     m_task.reset(new NetJob("XboxAuthorizationStep", APPLICATION->network()));
     m_task->setAskRetry(false);

--- a/launcher/minecraft/auth/steps/XboxUserStep.cpp
+++ b/launcher/minecraft/auth/steps/XboxUserStep.cpp
@@ -40,6 +40,7 @@ void XboxUserStep::perform()
     m_response.reset(new QByteArray());
     m_request = Net::Upload::makeByteArray(url, m_response.get(), xbox_auth_data.toUtf8());
     m_request->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(headers));
+    m_request->enableAutoRetry(true);
 
     m_task.reset(new NetJob("XboxUserStep", APPLICATION->network()));
     m_task->setAskRetry(false);

--- a/launcher/net/NetRequest.h
+++ b/launcher/net/NetRequest.h
@@ -41,6 +41,7 @@
 
 #include <QNetworkReply>
 #include <QUrl>
+#include <QTimer>
 #include <chrono>
 
 #include "HeaderProxy.h"
@@ -55,11 +56,11 @@ namespace Net {
 class NetRequest : public Task {
     Q_OBJECT
    protected:
-    explicit NetRequest() : Task() {}
+    explicit NetRequest();
 
    public:
     using Ptr = shared_qobject_ptr<class NetRequest>;
-    enum class Option { NoOptions = 0, AcceptLocalFiles = 1, MakeEternal = 2 };
+    enum class Option { NoOptions = 0, AcceptLocalFiles = 1, MakeEternal = 2, AutoRetry = 4 };
     Q_DECLARE_FLAGS(Options, Option)
 
    public:
@@ -71,6 +72,9 @@ class NetRequest : public Task {
     void setNetwork(QNetworkAccessManager* network) { m_network = network; }
     void addHeaderProxy(std::unique_ptr<Net::HeaderProxy> proxy) { m_headerProxies.push_back(std::move(proxy)); }
 
+    // automatically handle HTTP 429 Too Many Requests errors and retry
+    void enableAutoRetry(bool enable);
+
     QUrl url() const;
     void setUrl(QUrl url) { m_url = url; }
     int replyStatusCode() const;
@@ -79,6 +83,7 @@ class NetRequest : public Task {
 
    private:
     auto handleRedirect() -> bool;
+    void handleAutoRetry(int64_t delay);
     virtual QNetworkReply* getReply(QNetworkRequest&) = 0;
 
    protected slots:
@@ -109,6 +114,9 @@ class NetRequest : public Task {
     /// source URL
     QUrl m_url;
     std::vector<std::unique_ptr<Net::HeaderProxy>> m_headerProxies;
+
+    int m_retryCount = 0;
+    QTimer m_retryTimer;
 };
 }  // namespace Net
 


### PR DESCRIPTION
- Must be explicitly enabled for a request
- Uses Retry-After Header if present, falls back to exponential back off starting with 10 seconds
- if retry delay is greater than 1 minute or it retries more than 3 times then fail with a "Rate Limited" reason
- Sets task status to inform user of retry.

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
