### PR TITLE
Use Merge Groups for primary CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,33 +5,8 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    branches:
-      - "develop"
-      - "release-*"
-    paths:
-      # File types
-      - "**.cpp"
-      - "**.h"
-      - "**.java"
-      - "**.ui"
-
-      # Directories
-      - "buildconfig/**"
-      - "cmake/**"
-      - "launcher/**"
-      - "libraries/**"
-      - "program_info/**"
-      - "tests/**"
-
-      # Files
-      - "CMakeLists.txt"
-      - "COPYING.md"
-
-      # Workflows
-      - ".github/workflows/build.yml"
-      - ".github/actions/package/**"
-      - ".github/actions/setup-dependencies/**"
+  merge_group:
+    types: [checks_requested]
   pull_request:
     paths:
       # File types

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,33 +5,8 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    branches:
-      - "develop"
-      - "release-*"
-    paths:
-      # File types
-      - "**.cpp"
-      - "**.h"
-      - "**.java"
-      - "**.ui"
-
-      # Directories
-      - "buildconfig/**"
-      - "cmake/**"
-      - "launcher/**"
-      - "libraries/**"
-      - "program_info/**"
-      - "tests/**"
-
-      # Files
-      - "CMakeLists.txt"
-      - "COPYING.md"
-
-      # Workflows
-      - ".github/codeql/**"
-      - ".github/workflows/codeql.yml"
-      - ".github/actions/setup-dependencies/**"
+  merge_group:
+    types: [checks_requested]
   pull_request:
     paths:
       # File types


### PR DESCRIPTION
This should prevent any breakage to `develop`, as well as conflicts introduced by multiple PRs being merged without testing against each other
