### PR TITLE
Harden CI permissions

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -8,8 +8,7 @@ on:
 # the GitHub repository. This means that it should not evaluate user input in a
 # way that allows code injection.
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   backport:

--- a/.github/workflows/blocked-prs.yml
+++ b/.github/workflows/blocked-prs.yml
@@ -14,6 +14,8 @@ on:
         required: true
         type: number
 
+permissions: {}
+
 jobs:
   blocked_status:
     name: Check Blocked Status

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,8 @@ on:
         type: string
         default: Debug
 
+permissions: {}
+
 jobs:
   build:
     name: Build (${{ matrix.artifact-name }})
@@ -79,6 +81,7 @@ jobs:
     environment: ${{ inputs.environment || '' }}
 
     permissions:
+      contents: read
       # Required for Azure Trusted Signing
       id-token: write
       # Required for vcpkg binary cache

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,9 +58,15 @@ on:
       - ".github/actions/setup-dependencies/**"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   CodeQL:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      security-events: write
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/merge-blocking-pr.yml
+++ b/.github/workflows/merge-blocking-pr.yml
@@ -11,6 +11,8 @@ on:
         required: true
         type: number
 
+permissions: {}
+
 jobs:
   update-blocked-status:
     name: Update Blocked Status

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -66,8 +66,7 @@ on:
       - ".github/workflows/nix.yml"
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 env:
   DEBUG: ${{ github.ref_type != 'tag' }}
@@ -75,6 +74,9 @@ env:
 jobs:
   build:
     name: Build (${{ matrix.system }})
+
+    permissions:
+      contents: read
 
     strategy:
       fail-fast: false

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,12 +4,14 @@ on:
   release:
     types: [ released ]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   winget:
     name: Winget
+
+    permissions:
+      contents: read
 
     runs-on: ubuntu-slim
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,18 @@ on:
     tags:
       - "*"
 
+permissions: {}
+
 jobs:
   build_release:
     name: Build Release
     uses: ./.github/workflows/build.yml
+    permissions:
+      contents: read
+      # Required for Azure Trusted Signing
+      id-token: write
+      # Required for vcpkg binary cache
+      packages: write
     with:
       build-type: Release
       environment: Release
@@ -16,6 +24,8 @@ jobs:
 
   create_release:
     needs: build_release
+    permissions:
+      contents: write
     runs-on: ubuntu-slim
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,6 +6,8 @@ on:
     - cron: "0 0 * * 0"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   label:
     name: Label issues and PRs

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -6,13 +6,16 @@ on:
     - cron: "0 0 * * 0"
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   update-flake:
     if: github.repository == 'PrismLauncher/PrismLauncher'
+
+    permissions:
+      contents: write
+      pull-requests: write
+
     runs-on: ubuntu-slim
 
     steps:


### PR DESCRIPTION
This helps prevent any potential security issues due to runner tokens having unnecessary permissions
