### PR TITLE
Automatically merge major and minor release branches

### DIFF
--- a/.github/actions/merge-branches/action.yml
+++ b/.github/actions/merge-branches/action.yml
@@ -1,0 +1,54 @@
+name: Merge Branches
+description: Merge two sets of branches automatically
+
+inputs:
+  base:
+    description: Base branch to merge into
+    required: true
+  head:
+    description: Head branch to merge
+    required: true
+  token:
+    description: GitHub token used to query the API
+
+outputs:
+  base:
+    description: Base branch to merge into
+    value: ${{ inputs.base }}
+  head:
+    description: Head branch to merge
+    value: ${{ inputs.head }}
+
+runs:
+  using: composite
+
+  steps:
+    - name: Compare branches
+      id: compare
+      shell: bash
+      env:
+        BASE: ${{ inputs.base }}
+        HEAD: ${{ inputs.head }}
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        status="$(gh api "/repos/$GITHUB_REPOSITORY/compare/$BASE...$HEAD" --jq '.status')"
+        echo "status=$status" >> "$GITHUB_OUTPUT"
+
+    - name: Skip merge if branches are identical
+      if: ${{ steps.compare.outputs.status == 'identical' }}
+      shell: bash
+      run: |
+        echo "Base and head branches are identical. Skipping merge." >&2
+
+    - name: Merge branches
+      if: ${{ steps.compare.outputs.status != 'identical' }}
+      shell: bash
+      env:
+        BASE: ${{ inputs.base }}
+        HEAD: ${{ inputs.head }}
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        gh api "/repos/$GITHUB_REPOSITORY/merges" \
+          -F base="$BASE" \
+          -F head="$HEAD" \
+          -F commit_message="chore: automatic merge of $HEAD into $BASE"

--- a/.github/workflows/merge-release-branches.yml
+++ b/.github/workflows/merge-release-branches.yml
@@ -1,0 +1,35 @@
+name: Automatically merge release branches
+
+on:
+  schedule:
+    - cron: '0 */4 * * *'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  merge:
+    name: Merge (${{ matrix.head }} -> ${{ matrix.base }})
+
+    permissions:
+      contents: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - base: release-10.x
+            head: release-10.0.x
+
+    runs-on: ubuntu-slim
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Check and merge branches
+        uses: ./.github/actions/merge-branches
+        with:
+          base: ${{ matrix.base }}
+          head: ${{ matrix.head }}
+          token: ${{ github.token }}


### PR DESCRIPTION
Splitting our major and minor release branches (i.e., `release-10.x` and `release-10.0.x`) will allow us to unblock the many draft backports we currently have. Automatically merging the two will also help prevent the requirement of backporting to *both* branches - as fixes should be backported to `release-10.0.x`, and will always be propagated back "up" to the main release branch
