### PR TITLE
launcher/minecract/auth/AccountList.cpp: add missing QIcon include

### DIFF
--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -39,6 +39,7 @@
 
 #include <QDir>
 #include <QFile>
+#include <QIcon>
 #include <QIODevice>
 #include <QJsonArray>
 #include <QJsonDocument>


### PR DESCRIPTION
In member function ‘virtual QVariant AccountList::data(const QModelIndex&, int) const’: /var/tmp/portage/games-action/prismlauncher-9999/work/prismlauncher-9999/launcher/minecraft/auth/AccountList.cpp:331:35: error: incomplete type ‘QIcon’ used in nested name specifier
  331 |                     return QIcon::fromTheme("noaccount").pixmap(24, 24);
      |

Fixes: fc1e29111bff46ebe9c12277d4edadf7f5f29d8a

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
