### PR TITLE
Remove retrieving Xbox API token for gamertag

### DIFF
--- a/launcher/minecraft/auth/AccountData.cpp
+++ b/launcher/minecraft/auth/AccountData.cpp
@@ -303,7 +303,6 @@ bool AccountData::resumeStateFromV3(QJsonObject data)
         }  // leave msaClientID empty if it doesn't exist or isn't a string
         msaToken = tokenFromJSONV3(data, "msa");
         userToken = tokenFromJSONV3(data, "utoken");
-        xboxApiToken = tokenFromJSONV3(data, "xrp-main");
         mojangservicesToken = tokenFromJSONV3(data, "xrp-mc");
     }
 
@@ -333,7 +332,6 @@ QJsonObject AccountData::saveState() const
         output["msa-client-id"] = msaClientID;
         tokenToJSONV3(output, msaToken, "msa");
         tokenToJSONV3(output, userToken, "utoken");
-        tokenToJSONV3(output, xboxApiToken, "xrp-main");
         tokenToJSONV3(output, mojangservicesToken, "xrp-mc");
     } else if (type == AccountType::Offline) {
         output["type"] = "Offline";
@@ -358,28 +356,10 @@ QString AccountData::profileId() const
 QString AccountData::profileName() const
 {
     if (minecraftProfile.name.size() == 0) {
-        return QObject::tr("No profile (%1)").arg(accountDisplayString());
-    } else {
-        return minecraftProfile.name;
+        return QObject::tr("No Minecraft profile");
     }
-}
 
-QString AccountData::accountDisplayString() const
-{
-    switch (type) {
-        case AccountType::Offline: {
-            return QObject::tr("<Offline>");
-        }
-        case AccountType::MSA: {
-            if (xboxApiToken.extra.contains("gtg")) {
-                return xboxApiToken.extra["gtg"].toString();
-            }
-            return "Xbox profile missing";
-        }
-        default: {
-            return "Invalid Account";
-        }
-    }
+    return minecraftProfile.name;
 }
 
 QString AccountData::lastError() const

--- a/launcher/minecraft/auth/AccountData.h
+++ b/launcher/minecraft/auth/AccountData.h
@@ -95,9 +95,6 @@ struct AccountData {
     QJsonObject saveState() const;
     bool resumeStateFromV3(QJsonObject data);
 
-    //! userName for Mojang accounts, gamertag for MSA
-    QString accountDisplayString() const;
-
     //! Yggdrasil access token, as passed to the game.
     QString accessToken() const;
 
@@ -111,7 +108,6 @@ struct AccountData {
     QString msaClientID;
     Token msaToken;
     Token userToken;
-    Token xboxApiToken;
     Token mojangservicesToken;
 
     Token yggdrasilToken;

--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -338,8 +338,6 @@ QVariant AccountList::data(const QModelIndex& index, int role) const
             switch (index.column()) {
                 case ProfileNameColumn:
                     return account->profileName();
-                case NameColumn:
-                    return account->accountDisplayString();
                 case TypeColumn: {
                     switch (account->accountType()) {
                         case AccountType::MSA: {
@@ -356,9 +354,6 @@ QVariant AccountList::data(const QModelIndex& index, int role) const
                 default:
                     return QVariant();
             }
-
-        case Qt::ToolTipRole:
-            return account->accountDisplayString();
 
         case PointerRole:
             return QVariant::fromValue(account);
@@ -380,8 +375,6 @@ QVariant AccountList::headerData(int section, [[maybe_unused]] Qt::Orientation o
             switch (section) {
                 case ProfileNameColumn:
                     return tr("Username");
-                case NameColumn:
-                    return tr("Account");
                 case TypeColumn:
                     return tr("Type");
                 case StatusColumn:
@@ -394,8 +387,6 @@ QVariant AccountList::headerData(int section, [[maybe_unused]] Qt::Orientation o
             switch (section) {
                 case ProfileNameColumn:
                     return tr("Minecraft username associated with the account.");
-                case NameColumn:
-                    return tr("User name of the account.");
                 case TypeColumn:
                     return tr("Type of the account (MSA or Offline)");
                 case StatusColumn:
@@ -665,7 +656,7 @@ void AccountList::tryNext()
                     connect(m_currentTask.get(), &Task::succeeded, this, &AccountList::authSucceeded);
                     connect(m_currentTask.get(), &Task::failed, this, &AccountList::authFailed);
                     m_currentTask->start();
-                    qDebug() << "RefreshSchedule: Processing account" << account->accountDisplayString() << "with internal ID"
+                    qDebug() << "RefreshSchedule: Processing account" << account->profileName() << "with internal ID"
                              << accountId;
                     return;
                 }

--- a/launcher/minecraft/auth/AccountList.h
+++ b/launcher/minecraft/auth/AccountList.h
@@ -55,7 +55,6 @@ class AccountList : public QAbstractListModel {
     enum VListColumns {
         // TODO: Add icon column.
         ProfileNameColumn = 0,
-        NameColumn,
         TypeColumn,
         StatusColumn,
 

--- a/launcher/minecraft/auth/AuthFlow.cpp
+++ b/launcher/minecraft/auth/AuthFlow.cpp
@@ -31,7 +31,6 @@ AuthFlow::AuthFlow(AccountData* data, Action action) : Task(), m_data(data)
             m_steps.append(oauthStep);
         }
         m_steps.append(makeShared<XboxUserStep>(m_data));
-        m_steps.append(makeShared<XboxAuthorizationStep>(m_data, &m_data->xboxApiToken, "http://xboxlive.com", "Xbox"));
         m_steps.append(
             makeShared<XboxAuthorizationStep>(m_data, &m_data->mojangservicesToken, "rp://api.minecraftservices.com/", "Mojang"));
         m_steps.append(makeShared<LauncherLoginStep>(m_data));

--- a/launcher/minecraft/auth/MinecraftAccount.h
+++ b/launcher/minecraft/auth/MinecraftAccount.h
@@ -104,8 +104,6 @@ class MinecraftAccount : public QObject, public Usable {
    public: /* queries */
     QString internalId() const { return data.internalId; }
 
-    QString accountDisplayString() const { return data.accountDisplayString(); }
-
     QString accessToken() const { return data.accessToken(); }
 
     QString profileId() const { return data.profileId(); }

--- a/launcher/ui/pages/global/AccountListPage.cpp
+++ b/launcher/ui/pages/global/AccountListPage.cpp
@@ -63,7 +63,6 @@ AccountListPage::AccountListPage(QWidget* parent) : QMainWindow(parent), ui(new 
 
     ui->listView->setModel(m_accounts);
     ui->listView->header()->setSectionResizeMode(AccountList::VListColumns::ProfileNameColumn, QHeaderView::Stretch);
-    ui->listView->header()->setSectionResizeMode(AccountList::VListColumns::NameColumn, QHeaderView::Stretch);
     ui->listView->header()->setSectionResizeMode(AccountList::VListColumns::TypeColumn, QHeaderView::ResizeToContents);
     ui->listView->header()->setSectionResizeMode(AccountList::VListColumns::StatusColumn, QHeaderView::ResizeToContents);
     ui->listView->setSelectionMode(QAbstractItemView::SingleSelection);


### PR DESCRIPTION
Blocked on #4957 

The Xbox API token is only used to get the gamertag, which serves no good purpose to us, as the Minecraft profile name is way more important. Some users also may be discontent with seeing their gamertag, as changing it requires payment