### PR TITLE
Turn off debug assertions in Release builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,9 @@ set(CMAKE_C_STANDARD_REQUIRED true)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_C_STANDARD 11)
 include(GenerateExportHeader)
+
+add_compile_definitions($<$<CONFIG:Release>:QT_NO_DEBUG>)
+
 if(MSVC)
     # /GS Adds buffer security checks, default on but incuded anyway to mirror gcc's fstack-protector flag
     # /permissive- specify standards-conforming compiler behavior, also enabled by Qt6, default on with std:c++20


### PR DESCRIPTION
`QT_NO_DEBUG` doesn't touch `qDebug` and friends so we're good