### PR TITLE
Enable Address Sanitizer by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,7 +106,7 @@ if(CMAKE_GENERATOR STREQUAL "Unix Makefiles" OR CMAKE_GENERATOR MATCHES "^Ninja"
     set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 endif()
 
-option(DEBUG_ADDRESS_SANITIZER "Enable Address Sanitizer in Debug builds" OFF)
+option(DEBUG_ADDRESS_SANITIZER "Enable Address Sanitizer in Debug builds" ON)
 
 # If this is a Debug build turn on address sanitiser
 if (DEBUG_ADDRESS_SANITIZER)


### PR DESCRIPTION
If you're not using it in development you're basically handicapping yourself. ASan can do 90% of the work required to debug memory management issues, but not everyone is aware of its presence and that is has to be manually enabled

Configuration expressions prevent sanitizers from being enabled in builds that aren't `Debug` or `RelWithDebInfo`, so its safe to change the default to ON