### PR TITLE
Cache news feed

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -1022,6 +1022,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         m_metacache->addBase("translations", QDir("translations").absolutePath());
         m_metacache->addBase("meta", QDir("meta").absolutePath());
         m_metacache->addBase("java", QDir("cache/java").absolutePath());
+        m_metacache->addBase("feed", QDir("cache/feed").absolutePath());
         m_metacache->Load();
         qInfo() << "<> Cache initialized.";
     }

--- a/launcher/news/NewsChecker.cpp
+++ b/launcher/news/NewsChecker.cpp
@@ -39,6 +39,7 @@
 #include <QDomDocument>
 
 #include <QDebug>
+#include "Application.h"
 
 NewsChecker::NewsChecker(QNetworkAccessManager* network, const QString& feedUrl)
 {
@@ -54,10 +55,12 @@ void NewsChecker::reloadNews()
         return;
     }
 
+    m_entry = APPLICATION->metacache()->resolveEntry("feed", "feed.xml");
+
     qDebug() << "Reloading news.";
 
     NetJob::Ptr job{ new NetJob("News RSS Feed", m_network) };
-    job->addNetAction(Net::Download::makeByteArray(m_feedUrl, newsData.get()));
+    job->addNetAction(Net::Download::makeCached(m_feedUrl, m_entry));
     job->setAskRetry(false);
     connect(job.get(), &NetJob::succeeded, this, &NewsChecker::rssDownloadFinished);
     connect(job.get(), &NetJob::failed, this, &NewsChecker::rssDownloadFailed);
@@ -78,14 +81,16 @@ void NewsChecker::rssDownloadFinished()
         int errorLine = -1;
         int errorCol = -1;
 
-        // Parse the XML.
-        if (!doc.setContent(*newsData, false, &errorMsg, &errorLine, &errorCol)) {
-            QString fullErrorMsg = QString("Error parsing RSS feed XML. %1 at %2:%3.").arg(errorMsg).arg(errorLine).arg(errorCol);
-            fail(fullErrorMsg);
-            newsData->clear();
-            return;
+        QFile feed(m_entry->getFullPath());
+
+        if (feed.open(QFile::ReadOnly | QFile::Text)) {
+            QTextStream in(&feed);
+            // Parse the XML.
+            if (!doc.setContent(in.readAll(), false, &errorMsg, &errorLine, &errorCol)) {
+                fail(QString("Error parsing RSS feed XML. %1 at %2:%3.").arg(errorMsg).arg(errorLine).arg(errorCol));
+                return;
+            }
         }
-        newsData->clear();
     }
 
     // If the parsing succeeded, read it.

--- a/launcher/news/NewsChecker.h
+++ b/launcher/news/NewsChecker.h
@@ -84,7 +84,8 @@ class NewsChecker : public QObject {
     //! True if news has been loaded.
     bool m_loadedNews;
 
-    std::unique_ptr<QByteArray> newsData = std::make_unique<QByteArray>();
+    //! The cache entry for the feed.
+    MetaEntryPtr m_entry;
 
     /*!
      * Gets the error message that was given last time the news was loaded.


### PR DESCRIPTION
Caches news feed based on headers returned by our web server.

This is currently configured to be cached for 24h: https://github.com/PrismLauncher/prismlauncher.org/commit/33adb84343f2db0634859a7a0b659d0e536e5e16
