### PR TITLE
fix: queue search jobs in create modpack UI 

### DIFF
--- a/launcher/ui/pages/modplatform/flame/FlameModel.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameModel.cpp
@@ -201,8 +201,15 @@ void ListModel::performPaginatedSearch()
                                        m_filter->versions, ModPlatform::Side::NoSide, m_filter->categoryIds, m_filter->openSource },
                                      std::move(callbacks));
 
-    m_jobPtr = netJob;
-    m_jobPtr->start();
+    if (m_jobPtr && m_jobPtr->isRunning()) { // HACK(@Octol1ttle): See PrismLauncher#4965
+        connect(m_jobPtr.get(), &Task::succeeded, this, [this, netJob] {
+            m_jobPtr = netJob;
+            m_jobPtr->start();
+        });
+    } else {
+        m_jobPtr = netJob;
+        m_jobPtr->start();
+    }
 }
 
 void ListModel::searchWithTerm(const QString& term, int sort, std::shared_ptr<ModFilterWidget::Filter> filter, bool filterChanged)

--- a/launcher/ui/pages/modplatform/flame/FlamePage.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.cpp
@@ -205,8 +205,15 @@ void FlamePage::onSelectionChanged(QModelIndex curr, [[maybe_unused]] QModelInde
 
         auto netJob = api.getProjectVersions({ m_current, {}, {}, ModPlatform::ResourceType::Modpack }, std::move(callbacks));
 
-        m_job = netJob;
-        netJob->start();
+        if (m_job && m_job->isRunning()) { // HACK(@Octol1ttle): See PrismLauncher#4965
+            connect(m_job.get(), &Task::succeeded, this, [this, netJob] {
+                m_job = netJob;
+                m_job->start();
+            });
+        } else {
+            m_job = netJob;
+            m_job->start();
+        }
     } else {
         for (auto version : m_current->versions) {
             m_ui->versionSelectionBox->addItem(version.version, QVariant(version.downloadUrl));

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
@@ -167,8 +167,15 @@ void ModrinthPage::onSelectionChanged(QModelIndex curr, [[maybe_unused]] QModelI
             updateUI();
         };
         if (auto netJob = m_api.getProjectInfo({ m_current }, std::move(callbacks)); netJob) {
-            m_job = netJob;
-            m_job->start();
+            if (m_job && m_job->isRunning()) { // HACK(@Octol1ttle): See PrismLauncher#4965
+                connect(m_job.get(), &Task::succeeded, this, [this, netJob] {
+                    m_job = netJob;
+                    m_job->start();
+                });
+            } else {
+                m_job = netJob;
+                m_job->start();
+            }
         }
 
     } else
@@ -220,8 +227,15 @@ void ModrinthPage::onSelectionChanged(QModelIndex curr, [[maybe_unused]] QModelI
 
         auto netJob = m_api.getProjectVersions({ m_current, {}, {}, ModPlatform::ResourceType::Modpack }, std::move(callbacks));
 
-        m_job2 = netJob;
-        m_job2->start();
+        if (m_job2 && m_job2->isRunning()) { // HACK(@Octol1ttle): See PrismLauncher#4965
+            connect(m_job2.get(), &Task::succeeded, this, [this, netJob] {
+                m_job2 = netJob;
+                m_job2->start();
+            });
+        } else {
+            m_job2 = netJob;
+            m_job2->start();
+        }
 
     } else {
         for (auto version : m_current->versions) {


### PR DESCRIPTION
Closes #4962

Launching a new search drops the old one and deallocates the `NetJob` for it. The result of that is this connection will be deleted ([Qt docs](https://doc.qt.io/qt-6/qobject.html#connect-2): `The connection will automatically disconnect if the sender is destroyed.`):
https://github.com/PrismLauncher/PrismLauncher/blob/f1a4721a6abfad460c4f9cde4cd996949204399a/launcher/modplatform/ResourceAPI.cpp#L21-L26

The lambda-captured `response` will be dropped, its reference count will go to zero and the `QByteArray` will be destroyed while it may still be in use by a `ByteArraySink`.

Thanks @DioEgizio for getting an ASan trace and testing the fix