### PR TITLE
Fix InstanceStaging reentry crash during Modrinth pack updates

### DIFF
--- a/launcher/InstanceList.cpp
+++ b/launcher/InstanceList.cpp
@@ -928,6 +928,7 @@ class InstanceStaging : public Task {
         connect(child, &Task::progress, this, &InstanceStaging::setProgress);
         connect(child, &Task::stepProgress, this, &InstanceStaging::propagateStepProgress);
         connect(&m_backoffTimer, &QTimer::timeout, this, &InstanceStaging::childSucceeded);
+        m_backoffTimer.setSingleShot(true);
     }
 
     virtual ~InstanceStaging() {}
@@ -959,13 +960,17 @@ class InstanceStaging : public Task {
    private slots:
     void childSucceeded()
     {
+        if (!isRunning())
+            return;
         unsigned sleepTime = backoff();
         if (m_parent->commitStagedInstance(m_stagingPath, *m_child.get(), m_child->group(), *m_child.get())) {
+            m_backoffTimer.stop();
             emitSucceeded();
             return;
         }
         // we actually failed, retry?
         if (sleepTime == maxBackoff) {
+            m_backoffTimer.stop();
             emitFailed(tr("Failed to commit instance, even after multiple retries. It is being blocked by something."));
             return;
         }
@@ -974,12 +979,14 @@ class InstanceStaging : public Task {
     }
     void childFailed(const QString& reason)
     {
+        m_backoffTimer.stop();
         m_parent->destroyStagingPath(m_stagingPath);
         emitFailed(reason);
     }
 
     void childAborted()
     {
+        m_backoffTimer.stop();
         m_parent->destroyStagingPath(m_stagingPath);
         emitAborted();
     }


### PR DESCRIPTION
## Summary
- set `InstanceStaging` backoff timer to single-shot
- stop the backoff timer on success, failure, and abort
- ignore late `childSucceeded()` callbacks when the task is no longer running

## Root Cause
`InstanceStaging::childSucceeded()` could be re-entered by the retry timer after the task already transitioned out of `Running`, which triggered `Task::emitSucceeded()` assertion checks and aborted the app.

## Impact
Prevents SIGABRT crashes while updating or importing managed Modrinth packs when commit retries race with task completion.

## Testing
- `clang-format --dry-run -Werror --style=file:.clang-format launcher/InstanceList.cpp`
- functional verification: update a managed Modrinth pack and confirm no crash
