### PR TITLE
docs(README): use prismlauncher.org/nightly redirect for dev builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Please understand that these builds are not intended for most users. There may b
 There are development builds available through:
 
 - [GitHub Actions](https://github.com/PrismLauncher/PrismLauncher/actions) (includes builds from pull requests opened by contributors)
-- [nightly.link](https://nightly.link/PrismLauncher/PrismLauncher/workflows/build/develop) (this will always point only to the latest version of develop)
+- [nightly.link](https://prismlauncher.org/nightly) (this will always point only to the latest version of develop)
 
 These have debug information in the binaries, so their file sizes are relatively larger.
 


### PR DESCRIPTION
nightly.link can't find our artifacts automatically anymore due to the build workflow being run in the merge queue, which is in the context of a temp branch and not `develop` itself. This rediret introduced in https://github.com/PrismLauncher/prismlauncher.org/pull/1073 works around this by making some API calls to find the run ID of the latest merge queue job, and then redirecting to nightly.link with it
