### PR TITLE
URL protocol modpack import for any encoded URL

### DIFF
--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -48,6 +48,7 @@
 #include <QDir>
 #include <QFileInfo>
 #include <QUrl>
+#include <QUrlQuery>
 #include <QVariant>
 
 #include <QAction>

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -940,6 +940,11 @@ void MainWindow::processURLs(QList<QUrl> urls)
         QMap<QString, QString> extra_info;
         QUrl local_url;
         if (!url.isLocalFile()) {  // download the remote resource and identify
+
+            const bool isExternalURLImport =
+                (url.host().toLower() == "import") ||
+                (url.path().startsWith("/import", Qt::CaseInsensitive));
+
             QUrl dl_url;
             if (url.scheme() == "curseforge") {
                 // need to find the download link for the modpack / resource
@@ -993,7 +998,7 @@ void MainWindow::processURLs(QList<QUrl> urls)
                     dlUrlDialod.execWithTask(job.get());
                 }
 
-            } else if (url.scheme() == BuildConfig.LAUNCHER_APP_BINARY_NAME) {
+            } else if (url.scheme() == BuildConfig.LAUNCHER_APP_BINARY_NAME && !isExternalURLImport) {
                 QVariantMap receivedData;
                 const QUrlQuery query(url.query());
                 const auto items = query.queryItems();
@@ -1001,6 +1006,77 @@ void MainWindow::processURLs(QList<QUrl> urls)
                     receivedData.insert(it->first, it->second);
                 emit APPLICATION->oauthReplyRecieved(receivedData);
                 continue;
+            } else if (url.scheme() == "prismlauncher" && isExternalURLImport) {
+                // PrismLauncher URL protocol modpack import
+                // works for any prism fork
+                // preferred import format: <scheme>://import?url=ENCODED
+
+                const auto host = url.host().toLower();
+                const auto path = url.path(); 
+
+                QString encodedTarget;
+
+                {
+                    QUrlQuery query(url);
+                    const auto values = query.allQueryItemValues("url");
+                    if (!values.isEmpty()) {
+                        encodedTarget = values.first();
+                    }
+                }
+
+                // alternative import format: <scheme>://import/ENCODED
+                if (encodedTarget.isEmpty()) {
+
+                    QString p = path;
+
+                    if (p.startsWith("/import/", Qt::CaseInsensitive)) {
+                        p = p.mid(QString("/import/").size());
+                    } else if (host == "import" && p.startsWith("/")) {
+                        p = p.mid(1);
+                    }
+
+                    if (!p.isEmpty() && p != "/import") {
+                        encodedTarget = p;
+                    }
+                }
+
+                if (encodedTarget.isEmpty()) {
+                    CustomMessageBox::selectable(
+                        this,
+                        tr("Error"),
+                        tr("Invalid import link: missing 'url' parameter."),
+                        QMessageBox::Critical
+                    )->show();
+                    continue;
+                }
+
+                const QString decodedStr = QUrl::fromPercentEncoding(encodedTarget.toUtf8()).trimmed();
+
+                QUrl target = QUrl::fromUserInput(decodedStr);
+
+                // Validate: only allow http(s)
+                if (!target.isValid() || (target.scheme() != "https" && target.scheme() != "http")) {
+                    CustomMessageBox::selectable(
+                        this,
+                        tr("Error"),
+                        tr("Invalid import link: URL must be http(s)."),
+                        QMessageBox::Critical
+                    )->show();
+                    continue;
+                }
+
+                const auto res = QMessageBox::question(
+                    this,
+                    tr("Install modpack"),
+                    tr("Do you want to download and import a modpack from:\n%1\n\nURL:\n%2")
+                        .arg(target.host(), target.toString()),
+                    QMessageBox::Yes | QMessageBox::No,
+                    QMessageBox::Yes
+                );
+                if (res != QMessageBox::Yes) {
+                    continue;
+                }
+            
             } else {
                 dl_url = url;
             }

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -1012,7 +1012,6 @@ void MainWindow::processURLs(QList<QUrl> urls)
                 // PrismLauncher URL protocol modpack import
                 // works for any prism fork
                 // preferred import format: prismlauncher://import?url=ENCODED
-
                 const auto host = url.host().toLower();
                 const auto path = url.path(); 
 

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -1007,10 +1007,11 @@ void MainWindow::processURLs(QList<QUrl> urls)
                     receivedData.insert(it->first, it->second);
                 emit APPLICATION->oauthReplyRecieved(receivedData);
                 continue;
-            } else if (url.scheme() == "prismlauncher" && isExternalURLImport) {
+            } else if ((url.scheme() == "prismlauncher" || url.scheme() == BuildConfig.LAUNCHER_APP_BINARY_NAME) 
+                        && isExternalURLImport) {
                 // PrismLauncher URL protocol modpack import
                 // works for any prism fork
-                // preferred import format: <scheme>://import?url=ENCODED
+                // preferred import format: prismlauncher://import?url=ENCODED
 
                 const auto host = url.host().toLower();
                 const auto path = url.path(); 
@@ -1025,7 +1026,7 @@ void MainWindow::processURLs(QList<QUrl> urls)
                     }
                 }
 
-                // alternative import format: <scheme>://import/ENCODED
+                // alternative import format: prismlauncher://import/ENCODED
                 if (encodedTarget.isEmpty()) {
 
                     QString p = path;
@@ -1078,6 +1079,7 @@ void MainWindow::processURLs(QList<QUrl> urls)
                     continue;
                 }
             
+                dl_url = target;
             } else {
                 dl_url = url;
             }

--- a/program_info/win_install.nsi.in
+++ b/program_info/win_install.nsi.in
@@ -397,6 +397,10 @@ Section "@Launcher_DisplayName@"
   WriteRegStr HKCU Software\Classes\@Launcher_APP_BINARY_NAME@ "URL Protocol" ""
   WriteRegStr HKCU Software\Classes\@Launcher_APP_BINARY_NAME@\shell\open\command "" '"$INSTDIR\@Launcher_APP_BINARY_NAME@.exe" "%1"'
 
+  ; Write the URL Handler into registry for prismlauncher import
+  WriteRegStr HKCU Software\Classes\prismlauncher "URL Protocol" ""
+  WriteRegStr HKCU Software\Classes\prismlauncher\shell\open\command "" '"$INSTDIR\@Launcher_APP_BINARY_NAME@.exe" "%1"'
+
   ; Write the uninstall keys for Windows
   ; https://learn.microsoft.com/en-us/windows/win32/msi/uninstall-registry-key
   ${GetParameters} $R0


### PR DESCRIPTION
PR adds support for importing modpacks via external **`prismlauncher://import`** links. In short, this adds possibility for user to download modpack with a "single click" via a pre-prepared link provided by the modpack creator.

Motivation: 

Expands the possibilities for modpack distribution on: various websites, Discord servers, Github, etc not limited to only Modrinth and Curseforge. 
Useful for regions that lack convenient modpack distribution, as Cloudflare (and Curseforge) or Modrinth may be blocked (for example, in Russia)

Description:

* Detects “external URL import” links and extracts the encoded target URL from either `?url=...` or the `/import/...` path form
* Validates the decoded target (http/https only) and prompts the user for confirmation before importing.

Example of using feature: 

`prismlauncher://import?url=https%3A%2F%2Fcdn.modrinth.com%2Fdata%2F1KVo5zza%2Fversions%2FzF1GaleB%2FFabulously.Optimized-v12.0.1.mrpack` (should work in any prism fork because of my edit in win_install.nsi.in)

OR

`forkname://import?url=https%3A%2F%2Fgithub.com%2FFabulously-Optimized%2Ffabulously-optimized%2Freleases%2Fdownload%2Fv12.0.1%2FFabulously.Optimized-12.0.1.zip`