### PR TITLE
Fix hard to read menu bar colors on MacOS

### DIFF
--- a/launcher/ui/themes/ThemeManager.mm
+++ b/launcher/ui/themes/ThemeManager.mm
@@ -31,15 +31,6 @@ void ThemeManager::setTitlebarColorOnMac(WId windowId, QColor color)
     window.titlebarAppearsTransparent = YES;
     window.backgroundColor = [NSColor colorWithRed:color.redF() green:color.greenF() blue:color.blueF() alpha:color.alphaF()];
 
-    // Unfortunately there seems to be no easy way to set the titlebar text color.
-    // The closest we can do without dubious hacks is set the dark/light mode state based on the brightness of the
-    // background color, which should at least make the text readable even if we can't use the theme's text color.
-    // It's a good idea to set this anyway since it also affects some other UI elements like text shadows (PrismLauncher#3825).
-    if (color.lightnessF() < 0.5) {
-        window.appearance = [NSAppearance appearanceNamed:NSAppearanceNameDarkAqua];
-    } else {
-        window.appearance = [NSAppearance appearanceNamed:NSAppearanceNameAqua];
-    }
 }
 
 void ThemeManager::setTitlebarColorOfAllWindowsOnMac(QColor color)


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
Fixes #4783

Removes code that changes the MacOS menu bar to a dark or light background depending on selected theme. 

While the code changes the menu bar background color, it does not affect the menu bar text color. 

As a result, if your system is on dark appearance, the menu bar text color will always be white. When a white theme is selected, that code changes the menu bar background to white which makes the text super hard to read.

The reverse also happened on system light appearance. The text color is always dark, so changing the background to dark makes the background and text color match as shown in the issue.

In addition, changing the menu bar background like this also causes visible flashing behavior where is starts one color then visibly quickly changes to what is set based on the theme selected.

In my opinion, the menu bar should not be recolored. If we leave it be, It should always be readable.
It just might not match the users selected theme exactly. I think this is preferable to it matching the theme but being hard to read and causing strange color change visuals.

Researching other MacOs apps, it looks like most of them just rely on the system appearance for menu bar color and don't try to change it even if it does not match the theme.
