### PR TITLE
fix crash with skin format

### DIFF
--- a/launcher/minecraft/skins/SkinModel.cpp
+++ b/launcher/minecraft/skins/SkinModel.cpp
@@ -58,7 +58,7 @@ static QImage improveSkin(QImage skin)
     // It seems some older skins may use this format, which can't be drawn onto
     // https://github.com/PrismLauncher/PrismLauncher/issues/4032
     // https://doc.qt.io/qt-6/qpainter.html#begin
-    if (skin.format() == QImage::Format_Indexed8) {
+    if (skin.format() <= QImage::Format_Indexed8 || !skin.hasAlphaChannel()) {
         skin = skin.convertToFormat(QImage::Format_ARGB32);
     }
 


### PR DESCRIPTION
fixes #4994
All the formats lower than Format_Indexed8 will have less information and can't be used directly.
Also added the check for alphaChannel check just to be sure.

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
