### PR TITLE
feat(mods): highlight incompatible mods in red

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -326,6 +326,8 @@ set(MINECRAFT_SOURCES
     minecraft/mod/MetadataHandler.h
     minecraft/mod/Mod.h
     minecraft/mod/Mod.cpp
+    minecraft/mod/ModCompatibility.h
+    minecraft/mod/ModCompatibility.cpp
     minecraft/mod/ModDetails.h
     minecraft/mod/ModFolderModel.h
     minecraft/mod/ModFolderModel.cpp

--- a/launcher/minecraft/mod/ModCompatibility.cpp
+++ b/launcher/minecraft/mod/ModCompatibility.cpp
@@ -32,7 +32,6 @@ namespace {
 
 [[nodiscard]] QString normalizedVersionString(QString version)
 {
-    version = version.trimmed();
     if (version.startsWith("v", Qt::CaseInsensitive)) {
         version.remove(0, 1);
     }
@@ -41,17 +40,12 @@ namespace {
 
 [[nodiscard]] bool startsWithVersionComparator(const QString& value)
 {
-    auto trimmedValue = value.trimmed();
-    return trimmedValue.startsWith(">=") || trimmedValue.startsWith("<=") || trimmedValue.startsWith('>') || trimmedValue.startsWith('<') ||
-           trimmedValue.startsWith('=');
+    return value.startsWith(">=") || value.startsWith("<=") || value.startsWith('>') || value.startsWith('<') || value.startsWith('=');
 }
 
-[[nodiscard]] bool supportsWildcardPrefix(QString prefix, const QString& instanceMinecraftVersion)
+[[nodiscard]] bool supportsWildcardPrefix(const QString& prefix, const QString& normalizedInstanceVersion)
 {
-    auto normalizedInstanceVersion = normalizedVersionString(instanceMinecraftVersion);
-    prefix = normalizedVersionString(std::move(prefix));
-
-    if (prefix.isEmpty() || normalizedInstanceVersion.isEmpty()) {
+    if (prefix.isEmpty()) {
         return false;
     }
 
@@ -62,12 +56,12 @@ namespace {
     return normalizedInstanceVersion.startsWith(prefix + ".", Qt::CaseInsensitive);
 }
 
-[[nodiscard]] bool compareWithConstraint(const QString& instanceVersion, const QString& operation, const QString& versionConstraint)
+[[nodiscard]] bool compareWithConstraint(const QString& normalizedInstanceVersion,
+                                         const QString& operation,
+                                         const QString& versionConstraint)
 {
-    auto normalizedInstanceVersion = normalizedVersionString(instanceVersion);
     auto normalizedConstraint = normalizedVersionString(versionConstraint);
-
-    if (normalizedInstanceVersion.isEmpty() || normalizedConstraint.isEmpty()) {
+    if (normalizedConstraint.isEmpty()) {
         return false;
     }
 
@@ -95,44 +89,46 @@ namespace {
 
 [[nodiscard]] bool supportsSingleVersionPattern(const QString& pattern, const QString& instanceMinecraftVersion)
 {
-    auto trimmedPattern = pattern.trimmed();
-    auto normalizedInstanceVersion = normalizedVersionString(instanceMinecraftVersion);
-    if (trimmedPattern.isEmpty() || normalizedInstanceVersion.isEmpty()) {
+    if (pattern.isEmpty()) {
         return false;
     }
 
-    if (trimmedPattern == "*") {
+    auto normalizedPattern = normalizedVersionString(pattern);
+    if (normalizedPattern.isEmpty()) {
+        return false;
+    }
+
+    if (normalizedPattern == "*") {
         return true;
     }
 
-    auto normalizedPattern = normalizedVersionString(trimmedPattern);
-    if (normalizedPattern.compare(normalizedInstanceVersion, Qt::CaseInsensitive) == 0) {
+    if (normalizedPattern.compare(instanceMinecraftVersion, Qt::CaseInsensitive) == 0) {
         return true;
     }
 
-    if (trimmedPattern.endsWith(".x", Qt::CaseInsensitive)) {
-        auto prefix = trimmedPattern.left(trimmedPattern.size() - 2);
-        return supportsWildcardPrefix(prefix, normalizedInstanceVersion);
+    if (normalizedPattern.endsWith(".x", Qt::CaseInsensitive)) {
+        auto prefix = normalizedPattern.left(normalizedPattern.size() - 2);
+        return supportsWildcardPrefix(prefix, instanceMinecraftVersion);
     }
 
-    if (trimmedPattern.endsWith(".*", Qt::CaseInsensitive)) {
-        auto prefix = trimmedPattern.left(trimmedPattern.size() - 2);
-        return supportsWildcardPrefix(prefix, normalizedInstanceVersion);
+    if (normalizedPattern.endsWith(".*", Qt::CaseInsensitive)) {
+        auto prefix = normalizedPattern.left(normalizedPattern.size() - 2);
+        return supportsWildcardPrefix(prefix, instanceMinecraftVersion);
     }
 
     static const QRegularExpression s_comparatorPattern("^\\s*(<=|>=|<|>|=)\\s*(.+?)\\s*$");
-    if (auto comparatorMatch = s_comparatorPattern.match(trimmedPattern); comparatorMatch.hasMatch()) {
+    if (auto comparatorMatch = s_comparatorPattern.match(normalizedPattern); comparatorMatch.hasMatch()) {
         auto operation = comparatorMatch.captured(1);
         auto constraint = comparatorMatch.captured(2);
-        return compareWithConstraint(normalizedInstanceVersion, operation, constraint);
+        return compareWithConstraint(instanceMinecraftVersion, operation, constraint);
     }
 
     static const QRegularExpression s_rangePattern("^\\s*(.+?)\\s+-\\s+(.+?)\\s*$");
-    if (auto rangeMatch = s_rangePattern.match(trimmedPattern); rangeMatch.hasMatch()) {
+    if (auto rangeMatch = s_rangePattern.match(normalizedPattern); rangeMatch.hasMatch()) {
         auto lowerBound = rangeMatch.captured(1);
         auto upperBound = rangeMatch.captured(2);
-        return compareWithConstraint(normalizedInstanceVersion, ">=", lowerBound) &&
-               compareWithConstraint(normalizedInstanceVersion, "<=", upperBound);
+        return compareWithConstraint(instanceMinecraftVersion, ">=", lowerBound) &&
+               compareWithConstraint(instanceMinecraftVersion, "<=", upperBound);
     }
 
     return false;
@@ -140,13 +136,13 @@ namespace {
 
 [[nodiscard]] bool supportsVersionPattern(const QString& pattern, const QString& instanceMinecraftVersion)
 {
-    auto trimmedPattern = pattern.trimmed();
-    if (trimmedPattern.isEmpty()) {
+    if (pattern.isEmpty()) {
         return false;
     }
 
-    if (trimmedPattern.contains("||")) {
-        for (auto const& alternative : trimmedPattern.split("||", Qt::SkipEmptyParts)) {
+    static const QRegularExpression s_orSplitPattern("\\s*\\|\\|\\s*");
+    if (pattern.contains("||")) {
+        for (auto const& alternative : pattern.split(s_orSplitPattern, Qt::SkipEmptyParts)) {
             if (supportsVersionPattern(alternative, instanceMinecraftVersion)) {
                 return true;
             }
@@ -154,8 +150,9 @@ namespace {
         return false;
     }
 
-    if (trimmedPattern.contains(',')) {
-        auto alternatives = trimmedPattern.split(',', Qt::SkipEmptyParts);
+    static const QRegularExpression s_commaSplitPattern("\\s*,\\s*");
+    if (pattern.contains(',')) {
+        auto alternatives = pattern.split(s_commaSplitPattern, Qt::SkipEmptyParts);
         bool allConstraints = std::all_of(alternatives.cbegin(), alternatives.cend(),
                                           [](const QString& alternative) { return startsWithVersionComparator(alternative); });
 
@@ -176,7 +173,8 @@ namespace {
         return false;
     }
 
-    auto whitespaceParts = trimmedPattern.split(QRegularExpression("\\s+"), Qt::SkipEmptyParts);
+    static const QRegularExpression s_whitespaceSplitPattern("\\s+");
+    auto whitespaceParts = pattern.split(s_whitespaceSplitPattern, Qt::SkipEmptyParts);
     if (whitespaceParts.size() > 1) {
         bool allConstraints = std::all_of(whitespaceParts.cbegin(), whitespaceParts.cend(),
                                           [](const QString& part) { return startsWithVersionComparator(part); });
@@ -191,7 +189,7 @@ namespace {
         }
     }
 
-    return supportsSingleVersionPattern(trimmedPattern, instanceMinecraftVersion);
+    return supportsSingleVersionPattern(pattern, instanceMinecraftVersion);
 }
 
 }  // namespace
@@ -200,12 +198,13 @@ namespace ModCompatibility {
 
 bool supportsMinecraftVersion(const QStringList& supportedVersions, const QString& instanceMinecraftVersion)
 {
-    if (supportedVersions.isEmpty() || instanceMinecraftVersion.trimmed().isEmpty()) {
+    auto normalizedInstanceVersion = normalizedVersionString(instanceMinecraftVersion);
+    if (supportedVersions.isEmpty() || normalizedInstanceVersion.isEmpty()) {
         return true;
     }
 
     for (auto const& supportedVersion : supportedVersions) {
-        if (supportsVersionPattern(supportedVersion, instanceMinecraftVersion)) {
+        if (supportsVersionPattern(supportedVersion, normalizedInstanceVersion)) {
             return true;
         }
     }

--- a/launcher/minecraft/mod/ModCompatibility.cpp
+++ b/launcher/minecraft/mod/ModCompatibility.cpp
@@ -45,10 +45,6 @@ namespace {
 
 [[nodiscard]] bool supportsWildcardPrefix(const QString& prefix, const QString& normalizedInstanceVersion)
 {
-    if (prefix.isEmpty()) {
-        return false;
-    }
-
     if (normalizedInstanceVersion.compare(prefix, Qt::CaseInsensitive) == 0) {
         return true;
     }
@@ -61,10 +57,6 @@ namespace {
                                          const QString& versionConstraint)
 {
     auto normalizedConstraint = normalizedVersionString(versionConstraint);
-    if (normalizedConstraint.isEmpty()) {
-        return false;
-    }
-
     Version instance{ normalizedInstanceVersion };
     Version constraint{ normalizedConstraint };
 
@@ -89,15 +81,7 @@ namespace {
 
 [[nodiscard]] bool supportsSingleVersionPattern(const QString& pattern, const QString& instanceMinecraftVersion)
 {
-    if (pattern.isEmpty()) {
-        return false;
-    }
-
     auto normalizedPattern = normalizedVersionString(pattern);
-    if (normalizedPattern.isEmpty()) {
-        return false;
-    }
-
     if (normalizedPattern == "*") {
         return true;
     }
@@ -136,10 +120,6 @@ namespace {
 
 [[nodiscard]] bool supportsVersionPattern(const QString& pattern, const QString& instanceMinecraftVersion)
 {
-    if (pattern.isEmpty()) {
-        return false;
-    }
-
     static const QRegularExpression s_orSplitPattern("\\s*\\|\\|\\s*");
     if (pattern.contains("||")) {
         for (auto const& alternative : pattern.split(s_orSplitPattern, Qt::SkipEmptyParts)) {
@@ -199,7 +179,7 @@ namespace ModCompatibility {
 bool supportsMinecraftVersion(const QStringList& supportedVersions, const QString& instanceMinecraftVersion)
 {
     auto normalizedInstanceVersion = normalizedVersionString(instanceMinecraftVersion);
-    if (supportedVersions.isEmpty() || normalizedInstanceVersion.isEmpty()) {
+    if (supportedVersions.isEmpty()) {
         return true;
     }
 

--- a/launcher/minecraft/mod/ModCompatibility.cpp
+++ b/launcher/minecraft/mod/ModCompatibility.cpp
@@ -1,0 +1,230 @@
+// SPDX-FileCopyrightText: 2026 abhicommands <114682464+abhicommands@users.noreply.github.com>
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2026 abhicommands <114682464+abhicommands@users.noreply.github.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "ModCompatibility.h"
+
+#include <algorithm>
+
+#include <QRegularExpression>
+
+#include "Version.h"
+#include "minecraft/mod/Resource.h"
+
+namespace {
+
+[[nodiscard]] QString normalizedVersionString(QString version)
+{
+    version = version.trimmed();
+    if (version.startsWith("v", Qt::CaseInsensitive)) {
+        version.remove(0, 1);
+    }
+    return version;
+}
+
+[[nodiscard]] bool startsWithVersionComparator(const QString& value)
+{
+    auto trimmedValue = value.trimmed();
+    return trimmedValue.startsWith(">=") || trimmedValue.startsWith("<=") || trimmedValue.startsWith('>') || trimmedValue.startsWith('<') ||
+           trimmedValue.startsWith('=');
+}
+
+[[nodiscard]] bool supportsWildcardPrefix(QString prefix, const QString& instanceMinecraftVersion)
+{
+    auto normalizedInstanceVersion = normalizedVersionString(instanceMinecraftVersion);
+    prefix = normalizedVersionString(std::move(prefix));
+
+    if (prefix.isEmpty() || normalizedInstanceVersion.isEmpty()) {
+        return false;
+    }
+
+    if (normalizedInstanceVersion.compare(prefix, Qt::CaseInsensitive) == 0) {
+        return true;
+    }
+
+    return normalizedInstanceVersion.startsWith(prefix + ".", Qt::CaseInsensitive);
+}
+
+[[nodiscard]] bool compareWithConstraint(const QString& instanceVersion, const QString& operation, const QString& versionConstraint)
+{
+    auto normalizedInstanceVersion = normalizedVersionString(instanceVersion);
+    auto normalizedConstraint = normalizedVersionString(versionConstraint);
+
+    if (normalizedInstanceVersion.isEmpty() || normalizedConstraint.isEmpty()) {
+        return false;
+    }
+
+    Version instance{ normalizedInstanceVersion };
+    Version constraint{ normalizedConstraint };
+
+    if (operation == ">=") {
+        return instance >= constraint;
+    }
+    if (operation == "<=") {
+        return instance <= constraint;
+    }
+    if (operation == ">") {
+        return instance > constraint;
+    }
+    if (operation == "<") {
+        return instance < constraint;
+    }
+    if (operation == "=") {
+        return instance == constraint;
+    }
+
+    return false;
+}
+
+[[nodiscard]] bool supportsSingleVersionPattern(const QString& pattern, const QString& instanceMinecraftVersion)
+{
+    auto trimmedPattern = pattern.trimmed();
+    auto normalizedInstanceVersion = normalizedVersionString(instanceMinecraftVersion);
+    if (trimmedPattern.isEmpty() || normalizedInstanceVersion.isEmpty()) {
+        return false;
+    }
+
+    if (trimmedPattern == "*") {
+        return true;
+    }
+
+    auto normalizedPattern = normalizedVersionString(trimmedPattern);
+    if (normalizedPattern.compare(normalizedInstanceVersion, Qt::CaseInsensitive) == 0) {
+        return true;
+    }
+
+    if (trimmedPattern.endsWith(".x", Qt::CaseInsensitive)) {
+        auto prefix = trimmedPattern.left(trimmedPattern.size() - 2);
+        return supportsWildcardPrefix(prefix, normalizedInstanceVersion);
+    }
+
+    if (trimmedPattern.endsWith(".*", Qt::CaseInsensitive)) {
+        auto prefix = trimmedPattern.left(trimmedPattern.size() - 2);
+        return supportsWildcardPrefix(prefix, normalizedInstanceVersion);
+    }
+
+    static const QRegularExpression s_comparatorPattern("^\\s*(<=|>=|<|>|=)\\s*(.+?)\\s*$");
+    if (auto comparatorMatch = s_comparatorPattern.match(trimmedPattern); comparatorMatch.hasMatch()) {
+        auto operation = comparatorMatch.captured(1);
+        auto constraint = comparatorMatch.captured(2);
+        return compareWithConstraint(normalizedInstanceVersion, operation, constraint);
+    }
+
+    static const QRegularExpression s_rangePattern("^\\s*(.+?)\\s+-\\s+(.+?)\\s*$");
+    if (auto rangeMatch = s_rangePattern.match(trimmedPattern); rangeMatch.hasMatch()) {
+        auto lowerBound = rangeMatch.captured(1);
+        auto upperBound = rangeMatch.captured(2);
+        return compareWithConstraint(normalizedInstanceVersion, ">=", lowerBound) &&
+               compareWithConstraint(normalizedInstanceVersion, "<=", upperBound);
+    }
+
+    return false;
+}
+
+[[nodiscard]] bool supportsVersionPattern(const QString& pattern, const QString& instanceMinecraftVersion)
+{
+    auto trimmedPattern = pattern.trimmed();
+    if (trimmedPattern.isEmpty()) {
+        return false;
+    }
+
+    if (trimmedPattern.contains("||")) {
+        for (auto const& alternative : trimmedPattern.split("||", Qt::SkipEmptyParts)) {
+            if (supportsVersionPattern(alternative, instanceMinecraftVersion)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    if (trimmedPattern.contains(',')) {
+        auto alternatives = trimmedPattern.split(',', Qt::SkipEmptyParts);
+        bool allConstraints = std::all_of(alternatives.cbegin(), alternatives.cend(),
+                                          [](const QString& alternative) { return startsWithVersionComparator(alternative); });
+
+        if (allConstraints) {
+            for (auto const& constraint : alternatives) {
+                if (!supportsSingleVersionPattern(constraint, instanceMinecraftVersion)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        for (auto const& alternative : alternatives) {
+            if (supportsSingleVersionPattern(alternative, instanceMinecraftVersion)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    auto whitespaceParts = trimmedPattern.split(QRegularExpression("\\s+"), Qt::SkipEmptyParts);
+    if (whitespaceParts.size() > 1) {
+        bool allConstraints = std::all_of(whitespaceParts.cbegin(), whitespaceParts.cend(),
+                                          [](const QString& part) { return startsWithVersionComparator(part); });
+
+        if (allConstraints) {
+            for (auto const& constraint : whitespaceParts) {
+                if (!supportsSingleVersionPattern(constraint, instanceMinecraftVersion)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+    }
+
+    return supportsSingleVersionPattern(trimmedPattern, instanceMinecraftVersion);
+}
+
+}  // namespace
+
+namespace ModCompatibility {
+
+bool supportsMinecraftVersion(const QStringList& supportedVersions, const QString& instanceMinecraftVersion)
+{
+    if (supportedVersions.isEmpty() || instanceMinecraftVersion.trimmed().isEmpty()) {
+        return true;
+    }
+
+    for (auto const& supportedVersion : supportedVersions) {
+        if (supportsVersionPattern(supportedVersion, instanceMinecraftVersion)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool isIncompatibleWithInstanceVersion(const Resource& resource, const QString& instanceMinecraftVersion)
+{
+    if (!resource.enabled()) {
+        return false;
+    }
+
+    auto metadata = resource.metadata();
+    if (!metadata) {
+        return false;
+    }
+
+    return !supportsMinecraftVersion(metadata->mcVersions, instanceMinecraftVersion);
+}
+
+}  // namespace ModCompatibility

--- a/launcher/minecraft/mod/ModCompatibility.cpp
+++ b/launcher/minecraft/mod/ModCompatibility.cpp
@@ -215,6 +215,10 @@ bool supportsMinecraftVersion(const QStringList& supportedVersions, const QStrin
 
 bool isIncompatibleWithInstanceVersion(const Resource& resource, const QString& instanceMinecraftVersion)
 {
+    if (instanceMinecraftVersion.isEmpty()) {
+        return false;
+    }
+
     if (!resource.enabled()) {
         return false;
     }

--- a/launcher/minecraft/mod/ModCompatibility.h
+++ b/launcher/minecraft/mod/ModCompatibility.h
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2026 abhicommands <114682464+abhicommands@users.noreply.github.com>
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2026 abhicommands <114682464+abhicommands@users.noreply.github.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QString>
+#include <QStringList>
+
+class Resource;
+
+namespace ModCompatibility {
+
+[[nodiscard]] bool supportsMinecraftVersion(const QStringList& supportedVersions, const QString& instanceMinecraftVersion);
+[[nodiscard]] bool isIncompatibleWithInstanceVersion(const Resource& resource, const QString& instanceMinecraftVersion);
+
+}  // namespace ModCompatibility

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -583,5 +583,5 @@ void ModFolderModel::refreshInstanceMinecraftVersion()
         return;
     }
 
-    m_instanceMinecraftVersion = minecraftComponent->getVersion().trimmed();
+    m_instanceMinecraftVersion = minecraftComponent->getVersion();
 }

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -167,7 +167,7 @@ QVariant ModFolderModel::data(const QModelIndex& index, int role) const
                     warningMessage += tr("\nWarning: This resource is hard linked elsewhere. Editing it will also change the original.");
                 }
 
-                if (isIncompatibleWithInstanceVersion(at(row))) {
+                if (ModCompatibility::isIncompatibleWithInstanceVersion(at(row), m_instanceMinecraftVersion)) {
                     auto supportedVersions = at(row).mcVersions();
                     if (supportedVersions.isEmpty()) {
                         supportedVersions = tr("Unknown");
@@ -191,7 +191,8 @@ QVariant ModFolderModel::data(const QModelIndex& index, int role) const
             return {};
         }
         case Qt::ForegroundRole:
-            if ((column == NameColumn || column == McVersionsColumn) && isIncompatibleWithInstanceVersion(at(row))) {
+            if ((column == NameColumn || column == McVersionsColumn) &&
+                ModCompatibility::isIncompatibleWithInstanceVersion(at(row), m_instanceMinecraftVersion)) {
                 return QBrush(QColor(204, 32, 32));
             }
             return {};
@@ -281,12 +282,6 @@ Task* ModFolderModel::createParseTask(Resource& resource)
 bool ModFolderModel::isValid()
 {
     return m_dir.exists() && m_dir.isReadable();
-}
-
-void ModFolderModel::onUpdateSucceeded()
-{
-    refreshInstanceMinecraftVersion();
-    ResourceFolderModel::onUpdateSucceeded();
 }
 
 void ModFolderModel::onParseSucceeded(int ticket, QString mod_id)
@@ -589,13 +584,4 @@ void ModFolderModel::refreshInstanceMinecraftVersion()
     }
 
     m_instanceMinecraftVersion = minecraftComponent->getVersion().trimmed();
-}
-
-bool ModFolderModel::isIncompatibleWithInstanceVersion(const Mod& mod) const
-{
-    if (m_instanceMinecraftVersion.isEmpty()) {
-        return false;
-    }
-
-    return ModCompatibility::isIncompatibleWithInstanceVersion(mod, m_instanceMinecraftVersion);
 }

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -39,6 +39,8 @@
 
 #include <FileSystem.h>
 #include <QAbstractButton>
+#include <QBrush>
+#include <QColor>
 #include <QDebug>
 #include <QFileInfo>
 #include <QFileSystemWatcher>
@@ -53,6 +55,9 @@
 #include <algorithm>
 
 #include "minecraft/Component.h"
+#include "minecraft/MinecraftInstance.h"
+#include "minecraft/PackProfile.h"
+#include "minecraft/mod/ModCompatibility.h"
 #include "minecraft/mod/Resource.h"
 #include "minecraft/mod/ResourceFolderModel.h"
 #include "minecraft/mod/tasks/LocalModParseTask.h"
@@ -76,13 +81,30 @@ ModFolderModel::ModFolderModel(const QDir& dir, BaseInstance* instance, bool is_
                               QHeaderView::Interactive };
     m_columnsHideable = { false, true, false, true, true, true, true, true, true, true, true, true, true };
 
+    refreshInstanceMinecraftVersion();
+    if (auto* mcInstance = dynamic_cast<MinecraftInstance*>(instance); mcInstance != nullptr) {
+        auto* packProfile = mcInstance->getPackProfile();
+        if (packProfile != nullptr) {
+            connect(packProfile, &PackProfile::minecraftChanged, this, [this] {
+                auto oldVersion = m_instanceMinecraftVersion;
+                refreshInstanceMinecraftVersion();
+                if (oldVersion == m_instanceMinecraftVersion || m_resources.isEmpty()) {
+                    return;
+                }
+
+                emit dataChanged(index(0, NameColumn), index(m_resources.size() - 1, McVersionsColumn));
+            });
+        }
+    }
+
     connect(this, &ModFolderModel::parseFinished, this, &ModFolderModel::onParseFinished);
 }
 
 QVariant ModFolderModel::data(const QModelIndex& index, int role) const
 {
-    if (!validateIndex(index))
+    if (!validateIndex(index)) {
         return {};
+    }
 
     int row = index.row();
     int column = index.column();
@@ -134,35 +156,54 @@ QVariant ModFolderModel::data(const QModelIndex& index, int role) const
             }
 
         case Qt::ToolTipRole:
-            if (column == NameColumn) {
+            if (column == NameColumn || column == McVersionsColumn) {
+                QString warningMessage;
                 if (at(row).isSymLinkUnder(instDirPath())) {
-                    return m_resources[row]->internal_id() +
-                           tr("\nWarning: This resource is symbolically linked from elsewhere. Editing it will also change the original."
-                              "\nCanonical Path: %1")
-                               .arg(at(row).fileinfo().canonicalFilePath());
+                    warningMessage +=
+                        tr("\nWarning: This resource is symbolically linked from elsewhere. Editing it will also change the original."
+                           "\nCanonical Path: %1")
+                            .arg(at(row).fileinfo().canonicalFilePath());
+                } else if (at(row).isMoreThanOneHardLink()) {
+                    warningMessage += tr("\nWarning: This resource is hard linked elsewhere. Editing it will also change the original.");
                 }
-                if (at(row).isMoreThanOneHardLink()) {
-                    return m_resources[row]->internal_id() +
-                           tr("\nWarning: This resource is hard linked elsewhere. Editing it will also change the original.");
+
+                if (isIncompatibleWithInstanceVersion(at(row))) {
+                    auto supportedVersions = at(row).mcVersions();
+                    if (supportedVersions.isEmpty()) {
+                        supportedVersions = tr("Unknown");
+                    }
+                    warningMessage += tr("\nWarning: This enabled mod is incompatible with Minecraft %1. Supported versions: %2")
+                                          .arg(m_instanceMinecraftVersion, supportedVersions);
+                }
+
+                if (!warningMessage.isEmpty()) {
+                    return m_resources[row]->internal_id() + warningMessage;
                 }
             }
             return m_resources[row]->internal_id();
         case Qt::DecorationRole: {
-            if (column == NameColumn && (at(row).isSymLinkUnder(instDirPath()) || at(row).isMoreThanOneHardLink()))
+            if (column == NameColumn && (at(row).isSymLinkUnder(instDirPath()) || at(row).isMoreThanOneHardLink())) {
                 return QIcon::fromTheme("status-yellow");
+            }
             if (column == ImageColumn) {
                 return at(row).icon({ 32, 32 }, Qt::AspectRatioMode::KeepAspectRatioByExpanding);
             }
             return {};
         }
+        case Qt::ForegroundRole:
+            if ((column == NameColumn || column == McVersionsColumn) && isIncompatibleWithInstanceVersion(at(row))) {
+                return QBrush(QColor(204, 32, 32));
+            }
+            return {};
         case Qt::SizeHintRole:
             if (column == ImageColumn) {
                 return QSize(32, 32);
             }
             return {};
         case Qt::CheckStateRole:
-            if (column == ActiveColumn)
+            if (column == ActiveColumn) {
                 return at(row).enabled() ? Qt::Checked : Qt::Unchecked;
+            }
             return QVariant();
         default:
             return QVariant();
@@ -242,11 +283,18 @@ bool ModFolderModel::isValid()
     return m_dir.exists() && m_dir.isReadable();
 }
 
+void ModFolderModel::onUpdateSucceeded()
+{
+    refreshInstanceMinecraftVersion();
+    ResourceFolderModel::onUpdateSucceeded();
+}
+
 void ModFolderModel::onParseSucceeded(int ticket, QString mod_id)
 {
     auto iter = m_active_parse_tasks.constFind(ticket);
-    if (iter == m_active_parse_tasks.constEnd())
+    if (iter == m_active_parse_tasks.constEnd()) {
         return;
+    }
 
     int row = m_resources_index[mod_id];
 
@@ -349,8 +397,9 @@ QSet<Mod*> collectMods(QSet<Mod*> mods, QHash<QString, QSet<Mod*>> relation, std
 
 QModelIndexList ModFolderModel::getAffectedMods(const QModelIndexList& indexes, EnableAction action)
 {
-    if (indexes.isEmpty())
+    if (indexes.isEmpty()) {
         return {};
+    }
 
     QModelIndexList affectedList = {};
     auto affectedModsList = selectedMods(indexes);
@@ -380,8 +429,9 @@ QModelIndexList ModFolderModel::getAffectedMods(const QModelIndexList& indexes, 
 
 bool ModFolderModel::setResourceEnabled(const QModelIndexList& indexes, EnableAction action)
 {
-    if (indexes.isEmpty())
+    if (indexes.isEmpty()) {
         return {};
+    }
 
     auto indexedModsList = selectedMods(indexes);
     auto indexedMods = QSet(indexedModsList.begin(), indexedModsList.end());
@@ -516,4 +566,36 @@ bool ModFolderModel::deleteResources(const QModelIndexList& indexes)
         }
     }
     return rsp;
+}
+
+void ModFolderModel::refreshInstanceMinecraftVersion()
+{
+    auto* mcInstance = dynamic_cast<MinecraftInstance*>(m_instance);
+    if (mcInstance == nullptr) {
+        m_instanceMinecraftVersion.clear();
+        return;
+    }
+
+    auto* packProfile = mcInstance->getPackProfile();
+    if (packProfile == nullptr) {
+        m_instanceMinecraftVersion.clear();
+        return;
+    }
+
+    auto minecraftComponent = packProfile->getComponent("net.minecraft");
+    if (minecraftComponent == nullptr) {
+        m_instanceMinecraftVersion.clear();
+        return;
+    }
+
+    m_instanceMinecraftVersion = minecraftComponent->getVersion().trimmed();
+}
+
+bool ModFolderModel::isIncompatibleWithInstanceVersion(const Mod& mod) const
+{
+    if (m_instanceMinecraftVersion.isEmpty()) {
+        return false;
+    }
+
+    return ModCompatibility::isIncompatibleWithInstanceVersion(mod, m_instanceMinecraftVersion);
 }

--- a/launcher/minecraft/mod/ModFolderModel.h
+++ b/launcher/minecraft/mod/ModFolderModel.h
@@ -100,11 +100,18 @@ class ModFolderModel : public ResourceFolderModel {
     QStringList requiresList(QString id);
     QStringList requiredByList(QString id);
 
+   protected:
+    void onUpdateSucceeded() override;
+
    private slots:
     void onParseSucceeded(int ticket, QString resource_id) override;
     void onParseFinished();
 
    private:
+    void refreshInstanceMinecraftVersion();
+    bool isIncompatibleWithInstanceVersion(const Mod& mod) const;
+
     QHash<QString, QSet<Mod*>> m_requiredBy;
     QHash<QString, QSet<Mod*>> m_requires;
+    QString m_instanceMinecraftVersion;
 };

--- a/launcher/minecraft/mod/ModFolderModel.h
+++ b/launcher/minecraft/mod/ModFolderModel.h
@@ -100,16 +100,12 @@ class ModFolderModel : public ResourceFolderModel {
     QStringList requiresList(QString id);
     QStringList requiredByList(QString id);
 
-   protected:
-    void onUpdateSucceeded() override;
-
    private slots:
     void onParseSucceeded(int ticket, QString resource_id) override;
     void onParseFinished();
 
    private:
     void refreshInstanceMinecraftVersion();
-    bool isIncompatibleWithInstanceVersion(const Mod& mod) const;
 
     QHash<QString, QSet<Mod*>> m_requiredBy;
     QHash<QString, QSet<Mod*>> m_requires;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,6 +60,9 @@ ecm_add_test(MetaComponentParse_test.cpp LINK_LIBRARIES Launcher_logic Qt${QT_VE
 ecm_add_test(CatPack_test.cpp LINK_LIBRARIES Launcher_logic Qt${QT_VERSION_MAJOR}::Test
     TEST_NAME CatPack)
 
+ecm_add_test(ModCompatibility_test.cpp LINK_LIBRARIES Launcher_logic Qt${QT_VERSION_MAJOR}::Test
+    TEST_NAME ModCompatibility)
+
 
 ecm_add_test(XmlLogs_test.cpp LINK_LIBRARIES Launcher_logic Qt${QT_VERSION_MAJOR}::Test
     TEST_NAME XmlLogs)

--- a/tests/ModCompatibility_test.cpp
+++ b/tests/ModCompatibility_test.cpp
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2026 abhicommands <114682464+abhicommands@users.noreply.github.com>
+//
+// SPDX-License-Identifier: GPL-3.0-only
+
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2026 abhicommands <114682464+abhicommands@users.noreply.github.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <QFile>
+#include <QTemporaryDir>
+#include <QTest>
+
+#include "minecraft/mod/ModCompatibility.h"
+#include "minecraft/mod/Resource.h"
+
+class ModCompatibilityTest : public QObject {
+    Q_OBJECT
+
+   private slots:
+    void supportsVersionPatterns()
+    {
+        QVERIFY(ModCompatibility::supportsMinecraftVersion({ "1.21.1" }, "1.21.1"));
+        QVERIFY(ModCompatibility::supportsMinecraftVersion({ "1.21.x" }, "1.21.11"));
+        QVERIFY(ModCompatibility::supportsMinecraftVersion({ "1.21.*" }, "1.21.10"));
+        QVERIFY(ModCompatibility::supportsMinecraftVersion({ ">=1.21.0" }, "1.21.11"));
+        QVERIFY(ModCompatibility::supportsMinecraftVersion({ ">=1.21.0 <=1.21.11" }, "1.21.10"));
+        QVERIFY(ModCompatibility::supportsMinecraftVersion({ ">=1.21.0,<=1.21.11" }, "1.21.10"));
+        QVERIFY(ModCompatibility::supportsMinecraftVersion({ "1.21.9 - 1.21.11" }, "1.21.10"));
+        QVERIFY(ModCompatibility::supportsMinecraftVersion({ "*" }, "1.20.4"));
+        QVERIFY(!ModCompatibility::supportsMinecraftVersion({ "1.20.6" }, "1.21.1"));
+        QVERIFY(!ModCompatibility::supportsMinecraftVersion({ "1.21.11" }, "1.21.10"));
+        QVERIFY(!ModCompatibility::supportsMinecraftVersion({ "<1.21.10" }, "1.21.10"));
+    }
+
+    void incompatibleEnabledResourceIsReported()
+    {
+        QTemporaryDir tmp;
+        QVERIFY(tmp.isValid());
+
+        auto enabledFilePath = tmp.filePath("example.jar");
+        QFile enabledFile(enabledFilePath);
+        QVERIFY(enabledFile.open(QIODevice::WriteOnly));
+        enabledFile.close();
+
+        Resource resource{ QFileInfo(enabledFilePath) };
+
+        Metadata::ModStruct metadata;
+        metadata.mcVersions = { "1.20.6" };
+        resource.setMetadata(metadata);
+
+        QVERIFY(ModCompatibility::isIncompatibleWithInstanceVersion(resource, "1.21.1"));
+    }
+
+    void disabledResourceDoesNotReportIncompatibility()
+    {
+        QTemporaryDir tmp;
+        QVERIFY(tmp.isValid());
+
+        auto disabledFilePath = tmp.filePath("example.jar.disabled");
+        QFile disabledFile(disabledFilePath);
+        QVERIFY(disabledFile.open(QIODevice::WriteOnly));
+        disabledFile.close();
+
+        Resource resource{ QFileInfo(disabledFilePath) };
+
+        Metadata::ModStruct metadata;
+        metadata.mcVersions = { "1.20.6" };
+        resource.setMetadata(metadata);
+
+        QVERIFY(!ModCompatibility::isIncompatibleWithInstanceVersion(resource, "1.21.1"));
+    }
+};
+
+QTEST_GUILESS_MAIN(ModCompatibilityTest)
+
+#include "ModCompatibility_test.moc"


### PR DESCRIPTION
## Summary
- add `ModCompatibility` helper for Minecraft version compatibility matching (exact, wildcard, comparator, and range forms)
- highlight enabled incompatible mods in red in the mods list (`Name` and `Minecraft Versions` columns)
- add tooltip warning for incompatible enabled mods
- add focused unit tests for compatibility pattern handling and enabled/disabled behavior

## Verification
- `cmake --preset macos -DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_OSX_DEPLOYMENT_TARGET=26.0 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON`
- `cmake --build --preset macos --config Debug --parallel --target ModCompatibility`
- `ctest --preset macos -C Debug --output-on-failure -R "^ModCompatibility$"`
