### PR TITLE
Highlight resources incompatible with the Minecraft version

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -774,6 +774,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         m_settings->registerSetting("ModMetadataDisabled", false);
         m_settings->registerSetting("ModDependenciesDisabled", false);
         m_settings->registerSetting("SkipModpackUpdatePrompt", false);
+        m_settings->registerSetting("ShowModIncompat", false);
 
         // Minecraft offline player name
         m_settings->registerSetting("LastOfflinePlayerName", "");

--- a/launcher/minecraft/mod/DataPackFolderModel.cpp
+++ b/launcher/minecraft/mod/DataPackFolderModel.cpp
@@ -64,6 +64,8 @@ QVariant DataPackFolderModel::data(const QModelIndex& index, int role) const
     int column = index.column();
 
     switch (role) {
+        case Qt::BackgroundRole:
+            return rowBackground(row);
         case Qt::DisplayRole:
             switch (column) {
                 case PackFormatColumn: {

--- a/launcher/minecraft/mod/DataPackFolderModel.cpp
+++ b/launcher/minecraft/mod/DataPackFolderModel.cpp
@@ -66,8 +66,6 @@ QVariant DataPackFolderModel::data(const QModelIndex& index, int role) const
     switch (role) {
         case Qt::DisplayRole:
             switch (column) {
-                case NameColumn:
-                    return m_resources[row]->name();
                 case PackFormatColumn: {
                     auto& resource = at(row);
                     auto pack_format = resource.packFormat();
@@ -81,53 +79,51 @@ QVariant DataPackFolderModel::data(const QModelIndex& index, int role) const
                     return QString("%1 (%2 - %3)")
                         .arg(QString::number(pack_format), version_bounds.first.toString(), version_bounds.second.toString());
                 }
-                case DateColumn:
-                    return m_resources[row]->dateTimeChanged();
-
-                default:
-                    return {};
             }
+            break;
         case Qt::DecorationRole: {
-            if (column == NameColumn && (at(row).isSymLinkUnder(instDirPath()) || at(row).isMoreThanOneHardLink()))
-                return QIcon::fromTheme("status-yellow");
             if (column == ImageColumn) {
                 return at(row).image({ 32, 32 }, Qt::AspectRatioMode::KeepAspectRatioByExpanding);
             }
-            return {};
+            break;
         }
         case Qt::ToolTipRole: {
             if (column == PackFormatColumn) {
                 //: The string being explained by this is in the format: ID (Lower version - Upper version)
                 return tr("The data pack format ID, as well as the Minecraft versions it was designed for.");
             }
-            if (column == NameColumn) {
-                if (at(row).isSymLinkUnder(instDirPath())) {
-                    return m_resources[row]->internal_id() +
-                           tr("\nWarning: This resource is symbolically linked from elsewhere. Editing it will also change the original."
-                              "\nCanonical Path: %1")
-                               .arg(at(row).fileinfo().canonicalFilePath());
-                    ;
-                }
-                if (at(row).isMoreThanOneHardLink()) {
-                    return m_resources[row]->internal_id() +
-                           tr("\nWarning: This resource is hard linked elsewhere. Editing it will also change the original.");
-                }
-            }
-            return m_resources[row]->internal_id();
+            break;
         }
         case Qt::SizeHintRole:
             if (column == ImageColumn) {
                 return QSize(32, 32);
             }
-            return {};
-        case Qt::CheckStateRole:
-            if (column == ActiveColumn)
-                return at(row).enabled() ? Qt::Checked : Qt::Unchecked;
-            else
-                return {};
-        default:
-            return {};
+            break;
     }
+
+    // map the columns to the base equivilents
+    QModelIndex mappedIndex;
+    switch (column) {
+        case ActiveColumn:
+            mappedIndex = index.siblingAtColumn(ResourceFolderModel::ActiveColumn);
+            break;
+        case NameColumn:
+            mappedIndex = index.siblingAtColumn(ResourceFolderModel::NameColumn);
+            break;
+        case DateColumn:
+            mappedIndex = index.siblingAtColumn(ResourceFolderModel::DateColumn);
+            break;
+        case ProviderColumn:
+            mappedIndex = index.siblingAtColumn(ResourceFolderModel::ProviderColumn);
+            break;
+        // FIXME: there is no size column due to an oversight
+    }
+
+    if (mappedIndex.isValid()) {
+        return ResourceFolderModel::data(mappedIndex, role);
+    }
+
+    return {};
 }
 
 QVariant DataPackFolderModel::headerData(int section, [[maybe_unused]] Qt::Orientation orientation, int role) const

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -258,9 +258,11 @@ void ModFolderModel::onParseSucceeded(int ticket, QString mod_id)
     auto resource = find(mod_id);
 
     auto result = cast_task->result();
-    if (result && resource)
-        static_cast<Mod*>(resource.get())->finishResolvingWithDetails(std::move(result->details));
+    if (result && resource) {
+        auto* mod = static_cast<Mod*>(resource.get());
+        mod->finishResolvingWithDetails(std::move(result->details));
 
+    }
     emit dataChanged(index(row, RequiresColumn), index(row, RequiredByColumn));
 }
 

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -88,6 +88,8 @@ QVariant ModFolderModel::data(const QModelIndex& index, int role) const
     int column = index.column();
 
     switch (role) {
+        case Qt::BackgroundRole:
+            return rowBackground(row);
         case Qt::DisplayRole:
             switch (column) {
                 case VersionColumn: {
@@ -96,8 +98,9 @@ QVariant ModFolderModel::data(const QModelIndex& index, int role) const
                             return tr("Folder");
                         case ResourceType::SINGLEFILE:
                             return tr("File");
+                        default:
+                            return at(row).version();
                     }
-                    return at(row).version();
                 }
                 case SideColumn: {
                     return at(row).side();

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -90,23 +90,14 @@ QVariant ModFolderModel::data(const QModelIndex& index, int role) const
     switch (role) {
         case Qt::DisplayRole:
             switch (column) {
-                case NameColumn:
-                    return m_resources[row]->name();
                 case VersionColumn: {
                     switch (at(row).type()) {
                         case ResourceType::FOLDER:
                             return tr("Folder");
                         case ResourceType::SINGLEFILE:
                             return tr("File");
-                        default:
-                            break;
                     }
                     return at(row).version();
-                }
-                case DateColumn:
-                    return at(row).dateTimeChanged();
-                case ProviderColumn: {
-                    return at(row).provider();
                 }
                 case SideColumn: {
                     return at(row).side();
@@ -120,53 +111,54 @@ QVariant ModFolderModel::data(const QModelIndex& index, int role) const
                 case ReleaseTypeColumn: {
                     return at(row).releaseType();
                 }
-                case SizeColumn: {
-                    return at(row).sizeStr();
-                }
                 case RequiredByColumn: {
                     return at(row).requiredByCount();
                 }
                 case RequiresColumn: {
                     return at(row).requiresCount();
                 }
-                default:
-                    return QVariant();
             }
-
-        case Qt::ToolTipRole:
-            if (column == NameColumn) {
-                if (at(row).isSymLinkUnder(instDirPath())) {
-                    return m_resources[row]->internal_id() +
-                           tr("\nWarning: This resource is symbolically linked from elsewhere. Editing it will also change the original."
-                              "\nCanonical Path: %1")
-                               .arg(at(row).fileinfo().canonicalFilePath());
-                }
-                if (at(row).isMoreThanOneHardLink()) {
-                    return m_resources[row]->internal_id() +
-                           tr("\nWarning: This resource is hard linked elsewhere. Editing it will also change the original.");
-                }
-            }
-            return m_resources[row]->internal_id();
+            break;
         case Qt::DecorationRole: {
-            if (column == NameColumn && (at(row).isSymLinkUnder(instDirPath()) || at(row).isMoreThanOneHardLink()))
-                return QIcon::fromTheme("status-yellow");
             if (column == ImageColumn) {
                 return at(row).icon({ 32, 32 }, Qt::AspectRatioMode::KeepAspectRatioByExpanding);
             }
-            return {};
+            break;
         }
         case Qt::SizeHintRole:
             if (column == ImageColumn) {
                 return QSize(32, 32);
             }
-            return {};
-        case Qt::CheckStateRole:
-            if (column == ActiveColumn)
-                return at(row).enabled() ? Qt::Checked : Qt::Unchecked;
-            return QVariant();
+            break;
         default:
-            return QVariant();
+            break;
     }
+
+    // map the columns to the base equivilents
+    QModelIndex mappedIndex;
+    switch (column) {
+        case ActiveColumn:
+            mappedIndex = index.siblingAtColumn(ResourceFolderModel::ActiveColumn);
+            break;
+        case NameColumn:
+            mappedIndex = index.siblingAtColumn(ResourceFolderModel::NameColumn);
+            break;
+        case DateColumn:
+            mappedIndex = index.siblingAtColumn(ResourceFolderModel::DateColumn);
+            break;
+        case ProviderColumn:
+            mappedIndex = index.siblingAtColumn(ResourceFolderModel::ProviderColumn);
+            break;
+        case SizeColumn:
+            mappedIndex = index.siblingAtColumn(ResourceFolderModel::SizeColumn);
+            break;
+    }
+
+    if (mappedIndex.isValid()) {
+        return ResourceFolderModel::data(mappedIndex, role);
+    }
+
+    return {};
 }
 
 QVariant ModFolderModel::headerData(int section, [[maybe_unused]] Qt::Orientation orientation, int role) const

--- a/launcher/minecraft/mod/Resource.cpp
+++ b/launcher/minecraft/mod/Resource.cpp
@@ -7,6 +7,8 @@
 
 #include "FileSystem.h"
 #include "StringUtils.h"
+#include "minecraft/MinecraftInstance.h"
+#include "minecraft/PackProfile.h"
 
 Resource::Resource(QObject* parent) : QObject(parent) {}
 
@@ -109,6 +111,24 @@ void Resource::setMetadata(std::shared_ptr<Metadata::ModStruct>&& metadata)
         setStatus(ResourceStatus::INSTALLED);
 
     m_metadata = metadata;
+}
+
+void Resource::determineCompat(const BaseInstance* inst) {
+    if (m_metadata == nullptr) {
+        m_isCompatible = true;
+        return;
+    }
+
+    auto mcInst = dynamic_cast<const MinecraftInstance*>(inst);
+    if (mcInst == nullptr) {
+        m_isCompatible = true;
+        return;
+    }
+
+    auto profile = mcInst->getPackProfile();
+    QString mcVersion = profile->getComponentVersion("net.minecraft");
+
+    m_isCompatible = m_metadata->mcVersions.contains(mcVersion);
 }
 
 int Resource::compare(const Resource& other, SortType type) const

--- a/launcher/minecraft/mod/Resource.cpp
+++ b/launcher/minecraft/mod/Resource.cpp
@@ -113,22 +113,38 @@ void Resource::setMetadata(std::shared_ptr<Metadata::ModStruct>&& metadata)
     m_metadata = metadata;
 }
 
-void Resource::determineCompat(const BaseInstance* inst) {
+QStringList Resource::issues() const
+{
+    QStringList result;
+    result.reserve(m_issues.length());
+
+    for (const char* issue : m_issues) {
+        result.append(tr(issue));
+    }
+
+    return result;
+}
+
+void Resource::updateIssues(const BaseInstance* inst)
+{
+    m_issues.clear();
+
     if (m_metadata == nullptr) {
-        m_isCompatible = true;
         return;
     }
 
     auto mcInst = dynamic_cast<const MinecraftInstance*>(inst);
     if (mcInst == nullptr) {
-        m_isCompatible = true;
         return;
     }
 
     auto profile = mcInst->getPackProfile();
     QString mcVersion = profile->getComponentVersion("net.minecraft");
 
-    m_isCompatible = m_metadata->mcVersions.contains(mcVersion);
+    if (!m_metadata->mcVersions.empty() && !m_metadata->mcVersions.contains(mcVersion)) {
+        // delay translation until issues() is called
+        m_issues.append(QT_TR_NOOP("Not marked as compatible with the instance's game version."));
+    }
 }
 
 int Resource::compare(const Resource& other, SortType type) const

--- a/launcher/minecraft/mod/Resource.h
+++ b/launcher/minecraft/mod/Resource.h
@@ -122,11 +122,12 @@ class Resource : public QObject {
     void setMetadata(const Metadata::ModStruct& metadata) { setMetadata(std::make_shared<Metadata::ModStruct>(metadata)); }
 
     /**
-     * Returns whether the resource is compatible with the instance.
-     * This is initially true, and may be updated when calling determineCompat with an instance.
+     * Returns compatibility issues with the resource and the instance.
+     * This is initially empty, and may be updated when calling updateIssues.
      */
-    bool isCompatible() const { return m_isCompatible; }
-    void determineCompat(const BaseInstance* inst);
+    QStringList issues() const;
+    void updateIssues(const BaseInstance* inst);
+    bool hasIssues() const { return !m_issues.empty(); }
 
     /** Compares two Resources, for sorting purposes, considering a ascending order, returning:
      *  > 0: 'this' comes after 'other'
@@ -197,7 +198,7 @@ class Resource : public QObject {
     /* Whether the resource is enabled (e.g. shows up in the game) or not. */
     bool m_enabled = true;
 
-    bool m_isCompatible = true;
+    QList<const char*> m_issues;
 
     /* Used to keep trach of pending / concluded actions on the resource. */
     bool m_is_resolving = false;

--- a/launcher/minecraft/mod/Resource.h
+++ b/launcher/minecraft/mod/Resource.h
@@ -43,6 +43,8 @@
 #include "MetadataHandler.h"
 #include "QObjectPtr.h"
 
+class BaseInstance;
+
 enum class ResourceType {
     UNKNOWN,     //!< Indicates an unspecified resource type.
     ZIPFILE,     //!< The resource is a zip file containing the resource's class files.
@@ -119,6 +121,13 @@ class Resource : public QObject {
     void setMetadata(std::shared_ptr<Metadata::ModStruct>&& metadata);
     void setMetadata(const Metadata::ModStruct& metadata) { setMetadata(std::make_shared<Metadata::ModStruct>(metadata)); }
 
+    /**
+     * Returns whether the resource is compatible with the instance.
+     * This is initially true, and may be updated when calling determineCompat with an instance.
+     */
+    bool isCompatible() const { return m_isCompatible; }
+    void determineCompat(const BaseInstance* inst);
+
     /** Compares two Resources, for sorting purposes, considering a ascending order, returning:
      *  > 0: 'this' comes after 'other'
      *  = 0: 'this' is equal to 'other'
@@ -187,6 +196,8 @@ class Resource : public QObject {
 
     /* Whether the resource is enabled (e.g. shows up in the game) or not. */
     bool m_enabled = true;
+
+    bool m_isCompatible = true;
 
     /* Used to keep trach of pending / concluded actions on the resource. */
     bool m_is_resolving = false;

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -810,7 +810,13 @@ void ResourceFolderModel::applyUpdates(QSet<QString>& current_set, QSet<QString>
             auto const& current_resource = m_resources.at(row);
 
             if (new_resource->dateTimeChanged() == current_resource->dateTimeChanged()) {
-                // no significant change, ignore...
+                // no significant change
+                bool oldCompat = current_resource->isCompatible();
+                current_resource->determineCompat(m_instance);
+
+                if (current_resource->isCompatible() != oldCompat) {
+                    emit dataChanged(index(row, 0), index(row, columnCount({}) - 1));
+                }
                 continue;
             }
 
@@ -825,6 +831,8 @@ void ResourceFolderModel::applyUpdates(QSet<QString>& current_set, QSet<QString>
             }
 
             m_resources[row].reset(new_resource);
+            new_resource->determineCompat(m_instance);
+
             resolveResource(m_resources.at(row));
             emit dataChanged(index(row, 0), index(row, columnCount(QModelIndex()) - 1));
         }
@@ -872,6 +880,7 @@ void ResourceFolderModel::applyUpdates(QSet<QString>& current_set, QSet<QString>
 
             for (auto& added : added_set) {
                 auto res = new_resources[added];
+                res->determineCompat(m_instance);
                 m_resources.append(res);
                 resolveResource(m_resources.last());
             }

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -503,7 +503,7 @@ bool ResourceFolderModel::validateIndex(const QModelIndex& index) const
 // and they only delegate to the superclass for compatible columns
 QBrush ResourceFolderModel::rowBackground(int row) const
 {
-    if (m_resources[row]->hasIssues()) {
+    if (APPLICATION->settings()->get("ShowModIncompat").toBool() && m_resources[row]->hasIssues()) {
         return { QColor(255, 0, 0, 40) };
     } else {
         return {};
@@ -538,8 +538,10 @@ QVariant ResourceFolderModel::data(const QModelIndex& index, int role) const
             QString tooltip = m_resources[row]->internal_id();
 
             if (column == NameColumn) {
-                for (const QString& issue : at(row).issues()) {
-                    tooltip += "\n" + issue;
+                if (APPLICATION->settings()->get("ShowModIncompat").toBool()) {
+                    for (const QString& issue : at(row).issues()) {
+                        tooltip += "\n" + issue;
+                    }
                 }
 
                 if (at(row).isSymLinkUnder(instDirPath())) {
@@ -559,7 +561,7 @@ QVariant ResourceFolderModel::data(const QModelIndex& index, int role) const
         }
         case Qt::DecorationRole: {
             if (column == NameColumn) {
-                if (at(row).hasIssues()) {
+                if (APPLICATION->settings()->get("ShowModIncompat").toBool() && at(row).hasIssues()) {
                     return QIcon::fromTheme("status-bad");
                 } else if (at(row).isSymLinkUnder(instDirPath()) || at(row).isMoreThanOneHardLink()) {
                     return QIcon::fromTheme("status-yellow");

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -499,6 +499,17 @@ bool ResourceFolderModel::validateIndex(const QModelIndex& index) const
     return true;
 }
 
+// HACK: all subclasses need to call this to have the whole row painted
+// and they only delegate to the superclass for compatible columns
+QBrush ResourceFolderModel::rowBackground(int row) const
+{
+    if (!m_resources[row]->isCompatible()) {
+        return { QColor(255, 0, 0, 40) };
+    } else {
+        return {};
+    }
+}
+
 QVariant ResourceFolderModel::data(const QModelIndex& index, int role) const
 {
     if (!validateIndex(index))
@@ -508,6 +519,8 @@ QVariant ResourceFolderModel::data(const QModelIndex& index, int role) const
     int column = index.column();
 
     switch (role) {
+        case Qt::BackgroundRole:
+            return rowBackground(row);
         case Qt::DisplayRole:
             switch (column) {
                 case NameColumn:
@@ -521,25 +534,37 @@ QVariant ResourceFolderModel::data(const QModelIndex& index, int role) const
                 default:
                     return {};
             }
-        case Qt::ToolTipRole:
+        case Qt::ToolTipRole: {
+            QString tooltip = m_resources[row]->internal_id();
+
             if (column == NameColumn) {
-                if (at(row).isSymLinkUnder(instDirPath())) {
-                    return m_resources[row]->internal_id() +
-                           tr("\nWarning: This resource is symbolically linked from elsewhere. Editing it will also change the original."
-                              "\nCanonical Path: %1")
-                               .arg(at(row).fileinfo().canonicalFilePath());
-                    ;
+                if (!at(row).isCompatible()) {
+                    tooltip += tr("\nResource is not marked as compatible with the instance.");
                 }
+
+                if (at(row).isSymLinkUnder(instDirPath())) {
+                    tooltip +=
+                        m_resources[row]->internal_id() +
+                        tr("\nWarning: This resource is symbolically linked from elsewhere. Editing it will also change the original."
+                           "\nCanonical Path: %1")
+                            .arg(at(row).fileinfo().canonicalFilePath());
+                }
+
                 if (at(row).isMoreThanOneHardLink()) {
-                    return m_resources[row]->internal_id() +
-                           tr("\nWarning: This resource is hard linked elsewhere. Editing it will also change the original.");
+                    tooltip += tr("\nWarning: This resource is hard linked elsewhere. Editing it will also change the original.");
                 }
             }
 
-            return m_resources[row]->internal_id();
+            return tooltip;
+        }
         case Qt::DecorationRole: {
-            if (column == NameColumn && (at(row).isSymLinkUnder(instDirPath()) || at(row).isMoreThanOneHardLink()))
-                return QIcon::fromTheme("status-yellow");
+            if (column == NameColumn) {
+                if (!at(row).isCompatible()) {
+                    return QIcon::fromTheme("status-bad");
+                } else if (at(row).isSymLinkUnder(instDirPath()) || at(row).isMoreThanOneHardLink()) {
+                    return QIcon::fromTheme("status-yellow");
+                }
+            }
 
             return {};
         }

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -503,7 +503,7 @@ bool ResourceFolderModel::validateIndex(const QModelIndex& index) const
 // and they only delegate to the superclass for compatible columns
 QBrush ResourceFolderModel::rowBackground(int row) const
 {
-    if (!m_resources[row]->isCompatible()) {
+    if (m_resources[row]->hasIssues()) {
         return { QColor(255, 0, 0, 40) };
     } else {
         return {};
@@ -538,8 +538,8 @@ QVariant ResourceFolderModel::data(const QModelIndex& index, int role) const
             QString tooltip = m_resources[row]->internal_id();
 
             if (column == NameColumn) {
-                if (!at(row).isCompatible()) {
-                    tooltip += tr("\nResource is not marked as compatible with the instance.");
+                for (const QString& issue : at(row).issues()) {
+                    tooltip += "\n" + issue;
                 }
 
                 if (at(row).isSymLinkUnder(instDirPath())) {
@@ -559,7 +559,7 @@ QVariant ResourceFolderModel::data(const QModelIndex& index, int role) const
         }
         case Qt::DecorationRole: {
             if (column == NameColumn) {
-                if (!at(row).isCompatible()) {
+                if (at(row).hasIssues()) {
                     return QIcon::fromTheme("status-bad");
                 } else if (at(row).isSymLinkUnder(instDirPath()) || at(row).isMoreThanOneHardLink()) {
                     return QIcon::fromTheme("status-yellow");
@@ -836,10 +836,10 @@ void ResourceFolderModel::applyUpdates(QSet<QString>& current_set, QSet<QString>
 
             if (new_resource->dateTimeChanged() == current_resource->dateTimeChanged()) {
                 // no significant change
-                bool oldCompat = current_resource->isCompatible();
-                current_resource->determineCompat(m_instance);
+                bool hadIssues = !current_resource->hasIssues();
+                current_resource->updateIssues(m_instance);
 
-                if (current_resource->isCompatible() != oldCompat) {
+                if (hadIssues != current_resource->hasIssues()) {
                     emit dataChanged(index(row, 0), index(row, columnCount({}) - 1));
                 }
                 continue;
@@ -856,7 +856,7 @@ void ResourceFolderModel::applyUpdates(QSet<QString>& current_set, QSet<QString>
             }
 
             m_resources[row].reset(new_resource);
-            new_resource->determineCompat(m_instance);
+            new_resource->updateIssues(m_instance);
 
             resolveResource(m_resources.at(row));
             emit dataChanged(index(row, 0), index(row, columnCount(QModelIndex()) - 1));
@@ -905,7 +905,7 @@ void ResourceFolderModel::applyUpdates(QSet<QString>& current_set, QSet<QString>
 
             for (auto& added : added_set) {
                 auto res = new_resources[added];
-                res->determineCompat(m_instance);
+                res->updateIssues(m_instance);
                 m_resources.append(res);
                 resolveResource(m_resources.last());
             }

--- a/launcher/minecraft/mod/ResourceFolderModel.h
+++ b/launcher/minecraft/mod/ResourceFolderModel.h
@@ -153,6 +153,7 @@ class ResourceFolderModel : public QAbstractListModel {
 
     [[nodiscard]] bool validateIndex(const QModelIndex& index) const;
 
+    QBrush rowBackground(int row) const;
     QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override;
     bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole) override;
 

--- a/launcher/minecraft/mod/ResourcePackFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourcePackFolderModel.cpp
@@ -65,6 +65,8 @@ QVariant ResourcePackFolderModel::data(const QModelIndex& index, int role) const
     int column = index.column();
 
     switch (role) {
+        case Qt::BackgroundRole:
+            return rowBackground(row);
         case Qt::DisplayRole:
             switch (column) {
                 case PackFormatColumn: {

--- a/launcher/minecraft/mod/ResourcePackFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourcePackFolderModel.cpp
@@ -67,8 +67,6 @@ QVariant ResourcePackFolderModel::data(const QModelIndex& index, int role) const
     switch (role) {
         case Qt::DisplayRole:
             switch (column) {
-                case NameColumn:
-                    return m_resources[row]->name();
                 case PackFormatColumn: {
                     auto& resource = at(row);
                     auto pack_format = resource.packFormat();
@@ -82,55 +80,52 @@ QVariant ResourcePackFolderModel::data(const QModelIndex& index, int role) const
                     return QString("%1 (%2 - %3)")
                         .arg(QString::number(pack_format), version_bounds.first.toString(), version_bounds.second.toString());
                 }
-                case DateColumn:
-                    return m_resources[row]->dateTimeChanged();
-                case ProviderColumn:
-                    return m_resources[row]->provider();
-                case SizeColumn:
-                    return m_resources[row]->sizeStr();
-                default:
-                    return {};
             }
         case Qt::DecorationRole: {
-            if (column == NameColumn && (at(row).isSymLinkUnder(instDirPath()) || at(row).isMoreThanOneHardLink()))
-                return QIcon::fromTheme("status-yellow");
             if (column == ImageColumn) {
                 return at(row).image({ 32, 32 }, Qt::AspectRatioMode::KeepAspectRatioByExpanding);
             }
-            return {};
+            break;
         }
         case Qt::ToolTipRole: {
             if (column == PackFormatColumn) {
                 //: The string being explained by this is in the format: ID (Lower version - Upper version)
                 return tr("The resource pack format ID, as well as the Minecraft versions it was designed for.");
             }
-            if (column == NameColumn) {
-                if (at(row).isSymLinkUnder(instDirPath())) {
-                    return m_resources[row]->internal_id() +
-                           tr("\nWarning: This resource is symbolically linked from elsewhere. Editing it will also change the original."
-                              "\nCanonical Path: %1")
-                               .arg(at(row).fileinfo().canonicalFilePath());
-                    ;
-                }
-                if (at(row).isMoreThanOneHardLink()) {
-                    return m_resources[row]->internal_id() +
-                           tr("\nWarning: This resource is hard linked elsewhere. Editing it will also change the original.");
-                }
-            }
-            return m_resources[row]->internal_id();
+            break;
         }
         case Qt::SizeHintRole:
             if (column == ImageColumn) {
                 return QSize(32, 32);
             }
-            return {};
-        case Qt::CheckStateRole:
-            if (column == ActiveColumn)
-                return at(row).enabled() ? Qt::Checked : Qt::Unchecked;
-            return {};
-        default:
-            return {};
+            break;
     }
+
+    // map the columns to the base equivilents
+    QModelIndex mappedIndex;
+    switch (column) {
+        case ActiveColumn:
+            mappedIndex = index.siblingAtColumn(ResourceFolderModel::ActiveColumn);
+            break;
+        case NameColumn:
+            mappedIndex = index.siblingAtColumn(ResourceFolderModel::NameColumn);
+            break;
+        case DateColumn:
+            mappedIndex = index.siblingAtColumn(ResourceFolderModel::DateColumn);
+            break;
+        case ProviderColumn:
+            mappedIndex = index.siblingAtColumn(ResourceFolderModel::ProviderColumn);
+            break;
+        case SizeColumn:
+            mappedIndex = index.siblingAtColumn(ResourceFolderModel::SizeColumn);
+            break;
+    }
+
+    if (mappedIndex.isValid()) {
+        return ResourceFolderModel::data(mappedIndex, role);
+    }
+
+    return {};
 }
 
 QVariant ResourcePackFolderModel::headerData(int section, [[maybe_unused]] Qt::Orientation orientation, int role) const

--- a/launcher/minecraft/mod/TexturePackFolderModel.cpp
+++ b/launcher/minecraft/mod/TexturePackFolderModel.cpp
@@ -63,6 +63,8 @@ QVariant TexturePackFolderModel::data(const QModelIndex& index, int role) const
     int column = index.column();
 
     switch (role) {
+        case Qt::BackgroundRole:
+            return rowBackground(row);
         case Qt::DecorationRole: {
             if (column == ImageColumn) {
                 return at(row).image({ 32, 32 }, Qt::AspectRatioMode::KeepAspectRatioByExpanding);

--- a/launcher/minecraft/mod/TexturePackFolderModel.cpp
+++ b/launcher/minecraft/mod/TexturePackFolderModel.cpp
@@ -63,56 +63,44 @@ QVariant TexturePackFolderModel::data(const QModelIndex& index, int role) const
     int column = index.column();
 
     switch (role) {
-        case Qt::DisplayRole:
-            switch (column) {
-                case NameColumn:
-                    return m_resources[row]->name();
-                case DateColumn:
-                    return m_resources[row]->dateTimeChanged();
-                case ProviderColumn:
-                    return m_resources[row]->provider();
-                case SizeColumn:
-                    return m_resources[row]->sizeStr();
-                default:
-                    return {};
-            }
-        case Qt::ToolTipRole:
-            if (column == NameColumn) {
-                if (at(row).isSymLinkUnder(instDirPath())) {
-                    return m_resources[row]->internal_id() +
-                           tr("\nWarning: This resource is symbolically linked from elsewhere. Editing it will also change the original."
-                              "\nCanonical Path: %1")
-                               .arg(at(row).fileinfo().canonicalFilePath());
-                    ;
-                }
-                if (at(row).isMoreThanOneHardLink()) {
-                    return m_resources[row]->internal_id() +
-                           tr("\nWarning: This resource is hard linked elsewhere. Editing it will also change the original.");
-                }
-            }
-
-            return m_resources[row]->internal_id();
         case Qt::DecorationRole: {
-            if (column == NameColumn && (at(row).isSymLinkUnder(instDirPath()) || at(row).isMoreThanOneHardLink()))
-                return QIcon::fromTheme("status-yellow");
             if (column == ImageColumn) {
                 return at(row).image({ 32, 32 }, Qt::AspectRatioMode::KeepAspectRatioByExpanding);
             }
-            return {};
+            break;
         }
         case Qt::SizeHintRole:
             if (column == ImageColumn) {
                 return QSize(32, 32);
             }
-            return {};
-        case Qt::CheckStateRole:
-            if (column == ActiveColumn) {
-                return m_resources[row]->enabled() ? Qt::Checked : Qt::Unchecked;
-            }
-            return {};
-        default:
-            return {};
+            break;
     }
+
+    // map the columns to the base equivilents
+    QModelIndex mappedIndex;
+    switch (column) {
+        case ActiveColumn:
+            mappedIndex = index.siblingAtColumn(ResourceFolderModel::ActiveColumn);
+            break;
+        case NameColumn:
+            mappedIndex = index.siblingAtColumn(ResourceFolderModel::NameColumn);
+            break;
+        case DateColumn:
+            mappedIndex = index.siblingAtColumn(ResourceFolderModel::DateColumn);
+            break;
+        case ProviderColumn:
+            mappedIndex = index.siblingAtColumn(ResourceFolderModel::ProviderColumn);
+            break;
+        case SizeColumn:
+            mappedIndex = index.siblingAtColumn(ResourceFolderModel::SizeColumn);
+            break;
+    }
+
+    if (mappedIndex.isValid()) {
+        return ResourceFolderModel::data(mappedIndex, role);
+    }
+
+    return {};
 }
 
 QVariant TexturePackFolderModel::headerData(int section, [[maybe_unused]] Qt::Orientation orientation, int role) const

--- a/launcher/minecraft/mod/tasks/ResourceFolderLoadTask.h
+++ b/launcher/minecraft/mod/tasks/ResourceFolderLoadTask.h
@@ -41,8 +41,10 @@
 #include <QObject>
 #include <QRunnable>
 #include <memory>
-#include "minecraft/mod/Mod.h"
+#include "minecraft/mod/Resource.h"
 #include "tasks/Task.h"
+
+class BaseInstance;
 
 class ResourceFolderLoadTask : public Task {
     Q_OBJECT

--- a/launcher/minecraft/mod/tasks/ResourceFolderLoadTask.h
+++ b/launcher/minecraft/mod/tasks/ResourceFolderLoadTask.h
@@ -41,10 +41,8 @@
 #include <QObject>
 #include <QRunnable>
 #include <memory>
-#include "minecraft/mod/Resource.h"
+#include "minecraft/mod/Mod.h"
 #include "tasks/Task.h"
-
-class BaseInstance;
 
 class ResourceFolderLoadTask : public Task {
     Q_OBJECT

--- a/launcher/ui/pages/global/LauncherPage.cpp
+++ b/launcher/ui/pages/global/LauncherPage.cpp
@@ -244,6 +244,7 @@ void LauncherPage::applySettings()
     // Mods
     s->set("ModMetadataDisabled", !ui->metadataEnableBtn->isChecked());
     s->set("ModDependenciesDisabled", !ui->dependenciesEnableBtn->isChecked());
+    s->set("ShowModIncompat", ui->showModIncompatCheckBox->isChecked());
     s->set("SkipModpackUpdatePrompt", !ui->modpackUpdatePromptBtn->isChecked());
 }
 void LauncherPage::loadSettings()
@@ -293,6 +294,7 @@ void LauncherPage::loadSettings()
     ui->metadataEnableBtn->setChecked(!s->get("ModMetadataDisabled").toBool());
     ui->metadataWarningLabel->setHidden(ui->metadataEnableBtn->isChecked());
     ui->dependenciesEnableBtn->setChecked(!s->get("ModDependenciesDisabled").toBool());
+    ui->showModIncompatCheckBox->setChecked(s->get("ShowModIncompat").toBool());
     ui->modpackUpdatePromptBtn->setChecked(!s->get("SkipModpackUpdatePrompt").toBool());
 }
 

--- a/launcher/ui/pages/global/LauncherPage.ui
+++ b/launcher/ui/pages/global/LauncherPage.ui
@@ -41,9 +41,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>0</y>
+        <y>-149</y>
         <width>746</width>
-        <height>1194</height>
+        <height>1222</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -419,6 +419,16 @@
            </widget>
           </item>
           <item>
+           <widget class="QCheckBox" name="showModIncompatCheckBox">
+            <property name="toolTip">
+             <string>Currently this just shows mods which are not marked as compatible with the current Minecraft version.</string>
+            </property>
+            <property name="text">
+             <string>Detect and show mod incompatibilities (experimental)</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <widget class="QCheckBox" name="modpackUpdatePromptBtn">
             <property name="toolTip">
              <string>When creating a new modpack instance, suggest updating an existing instance instead.</string>
@@ -671,7 +681,7 @@
  <resources/>
  <connections/>
  <buttongroups>
-  <buttongroup name="sortingModeGroup"/>
   <buttongroup name="renamingBehaviorGroup"/>
+  <buttongroup name="sortingModeGroup"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION
Seems like everyone is giving this a go... my turn!

This time no AI, this is all my slop

Advantages compared to https://github.com/PrismLauncher/PrismLauncher/pull/5005:
- doesn't constantly redetermine the compatibility when moving the mouse over the list widget (ResourceFolderModel::data gets constantly called)
  - computers are, of course, fast, but this still feels bad
- Supports everything, not just mods
- 100% human made
- Can be turned off

Also has the same advantages compared to https://github.com/PrismLauncher/PrismLauncher/pull/5002 but that PR also was parsing version constraints even though they aren't present in `x-prismlauncher-mc-versions` which the data comes from.

I also moved most of the common column code to ResourceFolderModel instead of having it duplicated

Unsolved problems:
- it doesn't actually reflect the embedded JAR metadata (which supports a range of versions) so it would be good to add support for that in the future
- If a mod adds a compatible version on Modrinth/CurseForge without an update it's awkward to make the error go away
- We should probably replace the pack format column in Resource packs as it's incompatible with new MC versions (which support multiple pack versions), need launcher updates to add new MC versions, and a list of Minecraft versions is already stored by the launcher