### PR TITLE
fix(SkinManageDialog): add missing QMenu include

### DIFF
--- a/launcher/ui/dialogs/skins/SkinManageDialog.cpp
+++ b/launcher/ui/dialogs/skins/SkinManageDialog.cpp
@@ -28,6 +28,7 @@
 #include <QFileInfo>
 #include <QKeyEvent>
 #include <QListView>
+#include <QMenu>
 #include <QMimeDatabase>
 #include <QPainter>
 #include <QUrl>


### PR DESCRIPTION
launcher/ui/dialogs/skins/SkinManageDialog.cpp: In member function ‘void SkinManageDialog::show_context_menu(const QPoint&)’: launcher/ui/dialogs/skins/SkinManageDialog.cpp:344:18: error: variable ‘QMenu myMenu’ has initializer but incomplete type
  344 |     QMenu myMenu(tr("Context menu"), this);
      |                  ^~

Include appears to have been dropped transitively in either 0ba2c09787dbe3b852546dd24b437b832d575e4a or 45df360e4c751d30f8bfc38e5689f330e672492c

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->


Not certain on the exact change but this failure came after https://github.com/PrismLauncher/PrismLauncher/pull/4502 was merged.

Are conventional commits preferred here? Or is any other specific style preferred?

I haven't checked the 10.x branch specifically, but its likely that this needs to be backported as well.