### PR TITLE
Allow -Duser.language to be overriden

### DIFF
--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -568,6 +568,8 @@ QStringList MinecraftInstance::javaArguments()
 {
     QStringList args;
 
+    args << "-Duser.language=en";
+
     // custom args go first. we want to override them if we have our own here.
     args.append(extraArguments());
 
@@ -620,8 +622,6 @@ QStringList MinecraftInstance::javaArguments()
             args << QString("-XX:PermSize=%1m").arg(permgen);
         }
     }
-
-    args << "-Duser.language=en";
 
     if (javaVersion.isModular() && shouldApplyOnlineFixes())
         // allow reflective access to java.net - required by the skin fix


### PR DESCRIPTION
<img width="419" height="116" alt="image" src="https://github.com/user-attachments/assets/d148c39b-093b-414a-bb48-2ca07a87c89a" />

Before (dumping system properties from MC process):
<img width="383" height="103" alt="image" src="https://github.com/user-attachments/assets/15587ead-2de5-4600-acf5-d54e87004480" />

After:

<img width="247" height="109" alt="image" src="https://github.com/user-attachments/assets/b1811a43-cd51-489c-86fa-e0a6285e548b" />


Ideally we wouldn't force user.language but IIRC it does fix some poor mod code