### PR TITLE
feat: disable pch on codeql build

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Configure and Build
         run: |
-          cmake --preset linux
+          cmake --preset linux -DLauncher_USE_PCH=OFF
           cmake --build --preset linux --config Debug
 
       - name: Run tests


### PR DESCRIPTION
this allows us to notice when no-pch builds break

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
