### PR TITLE
ui: making trackpad scrolling smoother across all listing views

### DIFF
--- a/launcher/ui/pages/instance/ManagedPackPage.cpp
+++ b/launcher/ui/pages/instance/ManagedPackPage.cpp
@@ -103,6 +103,9 @@ ManagedPackPage::ManagedPackPage(BaseInstance* inst, InstanceWindow* instance_wi
         ui->versionsComboBox->setStyle(comboStyle);
     }
 
+    ui->versionsComboBox->view()->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    ui->versionsComboBox->view()->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
+
     ui->reloadButton->setVisible(false);
     connect(ui->reloadButton, &QPushButton::clicked, this, [this](bool) {
         ui->reloadButton->setVisible(false);

--- a/launcher/ui/pages/instance/ScreenshotsPage.ui
+++ b/launcher/ui/pages/instance/ScreenshotsPage.ui
@@ -38,6 +38,9 @@
       <property name="movement">
        <enum>QListView::Movement::Static</enum>
       </property>
+      <property name="verticalScrollMode">
+       <enum>QAbstractItemView::ScrollPerPixel</enum>
+      </property>
      </widget>
     </item>
    </layout>

--- a/launcher/ui/pages/instance/ServersPage.ui
+++ b/launcher/ui/pages/instance/ServersPage.ui
@@ -53,6 +53,9 @@
       <property name="rootIsDecorated">
        <bool>false</bool>
       </property>
+      <property name="verticalScrollMode">
+       <enum>QAbstractItemView::ScrollPerPixel</enum>
+      </property>
       <attribute name="headerStretchLastSection">
        <bool>false</bool>
       </attribute>

--- a/launcher/ui/pages/instance/WorldListPage.ui
+++ b/launcher/ui/pages/instance/WorldListPage.ui
@@ -53,6 +53,9 @@
       <property name="allColumnsShowFocus">
        <bool>true</bool>
       </property>
+      <property name="verticalScrollMode">
+       <enum>QAbstractItemView::ScrollPerPixel</enum>
+      </property>
       <attribute name="headerStretchLastSection">
        <bool>false</bool>
       </attribute>

--- a/launcher/ui/pages/modplatform/OptionalModDialog.ui
+++ b/launcher/ui/pages/modplatform/OptionalModDialog.ui
@@ -24,6 +24,9 @@
        <property name="alternatingRowColors">
         <bool>true</bool>
        </property>
+       <property name="verticalScrollMode">
+        <enum>QAbstractItemView::ScrollPerPixel</enum>
+       </property>
       </widget>
      </item>
      <item>

--- a/launcher/ui/pages/modplatform/ResourcePage.cpp
+++ b/launcher/ui/pages/modplatform/ResourcePage.cpp
@@ -63,6 +63,7 @@ ResourcePage::ResourcePage(ResourceDownloadDialog* parent, BaseInstance& base_in
     m_ui->searchEdit->installEventFilter(this);
 
     m_ui->versionSelectionBox->view()->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    m_ui->versionSelectionBox->view()->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
     m_ui->versionSelectionBox->view()->parentWidget()->setMaximumHeight(300);
 
     m_searchTimer.setTimerType(Qt::TimerType::CoarseTimer);

--- a/launcher/ui/pages/modplatform/ResourcePage.ui
+++ b/launcher/ui/pages/modplatform/ResourcePage.ui
@@ -47,6 +47,9 @@
         <height>48</height>
        </size>
       </property>
+      <property name="verticalScrollMode">
+       <enum>QAbstractItemView::ScrollPerPixel</enum>
+      </property>
      </widget>
      <widget class="ProjectDescriptionPage" name="packDescription">
       <property name="openExternalLinks">

--- a/launcher/ui/pages/modplatform/atlauncher/AtlOptionalModDialog.ui
+++ b/launcher/ui/pages/modplatform/atlauncher/AtlOptionalModDialog.ui
@@ -49,7 +49,11 @@
     </widget>
    </item>
    <item row="0" column="0" colspan="4">
-    <widget class="ModListView" name="treeView"/>
+    <widget class="ModListView" name="treeView">
+     <property name="verticalScrollMode">
+      <enum>QAbstractItemView::ScrollPerPixel</enum>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/launcher/ui/pages/modplatform/atlauncher/AtlPage.cpp
+++ b/launcher/ui/pages/modplatform/atlauncher/AtlPage.cpp
@@ -61,6 +61,7 @@ AtlPage::AtlPage(NewInstanceDialog* dialog, QWidget* parent) : QWidget(parent), 
     ui->packView->setIndentation(0);
 
     ui->versionSelectionBox->view()->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    ui->versionSelectionBox->view()->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
     ui->versionSelectionBox->view()->parentWidget()->setMaximumHeight(300);
 
     for (int i = 0; i < filterModel->getAvailableSortings().size(); i++) {

--- a/launcher/ui/pages/modplatform/atlauncher/AtlPage.ui
+++ b/launcher/ui/pages/modplatform/atlauncher/AtlPage.ui
@@ -52,6 +52,9 @@
          <height>48</height>
         </size>
        </property>
+       <property name="verticalScrollMode">
+        <enum>QAbstractItemView::ScrollPerPixel</enum>
+       </property>
       </widget>
      </item>
      <item>

--- a/launcher/ui/pages/modplatform/flame/FlamePage.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.cpp
@@ -62,6 +62,7 @@ FlamePage::FlamePage(NewInstanceDialog* dialog, QWidget* parent)
     m_ui->packView->setModel(m_listModel);
 
     m_ui->versionSelectionBox->view()->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    m_ui->versionSelectionBox->view()->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
     m_ui->versionSelectionBox->view()->parentWidget()->setMaximumHeight(300);
 
     m_search_timer.setTimerType(Qt::TimerType::CoarseTimer);

--- a/launcher/ui/pages/modplatform/flame/FlamePage.ui
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.ui
@@ -72,6 +72,9 @@
         <height>48</height>
        </size>
       </property>
+      <property name="verticalScrollMode">
+       <enum>QAbstractItemView::ScrollPerPixel</enum>
+      </property>
      </widget>
      <widget class="ProjectDescriptionPage" name="packDescription">
       <property name="openExternalLinks">

--- a/launcher/ui/pages/modplatform/ftb/FtbPage.cpp
+++ b/launcher/ui/pages/modplatform/ftb/FtbPage.cpp
@@ -60,6 +60,7 @@ FtbPage::FtbPage(NewInstanceDialog* dialog, QWidget* parent) : QWidget(parent), 
     m_ui->searchEdit->installEventFilter(this);
 
     m_ui->versionSelectionBox->view()->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    m_ui->versionSelectionBox->view()->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
     m_ui->versionSelectionBox->view()->parentWidget()->setMaximumHeight(300);
 
     for (int i = 0; i < m_filterModel->getAvailableSortings().size(); i++) {

--- a/launcher/ui/pages/modplatform/ftb/FtbPage.ui
+++ b/launcher/ui/pages/modplatform/ftb/FtbPage.ui
@@ -54,6 +54,9 @@
          <height>48</height>
         </size>
        </property>
+       <property name="verticalScrollMode">
+        <enum>QAbstractItemView::ScrollPerPixel</enum>
+       </property>
       </widget>
      </item>
      <item row="0" column="1">

--- a/launcher/ui/pages/modplatform/import_ftb/ImportFTBPage.ui
+++ b/launcher/ui/pages/modplatform/import_ftb/ImportFTBPage.ui
@@ -61,6 +61,9 @@
    </item>
    <item>
     <widget class="QTreeView" name="modpackList">
+     <property name="verticalScrollMode">
+      <enum>QAbstractItemView::ScrollPerPixel</enum>
+     </property>
      <property name="maximumSize">
       <size>
        <width>16777215</width>

--- a/launcher/ui/pages/modplatform/legacy_ftb/Page.cpp
+++ b/launcher/ui/pages/modplatform/legacy_ftb/Page.cpp
@@ -107,6 +107,7 @@ Page::Page(NewInstanceDialog* dialog, QWidget* parent) : QWidget(parent), dialog
     }
 
     ui->versionSelectionBox->view()->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    ui->versionSelectionBox->view()->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
     ui->versionSelectionBox->view()->parentWidget()->setMaximumHeight(300);
 
     connect(ui->sortByBox, &QComboBox::currentTextChanged, this, &Page::onSortingSelectionChanged);

--- a/launcher/ui/pages/modplatform/legacy_ftb/Page.ui
+++ b/launcher/ui/pages/modplatform/legacy_ftb/Page.ui
@@ -46,6 +46,9 @@
          <property name="alternatingRowColors">
           <bool>true</bool>
          </property>
+         <property name="verticalScrollMode">
+          <enum>QAbstractItemView::ScrollPerPixel</enum>
+         </property>
         </widget>
        </item>
        <item row="0" column="1">
@@ -80,6 +83,9 @@
          <property name="alternatingRowColors">
           <bool>true</bool>
          </property>
+         <property name="verticalScrollMode">
+          <enum>QAbstractItemView::ScrollPerPixel</enum>
+         </property>
         </widget>
        </item>
       </layout>
@@ -99,6 +105,9 @@
          </property>
          <property name="alternatingRowColors">
           <bool>true</bool>
+         </property>
+         <property name="verticalScrollMode">
+          <enum>QAbstractItemView::ScrollPerPixel</enum>
          </property>
         </widget>
        </item>

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
@@ -68,6 +68,7 @@ ModrinthPage::ModrinthPage(NewInstanceDialog* dialog, QWidget* parent)
     m_ui->packView->setModel(m_model);
 
     m_ui->versionSelectionBox->view()->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    m_ui->versionSelectionBox->view()->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
     m_ui->versionSelectionBox->view()->parentWidget()->setMaximumHeight(300);
 
     m_search_timer.setTimerType(Qt::TimerType::CoarseTimer);

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.ui
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.ui
@@ -54,6 +54,9 @@
         <height>48</height>
        </size>
       </property>
+      <property name="verticalScrollMode">
+       <enum>QAbstractItemView::ScrollPerPixel</enum>
+      </property>
      </widget>
      <widget class="ProjectDescriptionPage" name="packDescription">
       <property name="openExternalLinks">

--- a/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
+++ b/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
@@ -61,6 +61,9 @@ TechnicPage::TechnicPage(NewInstanceDialog* dialog, QWidget* parent)
     ui->searchEdit->installEventFilter(this);
     model = new Technic::ListModel(this);
     ui->packView->setModel(model);
+    ui->versionSelectionBox->view()->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
+    ui->versionSelectionBox->view()->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
+    ui->versionSelectionBox->view()->parentWidget()->setMaximumHeight(300);
 
     m_search_timer.setTimerType(Qt::TimerType::CoarseTimer);
     m_search_timer.setSingleShot(true);

--- a/launcher/ui/pages/modplatform/technic/TechnicPage.ui
+++ b/launcher/ui/pages/modplatform/technic/TechnicPage.ui
@@ -31,6 +31,9 @@
          <height>48</height>
         </size>
        </property>
+       <property name="verticalScrollMode">
+        <enum>QAbstractItemView::ScrollPerPixel</enum>
+       </property>
       </widget>
      </item>
      <item>

--- a/launcher/ui/widgets/ModListView.cpp
+++ b/launcher/ui/widgets/ModListView.cpp
@@ -35,6 +35,7 @@ ModListView::ModListView(QWidget* parent) : QTreeView(parent)
     setDragEnabled(true);
     setDragDropMode(QAbstractItemView::DropOnly);
     viewport()->setAcceptDrops(true);
+    setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
 }
 
 void ModListView::setModel(QAbstractItemModel* model)

--- a/launcher/ui/widgets/VersionListView.cpp
+++ b/launcher/ui/widgets/VersionListView.cpp
@@ -44,6 +44,7 @@
 VersionListView::VersionListView(QWidget* parent) : QTreeView(parent)
 {
     m_emptyString = tr("No versions are currently available.");
+    setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
 }
 
 void VersionListView::rowsInserted(const QModelIndex& parent, int start, int end)


### PR DESCRIPTION
Changed the item by item scrolling on all listing views to pixel by pixel, so they are now smoothly scrolling, and thus less disorienting. Also it just looks better. :D

( this is at every list, not just mod browsing! )

before;

https://github.com/user-attachments/assets/481ac8a5-6c3d-4f20-9dea-c583a8af5be4


after;


https://github.com/user-attachments/assets/630b3d35-7b4b-4d06-98bd-deab7a579faa

