### PR TITLE
net: add HTTP resume for downloads with safe fallback behavior

### DIFF
--- a/launcher/net/ChecksumValidator.h
+++ b/launcher/net/ChecksumValidator.h
@@ -69,6 +69,12 @@ class ChecksumValidator : public Validator {
         return true;
     }
 
+    auto reset() -> bool override
+    {
+        m_checksum.reset();
+        return true;
+    }
+
     auto validate(QNetworkReply&) -> bool override
     {
         if (m_expected.size() && m_expected != hash()) {

--- a/launcher/net/FileSink.cpp
+++ b/launcher/net/FileSink.cpp
@@ -39,6 +39,9 @@
 
 #include "net/Logging.h"
 
+#include <QDateTime>
+#include <QFileInfo>
+
 namespace Net {
 
 Task::State FileSink::init(QNetworkRequest& request)
@@ -48,48 +51,136 @@ Task::State FileSink::init(QNetworkRequest& request)
         return result;
     }
 
-    // create a new save file and open it for writing
-    if (!FS::ensureFilePathExists(m_filename)) {
-        qCCritical(taskNetLogC) << "Could not create folder for " + m_filename;
+    m_part_path = m_filename + ".part";
+    m_wroteAnyData = false;
+    m_part_size = -1;
+
+    if (m_output_file && m_output_file->isOpen()) {
+        m_output_file->close();
+    }
+    m_output_file.reset();
+
+    // create destination path and initialize validators
+    if (!FS::ensureFilePathExists(m_part_path)) {
+        qCCritical(taskNetLogC) << "Could not create folder for " + m_part_path;
         m_fail_reason = "Could not create folder";
         return Task::State::Failed;
     }
+    if (!initAllValidators(request)) {
+        m_fail_reason = "Failed to initialize validators";
+        return Task::State::Failed;
+    }
 
-    m_wroteAnyData = false;
-    m_output_file.reset(new PSaveFile(m_filename));
-    if (!m_output_file->open(QIODevice::WriteOnly)) {
-        qCCritical(taskNetLogC) << "Could not open " + m_filename + " for writing";
+    QFileInfo partInfo(m_part_path);
+    if (partInfo.exists()) {
+        auto modified = partInfo.lastModified();
+        if (modified.isValid() && modified.daysTo(QDateTime::currentDateTimeUtc()) > 7) {
+            qCWarning(taskNetLogC) << "Removing stale partial download" << m_part_path;
+            QFile::remove(m_part_path);
+            partInfo.refresh();
+        }
+    }
+
+    // if we already have partial data, pre-seed validators and continue from there
+    if (partInfo.exists() && partInfo.size() > 0) {
+        QFile seedFile(m_part_path);
+        if (!seedFile.open(QIODevice::ReadOnly)) {
+            qCWarning(taskNetLogC) << "Failed to open partial file for resume, restarting:" << m_part_path;
+            if (!QFile::remove(m_part_path) && QFile::exists(m_part_path)) {
+                qCCritical(taskNetLogC) << "Failed to remove invalid partial file" << m_part_path;
+                m_fail_reason = "Failed to reset partial file";
+                return Task::State::Failed;
+            }
+            if (!resetAllValidators()) {
+                m_fail_reason = "Failed to reset validators";
+                return Task::State::Failed;
+            }
+        } else {
+            constexpr qint64 CHUNK_BUFFER_SIZE = 1024 * 1024;
+            bool readError = false;
+            while (!seedFile.atEnd()) {
+                auto chunk = seedFile.read(CHUNK_BUFFER_SIZE);
+                if (seedFile.error() != QFile::NoError) {
+                    readError = true;
+                    break;
+                }
+                if (chunk.isEmpty()) {
+                    if (!seedFile.atEnd()) {
+                        readError = true;
+                    }
+                    break;
+                }
+                if (!writeAllValidators(chunk)) {
+                    readError = true;
+                    break;
+                }
+            }
+
+            if (readError) {
+                qCWarning(taskNetLogC) << "Partial download is invalid, restarting:" << m_part_path;
+                seedFile.close();
+                if (!QFile::remove(m_part_path) && QFile::exists(m_part_path)) {
+                    qCCritical(taskNetLogC) << "Failed to remove invalid partial file" << m_part_path;
+                    m_fail_reason = "Failed to reset partial file";
+                    return Task::State::Failed;
+                }
+                if (!resetAllValidators()) {
+                    m_fail_reason = "Failed to reset validators";
+                    return Task::State::Failed;
+                }
+            } else {
+                m_part_size = seedFile.size();
+                qCDebug(taskNetLogC) << "Resuming from partial file" << m_part_path << "with size" << m_part_size;
+                seedFile.close();
+            }
+        }
+    }
+
+    m_output_file = std::make_unique<QFile>(m_part_path);
+    QIODevice::OpenMode mode = QIODevice::WriteOnly;
+    if (QFileInfo(m_part_path).exists()) {
+        mode |= QIODevice::Append;
+    } else {
+        mode |= QIODevice::Truncate;
+    }
+    if (!m_output_file->open(mode)) {
+        qCCritical(taskNetLogC) << "Could not open" << m_part_path << "for writing";
         m_fail_reason = "Could not open file";
         return Task::State::Failed;
     }
 
-    if (initAllValidators(request))
-        return Task::State::Running;
-    m_fail_reason = "Failed to initialize validators";
-    return Task::State::Failed;
+    if (m_part_size < 0) {
+        m_part_size = m_output_file->size();
+    }
+    return Task::State::Running;
 }
 
 Task::State FileSink::write(QByteArray& data)
 {
-    if (!writeAllValidators(data) || m_output_file->write(data) != data.size()) {
-        qCCritical(taskNetLogC) << "Failed writing into " + m_filename;
-        m_output_file->cancelWriting();
+    if (!m_output_file || !m_output_file->isOpen() || !writeAllValidators(data) || m_output_file->write(data) != data.size()) {
+        qCCritical(taskNetLogC) << "Failed writing into" << m_part_path;
+        if (m_output_file && m_output_file->isOpen()) {
+            m_output_file->close();
+        }
         m_output_file.reset();
         m_wroteAnyData = false;
-        m_fail_reason = "Failed to write validators";
+        m_fail_reason = "Failed to write output";
         return Task::State::Failed;
     }
 
     m_wroteAnyData = true;
+    m_part_size += data.size();
     return Task::State::Running;
 }
 
 Task::State FileSink::abort()
 {
-    if (m_output_file) {
-        m_output_file->cancelWriting();
+    if (m_output_file && m_output_file->isOpen()) {
+        m_output_file->close();
     }
     failAllValidators();
+    m_part_size = currentLocalSize();
+    m_wroteAnyData = false;
     return Task::State::Failed;
 }
 
@@ -101,30 +192,62 @@ Task::State FileSink::finalize(QNetworkReply& reply)
     int statusCode = statusCodeV.toInt(&validStatus);
     if (validStatus) {
         // this leaves out 304 Not Modified
-        gotFile = statusCode == 200 || statusCode == 203;
+        gotFile = statusCode == 200 || statusCode == 203 || statusCode == 206;
     }
 
-    // if we wrote any data to the save file, we try to commit the data to the real file.
+    // if we wrote any data to the temporary file, try to commit it to the destination.
     // if it actually got a proper file, we write it even if it was empty
     if (gotFile || m_wroteAnyData) {
-        // ask validators for data consistency
-        // we only do this for actual downloads, not 'your data is still the same' cache hits
+        if (m_output_file && m_output_file->isOpen()) {
+            if (!m_output_file->flush()) {
+                qCCritical(taskNetLogC) << "Failed flushing partial file" << m_part_path;
+                m_fail_reason = "Failed to flush output file";
+                return Task::State::Failed;
+            }
+            m_output_file->close();
+        }
+
         if (!finalizeAllValidators(reply)) {
+            QFile::remove(m_part_path);
             m_fail_reason = "Failed to finalize validators";
             return Task::State::Failed;
         }
 
-        // nothing went wrong...
-        if (!m_output_file->commit()) {
+        QString backup_path;
+        bool destination_backed_up = false;
+        if (QFile::exists(m_filename)) {
+            backup_path = m_filename + ".old";
+
+            if (QFile::exists(backup_path) && !QFile::remove(backup_path)) {
+                qCCritical(taskNetLogC) << "Failed to prepare backup path" << backup_path;
+                m_fail_reason = "Failed to prepare file replacement backup";
+                return Task::State::Failed;
+            }
+
+            if (!QFile::rename(m_filename, backup_path)) {
+                qCCritical(taskNetLogC) << "Failed to backup destination file" << m_filename;
+                m_fail_reason = "Failed to replace destination file";
+                return Task::State::Failed;
+            }
+            destination_backed_up = true;
+        }
+
+        if (!QFile::rename(m_part_path, m_filename)) {
             qCCritical(taskNetLogC) << "Failed to commit changes to" << m_filename;
-            m_output_file->cancelWriting();
+            if (destination_backed_up && !QFile::rename(backup_path, m_filename)) {
+                qCCritical(taskNetLogC) << "Failed to restore destination file from backup" << backup_path;
+            }
             m_fail_reason = "Failed to commit changes";
             return Task::State::Failed;
         }
+
+        if (destination_backed_up && !QFile::remove(backup_path)) {
+            qCWarning(taskNetLogC) << "Failed to remove destination backup file" << backup_path;
+        }
     }
 
-    // then get rid of the save file
     m_output_file.reset();
+    m_part_size = -1;
 
     return finalizeCache(reply);
 }
@@ -143,5 +266,52 @@ bool FileSink::hasLocalData()
 {
     QFileInfo info(m_filename);
     return info.exists() && info.size() != 0;
+}
+
+qint64 FileSink::currentLocalSize()
+{
+    QFileInfo partInfo(m_part_path);
+    if (!partInfo.exists()) {
+        m_part_size = 0;
+        return 0;
+    }
+
+    auto actualSize = partInfo.size();
+    if (m_part_size < 0 || m_part_size != actualSize) {
+        m_part_size = actualSize;
+    }
+    return m_part_size;
+}
+
+void FileSink::truncate()
+{
+    if (m_output_file && m_output_file->isOpen()) {
+        m_output_file->close();
+    }
+
+    QFile file(m_part_path);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        qCCritical(taskNetLogC) << "Failed truncating partial file" << m_part_path;
+        m_fail_reason = "Failed to truncate partial file";
+        m_output_file.reset();
+        return;
+    }
+
+    file.close();
+    m_part_size = 0;
+    m_wroteAnyData = false;
+
+    if (!resetAllValidators()) {
+        m_fail_reason = "Failed to reset validators";
+        m_output_file.reset();
+        return;
+    }
+
+    m_output_file = std::make_unique<QFile>(m_part_path);
+    if (!m_output_file->open(QIODevice::WriteOnly | QIODevice::Append)) {
+        qCCritical(taskNetLogC) << "Failed to reopen partial file" << m_part_path;
+        m_fail_reason = "Failed to reopen partial file";
+        m_output_file.reset();
+    }
 }
 }  // namespace Net

--- a/launcher/net/FileSink.h
+++ b/launcher/net/FileSink.h
@@ -35,13 +35,14 @@
 
 #pragma once
 
-#include "PSaveFile.h"
 #include "Sink.h"
+
+#include <QFile>
 
 namespace Net {
 class FileSink : public Sink {
    public:
-    FileSink(QString filename) : m_filename(filename) {};
+    FileSink(QString filename) : m_filename(filename), m_part_path(filename + ".part") {};
     virtual ~FileSink() = default;
 
    public:
@@ -51,6 +52,8 @@ class FileSink : public Sink {
     auto finalize(QNetworkReply& reply) -> Task::State override;
 
     auto hasLocalData() -> bool override;
+    auto currentLocalSize() -> qint64 override;
+    void truncate() override;
 
    protected:
     virtual auto initCache(QNetworkRequest&) -> Task::State;
@@ -58,7 +61,9 @@ class FileSink : public Sink {
 
    protected:
     QString m_filename;
+    QString m_part_path;
     bool m_wroteAnyData = false;
-    std::unique_ptr<PSaveFile> m_output_file;
+    qint64 m_part_size = -1;
+    std::unique_ptr<QFile> m_output_file;
 };
 }  // namespace Net

--- a/launcher/net/NetRequest.cpp
+++ b/launcher/net/NetRequest.cpp
@@ -42,7 +42,9 @@
 #include <QDateTime>
 #include <QFileInfo>
 #include <QLocale>
+#include <QMetaObject>
 #include <QNetworkReply>
+#include <QRegularExpression>
 #include <QUrl>
 #include <cstdint>
 #include <memory>
@@ -80,6 +82,9 @@ void NetRequest::executeTask()
     }
 
     QNetworkRequest request(m_url);
+    m_firstDataChunk = true;
+    m_errorResponse.clear();
+
     m_state = m_sink->init(request);
     switch (m_state) {
         case State::Succeeded:
@@ -111,6 +116,13 @@ void NetRequest::executeTask()
     request.setHeader(QNetworkRequest::UserAgentHeader, user_agent.toUtf8());
     for (auto& header_proxy : m_headerProxies) {
         header_proxy->writeHeaders(request);
+    }
+
+    m_resumeOffset = m_sink->currentLocalSize();
+    qCDebug(logCat) << getUid().toString() << "Local partial size before request:" << m_resumeOffset << "for" << m_url.toString();
+    if (m_resumeOffset > 0) {
+        request.setRawHeader("Range", QString("bytes=%1-").arg(m_resumeOffset).toLatin1());
+        qCDebug(logCat) << getUid().toString() << "Attempting resume with Range from offset" << m_resumeOffset << "for" << m_url.toString();
     }
 
 #if defined(LAUNCHER_APPLICATION)
@@ -293,6 +305,47 @@ void NetRequest::downloadFinished()
         return;
     }
 
+    if (m_resumeOffset > 0 && replyStatusCode() == 416) {
+        if (m_416RetryCount >= MAX_416_RETRIES) {
+            qCCritical(logCat) << getUid().toString() << "Range retry limit reached for" << m_url.toString();
+            m_sink->abort();
+            m_failReason = tr("Failed to resume download after multiple retries");
+            emit failed(m_failReason);
+            emit finished();
+            return;
+        }
+
+        ++m_416RetryCount;
+        qCWarning(logCat) << getUid().toString() << "Server rejected resume range, retrying from start:" << m_url.toString();
+        m_sink->truncate();
+        m_resumeOffset = 0;
+
+        QMetaObject::invokeMethod(
+            this, [this] { executeTask(); }, Qt::QueuedConnection
+        );
+        return;
+    }
+
+    if (m_resumeOffset > 0 && replyStatusCode() == 404) {
+        qCWarning(logCat) << getUid().toString() << "Resume request returned 404, retrying from start:" << m_url.toString();
+        m_sink->truncate();
+        m_resumeOffset = 0;
+
+        QMetaObject::invokeMethod(
+            this, [this] { executeTask(); }, Qt::QueuedConnection
+        );
+        return;
+    }
+
+    if (m_resumeOffset > 0 && m_firstDataChunk) {
+        auto statusCode = replyStatusCode();
+        if (statusCode == 200 || statusCode == 203) {
+            qCWarning(logCat) << getUid().toString() << "Server ignored Range without readyRead, downloading from start:" << m_url.toString();
+            m_sink->truncate();
+            m_resumeOffset = 0;
+        }
+    }
+
     // handle HTTP redirection first
     if (handleRedirect()) {
         qCDebug(logCat) << getUid().toString() << "Request redirected:" << m_url.toString();
@@ -356,6 +409,63 @@ void NetRequest::downloadFinished()
 void NetRequest::downloadReadyRead()
 {
     if (m_state == State::Running) {
+        if (m_firstDataChunk) {
+            m_firstDataChunk = false;
+            auto statusCode = replyStatusCode();
+            qCDebug(logCat) << getUid().toString() << "First response chunk status" << statusCode << "for" << m_url.toString();
+
+            if (m_resumeOffset > 0) {
+                if (statusCode == 200 || statusCode == 203) {
+                    qCWarning(logCat) << getUid().toString() << "Server ignored Range, downloading from start:" << m_url.toString();
+                    m_sink->truncate();
+                    m_resumeOffset = 0;
+                } else if (statusCode == 206) {
+                    auto contentRange = QString::fromLatin1(m_reply->rawHeader("Content-Range"));
+                    qCDebug(logCat) << getUid().toString() << "Received Content-Range:" << contentRange;
+                    QRegularExpression regex("^bytes\\s+(\\d+)-(\\d+)/(\\d+|\\*)$", QRegularExpression::CaseInsensitiveOption);
+                    auto match = regex.match(contentRange);
+
+                    bool shouldRestart = false;
+                    if (!match.hasMatch()) {
+                        shouldRestart = true;
+                    } else {
+                        bool startOk = false;
+                        bool totalOk = false;
+                        auto rangeStart = match.captured(1).toLongLong(&startOk);
+                        auto totalStr = match.captured(3);
+                        qint64 totalSize = -1;
+                        if (totalStr != "*") {
+                            totalSize = totalStr.toLongLong(&totalOk);
+                        } else {
+                            totalOk = true;
+                        }
+                        if (!startOk || !totalOk || rangeStart != m_resumeOffset || (totalSize >= 0 && m_resumeOffset > totalSize)) {
+                            qCWarning(logCat) << getUid().toString() << "Content-Range validation failed. startOk =" << startOk
+                                              << "totalOk =" << totalOk << "rangeStart =" << rangeStart << "resumeOffset =" << m_resumeOffset
+                                              << "totalSize =" << totalSize;
+                            shouldRestart = true;
+                        }
+                    }
+
+                    if (shouldRestart) {
+                        qCWarning(logCat) << getUid().toString() << "Invalid Content-Range, restarting from start:" << contentRange;
+                        m_sink->truncate();
+                        m_resumeOffset = 0;
+
+                        if (m_reply) {
+                            disconnect(m_reply.get(), nullptr, this, nullptr);
+                            m_reply->abort();
+                        }
+
+                        QMetaObject::invokeMethod(
+                            this, [this] { executeTask(); }, Qt::QueuedConnection
+                        );
+                        return;
+                    }
+                }
+            }
+        }
+
         auto data = m_reply->readAll();
         m_state = m_sink->write(data);
         if (replyStatusCode() >= 400) {

--- a/launcher/net/NetRequest.h
+++ b/launcher/net/NetRequest.h
@@ -97,6 +97,10 @@ class NetRequest : public Task {
    protected:
     std::unique_ptr<Sink> m_sink;
     Options m_options;
+    bool m_firstDataChunk = true;
+    int m_416RetryCount = 0;
+    qint64 m_resumeOffset = 0;
+    static constexpr int MAX_416_RETRIES = 3;
 
     using logCatFunc = const QLoggingCategory& (*)();
     logCatFunc logCat = taskUploadLogC;

--- a/launcher/net/Sink.h
+++ b/launcher/net/Sink.h
@@ -51,6 +51,8 @@ class Sink {
     virtual auto finalize(QNetworkReply& reply) -> Task::State = 0;
 
     virtual auto hasLocalData() -> bool = 0;
+    virtual auto currentLocalSize() -> qint64 { return 0; }
+    virtual void truncate() {}
 
     QString failReason() const { return m_fail_reason; }
 
@@ -90,6 +92,14 @@ class Sink {
     {
         for (auto& validator : validators) {
             if (!validator->write(data))
+                return false;
+        }
+        return true;
+    }
+    bool resetAllValidators()
+    {
+        for (auto& validator : validators) {
+            if (!validator->reset())
                 return false;
         }
         return true;

--- a/launcher/net/Validator.h
+++ b/launcher/net/Validator.h
@@ -47,5 +47,6 @@ class Validator {
     virtual bool write(QByteArray& data) = 0;
     virtual bool abort() = 0;
     virtual bool validate(QNetworkReply& reply) = 0;
+    virtual bool reset() { return true; }
 };
 }  // namespace Net


### PR DESCRIPTION
## What this PR does
This adds resumable HTTP downloads in `launcher/net` for file-based sinks.

In short:
- keep partial downloads in `<file>.part`
- send `Range` requests when a partial file exists
- continue from partial data when the server supports it
- safely fall back to full redownload when resume is not usable

## Main changes
- `Sink` / `Validator` interfaces:
  - added backward-compatible defaults for resume/reset support
- `FileSink`:
  - switched to `.part` workflow
  - pre-seeds validators from existing partial data
  - supports truncation/reset/reopen for fallback paths
  - finalizes with safer replace flow
- `NetRequest`:
  - sends `Range: bytes=<offset>-` when local partial data exists
  - handles first-chunk resume validation (`206` + `Content-Range`)
  - falls back to restart-from-zero on resume failures (`404`, invalid resume response)
  - keeps bounded retry handling for range rejection paths

## Why
With unstable connections, interrupted large downloads should not always restart from zero.
When resume is unsupported or unreliable on a backend, we still need a clean recovery path.

## Manual testing notes
Tested with forced/real connection interruptions.
Observed in logs:
- **Modrinth (`cdn.modrinth.com`)**
  - resume request with `Range`
  - server returns `206 Partial Content`
  - file completes successfully
- **Forge CDN (`edge.forgecdn.net`)**
  - resume request is attempted
  - server may return `404` for ranged retry
  - launcher falls back to restart-from-zero and completes successfully

So both important paths were validated:
1. true partial resume where supported
2. robust fallback where resume is not usable

## Development notes
C++ is not my strongest language, so I worked on this together with GPT Codex to ensure correctness. Everything has been tested manually with real-world interruption scenarios, but additional review from experienced C++ developers would be appreciated.

## Scope / non-goals
- No dedicated Mojang assets/libraries resume matrix in this round.
- A separate crash issue observed in `Flame::FileResolvingTask` is intentionally **not** included here (to keep this PR focused).

## Compatibility
Existing sinks/validators remain source-compatible due to default virtual methods.