### PR TITLE
Fix: Remove trademark and special characters from instance folder names

### DIFF
--- a/aqtinstall.log
+++ b/aqtinstall.log
@@ -1,0 +1,6 @@
+2026-02-14 18:25:31,848 - aqt.main - INFO - installer 24540 aqtinstall(aqt) v3.3.0 on Python 3.13.12 [CPython MSC v.1944 64 bit (AMD64)]
+2026-02-14 18:25:31,849 - aqt.helper - DEBUG - helper 24540 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt6_660/Updates.xml.sha256
+2026-02-14 18:25:33,491 - aqt.main - ERROR - installer 24540 The packages ['qt_base', 'qtimageformats', 'qtnetworkauth'] were not found while parsing XML of package information!
+==============================Suggested follow-up:==============================
+* Please use 'aqt list-qt windows desktop --arch 6.6.0' to show architectures available.
+* Please use 'aqt list-qt windows desktop --modules 6.6.0 <arch>' to show modules available.

--- a/aqtinstall.log
+++ b/aqtinstall.log
@@ -1,6 +1,0 @@
-2026-02-14 18:25:31,848 - aqt.main - INFO - installer 24540 aqtinstall(aqt) v3.3.0 on Python 3.13.12 [CPython MSC v.1944 64 bit (AMD64)]
-2026-02-14 18:25:31,849 - aqt.helper - DEBUG - helper 24540 Attempt to download checksum at https://download.qt.io/online/qtsdkrepository/windows_x86/desktop/qt6_660/Updates.xml.sha256
-2026-02-14 18:25:33,491 - aqt.main - ERROR - installer 24540 The packages ['qt_base', 'qtimageformats', 'qtnetworkauth'] were not found while parsing XML of package information!
-==============================Suggested follow-up:==============================
-* Please use 'aqt list-qt windows desktop --arch 6.6.0' to show architectures available.
-* Please use 'aqt list-qt windows desktop --modules 6.6.0 <arch>' to show modules available.

--- a/launcher/FileSystem.cpp
+++ b/launcher/FileSystem.cpp
@@ -793,7 +793,7 @@ QString NormalizePath(QString path)
     }
 }
 
-static const QString BAD_WIN_CHARS = "<>:\"|?*\r\n";
+static const QString BAD_WIN_CHARS = "<>:\"|?*\r\n™®©";
 static const QString BAD_NTFS_CHARS = "<>:\"|?*";
 static const QString BAD_HFS_CHARS = ":";
 


### PR DESCRIPTION
Added trademark (™), registered (®), and copyright (©) symbols to BAD_WIN_CHARS to prevent crashes when mods attempt to access files in directories containing these characters.

Fixes #4508
Signed-off-by: Fernando-Colimon <colimonfernando10@gmail.com>
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
