### PR TITLE
fix(flame): avoid double-fail assert in file resolving

### DIFF
--- a/launcher/modplatform/flame/FileResolvingTask.cpp
+++ b/launcher/modplatform/flame/FileResolvingTask.cpp
@@ -60,7 +60,7 @@ void Flame::FileResolvingTask::executeTask()
     m_task = flameAPI.getFiles(fileIds, m_result.get());
 
     auto step_progress = std::make_shared<TaskStepProgress>();
-    connect(m_task.get(), &Task::finished, this, [this, step_progress]() {
+    connect(m_task.get(), &Task::succeeded, this, [this, step_progress]() {
         step_progress->state = TaskStepState::Succeeded;
         stepProgress(*step_progress);
         netJobFinished();

--- a/launcher/modplatform/flame/FileResolvingTask.cpp
+++ b/launcher/modplatform/flame/FileResolvingTask.cpp
@@ -157,7 +157,7 @@ void Flame::FileResolvingTask::netJobFinished()
     m_task = modrinthAPI.currentVersions(hashes, "sha1", m_result.get());
     (dynamic_cast<NetJob*>(m_task.get()))->setAskRetry(false);
     auto step_progress = std::make_shared<TaskStepProgress>();
-    connect(m_task.get(), &Task::finished, this, [this, step_progress]() {
+    connect(m_task.get(), &Task::succeeded, this, [this, step_progress]() {
         step_progress->state = TaskStepState::Succeeded;
         stepProgress(*step_progress);
         QJsonParseError parse_error{};
@@ -203,6 +203,7 @@ void Flame::FileResolvingTask::netJobFinished()
     connect(m_task.get(), &Task::failed, this, [this, step_progress](QString reason) {
         step_progress->state = TaskStepState::Failed;
         stepProgress(*step_progress);
+        getFlameProjects();
     });
     connect(m_task.get(), &Task::stepProgress, this, &FileResolvingTask::propagateStepProgress);
     connect(m_task.get(), &Task::progress, this, [this, step_progress](qint64 current, qint64 total) {


### PR DESCRIPTION
## Fix CurseForge pack import crash on network errors

### Problem
When importing a CurseForge pack with unstable internet, the launcher can crash with assert:
`ASSERT: "(!isRunning()) == false"` in `launcher/tasks/Task.cpp:115`.

### What happens
From log (full log available upon request):
- Requests to `api.curseforge.com/v1/mods/files` fail with network errors
- Launcher tries to parse response as JSON → parse error
- Fatal assert triggered

### Root cause
In `FileResolvingTask.cpp`, the `netJobFinished()` handler is connected to `Task::finished`, which fires on **both** success and failure.

On network error:
1. `failed` → `emitFailed()` → task marked as completed
2. `finished` → `netJobFinished()` → tries to call `emitFailed()` again
3. Second `emitFailed()` hits assert (task no longer in `Running` state)

### Fix
Replace `Task::finished` with `Task::succeeded` when connecting `netJobFinished()`.
Now the handler only runs on **successful** request completion.

### How to reproduce
1. Start importing a CurseForge pack
2. Simulate unstable connection (packet loss / disconnects)
3. Before fix: crash with assert in `Task.cpp:115`
4. After fix: normal error handling through UI