### PR TITLE
 [Backport release-10.x] Fix InstanceStaging reentry crash during Modrinth pack updates

### DIFF
--- a/launcher/InstanceList.cpp
+++ b/launcher/InstanceList.cpp
@@ -928,6 +928,7 @@ class InstanceStaging : public Task {
         connect(child, &Task::progress, this, &InstanceStaging::setProgress);
         connect(child, &Task::stepProgress, this, &InstanceStaging::propagateStepProgress);
         connect(&m_backoffTimer, &QTimer::timeout, this, &InstanceStaging::childSucceeded);
+        m_backoffTimer.setSingleShot(true);
     }
 
     virtual ~InstanceStaging() {}
@@ -959,13 +960,17 @@ class InstanceStaging : public Task {
    private slots:
     void childSucceeded()
     {
+        if (!isRunning())
+            return;
         unsigned sleepTime = backoff();
         if (m_parent->commitStagedInstance(m_stagingPath, *m_child.get(), m_child->group(), *m_child.get())) {
+            m_backoffTimer.stop();
             emitSucceeded();
             return;
         }
         // we actually failed, retry?
         if (sleepTime == maxBackoff) {
+            m_backoffTimer.stop();
             emitFailed(tr("Failed to commit instance, even after multiple retries. It is being blocked by something."));
             return;
         }
@@ -974,12 +979,14 @@ class InstanceStaging : public Task {
     }
     void childFailed(const QString& reason)
     {
+        m_backoffTimer.stop();
         m_parent->destroyStagingPath(m_stagingPath);
         emitFailed(reason);
     }
 
     void childAborted()
     {
+        m_backoffTimer.stop();
         m_parent->destroyStagingPath(m_stagingPath);
         emitAborted();
     }

--- a/launcher/minecraft/auth/steps/EntitlementsStep.cpp
+++ b/launcher/minecraft/auth/steps/EntitlementsStep.cpp
@@ -32,6 +32,7 @@ void EntitlementsStep::perform()
                                            { "Authorization", QString("Bearer %1").arg(m_data->yggdrasilToken.token).toUtf8() } };
 
     m_response.reset(new QByteArray());
+    m_request = Net::Download::makeByteArray(url, m_response.get());
     m_request->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(headers));
     m_request->enableAutoRetry(true);
 


### PR DESCRIPTION
Trial-based backport to `release-10.x`, triggered by a comment https://github.com/PrismLauncher/PrismLauncher/pull/4982#issuecomment-3916509169