### PR TITLE
Stop showing a star on the oldest java

### DIFF
--- a/launcher/java/JavaInstall.h
+++ b/launcher/java/JavaInstall.h
@@ -39,7 +39,6 @@ struct JavaInstall : public BaseVersion {
     JavaVersion id;
     QString arch;
     QString path;
-    bool recommended = false;
     bool is_64bit = false;
 };
 

--- a/launcher/java/JavaInstallList.cpp
+++ b/launcher/java/JavaInstallList.cpp
@@ -108,7 +108,7 @@ QVariant JavaInstallList::data(const QModelIndex& index, int role) const
         case VersionRole:
             return version->id.toString();
         case RecommendedRole:
-            return version->recommended;
+            return false;
         case PathRole:
             return version->path;
         case CPUArchitectureRole:
@@ -128,10 +128,6 @@ void JavaInstallList::updateListData(QList<BaseVersion::Ptr> versions)
     beginResetModel();
     m_vlist = versions;
     sortVersions();
-    if (m_vlist.size()) {
-        auto best = std::dynamic_pointer_cast<JavaInstall>(m_vlist[0]);
-        best->recommended = true;
-    }
     endResetModel();
     m_status = Status::Done;
     m_load_task.reset();


### PR DESCRIPTION
For some reason the launcher currently shows a star next to the oldest Java version which doesn't make sense.
 In future perhaps it could be changed to show a star next to the oldest/newest *compatible* Java version?