### PR TITLE
no more help for you

### DIFF
--- a/launcher/InstancePageProvider.h
+++ b/launcher/InstancePageProvider.h
@@ -45,7 +45,7 @@ class InstancePageProvider : protected QObject, public BasePageProvider {
         values.append(new ServersPage(onesix));
         values.append(new ScreenshotsPage(FS::PathCombine(onesix->gameRoot(), "screenshots")));
         values.append(new InstanceSettingsPage(onesix));
-        values.append(new OtherLogsPage("logs", tr("Other Logs"), "Other-Logs", inst));
+        values.append(new OtherLogsPage("logs", tr("Other Logs"), inst));
         return values;
     }
 

--- a/launcher/ui/InstanceWindow.cpp
+++ b/launcher/ui/InstanceWindow.cpp
@@ -77,11 +77,6 @@ InstanceWindow::InstanceWindow(BaseInstance* instance, QWidget* parent) : QMainW
         horizontalLayout->setObjectName(QStringLiteral("horizontalLayout"));
         horizontalLayout->setContentsMargins(0, 0, 6, 6);
 
-        auto btnHelp = new QPushButton(this);
-        btnHelp->setText(tr("Help"));
-        horizontalLayout->addWidget(btnHelp);
-        connect(btnHelp, &QPushButton::clicked, m_container, &PageContainer::help);
-
         auto spacer = new QSpacerItem(40, 20, QSizePolicy::Expanding, QSizePolicy::Minimum);
         horizontalLayout->addSpacerItem(spacer);
 

--- a/launcher/ui/ViewLogWindow.cpp
+++ b/launcher/ui/ViewLogWindow.cpp
@@ -5,7 +5,7 @@
 #include "ui/pages/instance/OtherLogsPage.h"
 
 ViewLogWindow::ViewLogWindow(QWidget* parent)
-    : QMainWindow(parent), m_page(new OtherLogsPage("launcher-logs", tr("Launcher Logs"), "Launcher-Logs", nullptr, parent))
+    : QMainWindow(parent), m_page(new OtherLogsPage("launcher-logs", tr("Launcher Logs"), nullptr, parent))
 {
     setAttribute(Qt::WA_DeleteOnClose);
     setWindowIcon(QIcon::fromTheme("log"));

--- a/launcher/ui/dialogs/CopyInstanceDialog.cpp
+++ b/launcher/ui/dialogs/CopyInstanceDialog.cpp
@@ -107,9 +107,6 @@ CopyInstanceDialog::CopyInstanceDialog(BaseInstance* original, QWidget* parent)
     updateLinkOptions();
     updateUseCloneCheckbox();
 
-    auto HelpButton = ui->buttonBox->button(QDialogButtonBox::Help);
-    connect(HelpButton, &QPushButton::clicked, this, &CopyInstanceDialog::help);
-    HelpButton->setText(tr("Help"));
     ui->buttonBox->button(QDialogButtonBox::Cancel)->setText(tr("Cancel"));
     ui->buttonBox->button(QDialogButtonBox::Ok)->setText(tr("OK"));
 }
@@ -150,11 +147,6 @@ QString CopyInstanceDialog::instGroup() const
 const InstanceCopyPrefs& CopyInstanceDialog::getChosenOptions() const
 {
     return m_selectedOptions;
-}
-
-void CopyInstanceDialog::help()
-{
-    DesktopServices::openUrl(QUrl(BuildConfig.HELP_URL.arg("instance-copy")));
 }
 
 void CopyInstanceDialog::checkAllCheckboxes(const bool& b)

--- a/launcher/ui/dialogs/CopyInstanceDialog.h
+++ b/launcher/ui/dialogs/CopyInstanceDialog.h
@@ -40,9 +40,6 @@ class CopyInstanceDialog : public QDialog {
     QString iconKey() const;
     const InstanceCopyPrefs& getChosenOptions() const;
 
-   public slots:
-    void help();
-
    private slots:
     void on_iconButton_clicked();
     void on_instNameTextBox_textChanged(const QString& arg1);

--- a/launcher/ui/dialogs/CopyInstanceDialog.ui
+++ b/launcher/ui/dialogs/CopyInstanceDialog.ui
@@ -385,7 +385,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/launcher/ui/dialogs/NewInstanceDialog.cpp
+++ b/launcher/ui/dialogs/NewInstanceDialog.cpp
@@ -93,7 +93,7 @@ NewInstanceDialog::NewInstanceDialog(const QString& initialGroup,
 
     // NOTE: m_buttons must be initialized before PageContainer, because it indirectly accesses m_buttons through setSuggestedPack! Do not
     // move this below.
-    m_buttons = new QDialogButtonBox(QDialogButtonBox::Help | QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+    m_buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
 
     m_container = new PageContainer(this, {}, this);
     m_container->useSidebarStyle(false);
@@ -119,12 +119,6 @@ NewInstanceDialog::NewInstanceDialog(const QString& initialGroup,
     CancelButton->setAutoDefault(false);
     CancelButton->setText(tr("Cancel"));
     connect(CancelButton, &QPushButton::clicked, this, &NewInstanceDialog::reject);
-
-    auto HelpButton = m_buttons->button(QDialogButtonBox::Help);
-    HelpButton->setDefault(false);
-    HelpButton->setAutoDefault(false);
-    HelpButton->setText(tr("Help"));
-    connect(HelpButton, &QPushButton::clicked, m_container, &PageContainer::help);
 
     if (!url.isEmpty()) {
         QUrl actualUrl(url);

--- a/launcher/ui/dialogs/ResourceDownloadDialog.cpp
+++ b/launcher/ui/dialogs/ResourceDownloadDialog.cpp
@@ -50,10 +50,7 @@
 namespace ResourceDownload {
 
 ResourceDownloadDialog::ResourceDownloadDialog(QWidget* parent, ResourceFolderModel* base_model)
-    : QDialog(parent)
-    , m_base_model(base_model)
-    , m_buttons(QDialogButtonBox::Help | QDialogButtonBox::Ok | QDialogButtonBox::Cancel)
-    , m_vertical_layout(this)
+    : QDialog(parent), m_base_model(base_model), m_buttons(QDialogButtonBox::Ok | QDialogButtonBox::Cancel), m_vertical_layout(this)
 {
     setObjectName(QStringLiteral("ResourceDownloadDialog"));
 
@@ -61,10 +58,10 @@ ResourceDownloadDialog::ResourceDownloadDialog(QWidget* parent, ResourceFolderMo
 
     setWindowIcon(QIcon::fromTheme("new"));
 
-    // small margins look ugly on macOS on modal windows
-    #ifndef Q_OS_MACOS
+// small margins look ugly on macOS on modal windows
+#ifndef Q_OS_MACOS
     m_buttons.setContentsMargins(0, 0, 6, 6);
-    #endif
+#endif
     // Bonk Qt over its stupid head and make sure it understands which button is the default one...
     // See: https://stackoverflow.com/questions/24556831/qbuttonbox-set-default-button
     auto OkButton = m_buttons.button(QDialogButtonBox::Ok);
@@ -77,10 +74,6 @@ ResourceDownloadDialog::ResourceDownloadDialog(QWidget* parent, ResourceFolderMo
     auto CancelButton = m_buttons.button(QDialogButtonBox::Cancel);
     CancelButton->setDefault(false);
     CancelButton->setAutoDefault(false);
-
-    auto HelpButton = m_buttons.button(QDialogButtonBox::Help);
-    HelpButton->setDefault(false);
-    HelpButton->setAutoDefault(false);
 
     setWindowModality(Qt::WindowModal);
 }
@@ -118,10 +111,10 @@ void ResourceDownloadDialog::reject()
 // won't work with subclasses if we put it in this ctor.
 void ResourceDownloadDialog::initializeContainer()
 {
-    // small margins look ugly on macOS on modal windows
-    #ifndef Q_OS_MACOS
+// small margins look ugly on macOS on modal windows
+#ifndef Q_OS_MACOS
     layout()->setContentsMargins(0, 0, 0, 0);
-    #endif
+#endif
 
     m_container = new PageContainer(this, {}, this);
     m_container->setSizePolicy(QSizePolicy::Policy::Preferred, QSizePolicy::Policy::Expanding);
@@ -142,9 +135,6 @@ void ResourceDownloadDialog::connectButtons()
 
     auto CancelButton = m_buttons.button(QDialogButtonBox::Cancel);
     connect(CancelButton, &QPushButton::clicked, this, &ResourceDownloadDialog::reject);
-
-    auto HelpButton = m_buttons.button(QDialogButtonBox::Help);
-    connect(HelpButton, &QPushButton::clicked, m_container, &PageContainer::help);
 }
 
 void ResourceDownloadDialog::confirm()

--- a/launcher/ui/pagedialog/PageDialog.cpp
+++ b/launcher/ui/pagedialog/PageDialog.cpp
@@ -43,16 +43,14 @@ PageDialog::PageDialog(BasePageProvider* pageProvider, QString defaultId, QWidge
 
     setLayout(mainLayout);
 
-    auto* buttons = new QDialogButtonBox(QDialogButtonBox::Help | QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
+    auto* buttons = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel);
     buttons->button(QDialogButtonBox::Ok)->setText(tr("&OK"));
     buttons->button(QDialogButtonBox::Cancel)->setText(tr("&Cancel"));
-    buttons->button(QDialogButtonBox::Help)->setText(tr("Help"));
     buttons->setContentsMargins(0, 0, 6, 6);
     m_container->addButtons(buttons);
 
     connect(buttons->button(QDialogButtonBox::Ok), &QPushButton::clicked, this, &PageDialog::accept);
     connect(buttons->button(QDialogButtonBox::Cancel), &QPushButton::clicked, this, &PageDialog::reject);
-    connect(buttons->button(QDialogButtonBox::Help), &QPushButton::clicked, m_container, &PageContainer::help);
 
     restoreGeometry(QByteArray::fromBase64(APPLICATION->settings()->get("PagedGeometry").toString().toUtf8()));
 }

--- a/launcher/ui/pages/BasePage.h
+++ b/launcher/ui/pages/BasePage.h
@@ -51,7 +51,6 @@ class BasePage {
     virtual QIcon icon() const = 0;
     virtual bool apply() { return true; }
     virtual bool shouldDisplay() const { return true; }
-    virtual QString helpPage() const { return QString(); }
     void opened()
     {
         isOpened = true;

--- a/launcher/ui/pages/global/APIPage.h
+++ b/launcher/ui/pages/global/APIPage.h
@@ -55,7 +55,6 @@ class APIPage : public QWidget, public BasePage {
     QString displayName() const override { return tr("Services"); }
     QIcon icon() const override { return QIcon::fromTheme("worlds"); }
     QString id() const override { return "apis"; }
-    QString helpPage() const override { return "APIs"; }
     virtual bool apply() override;
     void retranslate() override;
 

--- a/launcher/ui/pages/global/AccountListPage.h
+++ b/launcher/ui/pages/global/AccountListPage.h
@@ -65,7 +65,6 @@ class AccountListPage : public QMainWindow, public BasePage {
         return icon;
     }
     QString id() const override { return "accounts"; }
-    QString helpPage() const override { return "getting-started/adding-an-account"; }
     void retranslate() override;
 
    public slots:

--- a/launcher/ui/pages/global/AppearancePage.h
+++ b/launcher/ui/pages/global/AppearancePage.h
@@ -54,7 +54,6 @@ class AppearancePage : public AppearanceWidget, public BasePage {
     QString displayName() const override { return tr("Appearance"); }
     QIcon icon() const override { return QIcon::fromTheme("appearance"); }
     QString id() const override { return "appearance-settings"; }
-    QString helpPage() const override { return "Launcher-settings"; }
 
     bool apply() override
     {

--- a/launcher/ui/pages/global/ExternalToolsPage.h
+++ b/launcher/ui/pages/global/ExternalToolsPage.h
@@ -60,7 +60,6 @@ class ExternalToolsPage : public QWidget, public BasePage {
         return icon;
     }
     QString id() const override { return "external-tools"; }
-    QString helpPage() const override { return "Tools"; }
     virtual bool apply() override;
     void retranslate() override;
 

--- a/launcher/ui/pages/global/JavaPage.h
+++ b/launcher/ui/pages/global/JavaPage.h
@@ -58,7 +58,6 @@ class JavaPage : public QWidget, public BasePage {
     QString displayName() const override { return tr("Java"); }
     QIcon icon() const override { return QIcon::fromTheme("java"); }
     QString id() const override { return "java-settings"; }
-    QString helpPage() const override { return "Java-settings"; }
     void retranslate() override;
 
     bool apply() override;

--- a/launcher/ui/pages/global/LanguagePage.h
+++ b/launcher/ui/pages/global/LanguagePage.h
@@ -52,7 +52,6 @@ class LanguagePage : public QWidget, public BasePage {
     QString displayName() const override { return tr("Language"); }
     QIcon icon() const override { return QIcon::fromTheme("language"); }
     QString id() const override { return "language-settings"; }
-    QString helpPage() const override { return "Language-settings"; }
     bool apply() override;
 
     void retranslate() override;

--- a/launcher/ui/pages/global/LauncherPage.h
+++ b/launcher/ui/pages/global/LauncherPage.h
@@ -59,7 +59,6 @@ class LauncherPage : public QWidget, public BasePage {
     QString displayName() const override { return tr("General"); }
     QIcon icon() const override { return QIcon::fromTheme("settings"); }
     QString id() const override { return "launcher-settings"; }
-    QString helpPage() const override { return "Launcher-settings"; }
     bool apply() override;
     void retranslate() override;
 

--- a/launcher/ui/pages/global/MinecraftPage.h
+++ b/launcher/ui/pages/global/MinecraftPage.h
@@ -54,7 +54,6 @@ class MinecraftPage : public MinecraftSettingsWidget, public BasePage {
     QString displayName() const override { return tr("Minecraft"); }
     QIcon icon() const override { return QIcon::fromTheme("minecraft"); }
     QString id() const override { return "minecraft-settings"; }
-    QString helpPage() const override { return "Minecraft-settings"; }
     bool apply() override
     {
         saveSettings();

--- a/launcher/ui/pages/global/ProxyPage.h
+++ b/launcher/ui/pages/global/ProxyPage.h
@@ -56,7 +56,6 @@ class ProxyPage : public QWidget, public BasePage {
     QString displayName() const override { return tr("Proxy"); }
     QIcon icon() const override { return QIcon::fromTheme("proxy"); }
     QString id() const override { return "proxy-settings"; }
-    QString helpPage() const override { return "Proxy-settings"; }
     bool apply() override;
     void retranslate() override;
 

--- a/launcher/ui/pages/instance/DataPackPage.cpp
+++ b/launcher/ui/pages/instance/DataPackPage.cpp
@@ -295,14 +295,6 @@ QIcon GlobalDataPackPage::icon() const
     return m_underlyingPage->icon();
 }
 
-QString GlobalDataPackPage::helpPage() const
-{
-    if (m_underlyingPage == nullptr)
-        return {};
-
-    return m_underlyingPage->helpPage();
-}
-
 bool GlobalDataPackPage::shouldDisplay() const
 {
     return m_instance->settings()->get("GlobalDataPacksEnabled").toBool();

--- a/launcher/ui/pages/instance/DataPackPage.h
+++ b/launcher/ui/pages/instance/DataPackPage.h
@@ -31,7 +31,6 @@ class DataPackPage : public ExternalResourcesPage {
     QString displayName() const override { return QObject::tr("Data Packs"); }
     QIcon icon() const override { return QIcon::fromTheme("datapacks"); }
     QString id() const override { return "datapacks"; }
-    QString helpPage() const override { return "Data-packs"; }
     bool shouldDisplay() const override { return true; }
 
    public slots:
@@ -57,7 +56,6 @@ class GlobalDataPackPage : public QWidget, public BasePage {
     QString displayName() const override;
     QIcon icon() const override;
     QString id() const override { return "datapacks"; }
-    QString helpPage() const override;
 
     bool shouldDisplay() const override;
 

--- a/launcher/ui/pages/instance/ExternalResourcesPage.cpp
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.cpp
@@ -211,7 +211,7 @@ bool ExternalResourcesPage::eventFilter(QObject* obj, QEvent* ev)
 void ExternalResourcesPage::addItem()
 {
     auto list = GuiUtil::BrowseForFiles(
-        helpPage(), tr("Select %1", "Select whatever type of files the page contains. Example: 'Loader Mods'").arg(displayName()),
+        displayName(), tr("Select %1", "Select whatever type of files the page contains. Example: 'Loader Mods'").arg(displayName()),
         m_fileSelectionFilter.arg(displayName()), APPLICATION->settings()->get("CentralModsDir").toString(), this->parentWidget());
 
     if (!list.isEmpty()) {

--- a/launcher/ui/pages/instance/ExternalResourcesPage.h
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.h
@@ -26,7 +26,6 @@ class ExternalResourcesPage : public QMainWindow, public BasePage {
     virtual QString displayName() const override = 0;
     virtual QIcon icon() const override = 0;
     virtual QString id() const override = 0;
-    virtual QString helpPage() const override = 0;
 
     virtual bool shouldDisplay() const override = 0;
     QString extraHeaderInfoString();

--- a/launcher/ui/pages/instance/GameOptionsPage.h
+++ b/launcher/ui/pages/instance/GameOptionsPage.h
@@ -60,7 +60,6 @@ class GameOptionsPage : public QWidget, public BasePage {
     virtual QString displayName() const override { return tr("Game Options"); }
     virtual QIcon icon() const override { return QIcon::fromTheme("settings"); }
     virtual QString id() const override { return "gameoptions"; }
-    virtual QString helpPage() const override { return "Game-Options-management"; }
     void retranslate() override;
 
    private:  // data

--- a/launcher/ui/pages/instance/InstanceSettingsPage.h
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.h
@@ -58,5 +58,4 @@ class InstanceSettingsPage : public MinecraftSettingsWidget, public BasePage {
         saveSettings();
         return true;
     }
-    QString helpPage() const override { return "Instance-settings"; }
 };

--- a/launcher/ui/pages/instance/LogPage.h
+++ b/launcher/ui/pages/instance/LogPage.h
@@ -69,7 +69,6 @@ class LogPage : public QWidget, public BasePage {
     virtual QIcon icon() const override { return QIcon::fromTheme("log"); }
     virtual QString id() const override { return "console"; }
     virtual bool apply() override;
-    virtual QString helpPage() const override { return "Minecraft-Logs"; }
     virtual bool shouldDisplay() const override;
     void retranslate() override;
 

--- a/launcher/ui/pages/instance/ManagedPackPage.cpp
+++ b/launcher/ui/pages/instance/ManagedPackPage.cpp
@@ -181,11 +181,6 @@ QIcon ManagedPackPage::icon() const
     return QIcon::fromTheme(m_inst->getManagedPackType());
 }
 
-QString ManagedPackPage::helpPage() const
-{
-    return {};
-}
-
 void ManagedPackPage::retranslate()
 {
     ui->retranslateUi(this);

--- a/launcher/ui/pages/instance/ManagedPackPage.h
+++ b/launcher/ui/pages/instance/ManagedPackPage.h
@@ -38,7 +38,6 @@ class ManagedPackPage : public QWidget, public BasePage {
 
     QString displayName() const override;
     QIcon icon() const override;
-    QString helpPage() const override;
     QString id() const override { return "managed_pack"; }
     bool shouldDisplay() const override;
 
@@ -122,7 +121,6 @@ class ModrinthManagedPackPage final : public ManagedPackPage {
 
     void parseManagedPack() override;
     QString url() const override;
-    QString helpPage() const override { return "modrinth-managed-pack"; }
 
    public slots:
     void suggestVersion() override;
@@ -146,7 +144,6 @@ class FlameManagedPackPage final : public ManagedPackPage {
 
     void parseManagedPack() override;
     QString url() const override;
-    QString helpPage() const override { return "curseforge-managed-pack"; }
 
    public slots:
     void suggestVersion() override;

--- a/launcher/ui/pages/instance/ModFolderPage.h
+++ b/launcher/ui/pages/instance/ModFolderPage.h
@@ -56,7 +56,6 @@ class ModFolderPage : public ExternalResourcesPage {
     virtual QString displayName() const override { return tr("Mods"); }
     virtual QIcon icon() const override { return QIcon::fromTheme("loadermods"); }
     virtual QString id() const override { return "mods"; }
-    virtual QString helpPage() const override { return "Loader-mods"; }
 
     virtual bool shouldDisplay() const override;
 
@@ -87,7 +86,6 @@ class CoreModFolderPage : public ModFolderPage {
     virtual QString displayName() const override { return tr("Core Mods"); }
     virtual QIcon icon() const override { return QIcon::fromTheme("coremods"); }
     virtual QString id() const override { return "coremods"; }
-    virtual QString helpPage() const override { return "Core-mods"; }
 
     virtual bool shouldDisplay() const override;
 };
@@ -101,7 +99,6 @@ class NilModFolderPage : public ModFolderPage {
     virtual QString displayName() const override { return tr("Nilmods"); }
     virtual QIcon icon() const override { return QIcon::fromTheme("coremods"); }
     virtual QString id() const override { return "nilmods"; }
-    virtual QString helpPage() const override { return "Nilmods"; }
 
     virtual bool shouldDisplay() const override;
 };

--- a/launcher/ui/pages/instance/NotesPage.h
+++ b/launcher/ui/pages/instance/NotesPage.h
@@ -60,7 +60,6 @@ class NotesPage : public QWidget, public BasePage {
     }
     virtual QString id() const override { return "notes"; }
     virtual bool apply() override;
-    virtual QString helpPage() const override { return "Notes"; }
     void retranslate() override;
 
    private:

--- a/launcher/ui/pages/instance/OtherLogsPage.cpp
+++ b/launcher/ui/pages/instance/OtherLogsPage.cpp
@@ -50,11 +50,10 @@
 #include <QShortcut>
 #include <QUrl>
 
-OtherLogsPage::OtherLogsPage(QString id, QString displayName, QString helpPage, BaseInstance* instance, QWidget* parent)
+OtherLogsPage::OtherLogsPage(QString id, QString displayName, BaseInstance* instance, QWidget* parent)
     : QWidget(parent)
     , m_id(id)
     , m_displayName(displayName)
-    , m_helpPage(helpPage)
     , ui(new Ui::OtherLogsPage)
     , m_instance(instance)
     , m_basePath(instance ? instance->gameRoot() : APPLICATION->dataRoot())

--- a/launcher/ui/pages/instance/OtherLogsPage.h
+++ b/launcher/ui/pages/instance/OtherLogsPage.h
@@ -52,13 +52,12 @@ class OtherLogsPage : public QWidget, public BasePage {
     Q_OBJECT
 
    public:
-    explicit OtherLogsPage(QString id, QString displayName, QString helpPage, BaseInstance* instance = nullptr, QWidget* parent = 0);
+    explicit OtherLogsPage(QString id, QString displayName, BaseInstance* instance = nullptr, QWidget* parent = 0);
     ~OtherLogsPage();
 
     QString id() const override { return m_id; }
     QString displayName() const override { return m_displayName; }
     QIcon icon() const override { return QIcon::fromTheme("log"); }
-    QString helpPage() const override { return m_helpPage; }
     void retranslate() override;
 
     void openedImpl() override;
@@ -94,7 +93,6 @@ class OtherLogsPage : public QWidget, public BasePage {
    private:
     QString m_id;
     QString m_displayName;
-    QString m_helpPage;
 
     Ui::OtherLogsPage* ui;
     BaseInstance* m_instance;

--- a/launcher/ui/pages/instance/ResourcePackPage.h
+++ b/launcher/ui/pages/instance/ResourcePackPage.h
@@ -53,7 +53,6 @@ class ResourcePackPage : public ExternalResourcesPage {
     QString displayName() const override { return tr("Resource Packs"); }
     QIcon icon() const override { return QIcon::fromTheme("resourcepacks"); }
     QString id() const override { return "resourcepacks"; }
-    QString helpPage() const override { return "Resource-packs"; }
 
     virtual bool shouldDisplay() const override
     {

--- a/launcher/ui/pages/instance/ScreenshotsPage.h
+++ b/launcher/ui/pages/instance/ScreenshotsPage.h
@@ -68,7 +68,6 @@ class ScreenshotsPage : public QMainWindow, public BasePage {
     virtual QString displayName() const override { return tr("Screenshots"); }
     virtual QIcon icon() const override { return QIcon::fromTheme("screenshots"); }
     virtual QString id() const override { return "screenshots"; }
-    virtual QString helpPage() const override { return "Screenshots-management"; }
     virtual bool apply() override { return !m_uploadActive; }
     void retranslate() override;
 

--- a/launcher/ui/pages/instance/ServersPage.h
+++ b/launcher/ui/pages/instance/ServersPage.h
@@ -65,7 +65,6 @@ class ServersPage : public QMainWindow, public BasePage {
     virtual QString displayName() const override { return tr("Servers"); }
     virtual QIcon icon() const override { return QIcon::fromTheme("server"); }
     virtual QString id() const override { return "servers"; }
-    virtual QString helpPage() const override { return "Servers-management"; }
     void retranslate() override;
 
    protected:

--- a/launcher/ui/pages/instance/ShaderPackPage.h
+++ b/launcher/ui/pages/instance/ShaderPackPage.h
@@ -50,7 +50,6 @@ class ShaderPackPage : public ExternalResourcesPage {
     QString displayName() const override { return tr("Shader Packs"); }
     QIcon icon() const override { return QIcon::fromTheme("shaderpacks"); }
     QString id() const override { return "shaderpacks"; }
-    QString helpPage() const override { return "shader-packs"; }
 
     bool shouldDisplay() const override { return true; }
 

--- a/launcher/ui/pages/instance/TexturePackPage.h
+++ b/launcher/ui/pages/instance/TexturePackPage.h
@@ -53,7 +53,6 @@ class TexturePackPage : public ExternalResourcesPage {
     QString displayName() const override { return tr("Texture packs"); }
     QIcon icon() const override { return QIcon::fromTheme("resourcepacks"); }
     QString id() const override { return "texturepacks"; }
-    QString helpPage() const override { return "Texture-packs"; }
 
     virtual bool shouldDisplay() const override { return m_instance->traits().contains("texturepacks"); }
 

--- a/launcher/ui/pages/instance/VersionPage.h
+++ b/launcher/ui/pages/instance/VersionPage.h
@@ -60,7 +60,6 @@ class VersionPage : public QMainWindow, public BasePage {
     virtual QString displayName() const override { return tr("Version"); }
     virtual QIcon icon() const override;
     virtual QString id() const override { return "version"; }
-    virtual QString helpPage() const override { return "Instance-Version"; }
     virtual bool shouldDisplay() const override;
     void retranslate() override;
 

--- a/launcher/ui/pages/instance/WorldListPage.cpp
+++ b/launcher/ui/pages/instance/WorldListPage.cpp
@@ -252,9 +252,8 @@ void WorldListPage::on_actionData_Packs_triggered()
     pageContainer->hidePageList();
     layout->addWidget(pageContainer);
 
-    auto buttonBox = new QDialogButtonBox(QDialogButtonBox::Close | QDialogButtonBox::Help);
+    auto buttonBox = new QDialogButtonBox(QDialogButtonBox::Close);
     connect(buttonBox, &QDialogButtonBox::rejected, dialog, &QDialog::reject);
-    connect(buttonBox, &QDialogButtonBox::helpRequested, pageContainer, &PageContainer::help);
     layout->addWidget(buttonBox);
 
     dialog->setLayout(layout);

--- a/launcher/ui/pages/instance/WorldListPage.h
+++ b/launcher/ui/pages/instance/WorldListPage.h
@@ -58,7 +58,6 @@ class WorldListPage : public QMainWindow, public BasePage {
     virtual QString displayName() const override { return tr("Worlds"); }
     virtual QIcon icon() const override { return QIcon::fromTheme("worlds"); }
     virtual QString id() const override { return "worlds"; }
-    virtual QString helpPage() const override { return "Worlds"; }
     virtual bool shouldDisplay() const override;
     void retranslate() override;
 

--- a/launcher/ui/pages/modplatform/CustomPage.h
+++ b/launcher/ui/pages/modplatform/CustomPage.h
@@ -56,7 +56,6 @@ class CustomPage : public QWidget, public BasePage {
     virtual QString displayName() const override { return tr("Custom"); }
     virtual QIcon icon() const override { return QIcon::fromTheme("minecraft"); }
     virtual QString id() const override { return "vanilla"; }
-    virtual QString helpPage() const override { return "Vanilla-platform"; }
     virtual bool shouldDisplay() const override;
     void retranslate() override;
 

--- a/launcher/ui/pages/modplatform/ImportPage.h
+++ b/launcher/ui/pages/modplatform/ImportPage.h
@@ -55,7 +55,6 @@ class ImportPage : public QWidget, public BasePage {
     virtual QString displayName() const override { return tr("Import"); }
     virtual QIcon icon() const override { return QIcon::fromTheme("viewfolder"); }
     virtual QString id() const override { return "import"; }
-    virtual QString helpPage() const override { return "Zip-import"; }
     virtual bool shouldDisplay() const override;
     void retranslate() override;
 

--- a/launcher/ui/pages/modplatform/ResourcePackPage.h
+++ b/launcher/ui/pages/modplatform/ResourcePackPage.h
@@ -41,7 +41,6 @@ class ResourcePackResourcePage : public ResourcePage {
 
     QMap<QString, QString> urlHandlers() const override;
 
-    inline auto helpPage() const -> QString override { return "resourcepack-platform"; }
 
    protected:
     ResourcePackResourcePage(ResourceDownloadDialog* dialog, BaseInstance& instance);

--- a/launcher/ui/pages/modplatform/ResourcePage.h
+++ b/launcher/ui/pages/modplatform/ResourcePage.h
@@ -36,7 +36,6 @@ class ResourcePage : public QWidget, public BasePage {
     auto displayName() const -> QString override = 0;
     auto icon() const -> QIcon override = 0;
     auto id() const -> QString override = 0;
-    auto helpPage() const -> QString override = 0;
     bool shouldDisplay() const override = 0;
 
     /* Used internally */

--- a/launcher/ui/pages/modplatform/ShaderPackPage.h
+++ b/launcher/ui/pages/modplatform/ShaderPackPage.h
@@ -43,8 +43,6 @@ class ShaderPackResourcePage : public ResourcePage {
 
     QMap<QString, QString> urlHandlers() const override;
 
-    inline auto helpPage() const -> QString override { return "shaderpack-platform"; }
-
    protected:
     ShaderPackResourcePage(ShaderPackDownloadDialog* dialog, BaseInstance& instance);
 

--- a/launcher/ui/pages/modplatform/atlauncher/AtlPage.h
+++ b/launcher/ui/pages/modplatform/atlauncher/AtlPage.h
@@ -58,7 +58,6 @@ class AtlPage : public QWidget, public ModpackProviderBasePage {
     virtual QString displayName() const override { return "ATLauncher"; }
     virtual QIcon icon() const override { return QIcon::fromTheme("atlauncher"); }
     virtual QString id() const override { return "atl"; }
-    virtual QString helpPage() const override { return "ATL-platform"; }
     virtual bool shouldDisplay() const override;
     void retranslate() override;
 

--- a/launcher/ui/pages/modplatform/flame/FlamePage.h
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.h
@@ -62,7 +62,6 @@ class FlamePage : public QWidget, public ModpackProviderBasePage {
     virtual QString displayName() const override { return "CurseForge"; }
     virtual QIcon icon() const override { return QIcon::fromTheme("flame"); }
     virtual QString id() const override { return "flame"; }
-    virtual QString helpPage() const override { return "Flame-platform"; }
     virtual bool shouldDisplay() const override;
     void retranslate() override;
 

--- a/launcher/ui/pages/modplatform/flame/FlameResourcePages.h
+++ b/launcher/ui/pages/modplatform/flame/FlameResourcePages.h
@@ -93,8 +93,6 @@ class FlameModPage : public ModPage {
     inline auto debugName() const -> QString override { return Flame::debugName(); }
     inline auto metaEntryBase() const -> QString override { return Flame::metaEntryBase(); }
 
-    inline auto helpPage() const -> QString override { return "Mod-platform"; }
-
     void openUrl(const QUrl& url) override;
     std::unique_ptr<ModFilterWidget> createFilterWidget() override;
 
@@ -125,8 +123,6 @@ class FlameResourcePackPage : public ResourcePackResourcePage {
     inline auto debugName() const -> QString override { return Flame::debugName(); }
     inline auto metaEntryBase() const -> QString override { return Flame::metaEntryBase(); }
 
-    inline auto helpPage() const -> QString override { return ""; }
-
     void openUrl(const QUrl& url) override;
 };
 
@@ -149,8 +145,6 @@ class FlameTexturePackPage : public TexturePackResourcePage {
     inline auto id() const -> QString override { return Flame::id(); }
     inline auto debugName() const -> QString override { return Flame::debugName(); }
     inline auto metaEntryBase() const -> QString override { return Flame::metaEntryBase(); }
-
-    inline auto helpPage() const -> QString override { return ""; }
 
     void openUrl(const QUrl& url) override;
 };
@@ -175,8 +169,6 @@ class FlameShaderPackPage : public ShaderPackResourcePage {
     inline auto debugName() const -> QString override { return Flame::debugName(); }
     inline auto metaEntryBase() const -> QString override { return Flame::metaEntryBase(); }
 
-    inline auto helpPage() const -> QString override { return ""; }
-
     void openUrl(const QUrl& url) override;
 };
 
@@ -199,8 +191,6 @@ class FlameDataPackPage : public DataPackResourcePage {
     inline auto id() const -> QString override { return Flame::id(); }
     inline auto debugName() const -> QString override { return Flame::debugName(); }
     inline auto metaEntryBase() const -> QString override { return Flame::metaEntryBase(); }
-
-    inline auto helpPage() const -> QString override { return ""; }
 
     void openUrl(const QUrl& url) override;
 };

--- a/launcher/ui/pages/modplatform/ftb/FtbPage.h
+++ b/launcher/ui/pages/modplatform/ftb/FtbPage.h
@@ -60,7 +60,6 @@ class FtbPage : public QWidget, public ModpackProviderBasePage {
     virtual QString displayName() const override { return "FTB"; }
     virtual QIcon icon() const override { return QIcon::fromTheme("ftb_logo"); }
     virtual QString id() const override { return "ftb"; }
-    virtual QString helpPage() const override { return "FTB-platform"; }
     virtual bool shouldDisplay() const override;
     void retranslate() override;
 

--- a/launcher/ui/pages/modplatform/import_ftb/ImportFTBPage.h
+++ b/launcher/ui/pages/modplatform/import_ftb/ImportFTBPage.h
@@ -43,7 +43,6 @@ class ImportFTBPage : public QWidget, public ModpackProviderBasePage {
     QString displayName() const override { return tr("FTB App Import"); }
     QIcon icon() const override { return QIcon::fromTheme("ftb_logo"); }
     QString id() const override { return "import_ftb"; }
-    QString helpPage() const override { return "FTB-import"; }
     bool shouldDisplay() const override { return true; }
     void openedImpl() override;
     void retranslate() override;

--- a/launcher/ui/pages/modplatform/legacy_ftb/Page.h
+++ b/launcher/ui/pages/modplatform/legacy_ftb/Page.h
@@ -65,7 +65,6 @@ class Page : public QWidget, public ModpackProviderBasePage {
     QString displayName() const override { return "FTB Legacy"; }
     QIcon icon() const override { return QIcon::fromTheme("ftb_logo"); }
     QString id() const override { return "legacy_ftb"; }
-    QString helpPage() const override { return "FTB-legacy"; }
     bool shouldDisplay() const override;
     void openedImpl() override;
     void retranslate() override;

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.h
@@ -65,7 +65,6 @@ class ModrinthPage : public QWidget, public ModpackProviderBasePage {
     QString displayName() const override { return tr("Modrinth"); }
     QIcon icon() const override { return QIcon::fromTheme("modrinth"); }
     QString id() const override { return "modrinth"; }
-    QString helpPage() const override { return "Modrinth-platform"; }
 
     inline QString debugName() const { return "Modrinth"; }
     inline QString metaEntryBase() const { return "ModrinthModpacks"; };

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.h
@@ -91,8 +91,6 @@ class ModrinthModPage : public ModPage {
     inline auto debugName() const -> QString override { return Modrinth::debugName(); }
     inline auto metaEntryBase() const -> QString override { return Modrinth::metaEntryBase(); }
 
-    inline auto helpPage() const -> QString override { return "Mod-platform"; }
-
     std::unique_ptr<ModFilterWidget> createFilterWidget() override;
 
    protected:
@@ -119,8 +117,6 @@ class ModrinthResourcePackPage : public ResourcePackResourcePage {
     inline auto id() const -> QString override { return Modrinth::id(); }
     inline auto debugName() const -> QString override { return Modrinth::debugName(); }
     inline auto metaEntryBase() const -> QString override { return Modrinth::metaEntryBase(); }
-
-    inline auto helpPage() const -> QString override { return ""; }
 };
 
 class ModrinthTexturePackPage : public TexturePackResourcePage {
@@ -142,8 +138,6 @@ class ModrinthTexturePackPage : public TexturePackResourcePage {
     inline auto id() const -> QString override { return Modrinth::id(); }
     inline auto debugName() const -> QString override { return Modrinth::debugName(); }
     inline auto metaEntryBase() const -> QString override { return Modrinth::metaEntryBase(); }
-
-    inline auto helpPage() const -> QString override { return ""; }
 };
 
 class ModrinthShaderPackPage : public ShaderPackResourcePage {
@@ -166,7 +160,6 @@ class ModrinthShaderPackPage : public ShaderPackResourcePage {
     inline auto debugName() const -> QString override { return Modrinth::debugName(); }
     inline auto metaEntryBase() const -> QString override { return Modrinth::metaEntryBase(); }
 
-    inline auto helpPage() const -> QString override { return ""; }
 };
 
 class ModrinthDataPackPage : public DataPackResourcePage {
@@ -189,7 +182,6 @@ class ModrinthDataPackPage : public DataPackResourcePage {
     inline auto debugName() const -> QString override { return Modrinth::debugName(); }
     inline auto metaEntryBase() const -> QString override { return Modrinth::metaEntryBase(); }
 
-    inline auto helpPage() const -> QString override { return ""; }
 };
 
 }  // namespace ResourceDownload

--- a/launcher/ui/pages/modplatform/technic/TechnicPage.h
+++ b/launcher/ui/pages/modplatform/technic/TechnicPage.h
@@ -62,7 +62,6 @@ class TechnicPage : public QWidget, public ModpackProviderBasePage {
     virtual QString displayName() const override { return "Technic"; }
     virtual QIcon icon() const override { return QIcon::fromTheme("technic"); }
     virtual QString id() const override { return "technic"; }
-    virtual QString helpPage() const override { return "Technic-platform"; }
     virtual bool shouldDisplay() const override;
     void retranslate() override;
 

--- a/launcher/ui/widgets/JavaWizardWidget.cpp
+++ b/launcher/ui/widgets/JavaWizardWidget.cpp
@@ -235,7 +235,7 @@ JavaWizardWidget::ValidationStatus JavaWizardWidget::validate()
                                     "\n\n"
                                     "You can change the Java version in the settings later.\n")
                                      .arg(BuildConfig.LAUNCHER_DISPLAYNAME),
-                                 QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No | QMessageBox::Help, QMessageBox::NoButton)
+                                 QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No, QMessageBox::NoButton)
                                  ->exec();
 
                 } else {
@@ -246,15 +246,12 @@ JavaWizardWidget::ValidationStatus JavaWizardWidget::validate()
                                                              "\n\n"
                                                              "You can change the Java version in the settings later.\n")
                                                               .arg(BuildConfig.LAUNCHER_DISPLAYNAME),
-                                                          QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No | QMessageBox::Help,
-                                                          QMessageBox::NoButton)
+                                                          QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No, QMessageBox::NoButton)
                                  ->exec();
                 }
                 switch (button) {
                     case QMessageBox::Yes:
                         return ValidationStatus::JavaBad;
-                    case QMessageBox::Help:
-                        DesktopServices::openUrl(QUrl(BuildConfig.HELP_URL.arg("java-wizard")));
                     /* fallthrough */
                     case QMessageBox::No:
                     /* fallthrough */

--- a/launcher/ui/widgets/PageContainer.cpp
+++ b/launcher/ui/widgets/PageContainer.cpp
@@ -232,16 +232,6 @@ void PageContainer::showPage(int row)
     }
 }
 
-void PageContainer::help()
-{
-    if (m_currentPage) {
-        QString pageId = m_currentPage->helpPage();
-        if (pageId.isEmpty())
-            return;
-        DesktopServices::openUrl(QUrl(BuildConfig.HELP_URL.arg(pageId)));
-    }
-}
-
 void PageContainer::currentChanged(const QModelIndex& current)
 {
     int selected_index = current.isValid() ? m_proxyModel->mapToSource(current).row() : -1;

--- a/launcher/ui/widgets/PageContainer.h
+++ b/launcher/ui/widgets/PageContainer.h
@@ -96,9 +96,6 @@ class PageContainer : public QWidget, public BasePageContainer {
     void createUI();
     void retranslate();
 
-   public slots:
-    void help();
-
    signals:
     /** Emitted when the currently selected page is changed */
     void selectedPageChanged(BasePage* previous, BasePage* selected);


### PR DESCRIPTION
removed all help buttons from the launcher.
Why? you ask because we can't maintain them.
Is either this or we need to actually add pages to the website, see: https://github.com/PrismLauncher/prismlauncher.org/issues/97 . No the help button from main window was not removed, but can be because it points towards https://prismlauncher.org/wiki/help-pages/ that is just a 404 page. This is not a regression of the current PR.

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
