### PR TITLE
Actually check for updates on launch

### DIFF
--- a/launcher/updater/PrismExternalUpdater.cpp
+++ b/launcher/updater/PrismExternalUpdater.cpp
@@ -73,6 +73,9 @@ PrismExternalUpdater::PrismExternalUpdater(QWidget* parent, const QString& appDi
     priv->parent = parent;
     connectTimer();
     resetAutoCheckTimer();
+    if (priv->updateInterval == 0) { // "On Launch"
+        checkForUpdates(false);
+    }
 }
 
 PrismExternalUpdater::~PrismExternalUpdater()


### PR DESCRIPTION
When set to "On Launch" the updateInterval is 0, so the timer doesn't fire. We don't want it firing anyway (as it would do so continuously), so just run a check in the constructor (it works, I tested)