### PR TITLE
NewsDialog: Save and restore geometry

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -815,6 +815,8 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
 
         m_settings->registerSetting("UpdateDialogGeometry", "");
 
+        m_settings->registerSetting("NewsGeometry", "");
+
         m_settings->registerSetting("ModDownloadGeometry", "");
         m_settings->registerSetting("RPDownloadGeometry", "");
         m_settings->registerSetting("TPDownloadGeometry", "");

--- a/launcher/ui/dialogs/NewsDialog.cpp
+++ b/launcher/ui/dialogs/NewsDialog.cpp
@@ -1,4 +1,8 @@
 #include "NewsDialog.h"
+
+#include "Application.h"
+#include "settings/SettingsObject.h"
+
 #include "ui_NewsDialog.h"
 
 NewsDialog::NewsDialog(QList<NewsEntryPtr> entries, QWidget* parent) : QDialog(parent), ui(new Ui::NewsDialog())
@@ -23,6 +27,12 @@ NewsDialog::NewsDialog(QList<NewsEntryPtr> entries, QWidget* parent) : QDialog(p
 
     ui->currentArticleContentBrowser->setText(article_entry->content);
     ui->currentArticleContentBrowser->flush();
+
+    connect(this, &QDialog::finished, this, [this] {
+        APPLICATION->settings()->set("NewsGeometry", QString::fromUtf8(saveGeometry().toBase64()));
+    });
+    const QByteArray base64Geometry = APPLICATION->settings()->get("NewsGeometry").toString().toUtf8();
+    restoreGeometry(QByteArray::fromBase64(base64Geometry));
 }
 
 NewsDialog::~NewsDialog()


### PR DESCRIPTION
Closes #5038 

Tested by using the "Close" button, using the window decorations, and Alt+F4, works fine in all cases