### PR TITLE
Skin renderer: Do not enable backface culling

### DIFF
--- a/launcher/ui/dialogs/skins/draw/SkinOpenGLWindow.cpp
+++ b/launcher/ui/dialogs/skins/draw/SkinOpenGLWindow.cpp
@@ -217,9 +217,6 @@ void SkinOpenGLWindow::paintGL()
     glEnable(GL_DEPTH_TEST);
     glDepthFunc(GL_LESS);
 
-    // Enable back face culling
-    glEnable(GL_CULL_FACE);
-
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 


### PR DESCRIPTION
See #4914 (this does not close the issue fully as there's no lighting/shading implemented)