### PR TITLE
Update clang-tidy config

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -16,3 +16,4 @@ BraceWrapping:
 BreakBeforeBraces: Custom
 BreakConstructorInitializers: BeforeComma
 Cpp11BracedListStyle: false
+QualifierAlignment: Left

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,23 +1,32 @@
-Checks:
-  - modernize-use-using
-  - readability-avoid-const-params-in-decls
-  - misc-unused-parameters,
-  - readability-identifier-naming
+FormatStyle: file
 
-# ^ Without unused-parameters the readability-identifier-naming check doesn't cause any warnings.
+Checks:
+  'bugprone-*,clang-analyzer-*,cppcoreguidelines-*,hicpp-*,misc-*,modernize-*,performance-*,portability-*,readability-*,
+  -*-magic-numbers,
+  -*-non-private-member-variables-in-classes,
+  -*-special-member-functions,
+  -bugprone-easily-swappable-parameters,
+  -cppcoreguidelines-owning-memory,
+  -cppcoreguidelines-pro-type-static-cast-downcast,
+  -modernize-use-nodiscard,
+  -modernize-use-trailing-return-type,
+  -portability-avoid-pragma-once,
+  -readability-avoid-unconditional-preprocessor-if,
+  -readability-function-cognitive-complexity,
+  -readability-identifier-length,
+  -readability-redundant-access-specifiers'
 
 CheckOptions:
-  - { key: readability-identifier-naming.ClassCase,                   value: PascalCase }
-  - { key: readability-identifier-naming.EnumCase,                    value: PascalCase }
-  - { key: readability-identifier-naming.FunctionCase,                value: camelCase }
-  - { key: readability-identifier-naming.GlobalVariableCase,          value: camelCase }
-  - { key: readability-identifier-naming.GlobalFunctionCase,          value: camelCase }
-  - { key: readability-identifier-naming.GlobalConstantCase,          value: SCREAMING_SNAKE_CASE }
-  - { key: readability-identifier-naming.MacroDefinitionCase,         value: SCREAMING_SNAKE_CASE }
-  - { key: readability-identifier-naming.ClassMemberCase,             value: camelCase }
-  - { key: readability-identifier-naming.PrivateMemberPrefix,         value: m_ }
-  - { key: readability-identifier-naming.ProtectedMemberPrefix,       value: m_ }
-  - { key: readability-identifier-naming.PrivateStaticMemberPrefix,   value: s_ }
-  - { key: readability-identifier-naming.ProtectedStaticMemberPrefix, value: s_ }
-  - { key: readability-identifier-naming.PublicStaticConstantCase,    value: SCREAMING_SNAKE_CASE }
-  - { key: readability-identifier-naming.EnumConstantCase,            value: PascalCase }
+  - { key: misc-include-cleaner.MissingIncludes,                        value: false }
+  - { key: readability-identifier-naming.DefaultCase,                   value: camelBack }
+  - { key: readability-identifier-naming.NamespaceCase,                 value: CamelCase }
+  - { key: readability-identifier-naming.ClassCase,                     value: CamelCase }
+  - { key: readability-identifier-naming.ClassConstantCase,             value: CamelCase }
+  - { key: readability-identifier-naming.EnumCase,                      value: CamelCase }
+  - { key: readability-identifier-naming.EnumConstantCase,              value: CamelCase }
+  - { key: readability-identifier-naming.MacroDefinitionCase,           value: UPPER_CASE }
+  - { key: readability-identifier-naming.ClassMemberPrefix,             value: m_ }
+  - { key: readability-identifier-naming.StaticConstantPrefix,          value: s_ }
+  - { key: readability-identifier-naming.StaticVariablePrefix,          value: s_ }
+  - { key: readability-identifier-naming.GlobalConstantPrefix,          value: g_ }
+  - { key: readability-implicit-bool-conversion.AllowPointerConditions, value: true }

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -2003,7 +2003,7 @@ void Application::triggerUpdateCheck()
     }
 }
 
-QUrl Application::normalizeImportUrl(QString const& url)
+QUrl Application::normalizeImportUrl(const QString& url)
 {
     auto local_file = QFileInfo(url);
     if (local_file.exists()) {

--- a/launcher/Application.h
+++ b/launcher/Application.h
@@ -200,7 +200,7 @@ class Application : public QApplication {
     bool updaterEnabled();
     QString updaterBinaryName();
 
-    QUrl normalizeImportUrl(QString const& url);
+    QUrl normalizeImportUrl(const QString& url);
 
    signals:
     void updateAllowedChanged(bool status);

--- a/launcher/InstanceList.cpp
+++ b/launcher/InstanceList.cpp
@@ -565,7 +565,7 @@ InstanceList::InstListError InstanceList::loadList()
 void InstanceList::updateTotalPlayTime()
 {
     totalPlayTime = 0;
-    for (auto const& itr : m_instances) {
+    for (const auto& itr : m_instances) {
         totalPlayTime += itr->totalTimePlayed();
     }
 }
@@ -1032,9 +1032,9 @@ QString InstanceList::getStagedInstancePath()
 }
 
 bool InstanceList::commitStagedInstance(const QString& path,
-                                        InstanceName const& instanceName,
+                                        const InstanceName& instanceName,
                                         QString groupName,
-                                        InstanceTask const& commiting)
+                                        const InstanceTask& commiting)
 {
     if (groupName.isEmpty() && !groupName.isNull())
         groupName = QString();

--- a/launcher/Version.h
+++ b/launcher/Version.h
@@ -115,7 +115,7 @@ class Version {
 
         inline bool operator<(const Section& other) const
         {
-            static auto unequal_is_less = [](Section const& non_null) -> bool {
+            static auto unequal_is_less = [](const Section& non_null) -> bool {
                 if (non_null.m_stringPart.isEmpty())
                     return non_null.m_numPart == 0;
                 return (non_null.m_stringPart != QLatin1Char('.')) && non_null.isPreRelease();


### PR DESCRIPTION
Enables most of checks provided by clang-tidy, with checks that do not fit us excluded. The table containing naming conventions was using wrong values, that was fixed and now tidy correctly warns and fixes naming convention issues

Copied from #4444 