### PR TITLE
clang-tidy: clang-analyzer-*

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -578,16 +578,14 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
     }
 
     {
-        bool migrated = false;
-
-        if (!migrated)
-            migrated = handleDataMigration(
-                dataPath, FS::PathCombine(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation), "../../PolyMC"), "PolyMC",
-                "polymc.cfg");
-        if (!migrated)
-            migrated = handleDataMigration(
-                dataPath, FS::PathCombine(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation), "../../multimc"), "MultiMC",
-                "multimc.cfg");
+        auto migrated = handleDataMigration(
+            dataPath, FS::PathCombine(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation), "../../PolyMC"), "PolyMC",
+            "polymc.cfg");
+        if (!migrated) {
+            handleDataMigration(dataPath,
+                                FS::PathCombine(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation), "../../multimc"),
+                                "MultiMC", "multimc.cfg");
+        }
     }
 
     {

--- a/launcher/MTPixmapCache.h
+++ b/launcher/MTPixmapCache.h
@@ -14,26 +14,26 @@
     else                                                                    \
         type = Qt::DirectConnection;
 
-#define DEFINE_FUNC_NO_PARAM(NAME, RET_TYPE)                                                 \
+#define DEFINE_FUNC_NO_PARAM(NAME, RET_TYPE, RET_DEF)                                        \
     static RET_TYPE NAME()                                                                   \
     {                                                                                        \
-        RET_TYPE ret;                                                                        \
+        RET_TYPE ret = RET_DEF;                                                              \
         GET_TYPE()                                                                           \
         QMetaObject::invokeMethod(s_instance, "_" #NAME, type, Q_RETURN_ARG(RET_TYPE, ret)); \
         return ret;                                                                          \
     }
-#define DEFINE_FUNC_ONE_PARAM(NAME, RET_TYPE, PARAM_1_TYPE)                                                           \
+#define DEFINE_FUNC_ONE_PARAM(NAME, RET_TYPE, RET_DEF, PARAM_1_TYPE)                                                  \
     static RET_TYPE NAME(PARAM_1_TYPE p1)                                                                             \
     {                                                                                                                 \
-        RET_TYPE ret;                                                                                                 \
+        RET_TYPE ret = RET_DEF;                                                                                       \
         GET_TYPE()                                                                                                    \
         QMetaObject::invokeMethod(s_instance, "_" #NAME, type, Q_RETURN_ARG(RET_TYPE, ret), Q_ARG(PARAM_1_TYPE, p1)); \
         return ret;                                                                                                   \
     }
-#define DEFINE_FUNC_TWO_PARAM(NAME, RET_TYPE, PARAM_1_TYPE, PARAM_2_TYPE)                                            \
+#define DEFINE_FUNC_TWO_PARAM(NAME, RET_TYPE, RET_DEF, PARAM_1_TYPE, PARAM_2_TYPE)                                   \
     static RET_TYPE NAME(PARAM_1_TYPE p1, PARAM_2_TYPE p2)                                                           \
     {                                                                                                                \
-        RET_TYPE ret;                                                                                                \
+        RET_TYPE ret = RET_DEF;                                                                                      \
         GET_TYPE()                                                                                                   \
         QMetaObject::invokeMethod(s_instance, "_" #NAME, type, Q_RETURN_ARG(RET_TYPE, ret), Q_ARG(PARAM_1_TYPE, p1), \
                                   Q_ARG(PARAM_2_TYPE, p2));                                                          \
@@ -53,18 +53,18 @@ class PixmapCache final : public QObject {
     static void setInstance(PixmapCache* i) { s_instance = i; }
 
    public:
-    DEFINE_FUNC_NO_PARAM(cacheLimit, int)
-    DEFINE_FUNC_NO_PARAM(clear, bool)
-    DEFINE_FUNC_TWO_PARAM(find, bool, const QString&, QPixmap*)
-    DEFINE_FUNC_TWO_PARAM(find, bool, const QPixmapCache::Key&, QPixmap*)
-    DEFINE_FUNC_TWO_PARAM(insert, bool, const QString&, const QPixmap&)
-    DEFINE_FUNC_ONE_PARAM(insert, QPixmapCache::Key, const QPixmap&)
-    DEFINE_FUNC_ONE_PARAM(remove, bool, const QString&)
-    DEFINE_FUNC_ONE_PARAM(remove, bool, const QPixmapCache::Key&)
-    DEFINE_FUNC_TWO_PARAM(replace, bool, const QPixmapCache::Key&, const QPixmap&)
-    DEFINE_FUNC_ONE_PARAM(setCacheLimit, bool, int)
-    DEFINE_FUNC_NO_PARAM(markCacheMissByEviciton, bool)
-    DEFINE_FUNC_ONE_PARAM(setFastEvictionThreshold, bool, int)
+    DEFINE_FUNC_NO_PARAM(cacheLimit, int, -1)
+    DEFINE_FUNC_NO_PARAM(clear, bool, false)
+    DEFINE_FUNC_TWO_PARAM(find, bool, false, const QString&, QPixmap*)
+    DEFINE_FUNC_TWO_PARAM(find, bool, false, const QPixmapCache::Key&, QPixmap*)
+    DEFINE_FUNC_TWO_PARAM(insert, bool, false, const QString&, const QPixmap&)
+    DEFINE_FUNC_ONE_PARAM(insert, QPixmapCache::Key, {}, const QPixmap&)
+    DEFINE_FUNC_ONE_PARAM(remove, bool, false, const QString&)
+    DEFINE_FUNC_ONE_PARAM(remove, bool, false, const QPixmapCache::Key&)
+    DEFINE_FUNC_TWO_PARAM(replace, bool, false, const QPixmapCache::Key&, const QPixmap&)
+    DEFINE_FUNC_ONE_PARAM(setCacheLimit, bool, false, int)
+    DEFINE_FUNC_NO_PARAM(markCacheMissByEviciton, bool, false)
+    DEFINE_FUNC_ONE_PARAM(setFastEvictionThreshold, bool, false, int)
 
     // NOTE: Every function returns something non-void to simplify the macros.
    private slots:

--- a/launcher/modplatform/ModIndex.h
+++ b/launcher/modplatform/ModIndex.h
@@ -32,6 +32,7 @@ class QIODevice;
 namespace ModPlatform {
 
 enum class ModLoaderType : std::uint16_t {
+    None = 0U,
     NeoForge = 1U << 0U,
     Forge = 1U << 1U,
     Cauldron = 1U << 2U,

--- a/launcher/modplatform/flame/FlameAPI.h
+++ b/launcher/modplatform/flame/FlameAPI.h
@@ -79,6 +79,7 @@ class FlameAPI : public ResourceAPI {
             case ModPlatform::LegacyFabric:
             case ModPlatform::Ornithe:
             case ModPlatform::Rift:
+            case ModPlatform::None:
                 break;  // not supported
         }
         return 0;

--- a/launcher/modplatform/helpers/ExportToModList.h
+++ b/launcher/modplatform/helpers/ExportToModList.h
@@ -23,7 +23,9 @@
 namespace ExportToModList {
 
 enum Formats { HTML, MARKDOWN, PLAINTXT, JSON, CSV, CUSTOM };
-enum OptionalData { Authors = 1 << 0, Url = 1 << 1, Version = 1 << 2, FileName = 1 << 3 };
+enum OptionalDataValue { None = 0, Authors = 1 << 0, Url = 1 << 1, Version = 1 << 2, FileName = 1 << 3 };
+Q_DECLARE_FLAGS(OptionalData, OptionalDataValue)
+
 QString exportToModList(QList<Mod*> mods, Formats format, OptionalData extraData);
 QString exportToModList(QList<Mod*> mods, QString lineTemplate);
 }  // namespace ExportToModList

--- a/launcher/modplatform/import_ftb/PackInstallTask.cpp
+++ b/launcher/modplatform/import_ftb/PackInstallTask.cpp
@@ -63,12 +63,12 @@ void PackInstallTask::copySettings()
             instance.settings()->set("JvmArgs", m_pack.jvmArgs.toString());
         }
 
-        auto components = instance.getPackProfile();
+        auto* components = instance.getPackProfile();
         components->buildingFromScratch();
         components->setComponentVersion("net.minecraft", m_pack.mcVersion, true);
 
         auto modloader = m_pack.loaderType;
-        if (modloader.has_value())
+        if (modloader.has_value()) {
             switch (modloader.value()) {
                 case ModPlatform::NeoForge: {
                     components->setComponentVersion("net.neoforged", m_pack.loaderVersion, true);
@@ -86,28 +86,16 @@ void PackInstallTask::copySettings()
                     components->setComponentVersion("org.quiltmc.quilt-loader", m_pack.loaderVersion, true);
                     break;
                 }
-                case ModPlatform::Cauldron:
-                    break;
-                case ModPlatform::LiteLoader:
-                    break;
-                case ModPlatform::DataPack:
-                    break;
-                case ModPlatform::Babric:
-                    break;
-                case ModPlatform::BTA:
-                    break;
-                case ModPlatform::LegacyFabric:
-                    break;
-                case ModPlatform::Ornithe:
-                    break;
-                case ModPlatform::Rift:
+                default:
                     break;
             }
+        }
         components->saveNow();
 
         instance.setName(name());
-        if (m_instIcon == "default")
+        if (m_instIcon == "default") {
             m_instIcon = "ftb_logo";
+        }
         instance.setIconKey(m_instIcon);
     }
     emitSucceeded();

--- a/launcher/translations/POTranslator.cpp
+++ b/launcher/translations/POTranslator.cpp
@@ -183,8 +183,7 @@ void POTranslatorPrivate::reload()
                 nextFuzzy = true;
             }
         } else if (line.startsWith('"')) {
-            QByteArray temp;
-            QByteArray* out = &temp;
+            QByteArray* out = nullptr;
 
             switch (mode) {
                 case Mode::First:

--- a/launcher/ui/dialogs/ExportToModListDialog.cpp
+++ b/launcher/ui/dialogs/ExportToModListDialog.cpp
@@ -214,6 +214,8 @@ void ExportToModListDialog::addExtra(ExportToModList::OptionalData option)
         case ExportToModList::FileName:
             ui->templateText->insertPlainText("{filename}");
             break;
+        case ExportToModList::None:
+            break;
     }
 }
 void ExportToModListDialog::enableCustom(bool enabled)

--- a/launcher/ui/instanceview/InstanceView.cpp
+++ b/launcher/ui/instanceview/InstanceView.cpp
@@ -511,8 +511,7 @@ void InstanceView::paintEvent([[maybe_unused]] QPaintEvent* event)
 
     int wpWidth = viewport()->width();
     option.rect.setWidth(wpWidth);
-    for (int i = 0; i < m_groups.size(); ++i) {
-        VisualGroup* category = m_groups.at(i);
+    for (auto* category : m_groups) {
         int y = category->verticalPosition();
         y -= verticalOffset();
         QRect backup = option.rect;
@@ -522,7 +521,6 @@ void InstanceView::paintEvent([[maybe_unused]] QPaintEvent* event)
         option.rect.setLeft(m_leftMargin);
         option.rect.setRight(wpWidth - m_rightMargin);
         category->drawHeader(&painter, option);
-        y += category->totalHeight() + m_categoryMargin;
         option.rect = backup;
     }
 

--- a/launcher/ui/widgets/PageContainer.cpp
+++ b/launcher/ui/widgets/PageContainer.cpp
@@ -49,6 +49,7 @@
 #include <QStackedLayout>
 #include <QStyledItemDelegate>
 #include <QUrl>
+#include <utility>
 
 #include "settings/SettingsObject.h"
 
@@ -108,7 +109,7 @@ PageContainer::PageContainer(BasePageProvider* pageProvider, QString defaultId, 
     connect(m_pageList->selectionModel(), &QItemSelectionModel::currentRowChanged, this, &PageContainer::currentChanged);
     m_pageStack->setStackingMode(QStackedLayout::StackOne);
     m_pageList->setFocus();
-    selectPage(defaultId);
+    selectPage(std::move(defaultId));
 }
 
 bool PageContainer::selectPage(QString pageId)

--- a/launcher/ui/widgets/PageContainer.h
+++ b/launcher/ui/widgets/PageContainer.h
@@ -56,9 +56,7 @@ class QGridLayout;
 class PageContainer : public QWidget, public BasePageContainer {
     Q_OBJECT
    public:
-    explicit PageContainer(BasePageProvider* pageProvider,
-                           QString defaultId = QString(),
-                           QWidget* parent = nullptr);
+    explicit PageContainer(BasePageProvider* pageProvider, QString defaultId = QString(), QWidget* parent = nullptr);
     ~PageContainer() override = default;
 
     void addButtons(QWidget* buttons);

--- a/launcher/ui/widgets/PageContainer.h
+++ b/launcher/ui/widgets/PageContainer.h
@@ -57,7 +57,7 @@ class PageContainer : public QWidget, public BasePageContainer {
     Q_OBJECT
    public:
     explicit PageContainer(BasePageProvider* pageProvider, QString defaultId = QString(), QWidget* parent = 0);
-    virtual ~PageContainer() {}
+    ~PageContainer() override = default;
 
     void addButtons(QWidget* buttons);
     void addButtons(QLayout* buttons);

--- a/launcher/ui/widgets/ProjectItem.cpp
+++ b/launcher/ui/widgets/ProjectItem.cpp
@@ -47,30 +47,31 @@ void ProjectItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& o
         painter->setOpacity(0.4);  // Fade out the entire item
     }
     // The default icon size will be a square (and height is usually the lower value).
-    auto icon_width = rect.height(), icon_height = rect.height();
+    auto icon_width = rect.height();
     int icon_x_margin = (rect.height() - icon_width) / 2;
-    int icon_y_margin = (rect.height() - icon_height) / 2;
 
     if (!opt.icon.isNull()) {  // Icon painting
+        auto icon_height = 0;
         {
             auto icon_size = opt.decorationSize;
             icon_width = icon_size.width();
             icon_height = icon_size.height();
 
-            icon_y_margin = (rect.height() - icon_height) / 2;
-            icon_x_margin = icon_y_margin;  // use same margins for consistency
+            icon_x_margin = (rect.height() - icon_height) / 2;  // use same margins for consistency
         }
 
         // Centralize icon with a margin to separate from the other elements
         int x = rect.x() + icon_x_margin;
-        int y = rect.y() + icon_y_margin;
+        int y = rect.y() + icon_x_margin;
 
-        if (opt.features & QStyleOptionViewItem::HasCheckIndicator)
+        if (opt.features & QStyleOptionViewItem::HasCheckIndicator) {
             rect.translate(icon_x_margin / 2, 0);
+        }
 
         // Prevent 'scaling null pixmap' warnings
-        if (icon_width > 0 && icon_height > 0)
+        if (icon_width > 0 && icon_height > 0) {
             opt.icon.paint(painter, x, y, icon_width, icon_height);
+        }
     }
 
     // Change the rect so that funther painting is easier


### PR DESCRIPTION
This commit aims to fix all clang-analyzer-* warnings from clang-tidy. Here is the list of the ones found in project:
    "clang-analyzer-core.uninitialized.UndefReturn",
    "clang-analyzer-deadcode.DeadStores",
    "clang-analyzer-optin.core.EnumCastOutOfRange",
Some exceptions:
  clang-analyzer-cplusplus.NewDeleteLeaks -> may need to disable it as
is a false positive
  clang-analyzer-optin.cplusplus.VirtualCall -> may need to disable it
(or refactor a bunch of code to drop the virtual from those functions)

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
