### PR TITLE
actions(macos): build .dmg disk images

### DIFF
--- a/.github/actions/package/macos/action.yml
+++ b/.github/actions/package/macos/action.yml
@@ -119,13 +119,13 @@ runs:
       run: |
         if [ '${{ inputs.sparkle-ed25519-key }}' != '' ]; then
           echo '${{ inputs.sparkle-ed25519-key }}' > ed25519-priv.pem
-          signature-zip=$(/opt/homebrew/opt/openssl@3/bin/openssl pkeyutl -sign -rawin -in ${{ github.workspace }}/PrismLauncher.zip -inkey ed25519-priv.pem | openssl base64 | tr -d \\n)
-          signature-dmg=$(/opt/homebrew/opt/openssl@3/bin/openssl pkeyutl -sign -rawin -in ${{ github.workspace }}/PrismLauncher.dmg -inkey ed25519-priv.pem | openssl base64 | tr -d \\n) 
+          signature_zip=$(/opt/homebrew/opt/openssl@3/bin/openssl pkeyutl -sign -rawin -in ${{ github.workspace }}/PrismLauncher.zip -inkey ed25519-priv.pem | openssl base64 | tr -d \\n)
+          signature_dmg=$(/opt/homebrew/opt/openssl@3/bin/openssl pkeyutl -sign -rawin -in ${{ github.workspace }}/PrismLauncher.dmg -inkey ed25519-priv.pem | openssl base64 | tr -d \\n) 
           rm ed25519-priv.pem
           cat >> $GITHUB_STEP_SUMMARY << EOF
         ### Artifact Information :information_source:
-        - :memo: Sparkle Signature (ed25519): \`$signature-zip\` (ZIP)
-        - :memo: Sparkle Signature (ed25519): \`$signature-dmg\` (DMG)
+        - :memo: Sparkle Signature (ed25519): \`$signature_zip\` (ZIP)
+        - :memo: Sparkle Signature (ed25519): \`$signature_dmg\` (DMG)
         EOF
         else
           cat >> $GITHUB_STEP_SUMMARY << EOF

--- a/.github/actions/package/macos/action.yml
+++ b/.github/actions/package/macos/action.yml
@@ -91,10 +91,10 @@ runs:
             --password '${{ inputs.apple-notarize-password }}'
 
           xcrun stapler staple "Prism Launcher.app"
-          rm "../PrismLauncher.zip"
         else
           echo ":warning: Skipping notarization as credentials are not present." >> $GITHUB_STEP_SUMMARY
         fi
+        ditto -c -k --sequesterRsrc --keepParent "Prism Launcher.app" ../PrismLauncher.zip
 
     - name: Create DMG
       shell: bash
@@ -119,11 +119,13 @@ runs:
       run: |
         if [ '${{ inputs.sparkle-ed25519-key }}' != '' ]; then
           echo '${{ inputs.sparkle-ed25519-key }}' > ed25519-priv.pem
-          signature=$(/opt/homebrew/opt/openssl@3/bin/openssl pkeyutl -sign -rawin -in ${{ github.workspace }}/PrismLauncher.dmg -inkey ed25519-priv.pem | openssl base64 | tr -d \\n)
+          signature-zip=$(/opt/homebrew/opt/openssl@3/bin/openssl pkeyutl -sign -rawin -in ${{ github.workspace }}/PrismLauncher.zip -inkey ed25519-priv.pem | openssl base64 | tr -d \\n)
+          signature-dmg=$(/opt/homebrew/opt/openssl@3/bin/openssl pkeyutl -sign -rawin -in ${{ github.workspace }}/PrismLauncher.dmg -inkey ed25519-priv.pem | openssl base64 | tr -d \\n) 
           rm ed25519-priv.pem
           cat >> $GITHUB_STEP_SUMMARY << EOF
         ### Artifact Information :information_source:
-        - :memo: Sparkle Signature (ed25519): \`$signature\`
+        - :memo: Sparkle Signature (ed25519): \`$signature-zip\` (ZIP)
+        - :memo: Sparkle Signature (ed25519): \`$signature-dmg\` (DMG)
         EOF
         else
           cat >> $GITHUB_STEP_SUMMARY << EOF
@@ -133,6 +135,12 @@ runs:
         fi
 
     - name: Upload binary tarball
+      uses: actions/upload-artifact@v6
+      with:
+        name: PrismLauncher-${{ inputs.artifact-name }}-${{ inputs.version }}-${{ inputs.build-type }}
+        path: PrismLauncher.zip
+
+    - name: Upload disk image
       uses: actions/upload-artifact@v6
       with:
         name: PrismLauncher-${{ inputs.artifact-name }}-${{ inputs.version }}-${{ inputs.build-type }}

--- a/.github/actions/package/macos/action.yml
+++ b/.github/actions/package/macos/action.yml
@@ -143,5 +143,5 @@ runs:
     - name: Upload disk image
       uses: actions/upload-artifact@v6
       with:
-        name: PrismLauncher-${{ inputs.artifact-name }}-${{ inputs.version }}-${{ inputs.build-type }}
+        name: PrismLauncher-${{ inputs.artifact-name }}-${{ inputs.version }}-${{ inputs.build-type }}.dmg
         path: PrismLauncher.dmg

--- a/.github/actions/package/macos/action.yml
+++ b/.github/actions/package/macos/action.yml
@@ -91,17 +91,35 @@ runs:
             --password '${{ inputs.apple-notarize-password }}'
 
           xcrun stapler staple "Prism Launcher.app"
+          rm "../PrismLauncher.zip"
         else
           echo ":warning: Skipping notarization as credentials are not present." >> $GITHUB_STEP_SUMMARY
         fi
-        ditto -c -k --sequesterRsrc --keepParent "Prism Launcher.app" ../PrismLauncher.zip
+
+    - name: Create DMG
+      shell: bash
+      env:
+        INSTALL_DIR: install
+      run: |
+        cd ${{ env.INSTALL_DIR }}
+
+        mkdir -p src
+        cp -R "Prism Launcher.app" src/
+
+        ln -s /Applications src/
+
+        hdiutil create \
+            -volname "Prism Launcher ${{ inputs.version }}" \
+            -srcfolder src \
+            -ov -format ULMO \
+            "../PrismLauncher.dmg"
 
     - name: Make Sparkle signature
       shell: bash
       run: |
         if [ '${{ inputs.sparkle-ed25519-key }}' != '' ]; then
           echo '${{ inputs.sparkle-ed25519-key }}' > ed25519-priv.pem
-          signature=$(/opt/homebrew/opt/openssl@3/bin/openssl pkeyutl -sign -rawin -in ${{ github.workspace }}/PrismLauncher.zip -inkey ed25519-priv.pem | openssl base64 | tr -d \\n)
+          signature=$(/opt/homebrew/opt/openssl@3/bin/openssl pkeyutl -sign -rawin -in ${{ github.workspace }}/PrismLauncher.dmg -inkey ed25519-priv.pem | openssl base64 | tr -d \\n)
           rm ed25519-priv.pem
           cat >> $GITHUB_STEP_SUMMARY << EOF
         ### Artifact Information :information_source:
@@ -118,4 +136,4 @@ runs:
       uses: actions/upload-artifact@v6
       with:
         name: PrismLauncher-${{ inputs.artifact-name }}-${{ inputs.version }}-${{ inputs.build-type }}
-        path: PrismLauncher.zip
+        path: PrismLauncher.dmg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,7 @@ jobs:
           mv PrismLauncher-*.AppImage/PrismLauncher-*-aarch64.AppImage PrismLauncher-Linux-aarch64.AppImage
           mv PrismLauncher-*.AppImage.zsync/PrismLauncher-*-aarch64.AppImage.zsync PrismLauncher-Linux-aarch64.AppImage.zsync
           mv PrismLauncher-macOS*/PrismLauncher.zip PrismLauncher-macOS-${{ env.VERSION }}.zip
+          mv PrismLauncher-macOS*/PrismLauncher.dmg PrismLauncher-macOS-${{ env.VERSION }}.dmg
 
           tar --exclude='.git' -czf PrismLauncher-${{ env.VERSION }}.tar.gz PrismLauncher-${{ env.VERSION }}
 
@@ -121,4 +122,5 @@ jobs:
             PrismLauncher-Windows-MSVC-Portable-${{ env.VERSION }}.zip
             PrismLauncher-Windows-MSVC-Setup-${{ env.VERSION }}.exe
             PrismLauncher-macOS-${{ env.VERSION }}.zip
+            PrismLauncher-macOS-${{ env.VERSION }}.dmg
             PrismLauncher-${{ env.VERSION }}.tar.gz


### PR DESCRIPTION
what this PR does?
makes GitHub Actions package macOS builds in .dmg instead of .zip. (if zips are really needed """in case of emergency""", let me know)

why disk images over archives?
well, it's more convenient (drag-n-drop installation), customizable, and somehow smaller than zip when making .dmg with ULMO format. and disk images are very common when installing software on Macs.