### PR TITLE
change(cmake): dehardcode launcher names in info.plist

### DIFF
--- a/cmake/MacOSXBundleInfo.plist.in
+++ b/cmake/MacOSXBundleInfo.plist.in
@@ -7,7 +7,7 @@
     <key>NSMicrophoneUsageDescription</key>
     <string>A Minecraft mod wants to access your microphone.</string>
     <key>NSDownloadsFolderUsageDescription</key>
-    <string>Prism uses access to your Downloads folder to help you more quickly add mods that can't be automatically downloaded to your instance. You can change where Prism scans for downloaded mods in Settings or the prompt that appears.</string>
+    <string>${Launcher_Name} uses access to your Downloads folder to help you more quickly add mods that can't be automatically downloaded to your instance. You can change where ${Launcher_Name} scans for downloaded mods in Settings or the prompt that appears.</string>
     <key>NSLocalNetworkUsageDescription</key>
     <string>Minecraft uses the local network to find and connect to LAN servers.</string>
     <key>NSPrincipalClass</key>

--- a/cmake/MacOSXBundleInfo.plist.in
+++ b/cmake/MacOSXBundleInfo.plist.in
@@ -7,7 +7,7 @@
     <key>NSMicrophoneUsageDescription</key>
     <string>A Minecraft mod wants to access your microphone.</string>
     <key>NSDownloadsFolderUsageDescription</key>
-    <string>${Launcher_Name} uses access to your Downloads folder to help you more quickly add mods that can't be automatically downloaded to your instance. You can change where ${Launcher_Name} scans for downloaded mods in Settings or the prompt that appears.</string>
+    <string>${Launcher_DisplayName} uses access to your Downloads folder to help you more quickly add mods that can't be automatically downloaded to your instance. You can change where ${Launcher_DisplayName} scans for downloaded mods in Settings or the prompt that appears.</string>
     <key>NSLocalNetworkUsageDescription</key>
     <string>Minecraft uses the local network to find and connect to LAN servers.</string>
     <key>NSPrincipalClass</key>
@@ -61,7 +61,7 @@
                 <string>mrpack</string>
             </array>
             <key>CFBundleTypeName</key>
-            <string>${Launcher_Name} instance</string>
+            <string>${Launcher_DisplayName} instance</string>
             <key>CFBundleTypeOSTypes</key>
             <array>
                 <string>TEXT</string>

--- a/cmake/MacOSXBundleInfo.plist.in
+++ b/cmake/MacOSXBundleInfo.plist.in
@@ -61,7 +61,7 @@
                 <string>mrpack</string>
             </array>
             <key>CFBundleTypeName</key>
-            <string>Prism Launcher instance</string>
+            <string>${Launcher_Name} instance</string>
             <key>CFBundleTypeOSTypes</key>
             <array>
                 <string>TEXT</string>
@@ -87,10 +87,10 @@
         </dict>
         <dict>
             <key>CFBundleURLName</key>
-            <string>Prismlauncher</string>
+            <string>${Launcher_Name}</string>
             <key>CFBundleURLSchemes</key>
             <array>
-            <string>prismlauncher</string>
+            <string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
             </array>
         </dict>
     </array>


### PR DESCRIPTION
why?
~~dehardcoding == good~~ if maintainer of a fork that changed launcher name in their project forgets to change some values in `cmake/MacOSXBundleInfo.plist.in`, their launcher will override Prism's custom URL scheme