### PR TITLE
fix: URL import fix for Linux 

### DIFF
--- a/cmake/MacOSXBundleInfo.plist.in
+++ b/cmake/MacOSXBundleInfo.plist.in
@@ -90,6 +90,7 @@
             <string>${Launcher_Name}</string>
             <key>CFBundleURLSchemes</key>
             <array>
+            <string>prismlauncher</string>
             <string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
             </array>
         </dict>

--- a/program_info/org.prismlauncher.PrismLauncher.desktop.in
+++ b/program_info/org.prismlauncher.PrismLauncher.desktop.in
@@ -10,4 +10,4 @@ Icon=@Launcher_AppID@
 Categories=Game;ActionGame;AdventureGame;Simulation;PackageManager;
 Keywords=game;minecraft;mc;
 StartupWMClass=@Launcher_CommonName@
-MimeType=application/zip;application/x-modrinth-modpack+zip;x-scheme-handler/curseforge;x-scheme-handler/@Launcher_APP_BINARY_NAME@;
+MimeType=application/zip;application/x-modrinth-modpack+zip;x-scheme-handler/curseforge;x-scheme-handler/prismlauncher;x-scheme-handler/@Launcher_APP_BINARY_NAME@;


### PR DESCRIPTION
Related to https://github.com/PrismLauncher/PrismLauncher/pull/4990
Feature will not work on Linux for PrismLauncher forks. This PR should fix that by adding `x-scheme-handler/prismlauncher` to `org.prismlauncher.PrismLauncher.desktop.in`
There is no problem for MacOS because Prismlauncher scheme is predefined in `MacOSXBundleInfo.plist.in`:

```
<dict>
    <key>CFBundleURLName</key>
    <string>Prismlauncher</string>
    <key>CFBundleURLSchemes</key>
    <array>
    <string>prismlauncher</string>
    </array>
</dict>
```

But behaviour may break if prismlauncher hardcoded name will be changed to something another. It can be fixed by adding Launcher_APP_BINARY_NAME to array:

```
<array>
<string>prismlauncher</string>
<string>${Launcher_APP_BINARY_NAME}</string>
</array>
```

If it is not intended behaviour, it can be removed from PR