### PR TITLE
Use LLVM-based stdenv for Nix build/shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -86,6 +86,7 @@
         let
           pkgs = nixpkgsFor.${system};
           llvm = pkgs.llvmPackages_19;
+          mkShell = pkgs.mkShell.override { inherit (llvm) stdenv; };
 
           packages' = self.packages.${system};
 
@@ -131,7 +132,7 @@
         in
 
         {
-          default = pkgs.mkShell {
+          default = mkShell {
             name = "prism-launcher";
 
             inputsFrom = [ packages'.prismlauncher-unwrapped ];
@@ -139,10 +140,11 @@
             packages = with pkgs; [
               ccache
               llvm.clang-tools
+              python3 # Required for `run-clang-tidy`, etc.
             ];
 
             cmakeBuildType = "Debug";
-            cmakeFlags = [ "-GNinja" ] ++ packages'.prismlauncher.cmakeFlags;
+            cmakeFlags = [ "-GNinja" ] ++ packages'.prismlauncher-unwrapped.cmakeFlags;
             dontFixCmake = true;
 
             shellHook = ''
@@ -165,16 +167,24 @@
 
       formatter = forAllSystems (system: nixpkgsFor.${system}.nixfmt-rfc-style);
 
-      overlays.default = final: prev: {
-        prismlauncher-unwrapped = prev.callPackage ./nix/unwrapped.nix {
-          inherit
-            libnbtplusplus
-            self
-            ;
-        };
+      overlays.default =
+        final: prev:
 
-        prismlauncher = final.callPackage ./nix/wrapper.nix { };
-      };
+        let
+          llvm = final.llvmPackages_19 or prev.llvmPackages_19;
+        in
+
+        {
+          prismlauncher-unwrapped = prev.callPackage ./nix/unwrapped.nix {
+            inherit (llvm) stdenv;
+            inherit
+              libnbtplusplus
+              self
+              ;
+          };
+
+          prismlauncher = final.callPackage ./nix/wrapper.nix { };
+        };
 
       packages = forAllSystems (
         system:


### PR DESCRIPTION
Extracted from https://github.com/PrismLauncher/PrismLauncher/pull/5051

Since we use so much LLVM-based tooling, might as well use it for the
main compiler

This also allows for a bit of parity with our Debian-based development
container

Signed-off-by: Seth Flynn <getchoo@tuta.io>

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
