### PR TITLE
fix crash when updating datapacks

### DIFF
--- a/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
+++ b/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
@@ -151,7 +151,10 @@ void ModrinthCheckUpdate::checkVersionsResponse(QByteArray* response, std::optio
             // so we may want to filter it
             QString loader_filter;
             if (loader.has_value() && loader != 0) {
-                loader_filter = ModPlatform::getModLoaderAsString(ModPlatform::modLoaderTypesToList(*loader).first());
+                auto modLoaders = ModPlatform::modLoaderTypesToList(*loader);
+                if (!modLoaders.isEmpty()) {
+                    loader_filter = ModPlatform::getModLoaderAsString(modLoaders.first());
+                }
             }
 
             // Currently, we rely on a couple heuristics to determine whether an update is actually available or not:


### PR DESCRIPTION
Parent PR: #5101
so for datapacks and datapacks only we need an extra check. Why? Because Datapacks are treated as ModLoaderType but they aren't a modloader. So the modLoaderTypesToList will generate an empty list even if loader is 64 (not 0).

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
