### PR TITLE
Sort modpack versions properly

### DIFF
--- a/launcher/modplatform/ResourceAPI.cpp
+++ b/launcher/modplatform/ResourceAPI.cpp
@@ -2,6 +2,7 @@
 
 #include "Application.h"
 #include "Json.h"
+#include "Version.h"
 #include "net/NetJob.h"
 
 #include "modplatform/ModIndex.h"
@@ -114,8 +115,7 @@ Task::Ptr ResourceAPI::getProjectVersions(VersionSearchArgs&& args, Callback<QVe
             }
 
             auto orderSortPredicate = [](const ModPlatform::IndexedVersion& a, const ModPlatform::IndexedVersion& b) -> bool {
-                // dates are in RFC 3339 format
-                return a.date > b.date;
+                return Version(a.version) > Version(b.version);
             };
             std::sort(unsortedVersions.begin(), unsortedVersions.end(), orderSortPredicate);
         } catch (const JSONValidationError& e) {


### PR DESCRIPTION
Currently, PrismLauncher sorts the versions by date of release, which is a pretty good heuristic that works fine most of the time.

Except, some modpacks (most notably, Fabolously Optimized) like to release versions out of order, making for a pretty terrible user experience; I wasted way too much time trying to figure out what is the latest version of the modpack to support my MC game version!

Therefore, I took it upon myself to dig into the code and improve the sorting logic a bit; I essentially just sort assuming semver semantics, splitting the version string on every "-" and "." character, and comparing each version token accordingly.
Plus a special case for version tokens that contain text (like "alpha"), so that they get handled reasonably too.

This is the first time I'm contributing to Prism, so feel free to nitpick and point out any mistakes, I'll be happy to rewrite the patch to fix any problems!

Here's a couple of screenshots:

Before:
<img width="787" height="205" alt="image" src="https://github.com/user-attachments/assets/e4bd36c7-418f-49f2-9c85-bd150b62b969" />

After:
<img width="783" height="201" alt="image" src="https://github.com/user-attachments/assets/7175fae0-aa83-4728-9227-6f748d26fec5" />

