### PR TITLE
Add optimized JVM arguments and garbage collector presets

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -742,6 +742,8 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         m_settings->registerSetting("JavaVendor", "");
         m_settings->registerSetting("LastHostname", "");
         m_settings->registerSetting("JvmArgs", "");
+        m_settings->registerSetting("UseOptimizedJvmArgs", true);
+        m_settings->registerSetting("GarbageCollectorPreset", "ZGC");
         m_settings->registerSetting("IgnoreJavaCompatibility", false);
         m_settings->registerSetting("IgnoreJavaWizard", false);
         auto defaultEnableAutoJava = m_settings->get("JavaPath").toString().isEmpty();

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -436,6 +436,8 @@ set(JAVA_SOURCES
     java/JavaUtils.cpp
     java/JavaVersion.h
     java/JavaVersion.cpp
+    java/JavaPerformance.cpp
+    java/JavaPerformance.h
 
     java/JavaMetadata.h
     java/JavaMetadata.cpp

--- a/launcher/java/JavaPerformance.cpp
+++ b/launcher/java/JavaPerformance.cpp
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2026 Octol1ttle <l1ttleofficial@outlook.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "JavaPerformance.h"
+
+#include <QDebug>
+
+QStringList JavaPerformance::getMojangOptimizationArgs(const JavaVersion& version, const GarbageCollectorPreset preset)
+{
+    QStringList args;
+
+    // -XX:+UseCompactObjectHeaders
+    // JEPs: https://openjdk.org/jeps/450, https://openjdk.org/jeps/519
+    if (version.major() >= 24) {
+        if (version.major() == 24) {
+            args << "-XX:+UnlockExperimentalVMOptions";
+        }
+        args << "-XX:+UseCompactObjectHeaders";
+    }
+
+    // -XX:+AlwaysPreTouch
+    // Since Java 6 (minimum supported by us is Java 7)
+    args << "-XX:+AlwaysPreTouch";
+
+    // -XX:+UseStringDeduplication
+    // Since Java 8 for G1GC
+    // Since Java 18 for ZGC
+    if ((version.major() >= 8 && preset == GarbageCollectorPreset::G1GC)
+        // There is 1 GC that didn't get support for string deduplication in Java 18: Shenandoah GC
+        // Because of this, we cannot assume this argument is 100% guaranteed to be compatible with user arguments
+        || (version.major() >= 18 && preset != GarbageCollectorPreset::None)) {
+        args << "-XX:+UseStringDeduplication";
+    }
+
+    return args;
+}
+
+QStringList JavaPerformance::getGarbageCollectorArgs(const JavaVersion& version, const GarbageCollectorPreset preset)
+{
+    switch (preset) {
+        case GarbageCollectorPreset::None:
+            return {};
+        case GarbageCollectorPreset::G1GC:
+            return { "-XX:+UnlockExperimentalVMOptions", "-XX:+UseG1GC",
+                     "-XX:G1NewSizePercent=20",          "-XX:G1ReservePercent=20",
+                     "-XX:MaxGCPauseMillis=50",          "-XX:G1HeapRegionSize=32M" };
+        case GarbageCollectorPreset::ZGC:
+            QStringList args{ "-XX:+UseZGC" };
+            // Support for generations was added in Java 21 and became default in Java 23
+            if (version.major() >= 21 && version.major() < 23) {
+                args << "-XX:+ZGenerational";
+            }
+            return args;
+    }
+
+    Q_ASSERT_X(false, "JavaPerformance::getGarbageCollectorArgs", "No arguments specified for current garbage collector preset");
+    return {};
+}
+
+QStringList JavaPerformance::getCompletePerformanceArgs(const JavaVersion& version, const bool useOptimized, GarbageCollectorPreset preset)
+{
+    // ZGC was declared as production ready in Java 15, but did not receive support for macOS/aarch64 until Java 17
+    if (preset == GarbageCollectorPreset::ZGC && version.major() < 17) {
+        preset = GarbageCollectorPreset::G1GC;
+    }
+
+    if (!useOptimized) {
+        return getGarbageCollectorArgs(version, preset);
+    }
+    return getMojangOptimizationArgs(version, preset) + getGarbageCollectorArgs(version, preset);
+}

--- a/launcher/java/JavaPerformance.cpp
+++ b/launcher/java/JavaPerformance.cpp
@@ -19,6 +19,7 @@
 #include "JavaPerformance.h"
 
 #include <QDebug>
+#include <QObject>
 
 QStringList JavaPerformance::getMojangOptimizationArgs(const JavaVersion& version, const GarbageCollectorPreset preset)
 {
@@ -40,10 +41,7 @@ QStringList JavaPerformance::getMojangOptimizationArgs(const JavaVersion& versio
     // -XX:+UseStringDeduplication
     // Since Java 8 for G1GC
     // Since Java 18 for ZGC
-    if ((version.major() >= 8 && preset == GarbageCollectorPreset::G1GC)
-        // There is 1 GC that didn't get support for string deduplication in Java 18: Shenandoah GC
-        // Because of this, we cannot assume this argument is 100% guaranteed to be compatible with user arguments
-        || (version.major() >= 18 && preset != GarbageCollectorPreset::None)) {
+    if ((version.major() >= 8 && preset == GarbageCollectorPreset::G1GC) || version.major() >= 18) {
         args << "-XX:+UseStringDeduplication";
     }
 
@@ -72,11 +70,14 @@ QStringList JavaPerformance::getGarbageCollectorArgs(const JavaVersion& version,
     return {};
 }
 
-QStringList JavaPerformance::getCompletePerformanceArgs(const JavaVersion& version, const bool useOptimized, GarbageCollectorPreset preset)
+QStringList JavaPerformance::getCompletePerformanceArgs(const JavaVersion& version, const bool useOptimized, GarbageCollectorPreset preset, QString* warning)
 {
     // ZGC was declared as production ready in Java 15, but did not receive support for macOS/aarch64 until Java 17
     if (preset == GarbageCollectorPreset::ZGC && version.major() < 17) {
         preset = GarbageCollectorPreset::G1GC;
+        if (warning) {
+            *warning = QObject::tr("ZGC requires Java 17 or higher, using G1GC");
+        }
     }
 
     if (!useOptimized) {

--- a/launcher/java/JavaPerformance.h
+++ b/launcher/java/JavaPerformance.h
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2026 Octol1ttle <l1ttleofficial@outlook.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QStringList>
+
+#include "JavaVersion.h"
+
+namespace JavaPerformance {
+    enum class GarbageCollectorPreset : std::uint8_t {
+        None,
+        G1GC,
+        ZGC
+    };
+
+    QStringList getMojangOptimizationArgs(const JavaVersion& version, GarbageCollectorPreset preset);
+    QStringList getGarbageCollectorArgs(const JavaVersion& version, GarbageCollectorPreset preset);
+    QStringList getCompletePerformanceArgs(const JavaVersion& version, bool useOptimized, GarbageCollectorPreset preset);
+}

--- a/launcher/java/JavaPerformance.h
+++ b/launcher/java/JavaPerformance.h
@@ -31,5 +31,5 @@ namespace JavaPerformance {
 
     QStringList getMojangOptimizationArgs(const JavaVersion& version, GarbageCollectorPreset preset);
     QStringList getGarbageCollectorArgs(const JavaVersion& version, GarbageCollectorPreset preset);
-    QStringList getCompletePerformanceArgs(const JavaVersion& version, bool useOptimized, GarbageCollectorPreset preset);
+    QStringList getCompletePerformanceArgs(const JavaVersion& version, bool useOptimized, GarbageCollectorPreset preset, QString* warning = nullptr);
 }

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -96,6 +96,8 @@
 #include <QStandardPaths>
 #include <QWindow>
 
+#include "java/JavaPerformance.h"
+
 #ifdef Q_OS_LINUX
 #include "MangoHud.h"
 #endif
@@ -187,8 +189,10 @@ void MinecraftInstance::loadSpecificSettings()
 
     if (auto global_settings = globalSettings()) {
         m_settings->registerOverride(global_settings->getSetting("JavaPath"), locationOverride);
-        m_settings->registerOverride(global_settings->getSetting("JvmArgs"), argsOverride);
         m_settings->registerOverride(global_settings->getSetting("IgnoreJavaCompatibility"), locationOverride);
+        m_settings->registerOverride(global_settings->getSetting("JvmArgs"), argsOverride);
+        m_settings->registerOverride(global_settings->getSetting("UseOptimizedJvmArgs"), argsOverride);
+        m_settings->registerOverride(global_settings->getSetting("GarbageCollectorPreset"), argsOverride);
 
         // special!
         m_settings->registerPassthrough(global_settings->getSetting("JavaSignature"), locationOverride);
@@ -622,6 +626,16 @@ QStringList MinecraftInstance::javaArguments()
             args << QString("-XX:PermSize=%1m").arg(permgen);
         }
     }
+
+    const auto presetString = m_settings->get("GarbageCollectorPreset");
+    auto preset = JavaPerformance::GarbageCollectorPreset::None;
+    if (presetString == "G1GC") {
+        preset = JavaPerformance::GarbageCollectorPreset::G1GC;
+    }
+    if (presetString == "ZGC") {
+        preset = JavaPerformance::GarbageCollectorPreset::ZGC;
+    }
+    args.append(JavaPerformance::getCompletePerformanceArgs(javaVersion, m_settings->get("UseOptimizedJavaPreset").toBool(), preset));
 
     if (javaVersion.isModular() && shouldApplyOnlineFixes())
         // allow reflective access to java.net - required by the skin fix

--- a/launcher/ui/widgets/JavaSettingsWidget.cpp
+++ b/launcher/ui/widgets/JavaSettingsWidget.cpp
@@ -355,8 +355,17 @@ void JavaSettingsWidget::updateLauncherArgs()
             preset = JavaPerformance::GarbageCollectorPreset::ZGC;
         }
 
+        QString warning;
         m_ui->launcherArgsTextBox->setText(
-            JavaPerformance::getCompletePerformanceArgs(result.javaVersion, m_ui->optimizedArgsCheckBox->isChecked(), preset).join(" "));
+            JavaPerformance::getCompletePerformanceArgs(result.javaVersion, m_ui->optimizedArgsCheckBox->isChecked(), preset, &warning)
+                .join(" "));
+        if (!warning.isEmpty()) {
+            const auto warningColour(QStringLiteral("<span style='color:#f5c211'>%1</span>"));
+            m_ui->argsNoticeLabel->setText(warningColour.arg(warning));
+            m_ui->argsNoticeLabel->show();
+        } else {
+            m_ui->argsNoticeLabel->hide();
+        }
     });
     m_versionChecker->start();
 }

--- a/launcher/ui/widgets/JavaSettingsWidget.cpp
+++ b/launcher/ui/widgets/JavaSettingsWidget.cpp
@@ -44,6 +44,7 @@
 #include "FileSystem.h"
 #include "JavaCommon.h"
 #include "java/JavaInstallList.h"
+#include "java/JavaPerformance.h"
 #include "java/JavaUtils.h"
 #include "settings/Setting.h"
 #include "SysInfo.h"
@@ -104,8 +105,16 @@ JavaSettingsWidget::JavaSettingsWidget(BaseInstance* instance, QWidget* parent)
     connect(m_ui->maxMemSpinBox, &QSpinBox::valueChanged, this, &JavaSettingsWidget::updateThresholds);
     connect(m_ui->minMemSpinBox, &QSpinBox::valueChanged, this, &JavaSettingsWidget::updateThresholds);
 
+    connect(m_ui->javaInstallationGroupBox, &QGroupBox::toggled, this, &JavaSettingsWidget::updateLauncherArgs);
+    connect(m_ui->javaPathTextBox, &QLineEdit::textChanged, this, &JavaSettingsWidget::updateLauncherArgs);
+    connect(m_ui->optimizedArgsCheckBox, &QCheckBox::toggled, this, &JavaSettingsWidget::updateLauncherArgs);
+    connect(m_ui->noPresetRadioButton, &QRadioButton::toggled, this, &JavaSettingsWidget::updateLauncherArgs);
+    connect(m_ui->g1gcPresetRadioButton, &QRadioButton::toggled, this, &JavaSettingsWidget::updateLauncherArgs);
+    connect(m_ui->zgcPresetRadioButton, &QRadioButton::toggled, this, &JavaSettingsWidget::updateLauncherArgs);
+
     loadSettings();
     updateThresholds();
+    updateLauncherArgs();
 }
 
 JavaSettingsWidget::~JavaSettingsWidget()
@@ -129,7 +138,7 @@ void JavaSettingsWidget::loadSettings()
     m_ui->skipCompatibilityCheckBox->setChecked(settings->get("IgnoreJavaCompatibility").toBool());
 
     m_ui->javaArgumentsGroupBox->setChecked(m_instance == nullptr || settings->get("OverrideJavaArgs").toBool());
-    m_ui->jvmArgsTextBox->setPlainText(settings->get("JvmArgs").toString());
+    m_ui->userArgsTextBox->setPlainText(settings->get("JvmArgs").toString());
 
     if (m_instance == nullptr) {
         m_ui->skipWizardCheckBox->setChecked(settings->get("IgnoreJavaWizard").toBool());
@@ -153,7 +162,17 @@ void JavaSettingsWidget::loadSettings()
 
     // Java arguments
     m_ui->javaArgumentsGroupBox->setChecked(m_instance == nullptr || settings->get("OverrideJavaArgs").toBool());
-    m_ui->jvmArgsTextBox->setPlainText(settings->get("JvmArgs").toString());
+    m_ui->userArgsTextBox->setPlainText(settings->get("JvmArgs").toString());
+
+    m_ui->optimizedArgsCheckBox->setChecked(settings->get("UseOptimizedJvmArgs").toBool());
+    auto preset = settings->get("GarbageCollectorPreset").toString();
+    if (preset == "G1GC") {
+        m_ui->g1gcPresetRadioButton->toggle();
+    } else if (preset == "ZGC") {
+        m_ui->zgcPresetRadioButton->toggle();
+    } else {
+        m_ui->noPresetRadioButton->toggle();
+    }
 }
 
 void JavaSettingsWidget::saveSettings()
@@ -217,9 +236,19 @@ void JavaSettingsWidget::saveSettings()
         settings->set("OverrideJavaArgs", javaArgs);
 
     if (javaArgs) {
-        settings->set("JvmArgs", m_ui->jvmArgsTextBox->toPlainText().replace("\n", " "));
+        settings->set("JvmArgs", m_ui->userArgsTextBox->toPlainText().replace("\n", " "));
+        settings->set("UseOptimizedJvmArgs", m_ui->optimizedArgsCheckBox->isChecked());
+        QString preset = "None";
+        if (m_ui->g1gcPresetRadioButton->isChecked()) {
+            preset = "G1GC";
+        } else if (m_ui->zgcPresetRadioButton->isChecked()) {
+            preset = "ZGC";
+        }
+        settings->set("GarbageCollectorPreset", preset);
     } else {
         settings->reset("JvmArgs");
+        settings->reset("UseOptimizedJvmArgs");
+        settings->reset("GarbageCollectorPreset");
     }
 }
 
@@ -248,7 +277,7 @@ void JavaSettingsWidget::onJavaTest()
     QString jvmArgs;
 
     if (m_instance == nullptr || m_ui->javaArgumentsGroupBox->isChecked())
-        jvmArgs = m_ui->jvmArgsTextBox->toPlainText().replace("\n", " ");
+        jvmArgs = m_ui->userArgsTextBox->toPlainText().replace("\n", " ");
     else
         jvmArgs = APPLICATION->settings()->get("JvmArgs").toString();
 
@@ -304,4 +333,30 @@ void JavaSettingsWidget::updateThresholds()
     } else {
         m_ui->labelMaxMemNotice->hide();
     }
+}
+
+void JavaSettingsWidget::updateLauncherArgs()
+{
+    QString javaPath = APPLICATION->settings()->get("JavaPath").toString();
+    if (m_instance == nullptr || m_ui->javaInstallationGroupBox->isChecked()) {
+        javaPath = m_ui->javaPathTextBox->text();
+    }
+    m_versionChecker.reset(new JavaChecker(javaPath, "", 0, 0, 0, 0));
+    connect(m_versionChecker.get(), &JavaChecker::checkFinished, this, [this](const JavaChecker::Result& result) {
+        if (result.validity != JavaChecker::Result::Validity::Valid) {
+            m_ui->launcherArgsTextBox->setText(tr("Java path invalid"));
+            return;
+        }
+
+        auto preset = JavaPerformance::GarbageCollectorPreset::None;
+        if (m_ui->g1gcPresetRadioButton->isChecked()) {
+            preset = JavaPerformance::GarbageCollectorPreset::G1GC;
+        } else if (m_ui->zgcPresetRadioButton->isChecked()) {
+            preset = JavaPerformance::GarbageCollectorPreset::ZGC;
+        }
+
+        m_ui->launcherArgsTextBox->setText(
+            JavaPerformance::getCompletePerformanceArgs(result.javaVersion, m_ui->optimizedArgsCheckBox->isChecked(), preset).join(" "));
+    });
+    m_versionChecker->start();
 }

--- a/launcher/ui/widgets/JavaSettingsWidget.h
+++ b/launcher/ui/widgets/JavaSettingsWidget.h
@@ -60,9 +60,11 @@ class JavaSettingsWidget : public QWidget {
     void onJavaAutodetect();
     void onJavaTest();
     void updateThresholds();
+    void updateLauncherArgs();
 
    private:
     BaseInstance* m_instance;
     Ui::JavaSettingsWidget* m_ui;
     unique_qobject_ptr<JavaCommon::TestCheck> m_checker;
+    JavaChecker::Ptr m_versionChecker;
 };

--- a/launcher/ui/widgets/JavaSettingsWidget.ui
+++ b/launcher/ui/widgets/JavaSettingsWidget.ui
@@ -377,10 +377,10 @@
       <item row="0" column="1">
        <widget class="QCheckBox" name="optimizedArgsCheckBox">
         <property name="toolTip">
-         <string>Adds arguments that generally improve game performance. Some arguments may not be available depending on Java version</string>
+         <string>Some arguments may not be available depending on Java version</string>
         </property>
         <property name="text">
-         <string>Use optimized JVM arguments</string>
+         <string>Use Mojang optimized defaults</string>
         </property>
        </widget>
       </item>
@@ -415,7 +415,7 @@
       <item row="4" column="1">
        <widget class="QRadioButton" name="zgcPresetRadioButton">
         <property name="text">
-         <string>ZGC (if supported, requires Java 17+)</string>
+         <string>ZGC (requires Java 17+)</string>
         </property>
        </widget>
       </item>

--- a/launcher/ui/widgets/JavaSettingsWidget.ui
+++ b/launcher/ui/widgets/JavaSettingsWidget.ui
@@ -364,13 +364,24 @@
       <bool>false</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_6">
-      <item row="8" column="1">
-       <widget class="QPlainTextEdit" name="userArgsTextBox"/>
+      <item row="7" column="1">
+       <widget class="QLabel" name="argsNoticeLabel">
+        <property name="text">
+         <string notr="true">Java Arguments Notice</string>
+        </property>
+       </widget>
       </item>
       <item row="2" column="1">
        <widget class="QRadioButton" name="noPresetRadioButton">
         <property name="text">
          <string>None</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QRadioButton" name="g1gcPresetRadioButton">
+        <property name="text">
+         <string>G1GC</string>
         </property>
        </widget>
       </item>
@@ -384,17 +395,20 @@
         </property>
        </widget>
       </item>
+      <item row="9" column="1">
+       <widget class="QPlainTextEdit" name="userArgsTextBox"/>
+      </item>
+      <item row="4" column="1">
+       <widget class="QRadioButton" name="zgcPresetRadioButton">
+        <property name="text">
+         <string>ZGC</string>
+        </property>
+       </widget>
+      </item>
       <item row="5" column="1">
        <widget class="QLabel" name="optimizedArgsLabel">
         <property name="text">
          <string>Java Arguments chosen by launcher:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="7" column="1">
-       <widget class="QLabel" name="customArgsLabel">
-        <property name="text">
-         <string>Custom Java Arguments:</string>
         </property>
        </widget>
       </item>
@@ -405,17 +419,10 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
-       <widget class="QRadioButton" name="g1gcPresetRadioButton">
+      <item row="8" column="1">
+       <widget class="QLabel" name="customArgsLabel">
         <property name="text">
-         <string>G1GC</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QRadioButton" name="zgcPresetRadioButton">
-        <property name="text">
-         <string>ZGC (requires Java 17+)</string>
+         <string>Custom Java Arguments:</string>
         </property>
        </widget>
       </item>

--- a/launcher/ui/widgets/JavaSettingsWidget.ui
+++ b/launcher/ui/widgets/JavaSettingsWidget.ui
@@ -342,7 +342,7 @@
       <item row="3" column="0" colspan="4">
        <widget class="QLabel" name="labelMaxMemNotice">
         <property name="text">
-         <string>Memory Notice</string>
+         <string notr="true">Memory Notice</string>
         </property>
        </widget>
       </item>
@@ -364,8 +364,67 @@
       <bool>false</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_6">
+      <item row="8" column="1">
+       <widget class="QPlainTextEdit" name="userArgsTextBox"/>
+      </item>
+      <item row="2" column="1">
+       <widget class="QRadioButton" name="noPresetRadioButton">
+        <property name="text">
+         <string>None</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QCheckBox" name="optimizedArgsCheckBox">
+        <property name="toolTip">
+         <string>Adds arguments that generally improve game performance. Some arguments may not be available depending on Java version</string>
+        </property>
+        <property name="text">
+         <string>Use optimized JVM arguments</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QLabel" name="optimizedArgsLabel">
+        <property name="text">
+         <string>Java Arguments chosen by launcher:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="1">
+       <widget class="QLabel" name="customArgsLabel">
+        <property name="text">
+         <string>Custom Java Arguments:</string>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="1">
-       <widget class="QPlainTextEdit" name="jvmArgsTextBox"/>
+       <widget class="QLabel" name="gcPresetLabel">
+        <property name="text">
+         <string>Garbage collector preset:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QRadioButton" name="g1gcPresetRadioButton">
+        <property name="text">
+         <string>G1GC</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="QRadioButton" name="zgcPresetRadioButton">
+        <property name="text">
+         <string>ZGC (if supported, requires Java 17+)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="1">
+       <widget class="QLineEdit" name="launcherArgsTextBox">
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>
@@ -385,7 +444,7 @@
   <tabstop>minMemSpinBox</tabstop>
   <tabstop>maxMemSpinBox</tabstop>
   <tabstop>permGenSpinBox</tabstop>
-  <tabstop>jvmArgsTextBox</tabstop>
+  <tabstop>userArgsTextBox</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
<img width="507" height="312" alt="image" src="https://github.com/user-attachments/assets/a903c89b-5bf2-4204-a6d3-2dc048f03199" />

All arguments were taken from the [vanilla client JSON for 26.1-pre.2](https://piston-meta.mojang.com/v1/packages/ee6b66d7272da482969ab02872280ea86e7822a6/26.1-pre-2.json)

"Optimized JVM arguments" are arguments not directly related to garbage collection (`-XX:+UseCompactObjectHeaders` if J24+, `-XX:+AlwaysPreTouch`, and `-XX:+UseStringDeduplication` on compatible GCs)

Choosing ZGC on an incompatible Java version will result in G1GC being used instead

Pros and cons of hardcoding the arguments:
**+** The feature can be used on all Minecraft versions
**+** User has the most freedom, using the feature is simple
**+** Simplest implementation, no meta-side changes or maintenance are required
**-** Arguments will have to be updated manually when Mojang updates them

Including the arguments in the `net.minecraft` component:
**+** Least meta-side maintenance for us
**+** 2nd simplest launcher-side implementation
**-** Arguments are only available where Mojang provides them

Separate meta component `net.minecraft.java.args`:
**+** Gives us the most flexibility
**-** New component will need plenty of launcher-side changes (can't judge meta-side impact area right now)
**-** Overkill?