### PR TITLE
Mark accounts with errors in dropdown

### DIFF
--- a/launcher/minecraft/auth/MinecraftAccount.cpp
+++ b/launcher/minecraft/auth/MinecraftAccount.cpp
@@ -191,6 +191,14 @@ void MinecraftAccount::authFailed(QString reason)
     emit activityChanged(false);
 }
 
+QString MinecraftAccount::displayName() const
+{
+    if (const QList validStates{ AccountState::Unchecked, AccountState::Working, AccountState::Offline, AccountState::Online }; !validStates.contains(accountState())) {
+        return QString("⚠ %1").arg(profileName());
+    }
+    return profileName();
+}
+
 bool MinecraftAccount::isActive() const
 {
     return !m_currentTask.isNull();

--- a/launcher/minecraft/auth/MinecraftAccount.h
+++ b/launcher/minecraft/auth/MinecraftAccount.h
@@ -110,6 +110,8 @@ class MinecraftAccount : public QObject, public Usable {
 
     QString profileName() const { return data.profileName(); }
 
+    QString displayName() const;
+
     bool isActive() const;
 
     AccountType accountType() const noexcept { return data.type; }

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -458,7 +458,7 @@ void MainWindow::retranslateUi()
 
     MinecraftAccountPtr defaultAccount = APPLICATION->accounts()->defaultAccount();
     if (defaultAccount) {
-        auto profileLabel = profileInUseFilter(defaultAccount->profileName(), defaultAccount->isInUse());
+        auto profileLabel = profileInUseFilter(defaultAccount->displayName(), defaultAccount->isInUse());
         ui->actionAccountsButton->setText(profileLabel);
     }
 
@@ -658,7 +658,7 @@ void MainWindow::repopulateAccountsMenu()
     if (defaultAccount) {
         // this can be called before accountMenuButton exists
         if (ui->actionAccountsButton) {
-            auto profileLabel = profileInUseFilter(defaultAccount->profileName(), defaultAccount->isInUse());
+            auto profileLabel = profileInUseFilter(defaultAccount->displayName(), defaultAccount->isInUse());
             ui->actionAccountsButton->setText(profileLabel);
         }
     }
@@ -672,7 +672,7 @@ void MainWindow::repopulateAccountsMenu()
         // TODO: Nicer way to iterate?
         for (int i = 0; i < accounts->count(); i++) {
             MinecraftAccountPtr account = accounts->at(i);
-            auto profileLabel = profileInUseFilter(account->profileName(), account->isInUse());
+            auto profileLabel = profileInUseFilter(account->displayName(), account->isInUse());
             QAction* action = new QAction(profileLabel, this);
             action->setData(i);
             action->setCheckable(true);
@@ -752,7 +752,7 @@ void MainWindow::defaultAccountChanged()
 
     // FIXME: this needs adjustment for MSA
     if (account && account->profileName() != "") {
-        auto profileLabel = profileInUseFilter(account->profileName(), account->isInUse());
+        auto profileLabel = profileInUseFilter(account->displayName(), account->isInUse());
         ui->actionAccountsButton->setText(profileLabel);
         auto face = account->getFace();
         if (face.isNull()) {


### PR DESCRIPTION
Closes #4572 

<img width="168" height="105" alt="image" src="https://github.com/user-attachments/assets/44983c2e-3aae-4336-84bc-23b78ccb3ceb" />

Works correctly if the account state changes while the dropdown is open