### PR TITLE
Fix weird utf archive

### DIFF
--- a/launcher/archive/ArchiveReader.cpp
+++ b/launcher/archive/ArchiveReader.cpp
@@ -36,8 +36,9 @@ QStringList ArchiveReader::getFiles()
 bool ArchiveReader::collectFiles(bool onlyFiles)
 {
     return parse([this, onlyFiles](File* f) {
-        if (!onlyFiles || f->isFile())
+        if (!onlyFiles || f->isFile()) {
             m_fileNames << f->filename();
+        }
         return f->skip();
     });
 }
@@ -54,11 +55,11 @@ QString ArchiveReader::File::filename()
 QByteArray ArchiveReader::File::readAll(int* outStatus)
 {
     QByteArray data;
-    const void* buff;
-    size_t size;
-    la_int64_t offset;
+    const void* buff = nullptr;
+    size_t size = 0;
+    la_int64_t offset = 0;
 
-    int status;
+    int status = 0;
     while ((status = archive_read_data_block(m_archive.get(), &buff, &size, &offset)) == ARCHIVE_OK) {
         data.append(static_cast<const char*>(buff), static_cast<qsizetype>(size));
     }
@@ -84,10 +85,10 @@ int ArchiveReader::File::readNextHeader()
     return archive_read_next_header(m_archive.get(), &m_entry);
 }
 
-auto ArchiveReader::goToFile(QString filename) -> std::unique_ptr<File>
+auto ArchiveReader::goToFile(const QString& filename) -> std::unique_ptr<File>
 {
     auto f = std::make_unique<File>();
-    auto a = f->m_archive.get();
+    auto* a = f->m_archive.get();
     archive_read_support_format_all(a);
     archive_read_support_filter_all(a);
     auto fileName = m_archivePath.toStdWString();
@@ -109,15 +110,16 @@ auto ArchiveReader::goToFile(QString filename) -> std::unique_ptr<File>
 
 static int copy_data(struct archive* ar, struct archive* aw, bool notBlock = false)
 {
-    int r;
-    const void* buff;
-    size_t size;
-    la_int64_t offset;
+    int r = 0;
+    const void* buff = nullptr;
+    size_t size = 0;
+    la_int64_t offset = 0;
 
     for (;;) {
         r = archive_read_data_block(ar, &buff, &size, &offset);
-        if (r == ARCHIVE_EOF)
-            return (ARCHIVE_OK);
+        if (r == ARCHIVE_EOF) {
+            return ARCHIVE_OK;
+        }
         if (r < ARCHIVE_OK) {
             qCritical() << "Failed reading data block:" << archive_error_string(ar);
             return (r);
@@ -140,8 +142,9 @@ bool willEscapeRoot(const QDir& root, archive_entry* entry)
     const char* linkTargetC = archive_entry_symlink(entry);
     const char* hardlinkC = archive_entry_hardlink(entry);
 
-    if (!entryPathC || (!linkTargetC && !hardlinkC))
+    if (!entryPathC || (!linkTargetC && !hardlinkC)) {
         return false;
+    }
 
     QString entryPath = QString::fromUtf8(entryPathC);
     QString linkTarget = linkTargetC ? QString::fromUtf8(linkTargetC) : QString::fromUtf8(hardlinkC);
@@ -149,8 +152,9 @@ bool willEscapeRoot(const QDir& root, archive_entry* entry)
     QString linkFullPath = root.filePath(entryPath);
     auto rootDir = QUrl::fromLocalFile(root.absolutePath());
 
-    if (!rootDir.isParentOf(QUrl::fromLocalFile(linkFullPath)))
+    if (!rootDir.isParentOf(QUrl::fromLocalFile(linkFullPath))) {
         return true;
+    }
 
     QDir linkDir = QFileInfo(linkFullPath).dir();
     if (!QDir::isAbsolutePath(linkTarget)) {
@@ -159,14 +163,14 @@ bool willEscapeRoot(const QDir& root, archive_entry* entry)
     return !rootDir.isParentOf(QUrl::fromLocalFile(QDir::cleanPath(linkTarget)));
 }
 
-bool ArchiveReader::File::writeFile(archive* out, QString targetFileName, bool notBlock)
+bool ArchiveReader::File::writeFile(archive* out, const QString& targetFileName, bool notBlock)
 {
     return writeFile(out, targetFileName, {}, notBlock);
 };
 
-bool ArchiveReader::File::writeFile(archive* out, QString targetFileName, std::optional<QDir> root, bool notBlock)
+bool ArchiveReader::File::writeFile(archive* out, const QString& targetFileName, std::optional<QDir> root, bool notBlock)
 {
-    auto entry = m_entry;
+    auto* entry = m_entry;
     std::unique_ptr<archive_entry, decltype(&archive_entry_free)> entryClone(nullptr, &archive_entry_free);
     if (!targetFileName.isEmpty()) {
         entryClone.reset(archive_entry_clone(m_entry));
@@ -179,25 +183,29 @@ bool ArchiveReader::File::writeFile(archive* out, QString targetFileName, std::o
         return false;
     }
     if (archive_write_header(out, entry) < ARCHIVE_OK) {
-        qCritical() << "Failed to write header to entry:" << filename() << "-" << archive_error_string(out);
+        qCritical() << "Failed to write header to entry:" << filename() << "-" << archive_error_string(out) << targetFileName;
         return false;
-    } else if (archive_entry_size(m_entry) > 0) {
+    }
+    if (archive_entry_size(m_entry) > 0) {
         auto r = copy_data(m_archive.get(), out, notBlock);
-        if (r < ARCHIVE_OK)
+        if (r < ARCHIVE_OK) {
             qCritical() << "Failed reading data block:" << archive_error_string(out);
-        if (r < ARCHIVE_WARN)
+        }
+        if (r < ARCHIVE_WARN) {
             return false;
+        }
     }
     auto r = archive_write_finish_entry(out);
-    if (r < ARCHIVE_OK)
+    if (r < ARCHIVE_OK) {
         qCritical() << "Failed to finish writing entry:" << archive_error_string(out);
+    }
     return (r >= ARCHIVE_WARN);
 }
 
-bool ArchiveReader::parse(std::function<bool(File*, bool&)> doStuff)
+bool ArchiveReader::parse(const std::function<bool(File*, bool&)>& doStuff)
 {
     auto f = std::make_unique<File>();
-    auto a = f->m_archive.get();
+    auto* a = f->m_archive.get();
     archive_read_support_format_all(a);
     archive_read_support_filter_all(a);
     auto fileName = m_archivePath.toStdWString();
@@ -221,7 +229,7 @@ bool ArchiveReader::parse(std::function<bool(File*, bool&)> doStuff)
     return true;
 }
 
-bool ArchiveReader::parse(std::function<bool(File*)> doStuff)
+bool ArchiveReader::parse(const std::function<bool(File*)>& doStuff)
 {
     return parse([doStuff](File* f, bool&) { return doStuff(f); });
 }
@@ -245,26 +253,32 @@ QString ArchiveReader::getZipName()
 
 bool ArchiveReader::exists(const QString& filePath) const
 {
-    if (filePath == QLatin1String("/") || filePath.isEmpty())
+    if (filePath == QLatin1String("/") || filePath.isEmpty()) {
         return true;
+    }
     // Normalize input path (remove trailing slash, if any)
     QString normalizedPath = QDir::cleanPath(filePath);
-    if (normalizedPath.startsWith('/'))
+    if (normalizedPath.startsWith('/')) {
         normalizedPath.remove(0, 1);
-    if (normalizedPath == QLatin1String("."))
+    }
+    if (normalizedPath == QLatin1String(".")) {
         return true;
-    if (normalizedPath == QLatin1String(".."))
+    }
+    if (normalizedPath == QLatin1String("..")) {
         return false;  // root only
+    }
 
     // Check for exact file match
-    if (m_fileNames.contains(normalizedPath, Qt::CaseInsensitive))
+    if (m_fileNames.contains(normalizedPath, Qt::CaseInsensitive)) {
         return true;
+    }
 
     // Check for directory existence by seeing if any file starts with that path
     QString dirPath = normalizedPath + QLatin1Char('/');
     for (const QString& f : m_fileNames) {
-        if (f.startsWith(dirPath, Qt::CaseInsensitive))
+        if (f.startsWith(dirPath, Qt::CaseInsensitive)) {
             return true;
+        }
     }
 
     return false;

--- a/launcher/archive/ArchiveReader.cpp
+++ b/launcher/archive/ArchiveReader.cpp
@@ -24,6 +24,7 @@
 #include <QDir>
 #include <QFileInfo>
 #include <QUrl>
+#include <functional>
 #include <memory>
 #include <optional>
 
@@ -43,13 +44,19 @@ bool ArchiveReader::collectFiles(bool onlyFiles)
     });
 }
 
-QString ArchiveReader::File::filename()
+using getPathFunc = std::function<const char*(archive_entry*)>;
+static QString decodeLibArchivePath(archive_entry* entry, const getPathFunc& getUtf8Path, const getPathFunc& getPath)
 {
-    auto fileName = QString::fromUtf8(archive_entry_pathname_utf8(m_entry));
+    auto fileName = QString::fromUtf8(getUtf8Path(entry));
     if (fileName.isEmpty()) {
-        fileName = QString::fromUtf8(archive_entry_pathname(m_entry));
+        fileName = QString::fromLocal8Bit(getPath(entry));
     }
     return fileName;
+}
+
+QString ArchiveReader::File::filename()
+{
+    return decodeLibArchivePath(m_entry, archive_entry_pathname_utf8, archive_entry_pathname);
 }
 
 QByteArray ArchiveReader::File::readAll(int* outStatus)
@@ -136,18 +143,20 @@ static int copy_data(struct archive* ar, struct archive* aw, bool notBlock = fal
     }
 }
 
-bool willEscapeRoot(const QDir& root, archive_entry* entry)
+static bool willEscapeRoot(const QDir& root, archive_entry* entry)
 {
-    const char* entryPathC = archive_entry_pathname(entry);
-    const char* linkTargetC = archive_entry_symlink(entry);
-    const char* hardlinkC = archive_entry_hardlink(entry);
+    auto entryPath = decodeLibArchivePath(entry, archive_entry_pathname_utf8, archive_entry_pathname);
+    auto linkTarget = decodeLibArchivePath(entry, archive_entry_symlink_utf8, archive_entry_symlink);
+    auto hardLink = decodeLibArchivePath(entry, archive_entry_hardlink_utf8, archive_entry_hardlink);
 
-    if (!entryPathC || (!linkTargetC && !hardlinkC)) {
+    if (entryPath.isEmpty() || (linkTarget.isEmpty() && hardLink.isEmpty())) {
         return false;
     }
 
-    QString entryPath = QString::fromUtf8(entryPathC);
-    QString linkTarget = linkTargetC ? QString::fromUtf8(linkTargetC) : QString::fromUtf8(hardlinkC);
+    bool isHardLink = false;
+    if (isHardLink = linkTarget.isEmpty(); isHardLink) {
+        linkTarget = hardLink;
+    }
 
     QString linkFullPath = root.filePath(entryPath);
     auto rootDir = QUrl::fromLocalFile(root.absolutePath());
@@ -158,7 +167,7 @@ bool willEscapeRoot(const QDir& root, archive_entry* entry)
 
     QDir linkDir = QFileInfo(linkFullPath).dir();
     if (!QDir::isAbsolutePath(linkTarget)) {
-        linkTarget = (linkTargetC ? linkDir : root).filePath(linkTarget);
+        linkTarget = (!isHardLink ? linkDir : root).filePath(linkTarget);
     }
     return !rootDir.isParentOf(QUrl::fromLocalFile(QDir::cleanPath(linkTarget)));
 }

--- a/launcher/archive/ArchiveReader.cpp
+++ b/launcher/archive/ArchiveReader.cpp
@@ -44,7 +44,11 @@ bool ArchiveReader::collectFiles(bool onlyFiles)
 
 QString ArchiveReader::File::filename()
 {
-    return QString::fromUtf8(archive_entry_pathname_utf8(m_entry));
+    auto fileName = QString::fromUtf8(archive_entry_pathname_utf8(m_entry));
+    if (fileName.isEmpty()) {
+        fileName = QString::fromUtf8(archive_entry_pathname(m_entry));
+    }
+    return fileName;
 }
 
 QByteArray ArchiveReader::File::readAll(int* outStatus)

--- a/launcher/archive/ArchiveReader.h
+++ b/launcher/archive/ArchiveReader.h
@@ -23,6 +23,7 @@
 #include <QStringList>
 #include <memory>
 #include <optional>
+#include <utility>
 
 struct archive;
 struct archive_entry;
@@ -30,7 +31,7 @@ namespace MMCZip {
 class ArchiveReader {
    public:
     using ArchivePtr = std::unique_ptr<struct archive, int (*)(struct archive*)>;
-    ArchiveReader(QString fileName) : m_archivePath(fileName) {}
+    explicit ArchiveReader(QString fileName) : m_archivePath(std::move(fileName)) {}
     virtual ~ArchiveReader() = default;
 
     QStringList getFiles();
@@ -50,8 +51,8 @@ class ArchiveReader {
 
         QByteArray readAll(int* outStatus = nullptr);
         bool skip();
-        bool writeFile(archive* out, QString targetFileName = "", bool notBlock = false);
-        bool writeFile(archive* out, QString targetFileName, std::optional<QDir> root, bool notBlock = false);
+        bool writeFile(archive* out, const QString& targetFileName = "", bool notBlock = false);
+        bool writeFile(archive* out, const QString& targetFileName, std::optional<QDir> root, bool notBlock = false);
 
        private:
         int readNextHeader();
@@ -62,14 +63,14 @@ class ArchiveReader {
         archive_entry* m_entry;
     };
 
-    std::unique_ptr<File> goToFile(QString filename);
-    bool parse(std::function<bool(File*)>);
-    bool parse(std::function<bool(File*, bool&)>);
+    std::unique_ptr<File> goToFile(const QString& filename);
+    bool parse(const std::function<bool(File*)>&);
+    bool parse(const std::function<bool(File*, bool&)>&);
 
    private:
     QString m_archivePath;
     size_t m_blockSize = 10240;
 
-    QStringList m_fileNames = {};
+    QStringList m_fileNames;
 };
 }  // namespace MMCZip


### PR DESCRIPTION
fixes #5166
CF project that has this weird archive: https://www.curseforge.com/minecraft/modpacks/waccyys-fantasia

So what happens is that some entries in this archive return empty string for `archive_entry_pathname_utf8` but not for `archive_entry_pathname` because they are not marked as utf or something.