### PR TITLE
mod versions now list in newest first order

### DIFF
--- a/launcher/modplatform/packwiz/Packwiz.cpp
+++ b/launcher/modplatform/packwiz/Packwiz.cpp
@@ -24,10 +24,12 @@
 #include <QObject>
 #include <sstream>
 #include <string>
+#include <utility>
 
 #include "FileSystem.h"
 #include "StringUtils.h"
 
+#include "Version.h"
 #include "modplatform/ModIndex.h"
 
 #include <toml++/toml.h>
@@ -59,7 +61,7 @@ auto getRealIndexName(const QDir& index_dir, QString normalized_fname, bool shou
 }
 
 // Helpers
-static inline auto indexFileName(QString const& mod_slug) -> QString
+static inline auto indexFileName(const QString& mod_slug) -> QString
 {
     if (mod_slug.endsWith(".pw.toml"))
         return mod_slug;
@@ -115,7 +117,8 @@ auto V1::createModFormat([[maybe_unused]] const QDir& index_dir,
     mod.side = mod_version.side == ModPlatform::Side::NoSide ? mod_pack.side : mod_version.side;
     mod.loaders = mod_version.loaders;
     mod.mcVersions = mod_version.mcVersion;
-    mod.mcVersions.sort();
+    std::sort(mod.mcVersions.begin(), mod.mcVersions.end(),
+              [](QString a, QString b) { return Version(std::move(a)) <= Version(std::move(b)); });
     mod.releaseType = mod_version.version_type;
 
     mod.version_number = mod_version.version_number;
@@ -301,7 +304,8 @@ auto V1::getIndexForMod(const QDir& index_dir, QString slug) -> Mod
                     }
                 }
             }
-            mod.mcVersions.sort();
+            std::sort(mod.mcVersions.begin(), mod.mcVersions.end(),
+                      [](QString a, QString b) { return Version(std::move(a)) <= Version(std::move(b)); });
         }
     }
     mod.version_number = table["x-prismlauncher-version-number"].value_or("");


### PR DESCRIPTION
superseeds #4239 because the original author went unresponsive Closes #4052

Clicking a _pack_ in _menu_ -> _edit_ -> _mods_. Fixed minecraft version being in ascending order left-to-right (e.g. 1.21.6, 1.21.7, 1.21.8). Now version are shown in descending order (e.g. 1.21.8, 1.21.7, 1.21.6).

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
