### PR TITLE
Updated Resource Pack Formats

### DIFF
--- a/launcher/minecraft/mod/DataPack.cpp
+++ b/launcher/minecraft/mod/DataPack.cpp
@@ -24,6 +24,7 @@
 #include <QDebug>
 #include <QMap>
 #include <QRegularExpression>
+#include <utility>
 
 #include "MTPixmapCache.h"
 #include "Version.h"
@@ -31,61 +32,121 @@
 
 // Values taken from:
 // https://minecraft.wiki/w/Pack_format#List_of_data_pack_formats
-static const QMap<int, std::pair<Version, Version>> s_pack_format_versions = { { 4, { Version("1.13"), Version("1.14.4") } },
-                                                                               { 5, { Version("1.15"), Version("1.16.1") } },
-                                                                               { 6, { Version("1.16.2"), Version("1.16.5") } },
-                                                                               { 7, { Version("1.17"), Version("1.17.1") } },
-                                                                               { 8, { Version("1.18"), Version("1.18.1") } },
-                                                                               { 9, { Version("1.18.2"), Version("1.18.2") } },
-                                                                               { 10, { Version("1.19"), Version("1.19.3") } },
-                                                                               { 11, { Version("23w03a"), Version("23w05a") } },
-                                                                               { 12, { Version("1.19.4"), Version("1.19.4") } },
-                                                                               { 13, { Version("23w12a"), Version("23w14a") } },
-                                                                               { 14, { Version("23w16a"), Version("23w17a") } },
-                                                                               { 15, { Version("1.20"), Version("1.20.1") } },
-                                                                               { 16, { Version("23w31a"), Version("23w31a") } },
-                                                                               { 17, { Version("23w32a"), Version("23w35a") } },
-                                                                               { 18, { Version("1.20.2"), Version("1.20.2") } },
-                                                                               { 19, { Version("23w40a"), Version("23w40a") } },
-                                                                               { 20, { Version("23w41a"), Version("23w41a") } },
-                                                                               { 21, { Version("23w42a"), Version("23w42a") } },
-                                                                               { 22, { Version("23w43a"), Version("23w43b") } },
-                                                                               { 23, { Version("23w44a"), Version("23w44a") } },
-                                                                               { 24, { Version("23w45a"), Version("23w45a") } },
-                                                                               { 25, { Version("23w46a"), Version("23w46a") } },
-                                                                               { 26, { Version("1.20.3"), Version("1.20.4") } },
-                                                                               { 27, { Version("23w51a"), Version("23w51b") } },
-                                                                               { 28, { Version("24w05a"), Version("24w05b") } },
-                                                                               { 29, { Version("24w04a"), Version("24w04a") } },
-                                                                               { 30, { Version("24w05a"), Version("24w05b") } },
-                                                                               { 31, { Version("24w06a"), Version("24w06a") } },
-                                                                               { 32, { Version("24w07a"), Version("24w07a") } },
-                                                                               { 33, { Version("24w09a"), Version("24w09a") } },
-                                                                               { 34, { Version("24w10a"), Version("24w10a") } },
-                                                                               { 35, { Version("24w11a"), Version("24w11a") } },
-                                                                               { 36, { Version("24w12a"), Version("24w12a") } },
-                                                                               { 37, { Version("24w13a"), Version("24w13a") } },
-                                                                               { 38, { Version("24w14a"), Version("24w14a") } },
-                                                                               { 39, { Version("1.20.5-pre1"), Version("1.20.5-pre1") } },
-                                                                               { 40, { Version("1.20.5-pre2"), Version("1.20.5-pre2") } },
-                                                                               { 41, { Version("1.20.5"), Version("1.20.6") } },
-                                                                               { 42, { Version("24w18a"), Version("24w18a") } },
-                                                                               { 43, { Version("24w19a"), Version("24w19b") } },
-                                                                               { 44, { Version("24w20a"), Version("24w20a") } },
-                                                                               { 45, { Version("21w21a"), Version("21w21b") } },
-                                                                               { 46, { Version("1.21-pre1"), Version("1.21-pre1") } },
-                                                                               { 47, { Version("1.21-pre2"), Version("1.21-pre2") } },
-                                                                               { 48, { Version("1.21"), Version("1.21") } } };
+static const QMap<std::pair<int, int>, std::pair<Version, Version>> s_pack_format_versions = {
+    { { 4, 0 }, { Version("1.13"), Version("1.14.4") } },
+    { { 5, 0 }, { Version("1.15"), Version("1.16.1") } },
+    { { 6, 0 }, { Version("1.16.2"), Version("1.16.5") } },
+    { { 7, 0 }, { Version("1.17"), Version("1.17.1") } },
+    { { 8, 0 }, { Version("1.18"), Version("1.18.1") } },
+    { { 9, 0 }, { Version("1.18.2"), Version("1.18.2") } },
+    { { 10, 0 }, { Version("1.19"), Version("1.19.3") } },
+    { { 11, 0 }, { Version("23w03a"), Version("23w05a") } },
+    { { 12, 0 }, { Version("1.19.4"), Version("1.19.4") } },
+    { { 13, 0 }, { Version("23w12a"), Version("23w14a") } },
+    { { 14, 0 }, { Version("23w16a"), Version("23w17a") } },
+    { { 15, 0 }, { Version("1.20"), Version("1.20.1") } },
+    { { 16, 0 }, { Version("23w31a"), Version("23w31a") } },
+    { { 17, 0 }, { Version("23w32a"), Version("23w35a") } },
+    { { 18, 0 }, { Version("1.20.2"), Version("1.20.2") } },
+    { { 19, 0 }, { Version("23w40a"), Version("23w40a") } },
+    { { 20, 0 }, { Version("23w41a"), Version("23w41a") } },
+    { { 21, 0 }, { Version("23w42a"), Version("23w42a") } },
+    { { 22, 0 }, { Version("23w43a"), Version("23w43b") } },
+    { { 23, 0 }, { Version("23w44a"), Version("23w44a") } },
+    { { 24, 0 }, { Version("23w45a"), Version("23w45a") } },
+    { { 25, 0 }, { Version("23w46a"), Version("23w46a") } },
+    { { 26, 0 }, { Version("1.20.3"), Version("1.20.4") } },
+    { { 27, 0 }, { Version("23w51a"), Version("23w51b") } },
+    { { 28, 0 }, { Version("24w03a"), Version("24w03b") } },
+    { { 29, 0 }, { Version("24w04a"), Version("24w04a") } },
+    { { 30, 0 }, { Version("24w05a"), Version("24w05b") } },
+    { { 31, 0 }, { Version("24w06a"), Version("24w06a") } },
+    { { 32, 0 }, { Version("24w07a"), Version("24w07a") } },
+    { { 33, 0 }, { Version("24w09a"), Version("24w09a") } },
+    { { 34, 0 }, { Version("24w10a"), Version("24w10a") } },
+    { { 35, 0 }, { Version("24w11a"), Version("24w11a") } },
+    { { 36, 0 }, { Version("24w12a"), Version("24w12a") } },
+    { { 37, 0 }, { Version("24w13a"), Version("24w13a") } },
+    { { 38, 0 }, { Version("24w14a"), Version("24w14a") } },
+    { { 39, 0 }, { Version("1.20.5-pre1"), Version("1.20.5-pre1") } },
+    { { 40, 0 }, { Version("1.20.5-pre2"), Version("1.20.5-pre2") } },
+    { { 41, 0 }, { Version("1.20.5"), Version("1.20.6") } },
+    { { 42, 0 }, { Version("24w18a"), Version("24w18a") } },
+    { { 43, 0 }, { Version("24w19a"), Version("24w19b") } },
+    { { 44, 0 }, { Version("24w20a"), Version("24w20a") } },
+    { { 45, 0 }, { Version("24w21a"), Version("24w21b") } },
+    { { 46, 0 }, { Version("1.21-pre1"), Version("1.21-pre1") } },
+    { { 47, 0 }, { Version("1.21-pre2"), Version("1.21-pre2") } },
+    { { 48, 0 }, { Version("1.21"), Version("1.21.1") } },
+    { { 49, 0 }, { Version("24w33a"), Version("24w33a") } },
+    { { 50, 0 }, { Version("24w34a"), Version("24w34a") } },
+    { { 51, 0 }, { Version("24w35a"), Version("24w35a") } },
+    { { 52, 0 }, { Version("24w36a"), Version("24w36a") } },
+    { { 53, 0 }, { Version("24w37a"), Version("24w37a") } },
+    { { 54, 0 }, { Version("24w38a"), Version("24w38a") } },
+    { { 55, 0 }, { Version("24w39a"), Version("24w39a") } },
+    { { 56, 0 }, { Version("24w40a"), Version("24w40a") } },
+    { { 57, 0 }, { Version("1.21.2"), Version("1.21.3") } },
+    { { 58, 0 }, { Version("24w44a"), Version("24w44a") } },
+    { { 59, 0 }, { Version("24w45a"), Version("24w45a") } },
+    { { 60, 0 }, { Version("24w46a"), Version("1.21.4-pre1") } },
+    { { 61, 0 }, { Version("1.21.4"), Version("1.21.4") } },
+    { { 62, 0 }, { Version("25w02a"), Version("25w02a") } },
+    { { 63, 0 }, { Version("25w03a"), Version("25w03a") } },
+    { { 64, 0 }, { Version("25w04a"), Version("25w04a") } },
+    { { 65, 0 }, { Version("25w05a"), Version("25w05a") } },
+    { { 66, 0 }, { Version("25w06a"), Version("25w06a") } },
+    { { 67, 0 }, { Version("25w07a"), Version("25w07a") } },
+    { { 68, 0 }, { Version("25w08a"), Version("25w08a") } },
+    { { 69, 0 }, { Version("25w09a"), Version("25w09b") } },
+    { { 70, 0 }, { Version("25w10a"), Version("1.21.5-pre1") } },
+    { { 71, 0 }, { Version("1.21.5"), Version("1.21.5") } },
+    { { 72, 0 }, { Version("25w15a"), Version("25w15a") } },
+    { { 73, 0 }, { Version("25w16a"), Version("25w16a") } },
+    { { 74, 0 }, { Version("25w17a"), Version("25w17a") } },
+    { { 75, 0 }, { Version("25w18a"), Version("25w18a") } },
+    { { 76, 0 }, { Version("25w19a"), Version("25w19a") } },
+    { { 77, 0 }, { Version("25w20a"), Version("25w20a") } },
+    { { 78, 0 }, { Version("25w21a"), Version("25w21a") } },
+    { { 79, 0 }, { Version("1.21.6-pre1"), Version("1.21.6-pre2") } },
+    { { 80, 0 }, { Version("1.21.6"), Version("1.21.6") } },
+    { { 81, 0 }, { Version("1.21.7"), Version("1.21.8") } },
+    { { 82, 0 }, { Version("25w31a"), Version("25w31a") } },
+    { { 83, 0 }, { Version("25w32a"), Version("25w32a") } },
+    { { 83, 1 }, { Version("25w33a"), Version("25w33a") } },
+    { { 84, 0 }, { Version("25w34a"), Version("25w34b") } },
+    { { 85, 0 }, { Version("25w35a"), Version("25w35a") } },
+    { { 86, 0 }, { Version("25w36a"), Version("25w36b") } },
+    { { 87, 0 }, { Version("25w37a"), Version("1.21.9-pre1") } },
+    { { 87, 1 }, { Version("1.21.9-pre1"), Version("1.21.9-pre1") } },
+    { { 88, 0 }, { Version("1.21.9"), Version("1.21.10") } },
+    { { 89, 0 }, { Version("25w41a"), Version("25w41a") } },
+    { { 90, 0 }, { Version("25w42a"), Version("25w42a") } },
+    { { 91, 0 }, { Version("25w43a"), Version("25w43a") } },
+    { { 92, 0 }, { Version("25w44a"), Version("25w44a") } },
+    { { 93, 0 }, { Version("25w45a"), Version("25w45a") } },
+    { { 93, 1 }, { Version("25w46a"), Version("25w46a") } },
+    { { 94, 0 }, { Version("1.21.11-pre1"), Version("1.21.11-pre3") } },
+    { { 94, 1 }, { Version("1.21.11-pre4"), Version("1.21.11") } },
+    { { 95, 0 }, { Version("26.1-snap1"), Version("26.1-snap1") } },
+    { { 96, 0 }, { Version("26.1-snap2"), Version("26.1-snap2") } },
+    { { 97, 0 }, { Version("26.1-snap3"), Version("26.1-snap3") } },
+    { { 97, 1 }, { Version("26.1-snap4"), Version("26.1-snap4") } },
+    { { 98, 0 }, { Version("26.1-snap5"), Version("26.1-snap5") } },
+    { { 99, 0 }, { Version("26.1-snap6"), Version("26.1-snap6") } },
+    { { 99, 1 }, { Version("26.1-snap7"), Version("26.1-snap7") } },
+    { { 99, 2 }, { Version("26.1-snap8"), Version("26.1-snap9") } },
+    { { 99, 3 }, { Version("26.1-snap10"), Version("26.1-snap10") } },
+    { { 100, 0 }, { Version("26.1-snap11"), Version("26.1-snap11") } },
+};
 
-void DataPack::setPackFormat(int new_format_id)
+void DataPack::setPackFormat(int new_format_id, std::pair<int, int> min_format, std::pair<int, int> max_format)
 {
     QMutexLocker locker(&m_data_lock);
 
-    if (!s_pack_format_versions.contains(new_format_id)) {
-        qWarning() << "Pack format '" << new_format_id << "' is not a recognized data pack id!";
-    }
-
     m_pack_format = new_format_id;
+    m_min_format = min_format;
+    m_max_format = max_format;
 }
 
 void DataPack::setDescription(QString new_description)
@@ -140,18 +201,21 @@ QPixmap DataPack::image(QSize size, Qt::AspectRatioMode mode) const
     return image(size);
 }
 
-std::pair<Version, Version> DataPack::compatibleVersions() const
+static std::pair<Version, Version> map(std::pair<int, int> format, const QMap<std::pair<int, int>, std::pair<Version, Version>>& versions)
 {
-    if (!s_pack_format_versions.contains(m_pack_format)) {
+    if (format.first == 0 || !versions.contains(format)) {
         return { {}, {} };
     }
-
-    return s_pack_format_versions.constFind(m_pack_format).value();
+    return versions.constFind(format).value();
+}
+static std::pair<Version, Version> map(int format, const QMap<std::pair<int, int>, std::pair<Version, Version>>& versions)
+{
+    return map({ format, 0 }, versions);
 }
 
 int DataPack::compare(const Resource& other, SortType type) const
 {
-    auto const& cast_other = static_cast<DataPack const&>(other);
+    const auto& cast_other = static_cast<const DataPack&>(other);
     if (type == SortType::PACK_FORMAT) {
         auto this_ver = packFormat();
         auto other_ver = cast_other.packFormat();
@@ -168,21 +232,64 @@ int DataPack::compare(const Resource& other, SortType type) const
 
 bool DataPack::applyFilter(QRegularExpression filter) const
 {
-    if (filter.match(description()).hasMatch())
+    if (filter.match(description()).hasMatch()) {
         return true;
+    }
 
-    if (filter.match(QString::number(packFormat())).hasMatch())
+    if (filter.match(QString::number(packFormat())).hasMatch()) {
         return true;
+    }
 
-    if (filter.match(compatibleVersions().first.toString()).hasMatch())
-        return true;
-    if (filter.match(compatibleVersions().second.toString()).hasMatch())
-        return true;
-
+    auto versions = { map(m_pack_format, mappings()), map(m_min_format, mappings()), map(m_max_format, mappings()) };
+    for (const auto& version : versions) {
+        if (!version.first.isEmpty()) {
+            if (filter.match(version.first.toString()).hasMatch()) {
+                return true;
+            }
+            if (filter.match(version.second.toString()).hasMatch()) {
+                return true;
+            }
+        }
+    }
     return Resource::applyFilter(filter);
 }
 
 bool DataPack::valid() const
 {
-    return m_pack_format != 0;
+    return m_pack_format != 0 || (m_min_format.first != 0 && m_max_format.first != 0);
+}
+
+QMap<std::pair<int, int>, std::pair<Version, Version>> DataPack::mappings() const
+{
+    return s_pack_format_versions;
+}
+
+QString DataPack::packFormatStr() const
+{
+    if (m_pack_format != 0) {
+        auto version_bounds = map(m_pack_format, mappings());
+        if (version_bounds.first.toString().isEmpty()) {
+            return QString::number(m_pack_format);
+        }
+        return QString("%1 (%2 - %3)")
+            .arg(QString::number(m_pack_format), version_bounds.first.toString(), version_bounds.second.toString());
+    }
+    auto min_bound = map(m_min_format, mappings());
+    auto max_bound = map(m_max_format, mappings());
+    auto min_version = min_bound.first;
+    auto max_version = max_bound.second;
+    if (min_version.isEmpty() || max_version.isEmpty()) {
+        return tr("Unrecognized");
+    }
+    auto str = QString("[") + QString::number(m_min_format.first);
+    if (m_min_format.second != 0) {
+        str += "." + QString::number(m_min_format.second);
+    }
+
+    str += QString(" - ") + QString::number(m_max_format.first);
+    if (m_max_format.second != 0) {
+        str += "." + QString::number(m_max_format.second);
+    }
+
+    return str + QString(" (%2 - %3)").arg(min_version.toString(), max_version.toString());
 }

--- a/launcher/minecraft/mod/DataPack.h
+++ b/launcher/minecraft/mod/DataPack.h
@@ -25,6 +25,7 @@
 
 #include <QMutex>
 #include <QPixmapCache>
+#include <utility>
 
 class Version;
 
@@ -41,8 +42,6 @@ class DataPack : public Resource {
 
     /** Gets the numerical ID of the pack format. */
     int packFormat() const { return m_pack_format; }
-    /** Gets, respectively, the lower and upper versions supported by the set pack format. */
-    virtual std::pair<Version, Version> compatibleVersions() const;
 
     /** Gets the description of the data pack. */
     QString description() const { return m_description; }
@@ -51,7 +50,7 @@ class DataPack : public Resource {
     QPixmap image(QSize size, Qt::AspectRatioMode mode = Qt::AspectRatioMode::IgnoreAspectRatio) const;
 
     /** Thread-safe. */
-    void setPackFormat(int new_format_id);
+    void setPackFormat(int new_format_id, std::pair<int, int> min_format, std::pair<int, int> max_format);
 
     /** Thread-safe. */
     void setDescription(QString new_description);
@@ -61,8 +60,13 @@ class DataPack : public Resource {
 
     bool valid() const override;
 
-    [[nodiscard]] int compare(Resource const& other, SortType type) const override;
+    [[nodiscard]] int compare(const Resource& other, SortType type) const override;
     [[nodiscard]] bool applyFilter(QRegularExpression filter) const override;
+
+    QString packFormatStr() const;
+
+   protected:
+    virtual QMap<std::pair<int, int>, std::pair<Version, Version>> mappings() const;
 
    protected:
     mutable QMutex m_data_lock;
@@ -71,6 +75,8 @@ class DataPack : public Resource {
      * See https://minecraft.wiki/w/Data_pack#pack.mcmeta
      */
     int m_pack_format = 0;
+    std::pair<int, int> m_min_format;
+    std::pair<int, int> m_max_format;
 
     /** The data pack's description, as defined in the pack.mcmeta file.
      */

--- a/launcher/minecraft/mod/DataPackFolderModel.cpp
+++ b/launcher/minecraft/mod/DataPackFolderModel.cpp
@@ -69,17 +69,8 @@ QVariant DataPackFolderModel::data(const QModelIndex& index, int role) const
         case Qt::DisplayRole:
             switch (column) {
                 case PackFormatColumn: {
-                    auto& resource = at(row);
-                    auto pack_format = resource.packFormat();
-                    if (pack_format == 0)
-                        return tr("Unrecognized");
-
-                    auto version_bounds = resource.compatibleVersions();
-                    if (version_bounds.first.toString().isEmpty())
-                        return QString::number(pack_format);
-
-                    return QString("%1 (%2 - %3)")
-                        .arg(QString::number(pack_format), version_bounds.first.toString(), version_bounds.second.toString());
+                    const auto& resource = at(row);
+                    return resource.packFormatStr();
                 }
             }
             break;
@@ -118,7 +109,7 @@ QVariant DataPackFolderModel::data(const QModelIndex& index, int role) const
         case ProviderColumn:
             mappedIndex = index.siblingAtColumn(ResourceFolderModel::ProviderColumn);
             break;
-        // FIXME: there is no size column due to an oversight
+            // FIXME: there is no size column due to an oversight
     }
 
     if (mappedIndex.isValid()) {

--- a/launcher/minecraft/mod/ResourcePack.cpp
+++ b/launcher/minecraft/mod/ResourcePack.cpp
@@ -3,35 +3,101 @@
 #include <QCoreApplication>
 #include <QDebug>
 #include <QMap>
+#include <utility>
 #include "MTPixmapCache.h"
 #include "Version.h"
 
 // Values taken from:
 // https://minecraft.wiki/w/Pack_format#List_of_resource_pack_formats
-static const QMap<int, std::pair<Version, Version>> s_pack_format_versions = {
-    { 1, { Version("1.6.1"), Version("1.8.9") } },         { 2, { Version("1.9"), Version("1.10.2") } },
-    { 3, { Version("1.11"), Version("1.12.2") } },         { 4, { Version("1.13"), Version("1.14.4") } },
-    { 5, { Version("1.15"), Version("1.16.1") } },         { 6, { Version("1.16.2"), Version("1.16.5") } },
-    { 7, { Version("1.17"), Version("1.17.1") } },         { 8, { Version("1.18"), Version("1.18.2") } },
-    { 9, { Version("1.19"), Version("1.19.2") } },         { 11, { Version("22w42a"), Version("22w44a") } },
-    { 12, { Version("1.19.3"), Version("1.19.3") } },      { 13, { Version("1.19.4"), Version("1.19.4") } },
-    { 14, { Version("23w14a"), Version("23w16a") } },      { 15, { Version("1.20"), Version("1.20.1") } },
-    { 16, { Version("23w31a"), Version("23w31a") } },      { 17, { Version("23w32a"), Version("23w35a") } },
-    { 18, { Version("1.20.2"), Version("23w16a") } },      { 19, { Version("23w42a"), Version("23w42a") } },
-    { 20, { Version("23w43a"), Version("23w44a") } },      { 21, { Version("23w45a"), Version("23w46a") } },
-    { 22, { Version("1.20.3-pre1"), Version("23w51b") } }, { 24, { Version("24w03a"), Version("24w04a") } },
-    { 25, { Version("24w05a"), Version("24w05b") } },      { 26, { Version("24w06a"), Version("24w07a") } },
-    { 28, { Version("24w09a"), Version("24w10a") } },      { 29, { Version("24w11a"), Version("24w11a") } },
-    { 30, { Version("24w12a"), Version("23w12a") } },      { 31, { Version("24w13a"), Version("1.20.5-pre3") } },
-    { 32, { Version("1.20.5-pre4"), Version("1.20.6") } }, { 33, { Version("24w18a"), Version("24w20a") } },
-    { 34, { Version("24w21a"), Version("1.21") } }
+static const QMap<std::pair<int, int>, std::pair<Version, Version>> s_pack_format_versions = {
+    { { 1, 0 }, { Version("1.6.1"), Version("1.8.9") } },
+    { { 2, 0 }, { Version("1.9"), Version("1.10.2") } },
+    { { 3, 0 }, { Version("1.11"), Version("1.12.2") } },
+    { { 4, 0 }, { Version("1.13"), Version("1.14.4") } },
+    { { 5, 0 }, { Version("1.15"), Version("1.16.1") } },
+    { { 6, 0 }, { Version("1.16.2"), Version("1.16.5") } },
+    { { 7, 0 }, { Version("1.17"), Version("1.17.1") } },
+    { { 8, 0 }, { Version("1.18"), Version("1.18.2") } },
+    { { 9, 0 }, { Version("1.19"), Version("1.19.2") } },
+    { { 11, 0 }, { Version("22w42a"), Version("22w44a") } },
+    { { 12, 0 }, { Version("1.19.3"), Version("1.19.3") } },
+    { { 13, 0 }, { Version("1.19.4"), Version("1.19.4") } },
+    { { 14, 0 }, { Version("23w14a"), Version("23w16a") } },
+    { { 15, 0 }, { Version("1.20"), Version("1.20.1") } },
+    { { 16, 0 }, { Version("23w31a"), Version("23w31a") } },
+    { { 17, 0 }, { Version("23w32a"), Version("1.20.2-pre1") } },
+    { { 18, 0 }, { Version("1.20.2"), Version("1.20.2") } },
+    { { 19, 0 }, { Version("23w42a"), Version("23w42a") } },
+    { { 20, 0 }, { Version("23w43a"), Version("23w44a") } },
+    { { 21, 0 }, { Version("23w45a"), Version("23w46a") } },
+    { { 22, 0 }, { Version("1.20.3"), Version("1.20.4") } },
+    { { 24, 0 }, { Version("24w03a"), Version("24w04a") } },
+    { { 25, 0 }, { Version("24w05a"), Version("24w05b") } },
+    { { 26, 0 }, { Version("24w06a"), Version("24w07a") } },
+    { { 28, 0 }, { Version("24w09a"), Version("24w10a") } },
+    { { 29, 0 }, { Version("24w11a"), Version("24w11a") } },
+    { { 30, 0 }, { Version("24w12a"), Version("24w12a") } },
+    { { 31, 0 }, { Version("24w13a"), Version("1.20.5-pre3") } },
+    { { 32, 0 }, { Version("1.20.5"), Version("1.20.6") } },
+    { { 33, 0 }, { Version("24w18a"), Version("24w20a") } },
+    { { 34, 0 }, { Version("1.21"), Version("1.21.1") } },
+    { { 35, 0 }, { Version("24w33a"), Version("24w33a") } },
+    { { 36, 0 }, { Version("24w34a"), Version("24w35a") } },
+    { { 37, 0 }, { Version("24w36a"), Version("24w36a") } },
+    { { 38, 0 }, { Version("24w37a"), Version("24w37a") } },
+    { { 39, 0 }, { Version("24w38a"), Version("24w39a") } },
+    { { 40, 0 }, { Version("24w40a"), Version("24w40a") } },
+    { { 41, 0 }, { Version("1.21.2-pre1"), Version("1.21.2-pre2") } },
+    { { 42, 0 }, { Version("1.21.2"), Version("1.21.3") } },
+    { { 43, 0 }, { Version("24w44a"), Version("24w44a") } },
+    { { 44, 0 }, { Version("24w45a"), Version("24w45a") } },
+    { { 45, 0 }, { Version("24w46a"), Version("24w46a") } },
+    { { 46, 0 }, { Version("1.21.4"), Version("1.21.4") } },
+    { { 47, 0 }, { Version("25w02a"), Version("25w02a") } },
+    { { 48, 0 }, { Version("25w03a"), Version("25w03a") } },
+    { { 49, 0 }, { Version("25w04a"), Version("25w04a") } },
+    { { 50, 0 }, { Version("25w05a"), Version("25w05a") } },
+    { { 51, 0 }, { Version("25w06a"), Version("25w06a") } },
+    { { 52, 0 }, { Version("25w07a"), Version("25w07a") } },
+    { { 53, 0 }, { Version("25w08a"), Version("25w09b") } },
+    { { 54, 0 }, { Version("25w10a"), Version("25w10a") } },
+    { { 55, 0 }, { Version("1.21.5"), Version("1.21.5") } },
+    { { 56, 0 }, { Version("25w15a"), Version("25w15a") } },
+    { { 57, 0 }, { Version("25w16a"), Version("25w16a") } },
+    { { 58, 0 }, { Version("25w17a"), Version("25w17a") } },
+    { { 59, 0 }, { Version("25w18a"), Version("25w18a") } },
+    { { 60, 0 }, { Version("25w19a"), Version("25w19a") } },
+    { { 61, 0 }, { Version("25w20a"), Version("25w20a") } },
+    { { 62, 0 }, { Version("25w21a"), Version("25w21a") } },
+    { { 63, 0 }, { Version("1.21.6"), Version("1.21.6") } },
+    { { 64, 0 }, { Version("1.21.7"), Version("1.21.8") } },
+    { { 65, 0 }, { Version("25w31a"), Version("25w31a") } },
+    { { 65, 1 }, { Version("25w32a"), Version("25w32a") } },
+    { { 65, 2 }, { Version("25w33a"), Version("25w33a") } },
+    { { 66, 0 }, { Version("25w34a"), Version("25w34b") } },
+    { { 67, 0 }, { Version("25w35a"), Version("25w35a") } },
+    { { 68, 0 }, { Version("25w36a"), Version("25w36b") } },
+    { { 69, 0 }, { Version("1.21.9"), Version("1.21.10") } },
+    { { 70, 0 }, { Version("25w41a"), Version("25w41a") } },
+    { { 70, 1 }, { Version("25w42a"), Version("25w42a") } },
+    { { 71, 0 }, { Version("25w43a"), Version("25w43a") } },
+    { { 72, 0 }, { Version("25w44a"), Version("25w44a") } },
+    { { 73, 0 }, { Version("25w45a"), Version("25w45a") } },
+    { { 74, 0 }, { Version("25w46a"), Version("25w46a") } },
+    { { 75, 0 }, { Version("1.21.11"), Version("1.21.11") } },
+    { { 76, 0 }, { Version("26.1-snap1"), Version("26.1-snap1") } },
+    { { 77, 0 }, { Version("26.1-snap2"), Version("26.1-snap2") } },
+    { { 78, 0 }, { Version("26.1-snap3"), Version("26.1-snap3") } },
+    { { 78, 1 }, { Version("26.1-snap4"), Version("26.1-snap4") } },
+    { { 79, 0 }, { Version("26.1-snap5"), Version("26.1-snap5") } },
+    { { 80, 0 }, { Version("26.1-snap6"), Version("26.1-snap6") } },
+    { { 81, 0 }, { Version("26.1-snap7"), Version("26.1-snap7") } },
+    { { 81, 1 }, { Version("26.1-snap8"), Version("26.1-snap9") } },
+    { { 82, 0 }, { Version("26.1-snap10"), Version("26.1-snap10") } },
+    { { 83, 0 }, { Version("26.1-snap11"), Version("26.1-snap11") } },
 };
 
-std::pair<Version, Version> ResourcePack::compatibleVersions() const
+QMap<std::pair<int, int>, std::pair<Version, Version>> ResourcePack::mappings() const
 {
-    if (!s_pack_format_versions.contains(m_pack_format)) {
-        return { {}, {} };
-    }
-
-    return s_pack_format_versions.constFind(m_pack_format).value();
+    return s_pack_format_versions;
 }

--- a/launcher/minecraft/mod/ResourcePack.h
+++ b/launcher/minecraft/mod/ResourcePack.h
@@ -22,5 +22,5 @@ class ResourcePack : public DataPack {
     ResourcePack(QFileInfo file_info) : DataPack(file_info) {}
 
     /** Gets, respectively, the lower and upper versions supported by the set pack format. */
-    std::pair<Version, Version> compatibleVersions() const override;
+    QMap<std::pair<int, int>, std::pair<Version, Version>> mappings() const override;
 };

--- a/launcher/minecraft/mod/ResourcePackFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourcePackFolderModel.cpp
@@ -69,17 +69,8 @@ QVariant ResourcePackFolderModel::data(const QModelIndex& index, int role) const
             return rowBackground(row);
         case Qt::DisplayRole: {
             if (column == PackFormatColumn) {
-                auto& resource = at(row);
-                auto pack_format = resource.packFormat();
-                if (pack_format == 0)
-                    return tr("Unrecognized");
-
-                auto version_bounds = resource.compatibleVersions();
-                if (version_bounds.first.toString().isEmpty())
-                    return QString::number(pack_format);
-
-                return QString("%1 (%2 - %3)")
-                    .arg(QString::number(pack_format), version_bounds.first.toString(), version_bounds.second.toString());
+                const auto& resource = at(row);
+                return resource.packFormatStr();
             }
             break;
         }

--- a/launcher/minecraft/mod/tasks/LocalDataPackParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalDataPackParseTask.cpp
@@ -27,6 +27,7 @@
 #include "minecraft/mod/ResourcePack.h"
 
 #include <QCryptographicHash>
+#include <utility>
 
 namespace DataPackUtils {
 
@@ -163,6 +164,25 @@ bool processZIP(DataPack* pack, ProcessingLevel level)
     return true;
 }
 
+std::pair<int, int> parseVersion(const QJsonValue& value)
+{
+    if (value.isDouble()) {
+        // Single integer -> [major, 0]
+        return std::make_pair(value.toInt(), 0);
+    }
+    std::pair<int, int> version;
+    if (value.isArray()) {
+        QJsonArray arr = value.toArray();
+        if (arr.size() >= 1) {
+            version.first = arr.at(0).toInt();
+        }
+        if (arr.size() >= 2) {
+            version.second = arr.at(1).toInt();
+        }
+    }
+    return version;
+}
+
 // https://minecraft.wiki/w/Data_pack#pack.mcmeta
 // https://minecraft.wiki/w/Raw_JSON_text_format
 // https://minecraft.wiki/w/Tutorials/Creating_a_resource_pack#Formatting_pack.mcmeta
@@ -177,7 +197,20 @@ bool processMCMeta(DataPack* pack, QByteArray&& raw_data)
 
     try {
         auto pack_obj = Json::requireObject(json_doc.object(), "pack", {});
-        pack->setPackFormat(pack_obj["pack_format"].toInt());
+
+        int pack_format = 0;
+        std::pair<int, int> min_format;
+        std::pair<int, int> max_format;
+        if (pack_obj.contains("pack_format")) {
+            pack_format = pack_obj.value("pack_format").toInt();
+        }
+        if (pack_obj.contains("min_format")) {
+            min_format = parseVersion(pack_obj.value("min_format"));
+        }
+        if (pack_obj.contains("max_format")) {
+            max_format = parseVersion(pack_obj.value("max_format"));
+        }
+        pack->setPackFormat(pack_format, min_format, max_format);
         pack->setDescription(DataPackUtils::processComponent(pack_obj.value("description")));
     } catch (Json::JsonException& e) {
         qWarning() << "JsonException:" << e.what() << e.cause();


### PR DESCRIPTION
superseeds #4242
also this adds support for min_format and max_format and the major.minor versioning.

also have here https://gist.github.com/Trial97/e6fe2ae884d6cb1c46045e324b891621 a python file to help generate the mappings from the  https://minecraft.wiki/w/Pack_format tables
