### PR TITLE
Dehardcode branding in Linux manuals and Windows app info, make .mrpack MIME file name unique

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -445,7 +445,7 @@ elseif(UNIX)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${Launcher_MetaInfo} DESTINATION ${KDE_INSTALL_METAINFODIR})
     install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${Launcher_SVG} DESTINATION "${KDE_INSTALL_ICONDIR}/hicolor/scalable/apps")
     install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${Launcher_PNG_256} DESTINATION "${KDE_INSTALL_ICONDIR}/hicolor/256x256/apps" RENAME "${Launcher_AppID}.png")
-    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${Launcher_mrpack_MIMEInfo} DESTINATION ${KDE_INSTALL_MIMEDIR})
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${Launcher_mrpack_MIMEInfo} DESTINATION ${KDE_INSTALL_MIMEDIR})
 
     install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/launcher/qtlogging.ini" DESTINATION "share/${Launcher_Name}")
 

--- a/program_info/CMakeLists.txt
+++ b/program_info/CMakeLists.txt
@@ -28,7 +28,7 @@ set(Launcher_AppID "${Launcher_AppID}" PARENT_SCOPE)
 set(Launcher_SVGFileName "${Launcher_SVGFileName}" PARENT_SCOPE)
 
 set(Launcher_Desktop "program_info/${Launcher_AppID}.desktop" PARENT_SCOPE)
-set(Launcher_mrpack_MIMEInfo "program_info/modrinth-mrpack-mime.xml" PARENT_SCOPE)
+set(Launcher_mrpack_MIMEInfo "program_info/${Launcher_APP_BINARY_NAME}-modrinth-mrpack-mime.xml" PARENT_SCOPE)
 set(Launcher_MetaInfo "program_info/${Launcher_AppID}.metainfo.xml" PARENT_SCOPE)
 set(Launcher_PNG_256 "program_info/${Launcher_AppID}_256.png" PARENT_SCOPE)
 set(Launcher_SVG "program_info/${Launcher_SVGFileName}" PARENT_SCOPE)
@@ -48,6 +48,7 @@ configure_file(${Launcher_APP_BINARY_NAME}.qrc.in ${Launcher_APP_BINARY_NAME}.qr
 configure_file(${Launcher_APP_BINARY_NAME}.manifest.in ${Launcher_APP_BINARY_NAME}.manifest @ONLY)
 configure_file(${Launcher_APP_BINARY_NAME}.ico ${Launcher_APP_BINARY_NAME}.ico COPYONLY)
 configure_file(${Launcher_SVGFileName} ${Launcher_SVGFileName} COPYONLY)
+configure_file(modrinth-mrpack-mime.xml ${Launcher_APP_BINARY_NAME}-modrinth-mrpack-mime.xml COPYONLY)
 
 if(MSVC)
     set(Launcher_MSVC_Redist_NSIS_Section [=[

--- a/program_info/CMakeLists.txt
+++ b/program_info/CMakeLists.txt
@@ -10,13 +10,14 @@ endif()
 
 set(Launcher_CommonName "PrismLauncher")
 set(Launcher_DisplayName "Prism Launcher")
+set(Launcher_AppID "org.prismlauncher.PrismLauncher")
+set(Launcher_Domain "prismlauncher.org")
+set(Launcher_Git "https://github.com/PrismLauncher/PrismLauncher")
 
 set(Launcher_Name "${Launcher_CommonName}" PARENT_SCOPE)
 set(Launcher_DisplayName "${Launcher_DisplayName}" PARENT_SCOPE)
-
-set(Launcher_AppID "org.prismlauncher.PrismLauncher")
-set(Launcher_Domain "prismlauncher.org" PARENT_SCOPE)
-set(Launcher_Git "https://github.com/PrismLauncher/PrismLauncher" PARENT_SCOPE)
+set(Launcher_Domain "${Launcher_Domain}" PARENT_SCOPE)
+set(Launcher_Git "${Launcher_Git}" PARENT_SCOPE)
 
 set(Launcher_SVGFileName "${Launcher_AppID}.svg")
 set(Launcher_Copyright "© 2022-2026 Prism Launcher Contributors\\n© 2021-2022 PolyMC Contributors\\n© 2012-2021 MultiMC Contributors")
@@ -38,6 +39,7 @@ set(Launcher_Branding_ICO "program_info/${Launcher_APP_BINARY_NAME}.ico")
 set(Launcher_Branding_ICO "${Launcher_Branding_ICO}" PARENT_SCOPE)
 set(Launcher_Branding_WindowsRC "program_info/${Launcher_APP_BINARY_NAME}.rc" PARENT_SCOPE)
 set(Launcher_Branding_LogoQRC "program_info/${Launcher_APP_BINARY_NAME}.qrc" PARENT_SCOPE)
+set(Launcher_Authors "MultiMC & Prism Launcher Contributors")
 
 set(Launcher_Portable_File "program_info/portable.txt" PARENT_SCOPE)
 
@@ -77,7 +79,9 @@ endif()
 configure_file(win_install.nsi.in win_install.nsi @ONLY)
 
 if(SCDOC_FOUND)
-    set(in_scd "${CMAKE_CURRENT_SOURCE_DIR}/${Launcher_APP_BINARY_NAME}.6.scd")
+    configure_file(${Launcher_APP_BINARY_NAME}.6.scd.in ${Launcher_APP_BINARY_NAME}.6.scd @ONLY)
+
+    set(in_scd "${CMAKE_CURRENT_BINARY_DIR}/${Launcher_APP_BINARY_NAME}.6.scd")
     set(out_man "${CMAKE_CURRENT_BINARY_DIR}/${Launcher_APP_BINARY_NAME}.6")
     add_custom_command(
         DEPENDS "${in_scd}"

--- a/program_info/prismlauncher.6.scd.in
+++ b/program_info/prismlauncher.6.scd.in
@@ -1,14 +1,14 @@
-prismlauncher(6)
+@Launcher_APP_BINARY_NAME@(6)
 
 
 # NAME
 
-prismlauncher - a launcher and instance manager for Minecraft.
+@Launcher_APP_BINARY_NAME@ - a launcher and instance manager for Minecraft.
 
 
 # SYNOPSIS
 
-*prismlauncher* [OPTIONS...]
+*@Launcher_APP_BINARY_NAME@* [OPTIONS...]
 
 
 # DESCRIPTION
@@ -69,14 +69,14 @@ variables, besides other common Qt variables:
 
 # BUGS
 
-https://github.com/PrismLauncher/PrismLauncher/issues
+@Launcher_BUG_TRACKER_URL@
 
 # RESOURCES
 
-GitHub: https://github.com/PrismLauncher/PrismLauncher
+GitHub: @Launcher_Git@
 
-Main website: https://prismlauncher.org
+Main website: https://@Launcher_Domain@
 
 # AUTHORS
 
-Prism Launcher Contributors
+@Launcher_Authors@

--- a/program_info/prismlauncher.rc.in
+++ b/program_info/prismlauncher.rc.in
@@ -3,8 +3,8 @@
 #endif
 #include <windows.h>
 
-IDI_ICON1               ICON    DISCARDABLE     "prismlauncher.ico"
-1 RT_MANIFEST "prismlauncher.manifest"
+IDI_ICON1               ICON    DISCARDABLE     "@Launcher_APP_BINARY_NAME@.ico"
+1 RT_MANIFEST "@Launcher_APP_BINARY_NAME@.manifest"
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION     @Launcher_VERSION_NAME4_COMMA@
@@ -15,7 +15,7 @@ BEGIN
         BEGIN
                 BLOCK "000004b0"
                 BEGIN
-                        VALUE "CompanyName", "MultiMC & Prism Launcher Contributors"
+                        VALUE "CompanyName", "@Launcher_Authors@"
                         VALUE "FileDescription", "@Launcher_DisplayName@"
                         VALUE "FileVersion", "@Launcher_VERSION_NAME4@"
                         VALUE "ProductName", "@Launcher_DisplayName@"


### PR DESCRIPTION
Why rename .mrpack MIME file: see https://github.com/ElyPrismLauncher/Launcher/issues/121