### PR TITLE
Always use non-debug MSVC runtime library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,12 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_C_STANDARD 11)
 include(GenerateExportHeader)
 
+# NOTE: We can't statically link with the MSVC runtime due to GPL restrictions
+#
+# We also purposefully choose not to use the debug DLL, as that would require
+# users of our development builds to install the Windows SDK
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
+
 add_compile_definitions($<$<NOT:$<CONFIG:Debug>>:QT_NO_DEBUG>)
 add_compile_definitions(QT_WARN_DEPRECATED_UP_TO=0x060400)
 add_compile_definitions(QT_DISABLE_DEPRECATED_UP_TO=0x060400)
@@ -312,9 +318,8 @@ endif()
 ## NOTE(@getchoo): Never use pkg-config with MSVC since the vcpkg port makes our install bundle fail to find the dll
 if(MSVC)
     find_path(LIBQRENCODE_INCLUDE_DIR qrencode.h REQUIRED)
-    find_library(LIBQRENCODE_LIBRARY_RELEASE qrencode REQUIRED)
-    find_library(LIBQRENCODE_LIBRARY_DEBUG qrencoded)
-    set(LIBQRENCODE_LIBRARIES optimized ${LIBQRENCODE_LIBRARY_RELEASE} debug ${LIBQRENCODE_LIBRARY_DEBUG})
+    find_library(LIBQRENCODE_LIBRARY qrencode REQUIRED)
+    set(LIBQRENCODE_LIBRARIES ${LIBQRENCODE_LIBRARY})
 else()
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(libqrencode REQUIRED IMPORTED_TARGET libqrencode)

--- a/cmake/vcpkg-triplets/arm64-windows.cmake
+++ b/cmake/vcpkg-triplets/arm64-windows.cmake
@@ -1,0 +1,10 @@
+set(VCPKG_TARGET_ARCHITECTURE arm64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+
+# NOTE: This is the only change we're making to the default target
+#
+# Avoid using the debug VCRUNTIME. Otherwise, this would introduce the Windows SDK
+# as a requirement for testers :(
+# We also don't really need the debug versions of our libraries anyways
+set(VCPKG_BUILD_TYPE release)

--- a/cmake/vcpkg-triplets/x64-windows.cmake
+++ b/cmake/vcpkg-triplets/x64-windows.cmake
@@ -1,0 +1,10 @@
+set(VCPKG_TARGET_ARCHITECTURE x64)
+set(VCPKG_CRT_LINKAGE dynamic)
+set(VCPKG_LIBRARY_LINKAGE dynamic)
+
+# NOTE: This is the only change we're making to the default target
+#
+# Avoid using the debug VCRUNTIME. Otherwise, this would introduce the Windows SDK
+# as a requirement for testers :(
+# We also don't really need the debug versions of our libraries anyways
+set(VCPKG_BUILD_TYPE release)

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -1604,6 +1604,7 @@ if(WIN32 OR (UNIX AND APPLE))
         COMPONENT bundle
         DIRECTORIES
             ${CMAKE_SYSTEM_LIBRARY_PATH}
+            ${_VCPKG_INSTALLED_DIR}/${VCPKG_TARGET_TRIPLET}/bin
             ${QT_LIBS_DIR}
             ${QT_LIBEXECS_DIR}
         PRE_EXCLUDE_REGEXES


### PR DESCRIPTION
This allows users of development builds to (once again) run the launcher
without the Windows SDK installed

Signed-off-by: Seth Flynn <getchoo@tuta.io>

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
