### PR TITLE
JavaChecker: Add support for ppc64 and ppc64le architectures

### DIFF
--- a/launcher/java/JavaChecker.cpp
+++ b/launcher/java/JavaChecker.cpp
@@ -163,7 +163,7 @@ void JavaChecker::finished(int exitcode, QProcess::ExitStatus status)
     auto os_arch = results["os.arch"];
     auto java_version = results["java.version"];
     auto java_vendor = results["java.vendor"];
-    bool is_64 = os_arch == "x86_64" || os_arch == "amd64" || os_arch == "aarch64" || os_arch == "arm64" || os_arch == "riscv64";
+    bool is_64 = os_arch == "x86_64" || os_arch == "amd64" || os_arch == "aarch64" || os_arch == "arm64" || os_arch == "riscv64" || os_arch == "ppc64le" || os_arch == "ppc64";
 
     result.validity = Result::Validity::Valid;
     result.is_64bit = is_64;


### PR DESCRIPTION
I've been enjoying Minecraft for a while on both POWER8 and POWER9 workstations with downstream patches despite of the warning about wrong 32-bit Java. So let's get it fixed properly upstream. Thanks for your consideration.