### PR TITLE
ci(container): fix digest image reference for manifest

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -161,7 +161,7 @@ jobs:
           IMAGE_NAME: ${{ needs.build.outputs.image-name }}
         run: |
           podman manifest create "$IMAGE_NAME" \
-            $(printf "$IMAGE_NAME:%s " *)
+            $(printf "$IMAGE_NAME@sha256:%s " *)
 
       - name: Push manifest
         uses: redhat-actions/push-to-registry@v2


### PR DESCRIPTION
Signed-off-by: Seth Flynn <getchoo@tuta.io>

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
