### PR TITLE
fix: also export LIBGL_KOPPER_DRI2=1 on zink

### DIFF
--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -736,6 +736,7 @@ QProcessEnvironment MinecraftInstance::createLaunchEnvironment()
         env.insert("__GLX_VENDOR_LIBRARY_NAME", "mesa");
         env.insert("MESA_LOADER_DRIVER_OVERRIDE", "zink");
         env.insert("GALLIUM_DRIVER", "zink");
+        env.insert("LIBGL_KOPPER_DRI2", "1");
     }
 #endif
     return env;


### PR DESCRIPTION
fixes crashes on certain X11 systems

see https://discord.com/channels/1031648380885147709/1449943390631497891/1481376093687513248