### PR TITLE
fix: allow disabling gl and vulkan features with an envvar and disable it by default on appimage/portable

### DIFF
--- a/.github/actions/package/linux/action.yml
+++ b/.github/actions/package/linux/action.yml
@@ -90,6 +90,8 @@ runs:
         # FIXME(@getchoo): gamemode doesn't seem to be very portable with DBus. Find a way to make it work!
         find "$INSTALL_APPIMAGE_DIR" -name '*gamemode*' -exec rm {} +
 
+        #disable OpenGL and Vulkan launcher features until https://github.com/VHSgunzo/sharun/issues/35
+        echo "LAUNCHER_DISABLE_GLVULKAN=1" > "$INSTALL_APPIMAGE_DIR"/.env
         #makes the launcher use portals for file picking
         echo "QT_QPA_PLATFORMTHEME=xdgdesktopportal" > "$INSTALL_APPIMAGE_DIR"/.env
         ln -s org.prismlauncher.PrismLauncher.metainfo.xml "$INSTALL_APPIMAGE_DIR"/share/metainfo/org.prismlauncher.PrismLauncher.appdata.xml

--- a/launcher/HardwareInfo.cpp
+++ b/launcher/HardwareInfo.cpp
@@ -21,6 +21,7 @@
 #include <QCoreApplication>
 #include <QOffscreenSurface>
 #include <QOpenGLFunctions>
+#include <QProcessEnvironment>
 
 #ifndef Q_OS_MACOS
 #include <QVulkanInstance>
@@ -30,6 +31,9 @@
 namespace {
 bool vulkanInfo(QStringList& out)
 {
+    if (!QProcessEnvironment::systemEnvironment().value(QStringLiteral("LAUNCHER_DISABLE_GLVULKAN")).isEmpty()) {
+        return false;
+    }
 #ifndef Q_OS_MACOS
     QVulkanInstance inst;
     if (!inst.create()) {
@@ -53,6 +57,9 @@ bool vulkanInfo(QStringList& out)
 
 bool openGlInfo(QStringList& out)
 {
+    if (!QProcessEnvironment::systemEnvironment().value(QStringLiteral("LAUNCHER_DISABLE_GLVULKAN")).isEmpty()) {
+        return false;
+    }
     QOpenGLContext ctx;
     if (!ctx.create()) {
         qWarning() << "OpenGL context creation failed";

--- a/launcher/Launcher.in
+++ b/launcher/Launcher.in
@@ -21,6 +21,11 @@ echo "Launcher Dir: ${LAUNCHER_DIR}"
 # Makes the launcher use portals for file picking
 export QT_QPA_PLATFORMTHEME=xdgdesktopportal
 
+# disable OpenGL and Vulkan launcher features on sharun until https://github.com/VHSgunzo/sharun/issues/35
+if [[ -f "${LAUNCHER_DIR}/sharun" ]]; then
+    export LAUNCHER_DISABLE_GLVULKAN=1
+fi
+
 # Just to be sure...
 chmod +x "${LAUNCHER_DIR}/bin/${LAUNCHER_NAME}"
 

--- a/launcher/ui/dialogs/skins/draw/SkinOpenGLWindow.cpp
+++ b/launcher/ui/dialogs/skins/draw/SkinOpenGLWindow.cpp
@@ -20,6 +20,7 @@
 
 #include <QMouseEvent>
 #include <QOpenGLBuffer>
+#include <QProcessEnvironment>
 #include <QVector2D>
 #include <QVector3D>
 #include <QtMath>
@@ -330,6 +331,10 @@ void SkinOpenGLWindow::setElytraVisible(bool visible)
 
 bool SkinOpenGLWindow::hasOpenGL()
 {
+    if (!QProcessEnvironment::systemEnvironment().value(QStringLiteral("LAUNCHER_DISABLE_GLVULKAN")).isEmpty()) {
+        return false;
+    }
+
     QOpenGLContext ctx;
     return ctx.create();
 }


### PR DESCRIPTION

the previous approach didn't work with runtime symbol lookup errors. see https://github.com/PrismLauncher/PrismLauncher/issues/5112#issuecomment-4091771356 for example
