### PR TITLE
build(cmake): avoid re-defining `_FORTIFY_SOURCE`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,8 +69,13 @@ if(CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
     endif()
 else()
     add_compile_options("$<$<COMPILE_LANGUAGE:C,CXX>:-fstack-protector-strong;--param=ssp-buffer-size=4>")
-    # on non-debug builds we can enable optimizations
-    add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<NOT:$<CONFIG:Debug>>>:-O2;-D_FORTIFY_SOURCE=2>")
+
+    # Avoid re-defining _FORTIFY_SOURCE, as it can cause redefinition errors in setups that use it by default (i.e., package builds)
+    if(NOT (CMAKE_C_FLAGS MATCHES "-D_FORTIFY_SOURCE" OR CMAKE_CXX_FLAGS MATCHES "-D_FORTIFY_SOURCE"))
+        # NOTE: _FORTIFY_SOURCE requires optimizations in most newer versions of glibc
+        add_compile_options("$<$<AND:$<COMPILE_LANGUAGE:C,CXX>,$<CONFIG:Release,RelWithDebInfo>>:-D_FORTIFY_SOURCE=2>")
+    endif()
+
     # ATL's pack list needs more than the default 1 Mib stack on windows
     if(CMAKE_SYSTEM_NAME STREQUAL "Windows")
         add_link_options("$<$<COMPILE_LANGUAGE:C,CXX>:-Wl,--stack,8388608>")


### PR DESCRIPTION
Previously, applying this to anything except the default `Debug` build
configuration opened us up to issues with packaging systems (i.e.,
Arch's `makepkg` and Flatpak) who already define this OOTB. Specifically
matching the configurations we want to apply this to and checking if this
is applied globally by `$CFLAGS` or similar should prevent this
re-definition, restoring the behavior from before 8477cc4 and 5d0eeae
