### PR TITLE
make OpenJ9 logo square

### DIFF
--- a/launcher/resources/multimc/scalable/openj9_hex_custom.svg
+++ b/launcher/resources/multimc/scalable/openj9_hex_custom.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg width="166.28mm" height="191.82mm" version="1.1" viewBox="0 0 166.28 191.82" xmlns="http://www.w3.org/2000/svg">
+<svg width="191.82mm" height="191.82mm" version="1.1" viewBox="-12.7705 0 191.82 191.82" xmlns="http://www.w3.org/2000/svg">
  <g transform="matrix(3.7243 0 0 3.7243 -308.43 -457.22)">
   <path d="m105.14 123.12 21.971 12.7v25.4l-21.971 12.7-21.971-12.7v-25.4z" fill="#fff"/>
   <path d="m105.14 123.12 21.971 12.7v25.4l-21.971 12.7-21.971-12.7v-25.4z" fill="none" stroke="#65c2be" stroke-linecap="round" stroke-linejoin="round" stroke-width=".70556"/>


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
https://discord.com/channels/1031648380885147709/1485394368239243405/1485404465333928076
<img width="552" height="393" alt="image" src="https://github.com/user-attachments/assets/24b03149-e0d1-4134-8daf-b54a94356fdb" />

With this PR all names are aligned:
<img width="218" height="195" alt="image" src="https://github.com/user-attachments/assets/734838e7-832f-41ff-a649-5b02e8d7fa70" />
edit: why is it stretched? Qt not rendering svgs correctly, smh (its fine in inkscape)
edit: alright, better now:
<img width="191" height="195" alt="image" src="https://github.com/user-attachments/assets/ac0702da-8047-4b11-a307-6aefc0da5599" />

