### PR TITLE
fix: Bump Java 1.7 -> 1.8 to JavaCheck and Launcher library

### DIFF
--- a/libraries/javacheck/CMakeLists.txt
+++ b/libraries/javacheck/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.15)
 project(launcher Java)
-find_package(Java 1.7 REQUIRED COMPONENTS Development)
+find_package(Java 1.8 REQUIRED COMPONENTS Development)
 
 include(UseJava)
 set(CMAKE_JAVA_JAR_ENTRY_POINT JavaCheck)
-set(CMAKE_JAVA_COMPILE_FLAGS -target 7 -source 7 -Xlint:deprecation -Xlint:unchecked)
+set(CMAKE_JAVA_COMPILE_FLAGS -target 8 -source 8 -Xlint:deprecation -Xlint:unchecked)
 
 set(SRC
     JavaCheck.java

--- a/libraries/launcher/CMakeLists.txt
+++ b/libraries/launcher/CMakeLists.txt
@@ -1,10 +1,10 @@
 cmake_minimum_required(VERSION 3.15)
-project(launcher Java)
-find_package(Java 1.7 REQUIRED COMPONENTS Development)
+project(launcher LANGUAGES Java)
+find_package(Java 1.8 REQUIRED COMPONENTS Development)
 
 include(UseJava)
 set(CMAKE_JAVA_JAR_ENTRY_POINT org.prismlauncher.EntryPoint)
-set(CMAKE_JAVA_COMPILE_FLAGS -target 7 -source 7)
+set(CMAKE_JAVA_COMPILE_FLAGS -target 8 -source 8)
 
 set(SRC
     org/prismlauncher/EntryPoint.java
@@ -35,7 +35,7 @@ set(LEGACY_SRC
     legacy/org/prismlauncher/legacy/utils/url/ByteArrayUrlConnection.java
     legacy/org/prismlauncher/legacy/utils/url/UrlUtils.java
     legacy/net/minecraft/Launcher.java
-    legacy/org/prismlauncher/legacy/LegacyProxy.java
+    legacyshim/LegacyProxy.java
 )
 
 add_jar(NewLaunch ${SRC})

--- a/libraries/launcher/legacy/net/minecraft/Launcher.java
+++ b/libraries/launcher/legacy/net/minecraft/Launcher.java
@@ -4,6 +4,7 @@
  *  Copyright (C) 2022 icelimetea <fr3shtea@outlook.com>
  *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *  Copyright (C) 2022 solonovamax <solonovamax@12oclockpoint.com>
+ *  Copyright (C) 2026 Mehmet Samet Duman <dumanmehmetsamet@icloud.com>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -70,6 +71,7 @@ import java.util.Map;
  * Changing field and method declarations without further testing is not
  * recommended.
  */
+@SuppressWarnings({ "removal", "deprecation" })
 public final class Launcher extends Applet implements AppletStub {
     private static final long serialVersionUID = 1L;
 

--- a/libraries/launcher/legacy/org/prismlauncher/legacy/LegacyFrame.java
+++ b/libraries/launcher/legacy/org/prismlauncher/legacy/LegacyFrame.java
@@ -4,6 +4,7 @@
  *  Copyright (C) 2022 icelimetea <fr3shtea@outlook.com>
  *  Copyright (C) 2022 flow <flowlnlnln@gmail.com>
  *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
+ *  Copyright (C) 2026 Mehmet Samet Duman <dumanmehmetsamet@icloud.com>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -74,6 +75,7 @@ import javax.swing.JFrame;
 
 import net.minecraft.Launcher;
 
+@SuppressWarnings({ "removal", "deprecation" })
 final class LegacyFrame extends JFrame {
     private static final long serialVersionUID = 1L;
 
@@ -158,9 +160,8 @@ final class LegacyFrame extends JFrame {
     private final class ForceExitHandler extends WindowAdapter {
         @Override
         public void windowClosing(WindowEvent event) {
-            // FIXME better solution
-
-            new Thread(new Runnable() {
+            // Force exit after 30 seconds if the application hangs on stop
+            Thread forceExitThread = new Thread(new Runnable() {
                 @Override
                 public void run() {
                     try {
@@ -169,10 +170,12 @@ final class LegacyFrame extends JFrame {
                         Log.error("Thread interrupted", e);
                     }
 
-                    Log.warning("Forcing exit");
+                    Log.warning("Forcing exit due to hang");
                     System.exit(0);
                 }
-            }).start();
+            }, "ForceExitThread");
+            forceExitThread.setDaemon(true);
+            forceExitThread.start();
 
             if (launcher != null) {
                 launcher.stop();

--- a/libraries/launcher/legacy/org/prismlauncher/legacy/LegacyLauncher.java
+++ b/libraries/launcher/legacy/org/prismlauncher/legacy/LegacyLauncher.java
@@ -5,6 +5,7 @@
  *  Copyright (C) 2022 flow <flowlnlnln@gmail.com>
  *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
  *  Copyright (C) 2022 solonovamax <solonovamax@12oclockpoint.com>
+ *  Copyright (C) 2026 Mehmet Samet Duman <dumanmehmetsamet@icloud.com>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -73,7 +74,8 @@ import java.util.List;
 /**
  * Used to launch old versions which support applets.
  */
-final class LegacyLauncher extends AbstractLauncher {
+@SuppressWarnings({ "removal", "deprecation" })
+public final class LegacyLauncher extends AbstractLauncher {
     private final String user, session;
     private final String title;
     private final String appletClass;

--- a/libraries/launcher/legacyshim/LegacyProxy.java
+++ b/libraries/launcher/legacyshim/LegacyProxy.java
@@ -50,10 +50,11 @@
  *      limitations under the License.
  */
 
-package org.prismlauncher.legacy;
+package org.prismlauncher.legacyshim;
 
-import org.prismlauncher.launcher.Launcher;
+import org.prismlauncher.legacy.LegacyLauncher;
 import org.prismlauncher.legacy.fix.online.OnlineFixes;
+import org.prismlauncher.launcher.Launcher;
 import org.prismlauncher.utils.Parameters;
 
 // implementation of LegacyProxy


### PR DESCRIPTION
I think this patch is needed because -target and -source flag version
7 is deprecated and new versions is removed. Example, Java21. This
version not support version 7. Lastly, I changed path of LegacyProxy
.java because I think NewLaunchLegacy.jar doesnt read LegacyProxy.java

Signed-off-by: Mehmet Samet Duman <yongdohyun@projecttick.org>