### PR TITLE
Enable automatic update checking by default

### DIFF
--- a/launcher/updater/PrismExternalUpdater.cpp
+++ b/launcher/updater/PrismExternalUpdater.cpp
@@ -61,7 +61,7 @@ PrismExternalUpdater::PrismExternalUpdater(QWidget* parent, const QString& appDi
     auto settings_file = priv->dataDir.absoluteFilePath("prismlauncher_update.cfg");
     priv->settings = std::make_unique<QSettings>(settings_file, QSettings::Format::IniFormat);
     priv->allowBeta = priv->settings->value("allow_beta", false).toBool();
-    priv->autoCheck = priv->settings->value("auto_check", false).toBool();
+    priv->autoCheck = priv->settings->value("auto_check", true).toBool();
     bool interval_ok = false;
     // default once per day
     priv->updateInterval = priv->settings->value("update_interval", 86400).toInt(&interval_ok);


### PR DESCRIPTION
In support channels `Outdated Prism Launcher` is a very common occurrence. Even when Prism is not directly related to their issue, latest versions improve logging and error message propagation, without which diagnosing the issue may be difficult or not possible. Some updates replace Refraction's checks such as `Missing Libraries` into launcher warnings

This change does not affect existing installations
The default automatic update check interval is every 24 hours