### PR TITLE
add a option to skip meta refresh on launch

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -870,6 +870,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
             resetIfInvalid(m_settings->registerSetting("LegacyFMLLibsURLOverride", "").get());
         }
 
+        m_settings->registerSetting("MetaRefreshOnLaunch", true);
         m_settings->registerSetting("CloseAfterLaunch", false);
         m_settings->registerSetting("QuitAfterGameStop", false);
 

--- a/launcher/meta/Index.cpp
+++ b/launcher/meta/Index.cpp
@@ -15,6 +15,7 @@
 
 #include "Index.h"
 
+#include "Application.h"
 #include "JsonFormat.h"
 #include "QObjectPtr.h"
 #include "VersionList.h"
@@ -135,7 +136,7 @@ void Index::connectVersionList(const int row, const VersionList::Ptr& list)
 
 Task::Ptr Index::loadVersion(const QString& uid, const QString& version, Net::Mode mode, bool force)
 {
-    if (mode == Net::Mode::Offline) {
+    if (mode == Net::Mode::Offline || !APPLICATION->settings()->get("MetaRefreshOnLaunch").toBool()) {
         return get(uid, version)->loadTask(mode);
     }
 

--- a/launcher/ui/pages/global/APIPage.cpp
+++ b/launcher/ui/pages/global/APIPage.cpp
@@ -143,6 +143,7 @@ void APIPage::loadSettings()
     ui->msaClientID->setText(msaClientID);
     QString metaURL = s->get("MetaURLOverride").toString();
     ui->metaURL->setText(metaURL);
+    ui->metaRefreshOnLaunchCB->setCheckState(s->get("MetaRefreshOnLaunch").toBool() ? Qt::Checked : Qt::Unchecked);
     QString resourceURL = s->get("ResourceURLOverride").toString();
     ui->resourceURL->setText(resourceURL);
     QString fmlLibsURL = s->get("LegacyFMLLibsURLOverride").toString();
@@ -194,6 +195,7 @@ void APIPage::applySettings()
 
     s->set("FallbackMRBlockedMods", ui->FallbackMRBlockedMods->checkState());
     s->set("MetaURLOverride", metaURL.toString());
+    s->set("MetaRefreshOnLaunch", ui->metaRefreshOnLaunchCB->checkState() == Qt::Checked);
     s->set("ResourceURLOverride", resourceURL.toString());
     s->set("LegacyFMLLibsURLOverride", fmlLibsURL.toString());
     QString flameKey = ui->flameKey->text();

--- a/launcher/ui/pages/global/APIPage.ui
+++ b/launcher/ui/pages/global/APIPage.ui
@@ -32,9 +32,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-262</y>
-        <width>820</width>
-        <height>908</height>
+        <y>0</y>
+        <width>825</width>
+        <height>1236</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -123,6 +123,13 @@
            <widget class="QLineEdit" name="metaURL">
             <property name="placeholderText">
              <string>Use Default</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="metaRefreshOnLaunchCB">
+            <property name="text">
+             <string>Refresh on launch</string>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
related to https://github.com/PrismLauncher/PrismLauncher/issues/3785 It doesn't fix it but it should at least allow users to skip the redownload of the meta files.
So in a previous PR I added an automated way to refresh all the meta from the original index, to the component index to the actual index.

fixes #4065 by adding that toggle
