### PR TITLE
bypass curseforge blocked downloads via edge.forgecdn reconstruction

### DIFF
--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -489,6 +489,18 @@ void FlameCreationTask::idResolverSucceeded(QEventLoop& loop)
 {
     auto results = m_modIdResolver->getResults().files;
 
+    for (auto& result : results) {
+        if (result.version.downloadUrl.isEmpty()) {
+            QString fileIdStr = QString::number(result.fileId);
+            if (!fileIdStr.isEmpty() && !result.version.fileName.isEmpty()) {
+                QString cdnUrl = QString("https://edge.forgecdn.net/files/%1/%2/%3")
+                    .arg(fileIdStr.left(4), fileIdStr.mid(4), QUrl::toPercentEncoding(result.version.fileName));
+
+                result.version.downloadUrl = cdnUrl;
+            }
+        }
+    }
+
     QStringList optionalFiles;
     for (auto& result : results) {
         if (!result.required) {
@@ -575,9 +587,17 @@ void FlameCreationTask::setupDownloadJob(QEventLoop& loop)
         relpath = FS::PathCombine("minecraft", relpath);
         auto path = FS::PathCombine(m_stagingPath, relpath);
 
-        if (!result.version.downloadUrl.isEmpty()) {
-            qDebug() << "Will download" << result.version.downloadUrl << "to" << path;
-            auto dl = Net::ApiDownload::makeFile(result.version.downloadUrl, path);
+        QString finalUrl = result.version.downloadUrl;
+
+        if (finalUrl.isEmpty()) {
+            QString fileIdStr = QString::number(result.fileId);
+            finalUrl = QString("https://edge.forgecdn.net/files/%1/%2/%3")
+                .arg(fileIdStr.left(4), fileIdStr.mid(4), QUrl::toPercentEncoding(result.version.fileName));
+        }
+
+        if (!finalUrl.isEmpty()) {
+            qDebug() << "Will download" << finalUrl << "to" << path;
+            auto dl = Net::ApiDownload::makeFile(finalUrl, path);
             m_filesJob->addNetAction(dl);
         }
     }


### PR DESCRIPTION
if prism launcher hits a blocked curseforge file, instead of prompting the user to open every blocked mod in the browser, it reconstructs the direct edge.forgecdn.net url using the file id and file name already present in the modpack manifest

this avoids the browser tab spam and leftover files in downloads

this only works when prism can still access the modpack manifest normally, so it fixes blocked files inside a modpack, not cases where the whole modpack file itself is unavailable through the api

the same logic could also be used later for blocked mods downloaded individually (though not present in this pr)