### PR TITLE
CI: verify clang-tidy config before running

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -49,5 +49,5 @@ jobs:
           BASE_REF: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
         run: |
           nix develop --command bash -c '
-            clang-tidy -verify-config && git diff -U0 --no-color "$BASE_REF" | clang-tidy-diff.py -p1
+            clang-tidy -verify-config && git diff -U0 --no-color "$BASE_REF" | clang-tidy-diff.py -p1 -quiet -only-check-in-db
           '

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -49,5 +49,5 @@ jobs:
           BASE_REF: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
         run: |
           nix develop --command bash -c '
-            git diff -U0 --no-color "$BASE_REF" | clang-tidy-diff.py -p1
+            clang-tidy -verify-config && git diff -U0 --no-color "$BASE_REF" | clang-tidy-diff.py -p1
           '


### PR DESCRIPTION
Makes sure our checks/check options won't get silently ignored due to differences in LLVM versions

clang-tidy failure is "works as intended"

blocked by #5292