### PR TITLE
fix: clang-tidy action

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,32 +1,32 @@
 FormatStyle: file
 
 Checks:
-  'bugprone-*,clang-analyzer-*,cppcoreguidelines-*,hicpp-*,misc-*,modernize-*,performance-*,portability-*,readability-*,
-  -*-magic-numbers,
-  -*-non-private-member-variables-in-classes,
-  -*-special-member-functions,
-  -bugprone-easily-swappable-parameters,
-  -cppcoreguidelines-owning-memory,
-  -cppcoreguidelines-pro-type-static-cast-downcast,
-  -modernize-use-nodiscard,
-  -modernize-use-trailing-return-type,
-  -portability-avoid-pragma-once,
-  -readability-avoid-unconditional-preprocessor-if,
-  -readability-function-cognitive-complexity,
-  -readability-identifier-length,
-  -readability-redundant-access-specifiers'
+    "bugprone-*,clang-analyzer-*,cppcoreguidelines-*,hicpp-*,misc-*,modernize-*,performance-*,portability-*,readability-*,
+    -*-magic-numbers,
+    -*-non-private-member-variables-in-classes,
+    -*-special-member-functions,
+    -bugprone-easily-swappable-parameters,
+    -cppcoreguidelines-owning-memory,
+    -cppcoreguidelines-pro-type-static-cast-downcast,
+    -modernize-use-nodiscard,
+    -modernize-use-trailing-return-type,
+    -portability-avoid-pragma-once,
+    -readability-avoid-unconditional-preprocessor-if,
+    -readability-function-cognitive-complexity,
+    -readability-identifier-length,
+    -readability-redundant-access-specifiers"
 
 CheckOptions:
-  - { key: misc-include-cleaner.MissingIncludes,                        value: false }
-  - { key: readability-identifier-naming.DefaultCase,                   value: camelBack }
-  - { key: readability-identifier-naming.NamespaceCase,                 value: CamelCase }
-  - { key: readability-identifier-naming.ClassCase,                     value: CamelCase }
-  - { key: readability-identifier-naming.ClassConstantCase,             value: CamelCase }
-  - { key: readability-identifier-naming.EnumCase,                      value: CamelCase }
-  - { key: readability-identifier-naming.EnumConstantCase,              value: CamelCase }
-  - { key: readability-identifier-naming.MacroDefinitionCase,           value: UPPER_CASE }
-  - { key: readability-identifier-naming.ClassMemberPrefix,             value: m_ }
-  - { key: readability-identifier-naming.StaticConstantPrefix,          value: s_ }
-  - { key: readability-identifier-naming.StaticVariablePrefix,          value: s_ }
-  - { key: readability-identifier-naming.GlobalConstantPrefix,          value: g_ }
-  - { key: readability-implicit-bool-conversion.AllowPointerConditions, value: true }
+    misc-include-cleaner.MissingIncludes: false
+    readability-identifier-naming.DefaultCase: "camelBack"
+    readability-identifier-naming.NamespaceCase: "CamelCase"
+    readability-identifier-naming.ClassCase: "CamelCase"
+    readability-identifier-naming.ClassConstantCase: "CamelCase"
+    readability-identifier-naming.EnumCase: "CamelCase"
+    readability-identifier-naming.EnumConstantCase: "CamelCase"
+    readability-identifier-naming.MacroDefinitionCase: "UPPER_CASE"
+    readability-identifier-naming.ClassMemberPrefix: "m_"
+    readability-identifier-naming.StaticConstantPrefix: "s_"
+    readability-identifier-naming.StaticVariablePrefix: "s_"
+    readability-identifier-naming.GlobalConstantPrefix: "g_"
+    readability-implicit-bool-conversion.AllowPointerConditions: true

--- a/flake.lock
+++ b/flake.lock
@@ -18,15 +18,15 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1774388614,
-        "narHash": "sha256-cUgsPWt0NJz21K4i/5191mWaizw4XtT20WFqyxzSuQI=",
-        "rev": "1073dad219cb244572b74da2b20c7fe39cb3fa9e",
+        "lastModified": 1774709303,
+        "narHash": "sha256-D4ely1FsBcvtj/qSrNhSWpq+CUZKNiKwJIxpxnfy9o4=",
+        "rev": "8110df5ad7abf5d4c0f6fb0f8f978390e77f9685",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/25.11/nixos-25.11.8107.1073dad219cb/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre971119.8110df5ad7ab/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://channels.nixos.org/nixos-25.11/nixexprs.tar.xz"
+        "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "https://channels.nixos.org/nixos-25.11/nixexprs.tar.xz";
+    nixpkgs.url = "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz";
 
     libnbtplusplus = {
       url = "github:PrismLauncher/libnbtplusplus";
@@ -42,7 +42,7 @@
 
         let
           pkgs = nixpkgsFor.${system};
-          llvm = pkgs.llvmPackages_19;
+          llvm = pkgs.llvmPackages_22;
         in
 
         {
@@ -85,7 +85,7 @@
 
         let
           pkgs = nixpkgsFor.${system};
-          llvm = pkgs.llvmPackages_19;
+          llvm = pkgs.llvmPackages_22;
           python = pkgs.python3;
           mkShell = pkgs.mkShell.override { inherit (llvm) stdenv; };
 
@@ -189,7 +189,7 @@
         final: prev:
 
         let
-          llvm = final.llvmPackages_19 or prev.llvmPackages_19;
+          llvm = final.llvmPackages_22 or prev.llvmPackages_22;
         in
 
         {


### PR DESCRIPTION
This change switches to nixos unstable to get llvmPackages_22 so we can support all the clang-tidy options