### PR TITLE
Improve clang-tidy CI speed by only running autogen & autorcc

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -28,19 +28,14 @@ jobs:
           fetch-depth: 0 # Required for diffing later on
           submodules: "true"
 
-      - name: Setup sccache
-        uses: hendrikmuhs/ccache-action@v1.2.23
-        with:
-          variant: sccache
-
       - name: Install Nix
         uses: cachix/install-nix-action@v31
 
-      - name: Run build
+      - name: Run source generators
         # TODO(@getchoo): Figure out how to make this work with PCH
         run: |
           nix develop --command bash -c '
-            cmake -B build -D Launcher_USE_PCH=OFF -D CMAKE_CXX_COMPILER_LAUNCHER=sccache && cmake --build build
+            cmake -B build -D Launcher_USE_PCH=OFF && cmake --build build --target autogen autorcc
           '
 
       # TODO: Use SARIF after https://github.com/psastras/sarif-rs/issues/638 is fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,10 @@ endif()
 ##################################### Set CMake options #####################################
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOGEN_ORIGIN_DEPENDS OFF)
+set(CMAKE_GLOBAL_AUTOGEN_TARGET ON)
+set(CMAKE_GLOBAL_AUTORCC_TARGET ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake/")

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -1206,78 +1206,6 @@ if(WIN32)
     )
 endif()
 
-qt_wrap_ui(LAUNCHER_UI
-    ui/MainWindow.ui
-    ui/setupwizard/PasteWizardPage.ui
-    ui/setupwizard/AutoJavaWizardPage.ui
-    ui/setupwizard/LoginWizardPage.ui
-    ui/pages/global/AccountListPage.ui
-    ui/pages/global/JavaPage.ui
-    ui/pages/global/LauncherPage.ui
-    ui/pages/global/APIPage.ui
-    ui/pages/global/ProxyPage.ui
-    ui/pages/global/ExternalToolsPage.ui
-    ui/pages/instance/ExternalResourcesPage.ui
-    ui/pages/instance/NotesPage.ui
-    ui/pages/instance/LogPage.ui
-    ui/pages/instance/ServersPage.ui
-    ui/pages/instance/OtherLogsPage.ui
-    ui/pages/instance/VersionPage.ui
-    ui/pages/instance/ManagedPackPage.ui
-    ui/pages/instance/WorldListPage.ui
-    ui/pages/instance/ScreenshotsPage.ui
-    ui/pages/modplatform/atlauncher/AtlOptionalModDialog.ui
-    ui/pages/modplatform/atlauncher/AtlPage.ui
-    ui/pages/modplatform/CustomPage.ui
-    ui/pages/modplatform/ResourcePage.ui
-    ui/pages/modplatform/flame/FlamePage.ui
-    ui/pages/modplatform/legacy_ftb/Page.ui
-    ui/pages/modplatform/import_ftb/ImportFTBPage.ui
-    ui/pages/modplatform/ImportPage.ui
-    ui/pages/modplatform/OptionalModDialog.ui
-    ui/pages/modplatform/ftb/FtbPage.ui
-    ui/pages/modplatform/modrinth/ModrinthPage.ui
-    ui/pages/modplatform/technic/TechnicPage.ui
-    ui/widgets/CustomCommands.ui
-    ui/widgets/EnvironmentVariables.ui
-    ui/widgets/InfoFrame.ui
-    ui/widgets/ModFilterWidget.ui
-    ui/widgets/SubTaskProgressBar.ui
-    ui/widgets/AppearanceWidget.ui
-    ui/widgets/MinecraftSettingsWidget.ui
-    ui/widgets/JavaSettingsWidget.ui
-    ui/dialogs/CopyInstanceDialog.ui
-    ui/dialogs/CreateShortcutDialog.ui
-    ui/dialogs/ProfileSetupDialog.ui
-    ui/dialogs/ProgressDialog.ui
-    ui/dialogs/NewInstanceDialog.ui
-    ui/dialogs/NetworkJobFailedDialog.ui
-    ui/dialogs/NewComponentDialog.ui
-    ui/dialogs/NewsDialog.ui
-    ui/dialogs/ProfileSelectDialog.ui
-    ui/dialogs/ExportInstanceDialog.ui
-    ui/dialogs/ExportPackDialog.ui
-    ui/dialogs/ExportToModListDialog.ui
-    ui/dialogs/IconPickerDialog.ui
-    ui/dialogs/ImportResourceDialog.ui
-    ui/dialogs/MSALoginDialog.ui
-    ui/dialogs/AboutDialog.ui
-    ui/dialogs/ReviewMessageBox.ui
-    ui/dialogs/ScrollMessageBox.ui
-    ui/dialogs/BlockedModsDialog.ui
-    ui/dialogs/ChooseProviderDialog.ui
-    ui/dialogs/skins/SkinManageDialog.ui
-    ui/dialogs/ChooseOfflineNameDialog.ui
-)
-
-qt_wrap_ui(PRISM_UPDATE_UI
-    ui/dialogs/UpdateAvailableDialog.ui
-)
-
-if (NOT Apple)
-    set (LAUNCHER_UI ${LAUNCHER_UI} ${PRISM_UPDATE_UI})
-endif()
-
 qt_add_resources(LAUNCHER_RESOURCES
     resources/backgrounds/backgrounds.qrc
     resources/multimc/multimc.qrc
@@ -1294,12 +1222,6 @@ qt_add_resources(LAUNCHER_RESOURCES
     resources/documents/documents.qrc
     resources/shaders/shaders.qrc
     "${CMAKE_CURRENT_BINARY_DIR}/../${Launcher_Branding_LogoQRC}"
-)
-
-qt_wrap_ui(PRISMUPDATER_UI
-    updater/prismupdater/SelectReleaseDialog.ui
-    ui/widgets/SubTaskProgressBar.ui
-    ui/dialogs/ProgressDialog.ui
 )
 
 ######## Windows resource files ########
@@ -1321,7 +1243,7 @@ endif()
 ####### Targets ########
 
 # Add executable
-add_library(Launcher_logic STATIC ${LOGIC_SOURCES} ${LAUNCHER_SOURCES} ${LAUNCHER_UI} ${LAUNCHER_RESOURCES})
+add_library(Launcher_logic STATIC ${LOGIC_SOURCES} ${LAUNCHER_SOURCES} ${LAUNCHER_RESOURCES})
 target_include_directories(Launcher_logic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 target_compile_definitions(Launcher_logic PUBLIC LAUNCHER_APPLICATION)
 
@@ -1441,7 +1363,7 @@ endif()
 
 if(Launcher_BUILD_UPDATER)
     # Updater
-    add_library(prism_updater_logic STATIC ${PRISMUPDATER_SOURCES} ${TASKS_SOURCES} ${PRISMUPDATER_UI})
+    add_library(prism_updater_logic STATIC ${PRISMUPDATER_SOURCES} ${TASKS_SOURCES})
     target_include_directories(prism_updater_logic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
     if(${Launcher_USE_PCH})

--- a/launcher/ui/pages/modplatform/flame/FlameResourcePages.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameResourcePages.cpp
@@ -41,7 +41,7 @@
 #include <QList>
 #include <memory>
 #include "modplatform/flame/FlameAPI.h"
-#include "ui_ResourcePage.h"
+#include "../ui_ResourcePage.h"
 
 #include "FlameResourceModels.h"
 #include "ui/dialogs/ResourceDownloadDialog.h"

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.cpp
@@ -38,7 +38,7 @@
 
 #include "ModrinthResourcePages.h"
 #include "ui/pages/modplatform/DataPackModel.h"
-#include "ui_ResourcePage.h"
+#include "../ui_ResourcePage.h"
 
 #include "modplatform/modrinth/ModrinthAPI.h"
 


### PR DESCRIPTION
Instead of building the whole launcher we run the generators so that clang-tidy won't complain about missing files during scanning.

This doesn't work on it's own because we don't use `autouic` and specify UI sources manually. There's no reason to do that and the CMake function (`qt_wrap_ui`) is deprecated in favor of `autouic`, this PR fixes that