### PR TITLE
Allow selecting multiple items in Network Error dialog

### DIFF
--- a/launcher/ui/dialogs/NetworkJobFailedDialog.cpp
+++ b/launcher/ui/dialogs/NetworkJobFailedDialog.cpp
@@ -43,6 +43,8 @@ NetworkJobFailedDialog::NetworkJobFailedDialog(const QString& jobName, const int
     m_ui->detailsTable->header()->setSectionResizeMode(0, QHeaderView::Stretch);
     m_ui->detailsTable->header()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
 
+    m_ui->detailsTable->setSelectionMode(QAbstractItemView::ExtendedSelection);
+
     const auto* copyShortcut = new QShortcut(QKeySequence::Copy, m_ui->detailsTable);
     connect(copyShortcut, &QShortcut::activated, this, &NetworkJobFailedDialog::copyUrl);
 
@@ -74,6 +76,11 @@ void NetworkJobFailedDialog::copyUrl() const
         return;
     }
 
+    QString urls = items.first()->text(0);
+    for (auto& item : items.sliced(1)) {
+        urls += "\n" + item->text(0);
+    }
+
     auto* clipboard = QGuiApplication::clipboard();
-    clipboard->setText(items.first()->text(0));
+    clipboard->setText(urls);
 }


### PR DESCRIPTION
In Network Error (`NetworkJobFailed`) dialog, current (default) selection mode allows choosing and copying only one URL at a time.

When multiple downloads fail it would be really convenient to copy all the URLs at once, for manual downloading or debugging.
When copying multiple URLs they will be separated by a `LF` newline.

Not sure if using `CRLF` for Windows is needed, I can implement that with the preprocessor if so.