### PR TITLE
Add back drag and dropping to screenshots page

### DIFF
--- a/launcher/ui/pages/instance/ScreenshotsPage.cpp
+++ b/launcher/ui/pages/instance/ScreenshotsPage.cpp
@@ -69,6 +69,23 @@
 #include <FileSystem.h>
 #include "RWStorage.h"
 
+class ScreenshotsFSModel : public QFileSystemModel {
+    bool canDropMimeData(const QMimeData* data, Qt::DropAction action, int row, int column, const QModelIndex& parent) const override
+    {
+        QUrl root = QUrl::fromLocalFile(rootPath());
+        // this disables reordering items inside the model
+        // by rejecting drops if the file is already inside the folder
+        if (data->hasUrls()) {
+            for (auto& url : data->urls()) {
+                if (root.isParentOf(url)) {
+                    return false;
+                }
+            }
+        }
+        return QFileSystemModel::canDropMimeData(data, action, row, column, parent);
+    }
+};
+
 using SharedIconCache = RWStorage<QString, QIcon>;
 using SharedIconCachePtr = std::shared_ptr<SharedIconCache>;
 
@@ -237,7 +254,7 @@ class CenteredEditingDelegate : public QStyledItemDelegate {
 
 ScreenshotsPage::ScreenshotsPage(QString path, QWidget* parent) : QMainWindow(parent), ui(new Ui::ScreenshotsPage)
 {
-    m_model.reset(new QFileSystemModel());
+    m_model.reset(new ScreenshotsFSModel());
     m_filterModel.reset(new FilterModel());
     m_filterModel->setSourceModel(m_model.get());
     m_model->setFilter(QDir::Files);

--- a/launcher/ui/pages/instance/ScreenshotsPage.h
+++ b/launcher/ui/pages/instance/ScreenshotsPage.h
@@ -41,12 +41,13 @@
 
 #include "settings/Setting.h"
 
-class QFileSystemModel;
 class QIdentityProxyModel;
 class QItemSelection;
 namespace Ui {
 class ScreenshotsPage;
 }
+
+class ScreenshotsFSModel;
 
 struct ScreenShot;
 class ScreenshotList;
@@ -88,7 +89,7 @@ class ScreenshotsPage : public QMainWindow, public BasePage {
 
    private:
     Ui::ScreenshotsPage* ui;
-    std::shared_ptr<QFileSystemModel> m_model;
+    std::shared_ptr<ScreenshotsFSModel> m_model;
     std::shared_ptr<QIdentityProxyModel> m_filterModel;
     QString m_folder;
     bool m_valid = false;

--- a/launcher/ui/pages/instance/ScreenshotsPage.ui
+++ b/launcher/ui/pages/instance/ScreenshotsPage.ui
@@ -33,13 +33,13 @@
        <enum>QAbstractItemView::SelectionMode::ExtendedSelection</enum>
       </property>
       <property name="selectionBehavior">
-       <enum>QAbstractItemView::SelectionBehavior::SelectRows</enum>
-      </property>
-      <property name="movement">
-       <enum>QListView::Movement::Static</enum>
+       <enum>QAbstractItemView::SelectionBehavior::SelectItems</enum>
       </property>
       <property name="verticalScrollMode">
-       <enum>QAbstractItemView::ScrollPerPixel</enum>
+       <enum>QAbstractItemView::ScrollMode::ScrollPerPixel</enum>
+      </property>
+      <property name="movement">
+       <enum>QListView::Movement::Snap</enum>
       </property>
      </widget>
     </item>


### PR DESCRIPTION
Fixes #4548

And #1503 was technically fixed when drag and drop was disabled but can also be closed as this does not reintroduce the issue
