### PR TITLE
LaunchController: fix double task finish

### DIFF
--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -358,7 +358,6 @@ bool LaunchController::reauthenticateAccount(MinecraftAccountPtr account, QStrin
         }
     }
 
-    emitFailed(reason);
     return false;
 }
 

--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -50,7 +50,7 @@
 #include <QInputDialog>
 #include <QList>
 #include <QPushButton>
-#include <QRegularExpression>
+#include <utility>
 
 #include "BuildConfig.h"
 #include "JavaCommon.h"
@@ -82,9 +82,9 @@ void LaunchController::decideAccount()
     }
 
     // Select the account to use. If the instance has a specific account set, that will be used. Otherwise, the default account will be used
-    auto accounts = APPLICATION->accounts();
-    auto instanceAccountId = m_instance->settings()->get("InstanceAccountId").toString();
-    auto instanceAccountIndex = accounts->findAccountByProfileId(instanceAccountId);
+    auto* accounts = APPLICATION->accounts();
+    const auto instanceAccountId = m_instance->settings()->get("InstanceAccountId").toString();
+    const auto instanceAccountIndex = accounts->findAccountByProfileId(instanceAccountId);
     if (instanceAccountIndex == -1 || instanceAccountId.isEmpty()) {
         m_accountToUse = accounts->defaultAccount();
     } else {
@@ -141,7 +141,7 @@ LaunchDecision LaunchController::decideLaunchMode()
         }
     }
 
-    const auto accounts = APPLICATION->accounts();
+    const auto* accounts = APPLICATION->accounts();
     MinecraftAccountPtr accountToCheck = nullptr;
 
     if (m_accountToUse->accountType() != AccountType::Offline) {
@@ -213,7 +213,7 @@ LaunchDecision LaunchController::decideLaunchMode()
     return LaunchDecision::Abort;
 }
 
-bool LaunchController::askPlayDemo()
+bool LaunchController::askPlayDemo() const
 {
     QMessageBox box(m_parentWidget);
     box.setWindowTitle(tr("Play demo?"));
@@ -223,15 +223,15 @@ bool LaunchController::askPlayDemo()
     text += tr("\n\nDo you want to play the demo?");
     box.setText(text);
     box.setIcon(QMessageBox::Warning);
-    auto demoButton = box.addButton(tr("Play Demo"), QMessageBox::ButtonRole::YesRole);
-    auto cancelButton = box.addButton(tr("Cancel"), QMessageBox::ButtonRole::NoRole);
+    const auto* demoButton = box.addButton(tr("Play Demo"), QMessageBox::ButtonRole::YesRole);
+    auto* cancelButton = box.addButton(tr("Cancel"), QMessageBox::ButtonRole::NoRole);
     box.setDefaultButton(cancelButton);
 
     box.exec();
     return box.clickedButton() == demoButton;
 }
 
-QString LaunchController::askOfflineName(QString playerName, bool* ok)
+QString LaunchController::askOfflineName(const QString& playerName, bool* ok) const
 {
     if (ok != nullptr) {
         *ok = false;
@@ -253,7 +253,7 @@ QString LaunchController::askOfflineName(QString playerName, bool* ok)
             break;
     }
 
-    QString lastOfflinePlayerName = APPLICATION->settings()->get("LastOfflinePlayerName").toString();
+    const QString lastOfflinePlayerName = APPLICATION->settings()->get("LastOfflinePlayerName").toString();
     QString usedname = lastOfflinePlayerName.isEmpty() ? playerName : lastOfflinePlayerName;
 
     ChooseOfflineNameDialog dialog(message, m_parentWidget);
@@ -331,14 +331,14 @@ void LaunchController::login()
     launchInstance();
 }
 
-bool LaunchController::reauthenticateAccount(MinecraftAccountPtr account, QString reason)
+bool LaunchController::reauthenticateAccount(const MinecraftAccountPtr& account, const QString& reason)
 {
     auto button = QMessageBox::warning(
         m_parentWidget, tr("Account refresh failed"), tr("%1. Do you want to reauthenticate this account?").arg(reason),
         QMessageBox::StandardButton::Yes | QMessageBox::StandardButton::No, QMessageBox::StandardButton::Yes);
     if (button == QMessageBox::StandardButton::Yes) {
-        auto accounts = APPLICATION->accounts();
-        bool isDefault = accounts->defaultAccount() == account;
+        auto* accounts = APPLICATION->accounts();
+        const bool isDefault = accounts->defaultAccount() == account;
         accounts->removeAccount(accounts->index(accounts->findAccountByProfileId(account->profileId())));
         if (account->accountType() == AccountType::MSA) {
             auto newAccount = MSALoginDialog::newAccount(m_parentWidget);
@@ -346,8 +346,9 @@ bool LaunchController::reauthenticateAccount(MinecraftAccountPtr account, QStrin
             if (newAccount != nullptr) {
                 accounts->addAccount(newAccount);
 
-                if (isDefault)
+                if (isDefault) {
                     accounts->setDefaultAccount(newAccount);
+                }
 
                 if (m_accountToUse == account) {
                     m_accountToUse = nullptr;
@@ -378,8 +379,8 @@ void LaunchController::launchInstance()
         return;
     }
 
-    auto console = qobject_cast<InstanceWindow*>(m_parentWidget);
-    auto showConsole = m_instance->settings()->get("ShowConsole").toBool();
+    const auto* console = qobject_cast<InstanceWindow*>(m_parentWidget);
+    const auto showConsole = m_instance->settings()->get("ShowConsole").toBool();
     if (!console && showConsole) {
         APPLICATION->showInstanceWindow(m_instance);
     }
@@ -394,7 +395,7 @@ void LaunchController::launchInstance()
         online_mode = "online";
 
         // Prepend Server Status
-        QStringList servers = { "login.microsoftonline.com", "session.minecraft.net", "textures.minecraft.net", "api.mojang.com" };
+        const QStringList servers = { "login.microsoftonline.com", "session.minecraft.net", "textures.minecraft.net", "api.mojang.com" };
 
         m_launcher->prependStep(makeShared<PrintServers>(m_launcher, servers));
     } else {
@@ -464,10 +465,10 @@ void LaunchController::onFailed(QString reason)
     if (m_instance->settings()->get("ShowConsoleOnError").toBool()) {
         APPLICATION->showInstanceWindow(m_instance, "console");
     }
-    emitFailed(reason);
+    emitFailed(std::move(reason));
 }
 
-void LaunchController::onProgressRequested(Task* task)
+void LaunchController::onProgressRequested(Task* task) const
 {
     ProgressDialog progDialog(m_parentWidget);
     progDialog.setSkipButton(true, tr("Abort"));

--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -364,8 +364,8 @@ bool LaunchController::reauthenticateAccount(const MinecraftAccountPtr& account,
 
 void LaunchController::launchInstance()
 {
-    Q_ASSERT_X(m_instance != NULL, "launchInstance", "instance is NULL");
-    Q_ASSERT_X(m_session.get() != nullptr, "launchInstance", "session is NULL");
+    Q_ASSERT(m_instance != nullptr);
+    Q_ASSERT(m_session.get() != nullptr);
 
     if (!m_instance->reloadSettings()) {
         QMessageBox::critical(m_parentWidget, tr("Error!"), tr("Couldn't load the instance profile."));

--- a/launcher/LaunchController.h
+++ b/launcher/LaunchController.h
@@ -50,11 +50,11 @@ class LaunchController : public Task {
     void executeTask() override;
 
     LaunchController();
-    virtual ~LaunchController() = default;
+    ~LaunchController() override = default;
 
     void setInstance(BaseInstance* instance) { m_instance = instance; }
 
-    BaseInstance* instance() { return m_instance; }
+    BaseInstance* instance() const { return m_instance; }
 
     void setLaunchMode(const LaunchMode mode) { m_wantedLaunchMode = mode; }
 
@@ -68,7 +68,7 @@ class LaunchController : public Task {
 
     void setAccountToUse(MinecraftAccountPtr accountToUse) { m_accountToUse = std::move(accountToUse); }
 
-    QString id() { return m_instance->id(); }
+    QString id() const { return m_instance->id(); }
 
     bool abort() override;
 
@@ -77,27 +77,27 @@ class LaunchController : public Task {
     void launchInstance();
     void decideAccount();
     LaunchDecision decideLaunchMode();
-    bool askPlayDemo();
-    QString askOfflineName(QString playerName, bool* ok = nullptr);
-    bool reauthenticateAccount(MinecraftAccountPtr account, QString reason);
+    bool askPlayDemo() const;
+    QString askOfflineName(const QString& playerName, bool* ok = nullptr) const;
+    bool reauthenticateAccount(const MinecraftAccountPtr& account, const QString& reason);
 
    private slots:
     void readyForLaunch();
 
     void onSucceeded();
     void onFailed(QString reason);
-    void onProgressRequested(Task* task);
+    void onProgressRequested(Task* task) const;
 
    private:
     LaunchMode m_wantedLaunchMode = LaunchMode::Normal;
     LaunchMode m_actualLaunchMode = LaunchMode::Normal;
     BaseProfilerFactory* m_profiler = nullptr;
     QString m_offlineName;
-    BaseInstance* m_instance;
+    BaseInstance* m_instance = nullptr;
     QWidget* m_parentWidget = nullptr;
     InstanceWindow* m_console = nullptr;
     MinecraftAccountPtr m_accountToUse = nullptr;
-    AuthSessionPtr m_session;
-    LaunchTask* m_launcher;
-    MinecraftTarget::Ptr m_targetToJoin;
+    AuthSessionPtr m_session = nullptr;
+    LaunchTask* m_launcher = nullptr;
+    MinecraftTarget::Ptr m_targetToJoin = nullptr;
 };


### PR DESCRIPTION
If you click `No` on the `Do you want to reauthenticate?` dialog the code calls `emitFailed(reason)` and causes `decideLaunchMode` to return `LaunchDecision::Abort` and trigger `emitAborted()`, causing a double task finish

The crash isn't an assertion trip but a segfault here because right after `emitFailed` is called the `LaunchController` is deleted, so `emitAborted` is use-after-free