### PR TITLE
Search by project id (#) improvement

### DIFF
--- a/launcher/modplatform/ResourceAPI.cpp
+++ b/launcher/modplatform/ResourceAPI.cpp
@@ -148,9 +148,9 @@ Task::Ptr ResourceAPI::getProjectVersions(VersionSearchArgs&& args, Callback<QVe
     return netJob;
 }
 
-Task::Ptr ResourceAPI::getProjectInfo(ProjectInfoArgs&& args, Callback<ModPlatform::IndexedPack::Ptr>&& callbacks) const
+Task::Ptr ResourceAPI::getProjectInfo(ProjectInfoArgs&& args, Callback<ModPlatform::IndexedPack::Ptr>&& callbacks, bool askRetry) const
 {
-    auto [job, response] = getProject(args.pack->addonId.toString());
+    auto [job, response] = getProject(args.pack->addonId.toString(), askRetry);
 
     QObject::connect(job.get(), &NetJob::succeeded, [this, response, callbacks, args] {
         auto pack = args.pack;
@@ -284,7 +284,7 @@ QString ResourceAPI::mapMCVersionToModrinth(Version v) const
     return verStr;
 }
 
-std::pair<Task::Ptr, QByteArray*> ResourceAPI::getProject(QString addonId) const
+std::pair<Task::Ptr, QByteArray*> ResourceAPI::getProject(QString addonId, bool askRetry) const
 {
     auto project_url_optional = getInfoURL(addonId);
     if (!project_url_optional.has_value())
@@ -293,6 +293,7 @@ std::pair<Task::Ptr, QByteArray*> ResourceAPI::getProject(QString addonId) const
     auto project_url = project_url_optional.value();
 
     auto netJob = makeShared<NetJob>(QString("%1::GetProject").arg(addonId), APPLICATION->network());
+    netJob->setAskRetry(askRetry);
 
     auto [action, response] = Net::ApiDownload::makeByteArray(QUrl(project_url));
     netJob->addNetAction(action);

--- a/launcher/modplatform/ResourceAPI.h
+++ b/launcher/modplatform/ResourceAPI.h
@@ -115,10 +115,10 @@ class ResourceAPI {
    public slots:
     virtual Task::Ptr searchProjects(SearchArgs&&, Callback<QList<ModPlatform::IndexedPack::Ptr>>&&) const;
 
-    virtual std::pair<Task::Ptr, QByteArray*> getProject(QString addonId) const;
+    virtual std::pair<Task::Ptr, QByteArray*> getProject(QString addonId, bool askRetry = true) const;
     virtual std::pair<Task::Ptr, QByteArray*> getProjects(QStringList addonIds) const = 0;
 
-    virtual Task::Ptr getProjectInfo(ProjectInfoArgs&&, Callback<ModPlatform::IndexedPack::Ptr>&&) const;
+    virtual Task::Ptr getProjectInfo(ProjectInfoArgs&&, Callback<ModPlatform::IndexedPack::Ptr>&&, bool askRetry = true) const;
     Task::Ptr getProjectVersions(VersionSearchArgs&& args, Callback<QVector<ModPlatform::IndexedVersion>>&& callbacks) const;
     virtual Task::Ptr getDependencyVersion(DependencySearchArgs&&, Callback<ModPlatform::IndexedVersion>&&) const;
 

--- a/launcher/ui/pages/modplatform/ResourceModel.cpp
+++ b/launcher/ui/pages/modplatform/ResourceModel.cpp
@@ -163,7 +163,7 @@ void ResourceModel::search()
             };
             auto project = std::make_shared<ModPlatform::IndexedPack>();
             project->addonId = projectId;
-            if (auto job = m_api->getProjectInfo({ project }, std::move(callbacks)); job)
+            if (auto job = m_api->getProjectInfo({ project }, std::move(callbacks), false); job)
                 runSearchJob(job);
             return;
         }

--- a/launcher/ui/pages/modplatform/ResourceModel.cpp
+++ b/launcher/ui/pages/modplatform/ResourceModel.cpp
@@ -139,15 +139,16 @@ void ResourceModel::search()
     if (hasActiveSearchJob())
         return;
 
-    if (m_search_term.startsWith("#")) {
+    if (m_search_state != SearchState::ResetRequested && m_search_term.startsWith("#")) {
         auto projectId = m_search_term.mid(1);
         if (!projectId.isEmpty()) {
             ResourceAPI::Callback<ModPlatform::IndexedPack::Ptr> callbacks;
 
-            callbacks.on_fail = [this](QString reason, int) {
+            callbacks.on_fail = [this](QString reason, int network_error_code) {
                 if (!s_running_models.constFind(this).value())
                     return;
-                searchRequestFailed(reason, -1);
+                m_search_state = SearchState::ResetRequested;;
+                searchRequestFailed(reason, network_error_code);
             };
             callbacks.on_abort = [this] {
                 if (!s_running_models.constFind(this).value())
@@ -407,6 +408,9 @@ void ResourceModel::searchRequestFailed([[maybe_unused]] QString reason, int net
             // Network error
             QMessageBox::critical(nullptr, tr("Error"), tr("A network error occurred. Could not load mods."));
             break;
+        case 404:
+            // 404 Not Found, some APIs return this when nothing is found, no need to bother the user
+            break;
         case 409:
             // 409 Gone, notify user to update
             QMessageBox::critical(nullptr, tr("Error"),
@@ -414,7 +418,14 @@ void ResourceModel::searchRequestFailed([[maybe_unused]] QString reason, int net
             break;
     }
 
-    m_search_state = SearchState::Finished;
+    if (m_search_state == SearchState::ResetRequested) {
+        clearData();
+
+        m_next_search_offset = 0;
+        search();
+    } else {
+        m_search_state = SearchState::Finished;
+    }
 }
 
 void ResourceModel::searchRequestAborted()

--- a/launcher/ui/pages/modplatform/ResourceModel.cpp
+++ b/launcher/ui/pages/modplatform/ResourceModel.cpp
@@ -147,7 +147,9 @@ void ResourceModel::search()
             callbacks.on_fail = [this](QString reason, int network_error_code) {
                 if (!s_running_models.constFind(this).value())
                     return;
-                m_search_state = SearchState::ResetRequested;;
+                if (network_error_code == 404) {
+                    m_search_state = SearchState::ResetRequested;
+                }
                 searchRequestFailed(reason, network_error_code);
             };
             callbacks.on_abort = [this] {

--- a/launcher/ui/pages/modplatform/flame/FlameModel.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameModel.cpp
@@ -166,7 +166,7 @@ void ListModel::performPaginatedSearch()
 {
     static const FlameAPI api;
 
-    // activate id search only for numerical values because all CurseForge ids are numerical
+    // activate search by id only for numerical values because all CurseForge ids are numerical
     static const QRegularExpression s_projectIdExpr("^\\#[0-9]+$");
     if (m_searchState != ResetRequested && s_projectIdExpr.match(m_currentSearchTerm).hasMatch()) {
         auto projectId = m_currentSearchTerm.mid(1);

--- a/launcher/ui/pages/modplatform/flame/FlameModel.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameModel.cpp
@@ -165,7 +165,10 @@ void ListModel::fetchMore(const QModelIndex& parent)
 void ListModel::performPaginatedSearch()
 {
     static const FlameAPI api;
-    if (m_currentSearchTerm.startsWith("#")) {
+
+    // activate search by id only for numerical values because all CurseForge ids are numerical
+    static const QRegularExpression s_projectIdExpr("^\\#[0-9]+$");
+    if (s_projectIdExpr.match(m_currentSearchTerm).hasMatch()) {
         auto projectId = m_currentSearchTerm.mid(1);
         if (!projectId.isEmpty()) {
             ResourceAPI::Callback<ModPlatform::IndexedPack::Ptr> callbacks;

--- a/launcher/ui/pages/modplatform/flame/FlameModel.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameModel.cpp
@@ -166,14 +166,17 @@ void ListModel::performPaginatedSearch()
 {
     static const FlameAPI api;
 
-    // activate search by id only for numerical values because all CurseForge ids are numerical
+    // activate id search only for numerical values because all CurseForge ids are numerical
     static const QRegularExpression s_projectIdExpr("^\\#[0-9]+$");
-    if (s_projectIdExpr.match(m_currentSearchTerm).hasMatch()) {
+    if (m_searchState != ResetRequested && s_projectIdExpr.match(m_currentSearchTerm).hasMatch()) {
         auto projectId = m_currentSearchTerm.mid(1);
         if (!projectId.isEmpty()) {
             ResourceAPI::Callback<ModPlatform::IndexedPack::Ptr> callbacks;
 
-            callbacks.on_fail = [this](QString reason, int) { searchRequestFailed(reason); };
+            callbacks.on_fail = [this](QString reason, int) {
+                m_searchState = ResetRequested;
+                searchRequestFailed(reason);
+            };
             callbacks.on_succeed = [this](auto& pack) { searchRequestForOneSucceeded(pack); };
             callbacks.on_abort = [this] {
                 qCritical() << "Search task aborted by an unknown reason!";

--- a/launcher/ui/pages/modplatform/flame/FlameModel.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameModel.cpp
@@ -173,8 +173,10 @@ void ListModel::performPaginatedSearch()
         if (!projectId.isEmpty()) {
             ResourceAPI::Callback<ModPlatform::IndexedPack::Ptr> callbacks;
 
-            callbacks.on_fail = [this](QString reason, int) {
-                m_searchState = ResetRequested;
+            callbacks.on_fail = [this](QString reason, int network_error_code) {
+                if (network_error_code == 404) {
+                    m_searchState = ResetRequested;
+                }
                 searchRequestFailed(reason);
             };
             callbacks.on_succeed = [this](auto& pack) { searchRequestForOneSucceeded(pack); };

--- a/launcher/ui/pages/modplatform/flame/FlameModel.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameModel.cpp
@@ -178,7 +178,7 @@ void ListModel::performPaginatedSearch()
             };
             auto project = std::make_shared<ModPlatform::IndexedPack>();
             project->addonId = projectId;
-            if (auto job = api.getProjectInfo({ project }, std::move(callbacks)); job) {
+            if (auto job = api.getProjectInfo({ project }, std::move(callbacks), false); job) {
                 m_jobPtr = job;
                 m_jobPtr->start();
             }

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
@@ -148,7 +148,7 @@ void ModpackListModel::performPaginatedSearch()
             };
             auto project = std::make_shared<ModPlatform::IndexedPack>();
             project->addonId = projectId;
-            if (auto job = api.getProjectInfo({ project }, std::move(callbacks)); job) {
+            if (auto job = api.getProjectInfo({ project }, std::move(callbacks), false); job) {
                 m_jobPtr = job;
                 m_jobPtr->start();
             }

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
@@ -136,12 +136,15 @@ void ModpackListModel::performPaginatedSearch()
     static const ModrinthAPI api;
 
     // Modrinth ids are not limited to numbers and can be any length
-    if (m_currentSearchTerm.startsWith("#")) {
+    if (m_searchState != ResetRequested && m_currentSearchTerm.startsWith("#")) {
         auto projectId = m_currentSearchTerm.mid(1);
         if (!projectId.isEmpty()) {
             ResourceAPI::Callback<ModPlatform::IndexedPack::Ptr> callbacks;
 
-            callbacks.on_fail = [this](QString reason, int) { searchRequestFailed(reason); };
+            callbacks.on_fail = [this](QString reason, int) {
+                m_searchState = ResetRequested;
+                searchRequestFailed(reason);
+            };
             callbacks.on_succeed = [this](auto& pack) { searchRequestForOneSucceeded(pack); };
             callbacks.on_abort = [this] {
                 qCritical() << "Search task aborted by an unknown reason!";

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
@@ -135,6 +135,7 @@ void ModpackListModel::performPaginatedSearch()
         return;
     static const ModrinthAPI api;
 
+    // Modrinth ids are not limited to numbers and can be any length
     if (m_currentSearchTerm.startsWith("#")) {
         auto projectId = m_currentSearchTerm.mid(1);
         if (!projectId.isEmpty()) {

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
@@ -142,7 +142,9 @@ void ModpackListModel::performPaginatedSearch()
             ResourceAPI::Callback<ModPlatform::IndexedPack::Ptr> callbacks;
 
             callbacks.on_fail = [this](QString reason, int network_error_code) {
-                m_searchState = ResetRequested;
+                if (network_error_code == 404) {
+                    m_searchState = ResetRequested;
+                }
                 searchRequestFailed(reason, network_error_code);
             };
             callbacks.on_succeed = [this](auto& pack) { searchRequestForOneSucceeded(pack); };

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
@@ -141,14 +141,14 @@ void ModpackListModel::performPaginatedSearch()
         if (!projectId.isEmpty()) {
             ResourceAPI::Callback<ModPlatform::IndexedPack::Ptr> callbacks;
 
-            callbacks.on_fail = [this](QString reason, int) {
+            callbacks.on_fail = [this](QString reason, int network_error_code) {
                 m_searchState = ResetRequested;
-                searchRequestFailed(reason);
+                searchRequestFailed(reason, network_error_code);
             };
             callbacks.on_succeed = [this](auto& pack) { searchRequestForOneSucceeded(pack); };
             callbacks.on_abort = [this] {
                 qCritical() << "Search task aborted by an unknown reason!";
-                searchRequestFailed("Aborted");
+                searchRequestFailed("Aborted", 0);
             };
             auto project = std::make_shared<ModPlatform::IndexedPack>();
             project->addonId = projectId;
@@ -165,10 +165,10 @@ void ModpackListModel::performPaginatedSearch()
     ResourceAPI::Callback<QList<ModPlatform::IndexedPack::Ptr>> callbacks{};
 
     callbacks.on_succeed = [this](auto& doc) { searchRequestFinished(doc); };
-    callbacks.on_fail = [this](QString reason, int) { searchRequestFailed(reason); };
+    callbacks.on_fail = [this](QString reason, int network_error_code) { searchRequestFailed(reason, network_error_code); };
     callbacks.on_abort = [this] {
         qCritical() << "Search task aborted by an unknown reason!";
-        searchRequestFailed("Aborted");
+        searchRequestFailed("Aborted", 0);
     };
 
     auto netJob = api.searchProjects({ ModPlatform::ResourceType::Modpack, m_nextSearchOffset, m_currentSearchTerm, sort, m_filter->loaders,
@@ -320,13 +320,12 @@ void ModpackListModel::searchRequestForOneSucceeded(ModPlatform::IndexedPack::Pt
     endInsertRows();
 }
 
-void ModpackListModel::searchRequestFailed(QString)
+void ModpackListModel::searchRequestFailed(QString reason, int network_error_code)
 {
-    auto failed_action = dynamic_cast<NetJob*>(m_jobPtr.get())->getFailedActions().at(0);
-    if (failed_action->replyStatusCode() == -1) {
-        // Network error
+    if (network_error_code == -1) {
+        // Unknown error in network stack
         QMessageBox::critical(nullptr, tr("Error"), tr("A network error occurred. Could not load modpacks."));
-    } else if (failed_action->replyStatusCode() == 409) {
+    } else if (network_error_code == 409) {
         // 409 Gone, notify user to update
         QMessageBox::critical(nullptr, tr("Error"),
                               //: %1 refers to the launcher itself

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModel.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModel.h
@@ -85,7 +85,7 @@ class ModpackListModel : public QAbstractListModel {
 
    public slots:
     void searchRequestFinished(QList<ModPlatform::IndexedPack::Ptr>& doc_all);
-    void searchRequestFailed(QString reason);
+    void searchRequestFailed(QString reason, int network_error_code);
     void searchRequestForOneSucceeded(ModPlatform::IndexedPack::Ptr);
 
    protected slots:


### PR DESCRIPTION
When using search by id function (by prefixing the term with `#`) and the given term is not a valid id or not found, Network Error dialog is displayed asking for a manual retry.
This can be confusing because no search results is not an actual network error but the APIs indicate that as `404 Not Found` which gets displayed to the user as such. Example: #5284

This PR addresses the issue in two following ways:
1. Uses `netJob->setAskRetry(false)` for the `getProjectInfo` requests originating from a search, 
2. Limits feature activation exclusively to numerical values for CurseForge, searches prefixed by `#` but containing letters to function normally. There are at least two modpacks names of which shart with a `#`. All CF project ids are numerical, their json schema stores them as numbers and not strings.

This presents a drawback of quietly failing by displaying no results on actual network errors (only when search by id is activated).
`NetJob` has no mechanism of differentiating between 404 and other errors but a custom dialog can be added to the search logic itself if needed.

A related issue still persists even with all the changes:
`NetJob` automatically retries the request 3 times, but there is no reason to do so on `404 Not Found`. I did get a `429 Too Many Requests` from CurseForge once when testing searches in quick succession. Not retrying on `404` should make this 3 times less likely to happen.
I'd argue this applies to any requests, be it API queries or downloads. Can be fixed in a few lines but is out of the scope. I can make a separate PR if this is agreed on.