### PR TITLE
Allow disabling low RAM warning

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -735,12 +735,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         m_settings->registerSetting({ "MinMemAlloc", "MinMemoryAlloc" }, 512);
         m_settings->registerSetting({ "MaxMemAlloc", "MaxMemoryAlloc" }, SysInfo::defaultMaxJvmMem());
         m_settings->registerSetting("PermGen", 128);
-
-        // https://github.com/PrismLauncher/PrismLauncher/issues/5305
-        // arm64 Macs have configurations with very little physical memory, but the OS can compensate by compressing and swapping
-        // According to user reports, this is not noticeable under normal usage due to fast storage speeds
-        const bool lowMemWarningDefault = !(SysInfo::currentSystem() == "osx" && SysInfo::useQTForArch() == "arm64");
-        m_settings->registerSetting("LowMemWarning", lowMemWarningDefault);
+        m_settings->registerSetting("LowMemWarning", true);
 
         // Java Settings
         m_settings->registerSetting("JavaPath", "");

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -736,6 +736,12 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         m_settings->registerSetting({ "MaxMemAlloc", "MaxMemoryAlloc" }, SysInfo::defaultMaxJvmMem());
         m_settings->registerSetting("PermGen", 128);
 
+        // https://github.com/PrismLauncher/PrismLauncher/issues/5305
+        // arm64 Macs have configurations with very little physical memory, but the OS can compensate by compressing and swapping
+        // According to user reports, this is not noticeable under normal usage due to fast storage speeds
+        const bool lowMemWarningDefault = !(SysInfo::currentSystem() == "osx" && SysInfo::useQTForArch() == "arm64");
+        m_settings->registerSetting("LowMemWarning", lowMemWarningDefault);
+
         // Java Settings
         m_settings->registerSetting("JavaPath", "");
         m_settings->registerSetting("JavaSignature", "");

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -209,6 +209,7 @@ void MinecraftInstance::loadSpecificSettings()
         m_settings->registerOverride(global_settings->getSetting("MinMemAlloc"), memorySetting);
         m_settings->registerOverride(global_settings->getSetting("MaxMemAlloc"), memorySetting);
         m_settings->registerOverride(global_settings->getSetting("PermGen"), memorySetting);
+        m_settings->registerOverride(global_settings->getSetting("LowMemWarning"), memorySetting);
 
         // Native library workarounds
         auto nativeLibraryWorkaroundsOverride = m_settings->registerSetting("OverrideNativeWorkarounds", false);

--- a/launcher/minecraft/launch/EnsureAvailableMemory.cpp
+++ b/launcher/minecraft/launch/EnsureAvailableMemory.cpp
@@ -31,20 +31,25 @@ void EnsureAvailableMemory::executeTask()
     const uint64_t required = std::max(min, max);
 
     if (required > available) {
-        auto* dialog = CustomMessageBox::selectable(
-            nullptr, tr("Not enough RAM"),
-            tr("There is not enough RAM available to launch this instance with the current memory settings.\n\n"
-               "Required: %1 MiB\nAvailable: %2 MiB\n\n"
-               "Continue anyway? This may cause slowdowns in the game and your system.")
-                .arg(required)
-                .arg(available),
-            QMessageBox::Icon::Warning, QMessageBox::StandardButton::Yes | QMessageBox::StandardButton::No,
-            QMessageBox::StandardButton::No);
-        const auto response = dialog->exec();
-        dialog->deleteLater();
+        bool shouldAbort = false;
+
+        if (m_instance->settings()->get("LowMemWarning").toBool()) {
+            auto* dialog = CustomMessageBox::selectable(
+                nullptr, tr("Not enough RAM"),
+                tr("There is not enough RAM available to launch this instance with the current memory settings.\n\n"
+                   "Required: %1 MiB\nAvailable: %2 MiB\n\n"
+                   "Continue anyway? This may cause slowdowns in the game and your system.")
+                    .arg(required)
+                    .arg(available),
+                QMessageBox::Icon::Warning, QMessageBox::StandardButton::Yes | QMessageBox::StandardButton::No,
+                QMessageBox::StandardButton::No);
+
+            shouldAbort = dialog->exec() == QMessageBox::No;
+            dialog->deleteLater();
+        }
 
         const auto message = tr("Not enough RAM available to launch this instance");
-        if (response == QMessageBox::No) {
+        if (shouldAbort) {
             emit logLine(message, MessageLevel::Fatal);
             emitFailed(message);
             return;

--- a/launcher/minecraft/launch/EnsureAvailableMemory.cpp
+++ b/launcher/minecraft/launch/EnsureAvailableMemory.cpp
@@ -30,7 +30,7 @@ void EnsureAvailableMemory::executeTask()
     const uint64_t max = m_instance->settings()->get("MaxMemAlloc").toUInt();
     const uint64_t required = std::max(min, max);
 
-    if (required > available) {
+    if (static_cast<double>(required) * 0.9 > static_cast<double>(available)) {
         bool shouldAbort = false;
 
         if (m_instance->settings()->get("LowMemWarning").toBool()) {

--- a/launcher/ui/widgets/JavaSettingsWidget.cpp
+++ b/launcher/ui/widgets/JavaSettingsWidget.cpp
@@ -151,6 +151,7 @@ void JavaSettingsWidget::loadSettings()
         m_ui->maxMemSpinBox->setValue(min);
     }
     m_ui->permGenSpinBox->setValue(settings->get("PermGen").toInt());
+    m_ui->lowMemWarningCheckBox->setChecked(settings->get("LowMemWarning").toBool());
 
     // Java arguments
     m_ui->javaArgumentsGroupBox->setChecked(m_instance == nullptr || settings->get("OverrideJavaArgs").toBool());
@@ -205,10 +206,12 @@ void JavaSettingsWidget::saveSettings()
             settings->set("MaxMemAlloc", min);
         }
         settings->set("PermGen", m_ui->permGenSpinBox->value());
+        settings->set("LowMemWarning", m_ui->lowMemWarningCheckBox->isChecked());
     } else {
         settings->reset("MinMemAlloc");
         settings->reset("MaxMemAlloc");
         settings->reset("PermGen");
+        settings->reset("LowMemWarning");
     }
 
     // Java arguments

--- a/launcher/ui/widgets/JavaSettingsWidget.ui
+++ b/launcher/ui/widgets/JavaSettingsWidget.ui
@@ -55,7 +55,7 @@
         <item>
          <spacer name="horizontalSpacer">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -86,7 +86,7 @@
         <item>
          <spacer name="horizontalSpacer_7">
           <property name="orientation">
-           <enum>Qt::Horizontal</enum>
+           <enum>Qt::Orientation::Horizontal</enum>
           </property>
           <property name="sizeHint" stdset="0">
            <size>
@@ -101,10 +101,10 @@
       <item row="9" column="0">
        <spacer name="verticalSpacer_4">
         <property name="orientation">
-         <enum>Qt::Vertical</enum>
+         <enum>Qt::Orientation::Vertical</enum>
         </property>
         <property name="sizeType">
-         <enum>QSizePolicy::Fixed</enum>
+         <enum>QSizePolicy::Policy::Fixed</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -160,10 +160,10 @@
       <item row="3" column="0">
        <spacer name="verticalSpacer_5">
         <property name="orientation">
-         <enum>Qt::Vertical</enum>
+         <enum>Qt::Orientation::Vertical</enum>
         </property>
         <property name="sizeType">
-         <enum>QSizePolicy::Fixed</enum>
+         <enum>QSizePolicy::Policy::Fixed</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -190,156 +190,166 @@
      <property name="checked">
       <bool>false</bool>
      </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="2" column="2">
-       <widget class="QLabel" name="label_3">
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <layout class="QFormLayout" name="formLayout">
+        <item row="0" column="0">
+         <widget class="QLabel" name="labelMinMem">
+          <property name="text">
+           <string>M&amp;inimum Memory Usage:</string>
+          </property>
+          <property name="buddy">
+           <cstring>minMemSpinBox</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <layout class="QHBoxLayout" name="horizontalLayout_3">
+          <item>
+           <widget class="QSpinBox" name="minMemSpinBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>The amount of memory Minecraft is started with.</string>
+            </property>
+            <property name="suffix">
+             <string notr="true"> MiB</string>
+            </property>
+            <property name="minimum">
+             <number>8</number>
+            </property>
+            <property name="maximum">
+             <number>1048576</number>
+            </property>
+            <property name="singleStep">
+             <number>128</number>
+            </property>
+            <property name="value">
+             <number>256</number>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>(-Xms)</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="labelMaxMem">
+          <property name="text">
+           <string>Ma&amp;ximum Memory Usage:</string>
+          </property>
+          <property name="buddy">
+           <cstring>maxMemSpinBox</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <layout class="QHBoxLayout" name="horizontalLayout_5">
+          <item>
+           <widget class="QSpinBox" name="maxMemSpinBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>The maximum amount of memory Minecraft is allowed to use.</string>
+            </property>
+            <property name="suffix">
+             <string notr="true"> MiB</string>
+            </property>
+            <property name="minimum">
+             <number>8</number>
+            </property>
+            <property name="maximum">
+             <number>1048576</number>
+            </property>
+            <property name="singleStep">
+             <number>128</number>
+            </property>
+            <property name="value">
+             <number>1024</number>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>(-Xmx)</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_11">
+          <property name="text">
+           <string>&amp;PermGen Size:</string>
+          </property>
+          <property name="buddy">
+           <cstring>permGenSpinBox</cstring>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <layout class="QHBoxLayout" name="horizontalLayout_6">
+          <item>
+           <widget class="QSpinBox" name="permGenSpinBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>The amount of memory available to store loaded Java classes.</string>
+            </property>
+            <property name="suffix">
+             <string notr="true"> MiB</string>
+            </property>
+            <property name="minimum">
+             <number>4</number>
+            </property>
+            <property name="maximum">
+             <number>1048576</number>
+            </property>
+            <property name="singleStep">
+             <number>8</number>
+            </property>
+            <property name="value">
+             <number>64</number>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>(-XX:PermSize)</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="lowMemWarningCheckBox">
         <property name="text">
-         <string>(-XX:PermSize)</string>
+         <string>Warn when there is not enough memory available</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
-       <widget class="QSpinBox" name="permGenSpinBox">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>The amount of memory available to store loaded Java classes.</string>
-        </property>
-        <property name="suffix">
-         <string notr="true"> MiB</string>
-        </property>
-        <property name="minimum">
-         <number>4</number>
-        </property>
-        <property name="maximum">
-         <number>1048576</number>
-        </property>
-        <property name="singleStep">
-         <number>8</number>
-        </property>
-        <property name="value">
-         <number>64</number>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QSpinBox" name="maxMemSpinBox">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>The maximum amount of memory Minecraft is allowed to use.</string>
-        </property>
-        <property name="suffix">
-         <string notr="true"> MiB</string>
-        </property>
-        <property name="minimum">
-         <number>8</number>
-        </property>
-        <property name="maximum">
-         <number>1048576</number>
-        </property>
-        <property name="singleStep">
-         <number>128</number>
-        </property>
-        <property name="value">
-         <number>1024</number>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>(-Xmx)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QSpinBox" name="minMemSpinBox">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="toolTip">
-         <string>The amount of memory Minecraft is started with.</string>
-        </property>
-        <property name="suffix">
-         <string notr="true"> MiB</string>
-        </property>
-        <property name="minimum">
-         <number>8</number>
-        </property>
-        <property name="maximum">
-         <number>1048576</number>
-        </property>
-        <property name="singleStep">
-         <number>128</number>
-        </property>
-        <property name="value">
-         <number>256</number>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_11">
-        <property name="text">
-         <string>&amp;PermGen Size:</string>
-        </property>
-        <property name="buddy">
-         <cstring>permGenSpinBox</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>(-Xms)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="labelMaxMem">
-        <property name="text">
-         <string>Ma&amp;ximum Memory Usage:</string>
-        </property>
-        <property name="buddy">
-         <cstring>maxMemSpinBox</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="labelMinMem">
-        <property name="text">
-         <string>M&amp;inimum Memory Usage:</string>
-        </property>
-        <property name="buddy">
-         <cstring>minMemSpinBox</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="3">
-       <spacer name="horizontalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="3" column="0" colspan="4">
+      <item>
        <widget class="QLabel" name="labelMaxMemNotice">
         <property name="text">
          <string>Memory Notice</string>
@@ -382,9 +392,7 @@
   <tabstop>autodownloadJavaCheckBox</tabstop>
   <tabstop>javaTestBtn</tabstop>
   <tabstop>javaDownloadBtn</tabstop>
-  <tabstop>minMemSpinBox</tabstop>
   <tabstop>maxMemSpinBox</tabstop>
-  <tabstop>permGenSpinBox</tabstop>
   <tabstop>jvmArgsTextBox</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
Closes #5305 

To try and make the warning less annoying in some cases there is a 10% lenience around the required memory
If the required memory is 4096 then the launcher will warn only if there is less than ~3700 available