### PR TITLE
Don't count JAR mods when checking offline libraries

### DIFF
--- a/launcher/minecraft/LaunchProfile.cpp
+++ b/launcher/minecraft/LaunchProfile.cpp
@@ -349,7 +349,8 @@ void LaunchProfile::getLibraryFiles(const RuntimeContext& runtimeContext,
                                     QStringList& jars,
                                     QStringList& nativeJars,
                                     const QString& overridePath,
-                                    const QString& tempPath) const
+                                    const QString& tempPath,
+                                    bool addJarMods) const
 {
     QStringList native32, native64;
     jars.clear();
@@ -360,7 +361,7 @@ void LaunchProfile::getLibraryFiles(const RuntimeContext& runtimeContext,
     // NOTE: order is important here, add main jar last to the lists
     if (m_mainJar) {
         // FIXME: HACK!! jar modding is weird and unsystematic!
-        if (m_jarMods.size()) {
+        if (m_jarMods.size() && addJarMods) {
             QDir tempDir(tempPath);
             jars.append(tempDir.absoluteFilePath("minecraft.jar"));
         } else {

--- a/launcher/minecraft/LaunchProfile.h
+++ b/launcher/minecraft/LaunchProfile.h
@@ -87,7 +87,8 @@ class LaunchProfile : public ProblemProvider {
                          QStringList& jars,
                          QStringList& nativeJars,
                          const QString& overridePath,
-                         const QString& tempPath) const;
+                         const QString& tempPath,
+                         bool addJarMods = true) const;
     bool hasTrait(const QString& trait) const;
     ProblemSeverity getProblemSeverity() const override;
     const QList<PatchProblem> getProblems() const override;

--- a/launcher/minecraft/launch/EnsureOfflineLibraries.cpp
+++ b/launcher/minecraft/launch/EnsureOfflineLibraries.cpp
@@ -27,16 +27,27 @@ void EnsureOfflineLibraries::executeTask()
 {
     const auto profile = m_instance->getPackProfile()->getProfile();
     QStringList allJars;
-    profile->getLibraryFiles(m_instance->runtimeContext(), allJars, allJars, m_instance->getLocalLibraryPath(), m_instance->binRoot());
+    profile->getLibraryFiles(m_instance->runtimeContext(), allJars, allJars, m_instance->getLocalLibraryPath(), m_instance->binRoot(),
+                             false);
+
+    QStringList missing;
     for (const auto& jar : allJars) {
         if (!QFileInfo::exists(jar)) {
-            emit logLine(tr("This instance cannot be launched because some libraries are missing or have not been downloaded yet. Please "
-                            "try again in online mode with a working Internet connection"),
-                         MessageLevel::Fatal);
-            emitFailed("Required libraries are missing");
-            return;
+            missing.append(jar);
         }
     }
 
-    emitSucceeded();
+    if (missing.isEmpty()) {
+        emitSucceeded();
+        return;
+    }
+
+    emit logLine("Missing libraries:", MessageLevel::Error);
+    for (const auto& jar : missing) {
+        emit logLine("  " + jar, MessageLevel::Error);
+    }
+    emit logLine(tr("\nThis instance cannot be launched because some libraries are missing or have not been downloaded yet. Please "
+                    "try again in online mode with a working Internet connection"),
+                 MessageLevel::Fatal);
+    emitFailed("Required libraries are missing");
 }


### PR DESCRIPTION
Closes #5258 

When using JAR mods the automatically created `minecraft.jar` is added as a library. Offline libraries are checked before it is created by `ModMinecraftJar`. If the check is moved to after `ModMinecraftJar` the user can encounter a situation where if they don't have the original `minecraft.jar`, `ModMinecraftJar` silently fails

The issues are fixed by not counting JAR mods as libraries in `EnsureOfflineLibraries`

The logging has been also improved to include a list of missing libraries to aid debugging