### PR TITLE
CI/Nix: Bump macOS

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -88,7 +88,7 @@ jobs:
           - os: ubuntu-22.04-arm
             system: aarch64-linux
 
-          - os: macos-14
+          - os: macos-26
             system: aarch64-darwin
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Upstream issue: https://github.com/DeterminateSystems/magic-nix-cache-action/issues/182
Fixes (should fix, at least) https://github.com/PrismLauncher/PrismLauncher/actions/runs/24195976150/job/70625953958

As our build.yml uses macOS 26 I decided to bump to that instead of 15