### PR TITLE
fix(PrintInstanceInfo): add break before OS info

### DIFF
--- a/launcher/minecraft/launch/PrintInstanceInfo.cpp
+++ b/launcher/minecraft/launch/PrintInstanceInfo.cpp
@@ -61,6 +61,7 @@ void PrintInstanceInfo::executeTask()
     auto instance = m_parent->instance();
     QStringList log;
 
+    log << "";
     log << "OS: " + QString("%1 | %2 | %3").arg(QSysInfo::prettyProductName(), QSysInfo::kernelType(), QSysInfo::kernelVersion());
 #ifdef Q_OS_FREEBSD
     ::runSysctlHwModel(log);


### PR DESCRIPTION
the newline got lost somewhere probably in #5179 causing system&hardware info to be combined with Java path

the task where the Java path is printed has a lot of different outcomes so its easier to add the newline in PrintInstanceInfo