### PR TITLE
fix modpack upgrade

### DIFF
--- a/launcher/InstanceList.cpp
+++ b/launcher/InstanceList.cpp
@@ -924,23 +924,23 @@ class InstanceStaging : public Task {
         connect(child, &Task::progress, this, &InstanceStaging::setProgress);
         connect(child, &Task::stepProgress, this, &InstanceStaging::propagateStepProgress);
         connect(&m_backoffTimer, &QTimer::timeout, this, &InstanceStaging::childSucceeded);
-        m_backoffTimer.setSingleShot(true);
     }
 
-    virtual ~InstanceStaging() {}
+    ~InstanceStaging() override = default;
 
     // FIXME/TODO: add ability to abort during instance commit retries
     bool abort() override
     {
-        if (!canAbort())
+        if (!canAbort()) {
             return false;
+        }
 
         return m_child->abort();
     }
     bool canAbort() const override { return (m_child && m_child->canAbort()); }
 
    protected:
-    virtual void executeTask() override
+    void executeTask() override
     {
         if (m_stagingPath.isNull()) {
             emitFailed(tr("Could not create staging folder"));
@@ -954,10 +954,8 @@ class InstanceStaging : public Task {
    private slots:
     void childSucceeded()
     {
-        if (!isRunning())
-            return;
         unsigned sleepTime = backoff();
-        if (m_parent->commitStagedInstance(m_stagingPath, *m_child.get(), m_child->group(), *m_child.get())) {
+        if (m_parent->commitStagedInstance(m_stagingPath, *m_child, m_child->group(), *m_child)) {
             m_backoffTimer.stop();
             emitSucceeded();
             return;

--- a/launcher/ui/pages/instance/ManagedPackPage.cpp
+++ b/launcher/ui/pages/instance/ManagedPackPage.cpp
@@ -202,23 +202,24 @@ bool ManagedPackPage::runUpdateTask(InstanceTask* task)
 
     unique_qobject_ptr<Task> wrapped_task(APPLICATION->instances()->wrapInstanceTask(task));
 
-    connect(task, &Task::failed,
-            [this](QString reason) { CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show(); });
-    connect(task, &Task::succeeded, [this, task]() {
+    connect(wrapped_task.get(), &Task::failed,
+            [this](const QString& reason) { CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show(); });
+    connect(wrapped_task.get(), &Task::succeeded, [this, task]() {
         QStringList warnings = task->warnings();
-        if (warnings.count())
+        if (warnings.count()) {
             CustomMessageBox::selectable(this, tr("Warnings"), warnings.join('\n'), QMessageBox::Warning)->show();
+        }
     });
-    connect(task, &Task::aborted, [this] {
+    connect(wrapped_task.get(), &Task::aborted, [this] {
         CustomMessageBox::selectable(this, tr("Task aborted"), tr("The task has been aborted by the user."), QMessageBox::Information)
             ->show();
     });
 
     ProgressDialog loadDialog(this);
     loadDialog.setSkipButton(true, tr("Abort"));
-    loadDialog.execWithTask(task);
+    loadDialog.execWithTask(wrapped_task.get());
 
-    return task->wasSuccessful();
+    return wrapped_task->wasSuccessful();
 }
 
 void ManagedPackPage::suggestVersion()


### PR DESCRIPTION
so fun time:
- the code inside the managed pack does construct a `InstanceStaging` task but never uses its.
- it just reuse the task that is not wrapped
- meaning that he signals are connected in the `InstanceStaging` 
- the `InstanceStaging` doesn't start
- the child task finishes triggering the signals that were connected in `InstanceStaging`
- we get an assert failure on develop builds because the `InstanceStaging` never actually started(but emitSuccesfully was called)
- this still worked release builds because the asserts were never called
- and now the fun part to "fix" this assert in dev builds #4982 added a check if is running at the start of childSucceeded function
- it did hide now the assert because the code was never executed but that also meant that the update was never `commitStagedInstance`  so no update

partially reverts #4982 (because obvious reasons)
and in the managed pack page made use of wrapped_task instead of the bare import task

fixes #5330
