### PR TITLE
fix: force metadata version list refreshes to reload

### DIFF
--- a/launcher/BaseVersionList.h
+++ b/launcher/BaseVersionList.h
@@ -63,7 +63,7 @@ class BaseVersionList : public QAbstractListModel {
      * The task returned by this function should reset the model when it's done.
      * \return A pointer to a task that reloads the version list.
      */
-    virtual Task::Ptr getLoadTask() = 0;
+    virtual Task::Ptr getLoadTask(bool forceReload = false) = 0;
 
     //! Checks whether or not the list is loaded. If this returns false, the list should be
     // loaded.

--- a/launcher/java/JavaInstallList.cpp
+++ b/launcher/java/JavaInstallList.cpp
@@ -51,8 +51,9 @@ JavaInstallList::JavaInstallList(QObject* parent, bool onlyManagedVersions)
     : BaseVersionList(parent), m_only_managed_versions(onlyManagedVersions)
 {}
 
-Task::Ptr JavaInstallList::getLoadTask()
+Task::Ptr JavaInstallList::getLoadTask(bool forceReload)
 {
+    Q_UNUSED(forceReload)
     load();
     return getCurrentTask();
 }

--- a/launcher/java/JavaInstallList.h
+++ b/launcher/java/JavaInstallList.h
@@ -35,7 +35,7 @@ class JavaInstallList : public BaseVersionList {
    public:
     explicit JavaInstallList(QObject* parent = 0, bool onlyManagedVersions = false);
 
-    Task::Ptr getLoadTask() override;
+    Task::Ptr getLoadTask(bool forceReload = false) override;
     bool isLoaded() override;
     const BaseVersion::Ptr at(int i) const override;
     int count() const override;

--- a/launcher/meta/BaseEntity.cpp
+++ b/launcher/meta/BaseEntity.cpp
@@ -82,12 +82,12 @@ QUrl BaseEntity::url() const
     return QUrl(metaOverride).resolved(localFilename());
 }
 
-Task::Ptr BaseEntity::loadTask(Net::Mode mode)
+Task::Ptr BaseEntity::loadTask(Net::Mode mode, bool forceReload)
 {
     if (m_task && m_task->isRunning()) {
         return m_task;
     }
-    m_task.reset(new BaseEntityLoadTask(this, mode));
+    m_task.reset(new BaseEntityLoadTask(this, mode, forceReload));
     return m_task;
 }
 
@@ -107,7 +107,9 @@ BaseEntity::LoadStatus BaseEntity::status() const
     return m_load_status;
 }
 
-BaseEntityLoadTask::BaseEntityLoadTask(BaseEntity* parent, Net::Mode mode) : m_entity(parent), m_mode(mode) {}
+BaseEntityLoadTask::BaseEntityLoadTask(BaseEntity* parent, Net::Mode mode, bool forceReload)
+    : m_entity(parent), m_mode(mode), m_force_reload(forceReload)
+{}
 
 void BaseEntityLoadTask::executeTask()
 {
@@ -149,13 +151,18 @@ void BaseEntityLoadTask::executeTask()
     auto wasLoadedOffline = m_entity->m_load_status != BaseEntity::LoadStatus::NotLoaded && m_mode == Net::Mode::Offline;
     // if has is not present allways fetch from remote(e.g. the main index file), else only fetch if hash doesn't match
     auto wasLoadedRemote = m_entity->m_sha256.isEmpty() ? m_entity->m_load_status == BaseEntity::LoadStatus::Remote : hashMatches;
-    if (wasLoadedOffline || wasLoadedRemote) {
+    if (wasLoadedOffline || (wasLoadedRemote && !m_force_reload)) {
         emitSucceeded();
         return;
     }
     m_task.reset(new NetJob(QObject::tr("Download of meta file %1").arg(m_entity->localFilename()), APPLICATION->network()));
     auto url = m_entity->url();
     auto entry = APPLICATION->metacache()->resolveEntry("meta", m_entity->localFilename());
+    if (m_force_reload) {
+        // clear validators so manual refreshes fetch a fresh body
+        entry->setETag({});
+        entry->setRemoteChangedTimestamp({});
+    }
     entry->setStale(true);
     auto dl = Net::ApiDownload::makeCached(url, entry);
     /*

--- a/launcher/meta/BaseEntity.h
+++ b/launcher/meta/BaseEntity.h
@@ -43,7 +43,7 @@ class BaseEntity {
     void setSha256(QString sha256);
 
     virtual void parse(const QJsonObject& obj) = 0;
-    [[nodiscard]] Task::Ptr loadTask(Net::Mode loadType = Net::Mode::Online);
+    [[nodiscard]] Task::Ptr loadTask(Net::Mode loadType = Net::Mode::Online, bool forceReload = false);
 
    protected:
     QString m_sha256;       // the expected sha256
@@ -58,7 +58,7 @@ class BaseEntityLoadTask : public Task {
     Q_OBJECT
 
    public:
-    explicit BaseEntityLoadTask(BaseEntity* parent, Net::Mode mode);
+    explicit BaseEntityLoadTask(BaseEntity* parent, Net::Mode mode, bool forceReload);
     ~BaseEntityLoadTask() override = default;
 
     virtual void executeTask() override;
@@ -68,6 +68,7 @@ class BaseEntityLoadTask : public Task {
    private:
     BaseEntity* m_entity;
     Net::Mode m_mode;
+    bool m_force_reload = false;
     NetJob::Ptr m_task;
 };
 }  // namespace Meta

--- a/launcher/meta/VersionList.cpp
+++ b/launcher/meta/VersionList.cpp
@@ -32,11 +32,11 @@ VersionList::VersionList(const QString& uid, QObject* parent) : BaseVersionList(
     setObjectName("Version list: " + uid);
 }
 
-Task::Ptr VersionList::getLoadTask()
+Task::Ptr VersionList::getLoadTask(bool forceReload)
 {
     auto loadTask = makeShared<SequentialTask>(tr("Load meta for %1", "This is for the task name that loads the meta index.").arg(m_uid));
-    loadTask->addTask(APPLICATION->metadataIndex()->loadTask(Net::Mode::Online));
-    loadTask->addTask(this->loadTask(Net::Mode::Online));
+    loadTask->addTask(APPLICATION->metadataIndex()->loadTask(Net::Mode::Online, forceReload));
+    loadTask->addTask(this->loadTask(Net::Mode::Online, forceReload));
     return loadTask;
 }
 

--- a/launcher/meta/VersionList.h
+++ b/launcher/meta/VersionList.h
@@ -37,7 +37,7 @@ class VersionList : public BaseVersionList, public BaseEntity {
     enum Roles { UidRole = Qt::UserRole + 100, TimeRole, RequiresRole, VersionPtrRole };
 
     bool isLoaded() override;
-    Task::Ptr getLoadTask() override;
+    Task::Ptr getLoadTask(bool forceReload = false) override;
     const BaseVersion::Ptr at(int i) const override;
     int count() const override;
     void sortVersions() override;

--- a/launcher/ui/dialogs/InstallLoaderDialog.cpp
+++ b/launcher/ui/dialogs/InstallLoaderDialog.cpp
@@ -101,7 +101,7 @@ InstallLoaderDialog::InstallLoaderDialog(PackProfile* profile, const QString& ui
     buttonLayout->setContentsMargins(0, 0, 6, 6);
     #endif
     auto refreshButton = new QPushButton(tr("&Refresh"), this);
-    connect(refreshButton, &QPushButton::clicked, this, [this] { pageCast(container->selectedPage())->loadList(); });
+    connect(refreshButton, &QPushButton::clicked, this, [this] { pageCast(container->selectedPage())->loadList(true); });
     buttonLayout->addWidget(refreshButton);
 
     buttons->setOrientation(Qt::Horizontal);

--- a/launcher/ui/dialogs/VersionSelectDialog.cpp
+++ b/launcher/ui/dialogs/VersionSelectDialog.cpp
@@ -144,7 +144,7 @@ BaseVersion::Ptr VersionSelectDialog::selectedVersion() const
 
 void VersionSelectDialog::on_refreshButton_clicked()
 {
-    m_versionWidget->loadList();
+    m_versionWidget->loadList(true);
 }
 
 void VersionSelectDialog::setExactFilter(BaseVersionList::ModelRoles role, QString filter)

--- a/launcher/ui/java/InstallJavaDialog.cpp
+++ b/launcher/ui/java/InstallJavaDialog.cpp
@@ -121,8 +121,8 @@ class InstallJavaPage : public QWidget, public BasePage {
     void selectSearch() { javaVersionSelect->selectSearch(); }
     void loadList()
     {
-        majorVersionSelect->loadList();
-        javaVersionSelect->loadList();
+        majorVersionSelect->loadList(true);
+        javaVersionSelect->loadList(true);
     }
 
    public slots:

--- a/launcher/ui/java/VersionList.cpp
+++ b/launcher/ui/java/VersionList.cpp
@@ -33,9 +33,9 @@ VersionList::VersionList(Meta::Version::Ptr version, QObject* parent) : BaseVers
         sortVersions();
 }
 
-Task::Ptr VersionList::getLoadTask()
+Task::Ptr VersionList::getLoadTask(bool forceReload)
 {
-    auto task = m_version->loadTask(Net::Mode::Online);
+    auto task = m_version->loadTask(Net::Mode::Online, forceReload);
     connect(task.get(), &Task::finished, this, &VersionList::sortVersions);
     return task;
 }

--- a/launcher/ui/java/VersionList.h
+++ b/launcher/ui/java/VersionList.h
@@ -30,7 +30,7 @@ class VersionList : public BaseVersionList {
    public:
     explicit VersionList(Meta::Version::Ptr m_version, QObject* parent = 0);
 
-    Task::Ptr getLoadTask() override;
+    Task::Ptr getLoadTask(bool forceReload = false) override;
     bool isLoaded() override;
     const BaseVersion::Ptr at(int i) const override;
     int count() const override;

--- a/launcher/ui/pages/modplatform/CustomPage.cpp
+++ b/launcher/ui/pages/modplatform/CustomPage.cpp
@@ -80,14 +80,14 @@ void CustomPage::openedImpl()
 
 void CustomPage::refresh()
 {
-    ui->versionList->loadList();
+    ui->versionList->loadList(true);
 }
 
 void CustomPage::loaderRefresh()
 {
     if (ui->noneFilter->isChecked())
         return;
-    ui->loaderVersionList->loadList();
+    ui->loaderVersionList->loadList(true);
 }
 
 void CustomPage::filterChanged()

--- a/launcher/ui/widgets/VersionSelectWidget.cpp
+++ b/launcher/ui/widgets/VersionSelectWidget.cpp
@@ -127,9 +127,9 @@ void VersionSelectWidget::closeEvent(QCloseEvent* event)
     QWidget::closeEvent(event);
 }
 
-void VersionSelectWidget::loadList()
+void VersionSelectWidget::loadList(bool forceReload)
 {
-    m_load_task = m_vlist->getLoadTask();
+    m_load_task = m_vlist->getLoadTask(forceReload);
     connect(m_load_task.get(), &Task::succeeded, this, &VersionSelectWidget::onTaskSucceeded);
     connect(m_load_task.get(), &Task::failed, this, &VersionSelectWidget::onTaskFailed);
     connect(m_load_task.get(), &Task::progress, this, &VersionSelectWidget::changeProgress);

--- a/launcher/ui/widgets/VersionSelectWidget.h
+++ b/launcher/ui/widgets/VersionSelectWidget.h
@@ -57,7 +57,7 @@ class VersionSelectWidget : public QWidget {
     void initialize(BaseVersionList* vlist, bool forceLoad = false);
 
     //! Starts a task that loads the list.
-    void loadList();
+    void loadList(bool forceReload = false);
 
     bool hasVersions() const;
     BaseVersion::Ptr selectedVersion() const;


### PR DESCRIPTION
manual refreshes on version selection screens could reuse cached metadata and skip downloading updated manifests, so new versions would not appear until Prism was restarted. pass an explicit forced reload through the shared version list loading path and use it from refresh actions so manual refresh always reloads metadata

closes #2984