### PR TITLE
fix pessimizing-move warning

### DIFF
--- a/launcher/screenshots/ImgurUpload.cpp
+++ b/launcher/screenshots/ImgurUpload.cpp
@@ -118,7 +118,7 @@ auto ImgurUpload::Sink::finalize(QNetworkReply&) -> Task::State
 Net::NetRequest::Ptr ImgurUpload::make(ScreenShot::Ptr m_shot)
 {
     auto up = makeShared<ImgurUpload>(m_shot->m_file);
-    up->m_url = std::move(BuildConfig.IMGUR_BASE_URL + "image");
+    up->m_url = BuildConfig.IMGUR_BASE_URL + "image";
     up->m_sink.reset(new Sink(m_shot));
     up->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(QList<Net::HeaderPair>{
         { "Authorization", QString("Client-ID %1").arg(BuildConfig.IMGUR_CLIENT_ID).toUtf8() }, { "Accept", "application/json" } }));


### PR DESCRIPTION
```
/x/launcher/screenshots/ImgurUpload.cpp:121:17: error: moving a temporary object prevents copy elision [-Werror,-Wpessimizing-move]
  121 |     up->m_url = std::move(BuildConfig.IMGUR_BASE_URL + "image");
      |                 ^
/x/launcher/screenshots/ImgurUpload.cpp:121:17: note: remove std::move call here
  121 |     up->m_url = std::move(BuildConfig.IMGUR_BASE_URL + "image");
      |                 ^~~~~~~~~~                                    ~
```