### PR TITLE
Updater: Do not reset current task in finished signal

### DIFF
--- a/launcher/updater/prismupdater/PrismUpdater.cpp
+++ b/launcher/updater/prismupdater/PrismUpdater.cpp
@@ -1160,8 +1160,6 @@ void PrismUpdaterApp::downloadReleasePage(const QString& api_url, int page)
     m_current_task.reset(download);
     connect(download.get(), &Net::Download::finished, this, [this]() {
         qDebug() << "Download" << m_current_task->getUid().toString() << "finished";
-        m_current_task.reset();
-        m_current_url = "";
     });
 
     QCoreApplication::processEvents();


### PR DESCRIPTION
Closes #5362
Closes #5367

The order of signals in case of a success is "succeeded"->"finished"

The "succeeded" signal may launch another download if the updater needs to fetch more pages

But if we reset the task then the newly started download will be disposed and the updater will softlock