### PR TITLE
Task: Warn when disposing while running

### DIFF
--- a/launcher/tasks/Task.cpp
+++ b/launcher/tasks/Task.cpp
@@ -48,6 +48,13 @@ Task::Task(bool show_debug) : m_show_debug(show_debug)
     setAutoDelete(false);
 }
 
+Task::~Task()
+{
+    if (isRunning()) {
+        qCWarning(taskLogC) << "Task" << describe() << "disposed while running!";
+    }
+}
+
 void Task::setStatus(const QString& new_status)
 {
     if (m_status != new_status) {

--- a/launcher/tasks/Task.h
+++ b/launcher/tasks/Task.h
@@ -94,7 +94,7 @@ class Task : public QObject, public QRunnable {
 
    public:
     explicit Task(bool show_debug_log = true);
-    virtual ~Task() = default;
+    ~Task() override;
 
     bool isRunning() const;
     bool isFinished() const;


### PR DESCRIPTION
Related to the updater problem (see #5370)

I don't want to add an assert because it may be too annoying for developers rn (we still haven't fixed all double-finishes) and because it may be used in hacks that are too difficult to replace properly