### PR TITLE
Windows installer: Disable skipping files

### DIFF
--- a/program_info/win_install.nsi.in
+++ b/program_info/win_install.nsi.in
@@ -4,6 +4,7 @@
 
 !include "x64.nsh"
 
+AllowSkipFiles off
 Unicode true
 
 Name "@Launcher_DisplayName@"


### PR DESCRIPTION
Related to the updater problem... once again

If a user neglects to reboot their PC or manually kill `prismlauncher_updater.exe` in Task Manager, the installer will not be able to replace it. Some users will skip the file anyway, in which case the launcher will be up-to-date but the updater will still be broken

There's no reason to skip files during installation so it's best to disable it

Sources:
https://nsis.sourceforge.io/Docs/Chapter4.html#flags