### PR TITLE
Fix infinite loop in SkinManageDialog

### DIFF
--- a/launcher/minecraft/skins/SkinList.cpp
+++ b/launcher/minecraft/skins/SkinList.cpp
@@ -121,7 +121,7 @@ bool SkinList::update()
     auto folderContents = m_dir.entryInfoList();
     // if there are any untracked files...
     for (QFileInfo entry : folderContents) {
-        if (!entry.isFile() && entry.suffix() != "png")
+        if (!entry.isFile() || entry.suffix() != "png")
             continue;
 
         SkinModel w(entry.absoluteFilePath());


### PR DESCRIPTION
Closes #5384 

Infinite loop: I could only reproduce this on Windows. Due to an incorrect `if` check, non-png files can get added to `newSkins` and written to index.json. The writing to index.json will trigger another update. However the non-png file will not get *loaded* from index.json as it is not a valid skin. It'll be added to `newSkins` and written to index.json. The cycle repeats indefinitely