### PR TITLE
fix text overlap in project item views

### DIFF
--- a/launcher/ui/widgets/ProjectItem.cpp
+++ b/launcher/ui/widgets/ProjectItem.cpp
@@ -142,7 +142,7 @@ void ProjectItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem& o
             description_y -= opt.fontMetrics.height();
 
         // On the bottom, aligned to the left after the icon, and featuring at most two lines of text (with some margin space to spare)
-        painter->drawText(description_x, description_y, remaining_width, cut_text.size() * opt.fontMetrics.height(), Qt::TextWordWrap,
+        painter->drawText(description_x, description_y, remaining_width, num_lines * opt.fontMetrics.height(), Qt::TextWordWrap,
                           description);
     }
 


### PR DESCRIPTION
This PR fixes text overlap in QListViews that use ProjectItemDelegate when custom themes are applied.
Example with Fluent-Dark:
Before:
<img width="570" height="770" alt="image" src="https://github.com/user-attachments/assets/5087deaa-7c66-4d60-b9db-5abbe5b2bd2d" />
After:
<img width="558" height="766" alt="image" src="https://github.com/user-attachments/assets/fdce6875-9cac-4b48-b909-fbbee82c1483" />

