### PR TITLE
feat: add Manage Skins menu item to accounts button in MainWindow

### DIFF
--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -656,7 +656,7 @@ void MainWindow::repopulateAccountsMenu()
     auto accounts = APPLICATION->accounts();
     MinecraftAccountPtr defaultAccount = accounts->defaultAccount();
     
-    bool canChangeSkin = defaultAccount && (defaultAccount->accountType() != AccountType::Offline) && !defaultAccount->isActive();
+    bool canChangeSkin = defaultAccount && (defaultAccount->accountType() == AccountType::MSA) && !defaultAccount->isActive();
     ui->actionManageSkins->setEnabled(canChangeSkin);
 
     QString active_profileId = "";

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -105,6 +105,7 @@
 #include "ui/dialogs/NewInstanceDialog.h"
 #include "ui/dialogs/NewsDialog.h"
 #include "ui/dialogs/ProgressDialog.h"
+#include "ui/dialogs/skins/SkinManageDialog.h"
 #include "ui/instanceview/InstanceDelegate.h"
 #include "ui/instanceview/InstanceProxyModel.h"
 #include "ui/instanceview/InstanceView.h"
@@ -180,7 +181,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWi
         ui->instanceToolBar->insertSeparator(ui->actionLaunchInstance);
 
         // restore the instance toolbar settings
-        auto const setting_name = QString("WideBarVisibility_%1").arg(ui->instanceToolBar->objectName());
+        const auto setting_name = QString("WideBarVisibility_%1").arg(ui->instanceToolBar->objectName());
         instanceToolbarSetting = APPLICATION->settings()->getOrRegisterSetting(setting_name);
 
         ui->instanceToolBar->setVisibilityState(QByteArray::fromBase64(instanceToolbarSetting->get().toString().toUtf8()));
@@ -396,6 +397,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWi
     // Shouldn't have to use lambdas here like this, but if I don't, the compiler throws a fit.
     // Template hell sucks...
     connect(APPLICATION->accounts(), &AccountList::defaultAccountChanged, [this] { defaultAccountChanged(); });
+    connect(APPLICATION->accounts(), &AccountList::listActivityChanged, [this] { defaultAccountChanged(); });
     connect(APPLICATION->accounts(), &AccountList::listChanged, [this] { defaultAccountChanged(); });
 
     // Show initial account
@@ -653,6 +655,9 @@ void MainWindow::repopulateAccountsMenu()
 
     auto accounts = APPLICATION->accounts();
     MinecraftAccountPtr defaultAccount = accounts->defaultAccount();
+    
+    bool canChangeSkin = defaultAccount && (defaultAccount->accountType() != AccountType::Offline) && !defaultAccount->isActive();
+    ui->actionManageSkins->setEnabled(canChangeSkin);
 
     QString active_profileId = "";
     if (defaultAccount) {
@@ -709,6 +714,7 @@ void MainWindow::repopulateAccountsMenu()
     connect(ui->actionNoDefaultAccount, &QAction::triggered, this, &MainWindow::changeActiveAccount);
 
     ui->accountsMenu->addSeparator();
+    ui->accountsMenu->addAction(ui->actionManageSkins);
     ui->accountsMenu->addAction(ui->actionManageAccounts);
 
     accountsButtonMenu->addActions(ui->accountsMenu->actions());
@@ -942,9 +948,7 @@ void MainWindow::processURLs(QList<QUrl> urls)
         QUrl local_url;
         if (!url.isLocalFile()) {  // download the remote resource and identify
 
-            const bool isExternalURLImport =
-                (url.host().toLower() == "import") ||
-                (url.path().startsWith("/import", Qt::CaseInsensitive));
+            const bool isExternalURLImport = (url.host().toLower() == "import") || (url.path().startsWith("/import", Qt::CaseInsensitive));
 
             QUrl dl_url;
             if (url.scheme() == "curseforge" || (url.scheme() == BuildConfig.LAUNCHER_APP_BINARY_NAME && url.host() == "install")) {
@@ -952,7 +956,7 @@ void MainWindow::processURLs(QList<QUrl> urls)
                 // format of url curseforge://install?addonId=IDHERE&fileId=IDHERE
                 // format of url binaryname://install?platform=curseforge&addonId=IDHERE&fileId=IDHERE
                 QUrlQuery query(url);
-                
+
                 // check if this is a binaryname:// url
                 if (url.scheme() == BuildConfig.LAUNCHER_APP_BINARY_NAME) {
                     // check this is an curseforge platform request
@@ -1015,8 +1019,7 @@ void MainWindow::processURLs(QList<QUrl> urls)
                     receivedData.insert(it->first, it->second);
                 emit APPLICATION->oauthReplyRecieved(receivedData);
                 continue;
-            } else if ((url.scheme() == "prismlauncher" || url.scheme() == BuildConfig.LAUNCHER_APP_BINARY_NAME)
-                        && isExternalURLImport) {
+            } else if ((url.scheme() == "prismlauncher" || url.scheme() == BuildConfig.LAUNCHER_APP_BINARY_NAME) && isExternalURLImport) {
                 // PrismLauncher URL protocol modpack import
                 // works for any prism fork
                 // preferred import format: prismlauncher://import?url=ENCODED
@@ -1035,7 +1038,6 @@ void MainWindow::processURLs(QList<QUrl> urls)
 
                 // alternative import format: prismlauncher://import/ENCODED
                 if (encodedTarget.isEmpty()) {
-
                     QString p = path;
 
                     if (p.startsWith("/import/", Qt::CaseInsensitive)) {
@@ -1050,12 +1052,9 @@ void MainWindow::processURLs(QList<QUrl> urls)
                 }
 
                 if (encodedTarget.isEmpty()) {
-                    CustomMessageBox::selectable(
-                        this,
-                        tr("Error"),
-                        tr("Invalid import link: missing 'url' parameter."),
-                        QMessageBox::Critical
-                    )->show();
+                    CustomMessageBox::selectable(this, tr("Error"), tr("Invalid import link: missing 'url' parameter."),
+                                                 QMessageBox::Critical)
+                        ->show();
                     continue;
                 }
 
@@ -1065,23 +1064,15 @@ void MainWindow::processURLs(QList<QUrl> urls)
 
                 // Validate: only allow http(s)
                 if (!target.isValid() || (target.scheme() != "https" && target.scheme() != "http")) {
-                    CustomMessageBox::selectable(
-                        this,
-                        tr("Error"),
-                        tr("Invalid import link: URL must be http(s)."),
-                        QMessageBox::Critical
-                    )->show();
+                    CustomMessageBox::selectable(this, tr("Error"), tr("Invalid import link: URL must be http(s)."), QMessageBox::Critical)
+                        ->show();
                     continue;
                 }
 
                 const auto res = QMessageBox::question(
-                    this,
-                    tr("Install modpack"),
-                    tr("Do you want to download and import a modpack from:\n%1\n\nURL:\n%2")
-                        .arg(target.host(), target.toString()),
-                    QMessageBox::Yes | QMessageBox::No,
-                    QMessageBox::Yes
-                );
+                    this, tr("Install modpack"),
+                    tr("Do you want to download and import a modpack from:\n%1\n\nURL:\n%2").arg(target.host(), target.toString()),
+                    QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
                 if (res != QMessageBox::Yes) {
                     continue;
                 }
@@ -1393,6 +1384,16 @@ void MainWindow::on_actionEditInstance_triggered()
                                      tr("This instance is not editable. It may be broken, invalid, or too old. Check logs for details."),
                                      QMessageBox::Critical)
             ->show();
+    }
+}
+
+void MainWindow::on_actionManageSkins_triggered()
+{
+    auto account = APPLICATION->accounts()->defaultAccount();
+
+    if (account && (account->accountType() != AccountType::Offline) && !account->isActive()) {
+        SkinManageDialog dialog(this, account);
+        dialog.exec();
     }
 }
 

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -1391,7 +1391,7 @@ void MainWindow::on_actionManageSkins_triggered()
 {
     auto account = APPLICATION->accounts()->defaultAccount();
 
-    if (account && (account->accountType() != AccountType::Offline) && !account->isActive()) {
+    if (account && (account->accountType() == AccountType::MSA) && !account->isActive()) {
         SkinManageDialog dialog(this, account);
         dialog.exec();
     }

--- a/launcher/ui/MainWindow.h
+++ b/launcher/ui/MainWindow.h
@@ -130,6 +130,8 @@ class MainWindow : public QMainWindow {
 
     void on_actionSettings_triggered();
 
+    void on_actionManageSkins_triggered();
+
     void on_actionManageAccounts_triggered();
 
     void on_actionReportBug_triggered();

--- a/launcher/ui/MainWindow.ui
+++ b/launcher/ui/MainWindow.ui
@@ -322,6 +322,14 @@
     <enum>QAction::PreferencesRole</enum>
    </property>
   </action>
+  <action name="actionManageSkins">
+   <property name="icon">
+    <iconset theme="settings"/>
+   </property>
+   <property name="text">
+    <string>Manage &amp;Skins...</string>
+   </property>
+  </action>
   <action name="actionManageAccounts">
    <property name="icon">
     <iconset theme="accounts"/>


### PR DESCRIPTION
addresses the need for a "Manage Skins" shortcut directly from the accounts menu

#3489 #4927 #5391

### changes:
- added "Manage Skins" action to the MainWindow accounts menu, where it uses the "edit" icon.
- implemented logic to disable the button for Offline accounts (since they don't support skin changes).
- note: the other changes below are after i ran `clang-format` as specified in the contribution guidelines.

### testing:
- verified on windows 11 (MinGW 14.2 / Qt 6.11).
- confirmed the button greys out correctly when switching to an Offline profile.

<img width="248" height="222" alt="image" src="https://github.com/user-attachments/assets/8f4e1eb9-3b8a-4ba8-a772-089b1fdf43b6" />
<img width="212" height="200" alt="image" src="https://github.com/user-attachments/assets/c4defbe0-baca-4e0c-b64e-36b099e9fadf" />
