### PR TITLE
Fixes for task abort logic

### DIFF
--- a/launcher/InstanceCreationTask.cpp
+++ b/launcher/InstanceCreationTask.cpp
@@ -18,7 +18,7 @@ bool InstanceCreationTask::abort()
         return m_gameFilesTask->abort();
     }
 
-    return true;
+    return InstanceTask::abort();
 }
 
 void InstanceCreationTask::executeTask()

--- a/launcher/net/NetJob.cpp
+++ b/launcher/net/NetJob.cpp
@@ -100,12 +100,17 @@ auto NetJob::canAbort() const -> bool
 
 auto NetJob::abort() -> bool
 {
-    bool fullyAborted = true;
-
     // fail all downloads on the queue
     for (auto task : m_queue)
         m_failed.insert(task.get(), task);
     m_queue.clear();
+
+    if (m_doing.isEmpty()) {
+        // no downloads to abort, NetJob is not running
+        return true;
+    }
+
+    bool fullyAborted = true;
 
     // abort active downloads
     auto toKill = m_doing.values();

--- a/launcher/tasks/Task.h
+++ b/launcher/tasks/Task.h
@@ -165,7 +165,7 @@ class Task : public QObject, public QRunnable {
     //! used by external code to ask the task to abort
     virtual bool abort()
     {
-        if (canAbort())
+        if (canAbort() && isRunning())
             emitAborted();
         return canAbort();
     }


### PR DESCRIPTION
Fixes #5397.

There are two underlying issues fixed here:

1. The freeze itself is caused by `abort()` method in `InstanceCreationTask` not calling its super. The task is never aborted and hangs indefinitely. https://github.com/PrismLauncher/PrismLauncher/blob/f40cbf816e1c594584587a981d29971692e615ab/launcher/InstanceCreationTask.cpp#L21
2. While searching for the cause I discovered another related bug: when tasks containing other subtasks are aborted, they do not check if the subtasks are still running and often they are not, causing a crash via assertion on `Debug` build and undesired/undefined behavior on `Release` builds. Example: https://github.com/PrismLauncher/PrismLauncher/blob/f40cbf816e1c594584587a981d29971692e615ab/launcher/modplatform/flame/FlameInstanceCreationTask.cpp#L85

I decided to fix this in by making the `Task` itself call `emitAborted()` only if it is still running. There should be no reason to invoke on-aborted callbacks if the task has already succeeded or failed.
Similar fix to `NetJob` because it overrides logic from `Task`. Similar to how it was already done in `ConcurrentTask`. 
The alternative of fixing this individually in all the `abort()` overrides does not seem practical to me, I have found too much occurrences (30 - 50?).

I need advice on what to do with `Task::State::Inactive`. Not sure how it is actually used and what is the correct behavior should be when `abort()` is called on a task in this state (can it happen anywhere in the existing code?).