### PR TITLE
NetJob: do not automatically retry on `404 Not Found` response

### DIFF
--- a/launcher/net/NetJob.cpp
+++ b/launcher/net/NetJob.cpp
@@ -69,11 +69,15 @@ void NetJob::executeNextSubTask()
     // We're finished, check for failures and retry if we can (up to 3 times)
     if (isRunning() && m_queue.isEmpty() && m_doing.isEmpty() && !m_failed.isEmpty() && m_try < 3) {
         m_try += 1;
-        while (!m_failed.isEmpty()) {
-            auto task = m_failed.take(*m_failed.keyBegin());
-            m_done.remove(task.get());
-            m_queue.enqueue(task);
-        }
+        m_failed.removeIf([this](QHash<Task*, Task::Ptr>::iterator task) {
+            // there is no point in retying on 404 Not Found
+            if (static_cast<Net::NetRequest*>(task->get())->replyStatusCode() == 404) {
+                return false;
+            }
+            m_done.remove(task->get());
+            m_queue.enqueue(*task);
+            return true;
+        });
     }
     ConcurrentTask::executeNextSubTask();
 }


### PR DESCRIPTION
Currently `NetJob` automatically retries all the requests 3 times no matter which error code the server responds with.
Retrying on `404 Not Found` does not make sense to me, it is not uses for temporary errors. And even if a host uses it as an anti-crawling measure - trying again instantly won't help.

Excluding `404` from automatic retry logic can avoid unnecessary requests and `429 Too Many Requests` responses which I have encountered due to this while working on #5303.

Some other error responses can probably benefit from same logic, but they are not common, and if needed they now can be easily added.