### PR TITLE
fix world size uninitialized memory and UI refresh signal

### DIFF
--- a/launcher/minecraft/WorldList.cpp
+++ b/launcher/minecraft/WorldList.cpp
@@ -157,7 +157,8 @@ bool WorldList::resetIcon(int row)
         return false;
     World& m = m_worlds[row];
     if (m.resetIcon()) {
-        emit dataChanged(index(row), index(row), { WorldList::IconFileRole });
+        QModelIndex modelIndex = index(row, NameColumn);
+        emit dataChanged(modelIndex, modelIndex, { WorldList::IconFileRole });
         return true;
     }
     return false;
@@ -426,7 +427,7 @@ void WorldList::loadWorldsAsync()
                         m_worlds[row].setSize(size);
 
                         // Notify views
-                        QModelIndex modelIndex = index(row);
+                        QModelIndex modelIndex = index(row, SizeColumn);
                         emit dataChanged(modelIndex, modelIndex, { SizeRole });
                     }
                 },


### PR DESCRIPTION
fixes #4737

to prevent arbitrary values in m_size we force it to be 0 in the World constructor, and fixed the view notifying issue.
`index(row, column = 0)` also takes a column value, so for `loadWorldsAsync` i had to specify it as `index(row, SizeColumn);`

to prevent ambiguity i also updated `index()` at `resetIcon`. that worked before without specifying column because the icon sat in the first column, so it worked fine. then whoever added the size column didn't know about this quirk so it didn't properly update. although i still don't know how or why for some instances this worked fine.