### PR TITLE
feat: auto-select newly added instance icons

### DIFF
--- a/launcher/icons/IconList.cpp
+++ b/launcher/icons/IconList.cpp
@@ -331,23 +331,34 @@ int IconList::rowCount(const QModelIndex& parent) const
     return parent.isValid() ? 0 : m_icons.size();
 }
 
-void IconList::installIcons(const QStringList& iconFiles)
+QStringList IconList::installIcons(const QStringList& iconFiles)
 {
-    for (const QString& file : iconFiles)
-        installIcon(file, {});
+    QStringList installedKeys;
+    for (const QString& file : iconFiles) {
+        QString key = installIcon(file, {});
+        if (!key.isEmpty()) {
+            installedKeys << key;
+        }
+    }
+    return installedKeys;
 }
 
-void IconList::installIcon(const QString& file, const QString& name)
+QString IconList::installIcon(const QString& file, const QString& name)
 {
     QFileInfo fileinfo(file);
     if (!fileinfo.isReadable() || !fileinfo.isFile())
-        return;
+        return QString();
 
     if (!IconUtils::isIconSuffix(fileinfo.suffix()))
-        return;
+        return QString();
 
-    QString target = FS::PathCombine(getDirectory(), name.isEmpty() ? fileinfo.fileName() : name);
-    QFile::copy(file, target);
+    QString iconKey = name.isEmpty() ? fileinfo.baseName() : name;
+    QString target = FS::PathCombine(getDirectory(), iconKey);
+
+    if (QFile::copy(file, target)) {
+        return iconKey;
+    }
+    return QString();
 }
 
 bool IconList::iconFileExists(const QString& key) const

--- a/launcher/icons/IconList.h
+++ b/launcher/icons/IconList.h
@@ -74,8 +74,8 @@ class IconList : public QAbstractListModel {
     bool iconFileExists(const QString& key) const;
     QString iconDirectory(const QString& key) const;
 
-    void installIcons(const QStringList& iconFiles);
-    void installIcon(const QString& file, const QString& name);
+    QString installIcon(const QString& file, const QString& name);
+    QStringList installIcons(const QStringList& iconFiles);
 
     const MMCIcon* icon(const QString& key) const;
 

--- a/launcher/ui/dialogs/IconPickerDialog.cpp
+++ b/launcher/ui/dialogs/IconPickerDialog.cpp
@@ -18,6 +18,7 @@
 #include <QLineEdit>
 #include <QPushButton>
 #include <QSortFilterProxyModel>
+#include <QTimer>
 
 #include "Application.h"
 
@@ -119,7 +120,27 @@ void IconPickerDialog::addNewIcon()
     //: The type of icon files
     auto filter = IconUtils::getIconFilter();
     QStringList fileNames = QFileDialog::getOpenFileNames(this, selectIcons, QString(), tr("Icons %1").arg(filter));
-    APPLICATION->icons()->installIcons(fileNames);
+    QStringList newKeys = APPLICATION->icons()->installIcons(fileNames);
+
+    // If we added at least one icon, select the first one automatically
+    if (!newKeys.isEmpty()) {
+        const QString& firstKey = newKeys.first();
+
+        // We have to delay this until the icon appears in the UI
+        // I tried making a connection to detect when it changes, but that introduced way too many problems
+        QTimer::singleShot(100, this, [this, firstKey]() {
+            auto iconList = APPLICATION->icons();
+            int row = iconList->getIconIndex(firstKey);
+            QModelIndex sourceIndex = iconList->index(row);
+            
+            if (sourceIndex.isValid()) {
+                QModelIndex proxyIndex = proxyModel->mapFromSource(sourceIndex);
+                
+                ui->iconView->setCurrentIndex(proxyIndex);
+                ui->iconView->scrollTo(proxyIndex);
+            }
+        });
+    }
 }
 
 void IconPickerDialog::removeSelectedIcon()


### PR DESCRIPTION
implement #5401 where when adding an icon it immediately selects it after (or the first icon if you added many)

i had to rewrite `IconList::installIcons` and `IconList::installIcon` to make this work, so now it returns `QStringList` of the icon names

to actually select them once loaded, i tried making a connection to detect it dynamically, but it greatly increased complexity and just didn't work, so i put a lenient 100ms timer after installing them

tested on windows 11 home mingw x64