### PR TITLE
Fix Cmd+Q on macOS closing active window instead of quitting

### DIFF
--- a/launcher/ui/MainWindow.ui
+++ b/launcher/ui/MainWindow.ui
@@ -520,7 +520,7 @@
     <string>Close the current window</string>
    </property>
    <property name="menuRole">
-    <enum>QAction::QuitRole</enum>
+    <enum>QAction::MenuRole::NoRole</enum>
    </property>
   </action>
   <action name="actionViewInstanceFolder">


### PR DESCRIPTION
Fixes #1382

## Problem

On macOS, pressing Cmd+Q closes only the current window instead of quitting the application. This is inconsistent with standard macOS behavior, where Cmd+Q quits the application.

## Cause

`actionCloseWindow` in `MainWindow.ui` has its `menuRole` set to `QAction::QuitRole`. On macOS, Qt's menu-merging system uses `menuRole` to extract well-known actions (Quit, About, Preferences) from their original menus and place them in the native application menu, automatically binding Cmd+Q to whichever action has `QuitRole`. Because the Close Window action was tagged with this role, Cmd+Q was invoking `Application::closeCurrentWindow()` instead of quit.

With `QuitRole` removed from this action, Qt automatically creates a default "Quit <app>" item in the application menu bound to Cmd+Q, which calls `QCoreApplication::quit()` — the expected behavior.

## Change

Single-line change in `launcher/ui/MainWindow.ui`:
`actionCloseWindow`'s `menuRole` is changed from `QAction::QuitRole` to `QAction::MenuRole::NoRole`, matching the style used elsewhere in the project (e.g. `ExternalResourcesPage.ui`).

## Impact

`QAction::menuRole` is consulted only by Qt's native macOS menu-bar integration during menu merging. On Windows, Linux, and BSD, the property is stored on the `QAction` but never read by `QMenuBar`. This change has no effect on non-macOS platforms.

## Testing

Tested on macOS 26.2 with the CI-built artifact from this branch:

- Cmd+Q with only the main window open → app quits ✓
- Cmd+Q with main window + instance edit window open, instance window focused → app quits ✓
- Cmd+Q with main window + instance edit window open, main window focused → app quits ✓
- Cmd+W still closes only the current window ✓
- File menu shows "Close Window" entry with Cmd+W shortcut ✓
- Application menu shows "Quit Prism Launcher" entry with Cmd+Q shortcut ✓

## AI Usage

AI was used to help identify the cause and research solutions. Coding and testing was done by me.