### PR TITLE
feat(ui): allow custom background image for instance list cat

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -644,6 +644,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         m_settings->registerSetting("IconTheme", QString());
         m_settings->registerSetting("ApplicationTheme", QString());
         m_settings->registerSetting("BackgroundCat", QString("kitteh"));
+        m_settings->registerSetting("BackgroundCatPath", QString());
 
         // Remembered state
         m_settings->registerSetting("LastUsedGroupForNewInstance", QString());

--- a/launcher/ui/themes/ThemeManager.cpp
+++ b/launcher/ui/themes/ThemeManager.cpp
@@ -23,6 +23,7 @@
 #include <QDirIterator>
 #include <QIcon>
 #include <QImageReader>
+#include <QFileInfo>
 #include <QStyle>
 #include <QStyleFactory>
 #include "Exception.h"
@@ -282,6 +283,15 @@ void ThemeManager::applyCurrentlySelectedTheme(bool initial)
 
 QString ThemeManager::getCatPack(QString catName)
 {
+    const auto customCatPath = APPLICATION->settings()->get("BackgroundCatPath").toString().trimmed();
+    if (!customCatPath.isEmpty()) {
+        QFileInfo customCatFile(customCatPath);
+        if (customCatFile.isFile() && customCatFile.isReadable()) {
+            return customCatFile.absoluteFilePath();
+        }
+        themeWarningLog() << "Configured custom cat background is invalid:" << customCatPath;
+    }
+
     auto catIter = m_catPacks.find(!catName.isEmpty() ? catName : APPLICATION->settings()->get("BackgroundCat").toString());
     if (catIter != m_catPacks.end()) {
         auto& catPack = catIter->second;

--- a/launcher/ui/widgets/AppearanceWidget.cpp
+++ b/launcher/ui/widgets/AppearanceWidget.cpp
@@ -38,7 +38,12 @@
 #include "ui_AppearanceWidget.h"
 
 #include <DesktopServices.h>
+#include <QDir>
+#include <QFileDialog>
+#include <QFileInfo>
 #include <QGraphicsOpacityEffect>
+#include <QImageReader>
+#include <QLineEdit>
 #include "BuildConfig.h"
 #include "ui/themes/ITheme.h"
 #include "ui/themes/ThemeManager.h"
@@ -86,6 +91,32 @@ AppearanceWidget::AppearanceWidget(bool themesOnly, QWidget* parent)
     connect(m_ui->catPackFolder, &QPushButton::clicked, this,
             [] { DesktopServices::openPath(APPLICATION->themeManager()->getCatPacksFolder().path()); });
     connect(m_ui->reloadThemesButton, &QPushButton::pressed, this, &AppearanceWidget::loadThemeSettings);
+
+    connect(m_ui->catImageBrowseButton, &QPushButton::clicked, this, [this] {
+        QStringList supportedPatterns;
+        for (const auto& format : QImageReader::supportedImageFormats()) {
+            supportedPatterns.append("*." + QString::fromLatin1(format));
+        }
+        supportedPatterns.removeDuplicates();
+        supportedPatterns.sort();
+
+        const auto currentPath = m_ui->catImagePathEdit->text().trimmed();
+        const auto initialDir = currentPath.isEmpty() ? APPLICATION->themeManager()->getCatPacksFolder().absolutePath()
+                                                      : QFileInfo(currentPath).absolutePath();
+        const auto file = QFileDialog::getOpenFileName(this, tr("Select background image"), initialDir,
+                                                       tr("Image files (%1);;All files (*)").arg(supportedPatterns.join(' ')));
+        if (file.isEmpty()) {
+            return;
+        }
+
+        m_ui->catImagePathEdit->setText(QDir::toNativeSeparators(QFileInfo(file).absoluteFilePath()));
+        updateCatPreview();
+    });
+    connect(m_ui->catImageClearButton, &QPushButton::clicked, this, [this] {
+        m_ui->catImagePathEdit->clear();
+        updateCatPreview();
+    });
+    connect(m_ui->catImagePathEdit, &QLineEdit::textChanged, this, [this] { updateCatPreview(); });
 }
 
 AppearanceWidget::~AppearanceWidget()
@@ -102,6 +133,8 @@ void AppearanceWidget::applySettings()
     settings->set("CatOpacity", m_ui->catOpacitySlider->value());
     auto catFit = m_ui->catFitComboBox->currentIndex();
     settings->set("CatFit", catFit == 0 ? "fit" : catFit == 1 ? "fill" : "strech");
+    settings->set("BackgroundCatPath", m_ui->catImagePathEdit->text().trimmed());
+    APPLICATION->currentCatChanged(m_ui->catPackComboBox->currentIndex());
 }
 
 void AppearanceWidget::loadSettings()
@@ -122,6 +155,7 @@ void AppearanceWidget::loadSettings()
 
     auto catFit = settings->get("CatFit").toString();
     m_ui->catFitComboBox->setCurrentIndex(catFit == "fit" ? 0 : catFit == "fill" ? 1 : 2);
+    m_ui->catImagePathEdit->setText(settings->get("BackgroundCatPath").toString());
 }
 
 void AppearanceWidget::retranslateUi()

--- a/launcher/ui/widgets/AppearanceWidget.ui
+++ b/launcher/ui/widgets/AppearanceWidget.ui
@@ -370,6 +370,60 @@
         </item>
        </widget>
       </item>
+      <item>
+       <spacer name="verticalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Orientation::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Policy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>0</width>
+          <height>6</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QLabel" name="catImagePathLabel">
+        <property name="text">
+         <string>Custom Cat Image</string>
+        </property>
+        <property name="buddy">
+         <cstring>catImagePathEdit</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout_6">
+        <item>
+         <widget class="QLineEdit" name="catImagePathEdit">
+          <property name="placeholderText">
+           <string>Use selected cat pack image</string>
+          </property>
+          <property name="clearButtonEnabled">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="catImageBrowseButton">
+          <property name="text">
+           <string>Browse...</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="catImageClearButton">
+          <property name="text">
+           <string>Reset</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
      </layout>
     </widget>
    </item>
@@ -624,6 +678,9 @@
   <tabstop>consoleFont</tabstop>
   <tabstop>fontSizeBox</tabstop>
   <tabstop>catFitComboBox</tabstop>
+  <tabstop>catImagePathEdit</tabstop>
+  <tabstop>catImageBrowseButton</tabstop>
+  <tabstop>catImageClearButton</tabstop>
   <tabstop>catOpacitySlider</tabstop>
   <tabstop>consolePreview</tabstop>
  </tabstops>


### PR DESCRIPTION
Hello!

I added support for using a custom image as the instance list background,
while keeping the current cat pack behavior as a fallback.

This was inspired by a friend who said:
"it would be really nice if we could change the Prism Launcher background."

What changed:
- added a new `BackgroundCatPath` setting
- added UI controls in Appearance to browse/reset a custom image
- wired save/load for the custom image path
- updated ThemeManager to use a valid custom image first, then fall back to
  the selected cat pack if needed

I manually reviewed, audited, and tested this change locally on Windows 10 Pro (19045.6036).
I also validated the full flow in Prism Launcher:
custom image selection, persistence after restart, and fallback behavior.

Thanks to the Prism team for building such an incredible launcher!

P.S.: I know it may seem redundant, since catpacks exist, but it's not obvious for everyone (wasn't for me too), even for the ones that use it frequently. So I thought it would be a good idea to also have an easy option, besides the catpacks.

Assisted-by: Codex:GPT-5.3
