### PR TITLE
fix: ignore non-existent or empty paths in processURLs

### DIFF
--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -937,6 +937,9 @@ void MainWindow::processURLs(QList<QUrl> urls)
 {
     // NOTE: This loop only processes one dropped file!
     for (auto& url : urls) {
+        if (url.isEmpty() || url.toString().trimmed().isEmpty())
+            continue;
+
         qDebug() << "Processing" << url;
 
         // The isLocalFile() check below doesn't work as intended without an explicit scheme.
@@ -1115,6 +1118,11 @@ void MainWindow::processURLs(QList<QUrl> urls)
 
         auto localFileName = QDir::toNativeSeparators(local_url.toLocalFile());
         QFileInfo localFileInfo(localFileName);
+
+        if (localFileName.isEmpty() || !localFileInfo.exists()) {
+            qDebug() << "Ignoring invalid path" << localFileName;
+            continue;
+        }
 
         auto type = ResourceUtils::identify(localFileInfo);
 


### PR DESCRIPTION
fixes #4995

the issue was that if you entered empty strings or spaces as the first argument, it lead to the type being unknown, which launched the add instance menu anyway

https://github.com/PrismLauncher/PrismLauncher/blob/5a9fdffd7d878e7107b91b7f6f9c21fd041ad2d8/launcher/ui/MainWindow.cpp#L1121-L1124

that's why here i add a simple check for empty file paths so this doesn't happen

i tested this with a regular URL in the path and it fetches it just fine (checked on windows 11)

i think the issue appeared in lutris because they likely launch games or apps with empty string as first argument, where here it lead to this issue