### PR TITLE
Add wrappGAppsHook3 to nativeBuildInputs

### DIFF
--- a/nix/unwrapped.nix
+++ b/nix/unwrapped.nix
@@ -67,6 +67,7 @@ stdenv.mkDerivation {
     extra-cmake-modules
     jdk17
     stripJavaArchivesHook
+    wrapGAppsHook3
   ];
 
   buildInputs = [


### PR DESCRIPTION
This resolves #4595.

I used an overlay to make the change to the unwrapped package and this resolved the crashing issue when trying to open a file selector dialog.
