### PR TITLE
Linux: Make gamemode optional at build time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,22 @@ endif()
 # Java downloader
 option(Launcher_ENABLE_JAVA_DOWNLOADER "Build the java downloader feature" ${Launcher_ENABLE_JAVA_DOWNLOADER_DEFAULT})
 
+# Gamemode support (Linux only)
+set(Launcher_ENABLE_GAMEMODE_DEFAULT OFF)
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(Launcher_ENABLE_GAMEMODE_DEFAULT ON)
+endif()
+
+option(Launcher_ENABLE_GAMEMODE "Enable gamemode support" ${Launcher_ENABLE_GAMEMODE_DEFAULT})
+
+if(Launcher_ENABLE_GAMEMODE AND NOT CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    message(FATAL_ERROR "Gamemode support is only available on Linux")
+endif()
+
+if(Launcher_ENABLE_GAMEMODE)
+    add_compile_definitions(GAMEMODE_ENABLED)
+endif()
+
 # Native libraries
 if(UNIX AND APPLE)
     set(Launcher_GLFW_LIBRARY_NAME "libglfw.dylib" CACHE STRING "Name of native glfw library")
@@ -303,7 +319,7 @@ endif()
 
 find_package(cmark REQUIRED)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if(Launcher_ENABLE_GAMEMODE)
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(gamemode REQUIRED IMPORTED_TARGET gamemode)
 endif()

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -131,7 +131,9 @@
 #ifdef Q_OS_LINUX
 #include <dlfcn.h>
 #include "LibraryUtils.h"
+#ifdef GAMEMODE_ENABLED
 #include "gamemode_client.h"
+#endif
 #endif
 
 #if defined(Q_OS_LINUX)
@@ -1839,8 +1841,11 @@ void Application::updateCapabilities()
         m_capabilities |= SupportsFlame;
 
 #ifdef Q_OS_LINUX
+
+#ifdef GAMEMODE_ENABLED
     if (gamemode_query_status() >= 0)
         m_capabilities |= SupportsGameMode;
+#endif
 
     if (!LibraryUtils::findMangoHud().isEmpty())
         m_capabilities |= SupportsMangoHud;

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -1356,7 +1356,7 @@ else()
     target_link_libraries(Launcher_logic LibArchive::LibArchive)
 endif()
 
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if (Launcher_ENABLE_GAMEMODE)
     target_link_libraries(Launcher_logic
         gamemode
     )

--- a/launcher/minecraft/launch/LauncherPartLaunch.cpp
+++ b/launcher/minecraft/launch/LauncherPartLaunch.cpp
@@ -44,7 +44,7 @@
 #include "launch/LaunchTask.h"
 #include "minecraft/MinecraftInstance.h"
 
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) && defined(GAMEMODE_ENABLED)
 #include "gamemode_client.h"
 #endif
 
@@ -149,7 +149,7 @@ void LauncherPartLaunch::executeTask()
         m_process.start(javaPath, args);
     }
 
-#ifdef Q_OS_LINUX
+#if defined(Q_OS_LINUX) && defined(GAMEMODE_ENABLED)
     if (instance->settings()->get("EnableFeralGamemode").toBool() && APPLICATION->capabilities() & Application::SupportsGameMode) {
         auto pid = m_process.processId();
         if (pid) {

--- a/nix/unwrapped.nix
+++ b/nix/unwrapped.nix
@@ -16,6 +16,8 @@
   zlib,
   msaClientID ? null,
   libarchive,
+
+  gamemodeSupport ? stdenv.hostPlatform.isLinux,
 }:
 
 let
@@ -78,11 +80,12 @@ stdenv.mkDerivation {
     tomlplusplus
     zlib
   ]
-  ++ lib.optional stdenv.hostPlatform.isLinux gamemode;
+  ++ lib.optional gamemodeSupport gamemode;
 
   cmakeFlags = [
     # downstream branding
     (lib.cmakeFeature "Launcher_BUILD_PLATFORM" "nixpkgs")
+    (lib.cmakeBool "Launcher_ENABLE_GAMEMODE" gamemodeSupport)
   ]
   ++ lib.optionals (msaClientID != null) [
     (lib.cmakeFeature "Launcher_MSA_CLIENT_ID" (toString msaClientID))

--- a/nix/wrapper.nix
+++ b/nix/wrapper.nix
@@ -50,8 +50,12 @@ assert lib.assertMsg (
   textToSpeechSupport -> stdenv.hostPlatform.isLinux
 ) "textToSpeechSupport only has an effect on Linux.";
 
+assert lib.assertMsg (
+  gamemodeSupport -> stdenv.hostPlatform.isLinux
+) "gamemodeSupport only has an effect on Linux.";
+
 let
-  prismlauncher' = prismlauncher-unwrapped.override { inherit msaClientID; };
+  prismlauncher' = prismlauncher-unwrapped.override { inherit msaClientID gamemodeSupport; };
 in
 
 symlinkJoin {


### PR DESCRIPTION
Allows users to disable the gamemode dependency at build time, removes the strict gamemode build dependency.

closes #5182 