### PR TITLE
Use "Discrete" key from switcheroo if present

### DIFF
--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -131,7 +131,8 @@
     for (const auto& gpu : gpus) {
         QString name = qvariant_cast<QString>(gpu[QStringLiteral("Name")]);
         bool defaultGpu = qvariant_cast<bool>(gpu[QStringLiteral("Default")]);
-        if (!defaultGpu) {
+        bool discrete = qvariant_cast<bool>(gpu.value(QStringLiteral("Discrete"), !defaultGpu));
+        if (discrete) {
             QStringList envList = qvariant_cast<QStringList>(gpu[QStringLiteral("Environment")]);
             for (int i = 0; i + 1 < envList.size(); i += 2) {
                 env.insert(envList[i], envList[i + 1]);


### PR DESCRIPTION
Closes #5453 

"Discrete" key was [added](https://gitlab.freedesktop.org/hadess/switcheroo-control/-/commit/b09ea5edbded403e9525e77d2f313fb989287a1b) around a year ago, since the 3.0 tag.

For backwards compatibility, if the "Discrete" key is not provided at all, the current behavior stays (use non-default GPU)