### PR TITLE
Fixes to translations

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -937,15 +937,6 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         qInfo() << "<> Network done.";
     }
 
-    // load translations
-    {
-        m_translations.reset(new TranslationsModel("translations"));
-        auto bcp47Name = m_settings->get("Language").toString();
-        m_translations->selectLanguage(bcp47Name);
-        qInfo() << "Your language is" << bcp47Name;
-        qInfo() << "<> Translations loaded.";
-    }
-
     // Instance icons
     {
         auto setting = APPLICATION->settings()->getSetting("IconsDir");
@@ -1024,8 +1015,16 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         qInfo() << "<> Cache initialized.";
     }
 
-    // now we have network, download translation updates
-    m_translations->downloadIndex();
+    // load translations
+    {
+        m_translations.reset(new TranslationsModel("translations"));
+        auto bcp47Name = m_settings->get("Language").toString();
+        m_translations->selectLanguage(bcp47Name);
+        qInfo() << "Your language is" << bcp47Name;
+        qInfo() << "<> Translations loaded.";
+
+        m_translations->downloadIndex();
+    }
 
     // FIXME: what to do with these?
     m_profilers.insert("jprofiler", std::shared_ptr<BaseProfilerFactory>(new JProfilerFactory()));

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -1018,12 +1018,9 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
     // load translations
     {
         m_translations.reset(new TranslationsModel("translations"));
-        auto bcp47Name = m_settings->get("Language").toString();
-        m_translations->selectLanguage(bcp47Name);
-        qInfo() << "Your language is" << bcp47Name;
-        qInfo() << "<> Translations loaded.";
-
         m_translations->downloadIndex();
+        qInfo() << "Your language is" << m_translations->selectedLanguage();
+        qInfo() << "<> Translations loaded.";
     }
 
     // FIXME: what to do with these?

--- a/launcher/translations/TranslationsModel.cpp
+++ b/launcher/translations/TranslationsModel.cpp
@@ -179,6 +179,7 @@ TranslationsModel::TranslationsModel(const QString& path, QObject* parent) : QAb
 {
     d = std::make_unique<Private>();
     d->m_dir.setPath(path);
+    d->m_selectedLanguage = APPLICATION->settings()->get("Language").toString();
     FS::ensureFolderPathExists(path);
     reloadLocalFiles();
 
@@ -202,22 +203,20 @@ void TranslationsModel::indexReceived()
 {
     qDebug() << "Got translations index!";
     d->m_indexJob.reset();
+    reloadLocalFiles();
 
     if (d->m_noLanguageSet) {
-        reloadLocalFiles();
-
         auto language = getSystemLocaleName();
         if (!findLanguageAsOptional(language).has_value()) {
             language = getSystemLanguage();
         }
         selectLanguage(language);
-        if (selectedLanguage() != g_defaultLangCode) {
-            updateLanguage(selectedLanguage());
-        }
         APPLICATION->settings()->set("Language", selectedLanguage());
         d->m_noLanguageSet = false;
-    } else if (d->m_selectedLanguage != g_defaultLangCode) {
-        downloadTranslation(d->m_selectedLanguage);
+    }
+
+    if (selectedLanguage() != g_defaultLangCode) {
+        updateLanguage(selectedLanguage());
     }
 }
 

--- a/launcher/translations/TranslationsModel.cpp
+++ b/launcher/translations/TranslationsModel.cpp
@@ -267,7 +267,12 @@ void TranslationsModel::reloadLocalFiles()
 {
     QMap<QString, Language> languages = { { g_defaultLangCode, Language(g_defaultLangCode) } };
 
-    readIndex(d->m_dir.absoluteFilePath("index_v2.json"), languages);
+    const auto indexPath = d->m_dir.absoluteFilePath("index_v2.json");
+    if (!QFileInfo::exists(indexPath)) {
+        downloadIndex();
+        return;
+    }
+    readIndex(indexPath, languages);
     auto entries = d->m_dir.entryInfoList({ "mmc_*.qm", "*.po" }, QDir::Files | QDir::NoDotAndDotDot);
     for (auto& entry : entries) {
         auto completeSuffix = entry.completeSuffix();


### PR DESCRIPTION
* If the translations folder was deleted (e.g. user clicked `Help` -> `Clear metadata cache`), the launcher would detect that but would not re-download the index, the user is left with no translations. The launcher will now download the index if it is missing during reloading
* The launcher tries to select the current language in `Application` immediately after creating `TranslationsModel`. If the translations index is missing when this happens, then the launcher would not select the language and reset to English. Now the selected language is remembered but not explicitly selected until index reload and translation download