### PR TITLE
Don't delete base directories when evicting metacache

### DIFF
--- a/launcher/FileSystem.cpp
+++ b/launcher/FileSystem.cpp
@@ -684,6 +684,32 @@ bool deletePath(QString path)
     return err.value() == 0;
 }
 
+bool deleteContents(const QString& path)
+{
+    const QFileInfo info(path);
+    if (!info.exists()) {
+        return true;
+    }
+    if (!info.isDir()) {
+        qWarning() << "Attempted to delete contents of non-directory path:" << path;
+        return false;
+    }
+
+    bool ret = true;
+
+    for (const auto& entry : fs::directory_iterator(StringUtils::toStdString(path))) {
+        std::error_code err;
+
+        fs::remove_all(entry.path(), err);
+        if (err.value() != 0) {
+            qWarning().nospace() << "Could not delete directory entry " << entry.path() << ": " << QString::fromStdString(err.message());
+            ret = false;
+        }
+    }
+
+    return ret;
+}
+
 bool trash(QString path, QString* pathInTrash)
 {
     // FIXME: Figure out trash in Flatpak. Qt seemingly doesn't use the Trash portal

--- a/launcher/FileSystem.h
+++ b/launcher/FileSystem.h
@@ -291,6 +291,13 @@ bool move(const QString& source, const QString& dest);
  */
 bool deletePath(QString path);
 
+/**
+ * Delete a folder's contents recursively but not the folder itself.
+ * @param path The path to the folder.
+ * @return Whether the deletion was completely successful.
+ */
+bool deleteContents(const QString& path);
+
 bool removeFiles(QStringList listFile);
 
 /**

--- a/launcher/net/HttpMetaCache.cpp
+++ b/launcher/net/HttpMetaCache.cpp
@@ -182,7 +182,7 @@ auto HttpMetaCache::evictAll() -> bool
         }
         map.entry_list.clear();
         // AND all return codes together so the result is true iff all runs of deletePath() are true
-        ret &= FS::deletePath(map.base_path);
+        ret &= FS::deleteContents(map.base_path);
     }
     return ret;
 }


### PR DESCRIPTION
Classes like `TranslationsModel` use `QFileSystemWatcher` to watch a directory (`translations`). By deleting the directory we prevent the watcher from functioning again:

https://doc.qt.io/qt-6/qfilesystemwatcher.html#details
> Note that QFileSystemWatcher stops monitoring files once they have been renamed or removed from disk, **and directories once they have been removed from disk.**

This has been fixed by deleting the contents of the directories rather than the directories themselves