### PR TITLE
Add support for modrinth://modpack links

### DIFF
--- a/cmake/MacOSXBundleInfo.plist.in
+++ b/cmake/MacOSXBundleInfo.plist.in
@@ -87,6 +87,14 @@
         </dict>
         <dict>
             <key>CFBundleURLName</key>
+            <string>Modrinth</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+            <string>modrinth</string>
+            </array>
+        </dict>
+        <dict>
+            <key>CFBundleURLName</key>
             <string>${Launcher_Name}</string>
             <key>CFBundleURLSchemes</key>
             <array>

--- a/launcher/modplatform/modrinth/ModrinthAPI.cpp
+++ b/launcher/modplatform/modrinth/ModrinthAPI.cpp
@@ -10,6 +10,20 @@
 #include "net/ApiUpload.h"
 #include "net/NetJob.h"
 
+QString ModrinthAPI::getModpackIdFromUrl(const QUrl& url)
+{
+    if (url.scheme().compare("modrinth", Qt::CaseInsensitive) != 0 || url.host().compare("modpack", Qt::CaseInsensitive) != 0) {
+        return {};
+    }
+
+    const auto segments = QUrl::fromPercentEncoding(url.path().toUtf8()).split('/', Qt::SkipEmptyParts);
+    if (segments.size() != 1) {
+        return {};
+    }
+
+    return segments.constFirst().trimmed();
+}
+
 std::pair<Task::Ptr, QByteArray*> ModrinthAPI::currentVersion(const QString& hash, const QString& hash_format) const
 {
     auto netJob = makeShared<NetJob>(QString("Modrinth::GetCurrentVersion"), APPLICATION->network());

--- a/launcher/modplatform/modrinth/ModrinthAPI.h
+++ b/launcher/modplatform/modrinth/ModrinthAPI.h
@@ -10,6 +10,7 @@
 #include "modplatform/modrinth/ModrinthPackIndex.h"
 
 #include <QDebug>
+#include <QUrl>
 #include <utility>
 
 class ModrinthAPI final : public ResourceAPI {
@@ -35,6 +36,8 @@ class ModrinthAPI final : public ResourceAPI {
                                                      std::optional<ModPlatform::ModLoaderTypes> loaders) const;
 
     std::pair<Task::Ptr, QByteArray*> getProjects(QStringList addonIds) const override;
+
+    static QString getModpackIdFromUrl(const QUrl& url);
 
     std::pair<Task::Ptr, QByteArray*> getModCategories() const override;
     static QList<ModPlatform::Category> loadCategories(const QByteArray& response, const QString& projectType);

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -125,6 +125,7 @@
 #include "modplatform/ModIndex.h"
 #include "modplatform/flame/FlameAPI.h"
 #include "modplatform/flame/FlameModIndex.h"
+#include "modplatform/modrinth/ModrinthAPI.h"
 
 #include "KonamiCode.h"
 
@@ -960,6 +961,21 @@ void MainWindow::processURLs(QList<QUrl> urls)
         QMap<QString, QString> extra_info;
         QUrl local_url;
         if (!url.isLocalFile()) {  // download the remote resource and identify
+            if (url.scheme().compare("modrinth", Qt::CaseInsensitive) == 0) {
+                const auto packId = ModrinthAPI::getModpackIdFromUrl(url);
+                if (!packId.isEmpty()) {
+                    extra_info.insert("pack_id", packId);
+                    addInstance(url.toString(), extra_info);
+                } else {
+                    CustomMessageBox::selectable(
+                        this, tr("Error"),
+                        tr("Unsupported Modrinth link.\n\nPrism Launcher currently only supports modpack links such as "
+                           "modrinth://modpack/fabulously-optimized."),
+                        QMessageBox::Critical)
+                        ->show();
+                }
+                continue;
+            }
 
             const bool isExternalURLImport = (url.host().toLower() == "import") || (url.path().startsWith("/import", Qt::CaseInsensitive));
 

--- a/launcher/ui/dialogs/NewInstanceDialog.cpp
+++ b/launcher/ui/dialogs/NewInstanceDialog.cpp
@@ -136,9 +136,19 @@ NewInstanceDialog::NewInstanceDialog(const QString& initialGroup,
 
     if (!url.isEmpty()) {
         QUrl actualUrl(url);
-        m_container->selectPage("import");
-        m_importPage->setUrl(url);
-        m_importPage->setExtraInfo(extraInfo);
+        const auto packId = extraInfo.value("pack_id");
+        if (actualUrl.scheme().compare("modrinth", Qt::CaseInsensitive) == 0 && !packId.isEmpty()) {
+            auto* page = dynamic_cast<ModrinthPage*>(m_container->getPage("modrinth"));
+            if (page) {
+                m_searchTerm = "#" + packId;
+                page->setSearchTerm(m_searchTerm);
+                m_container->selectPage(page->id());
+            }
+        } else {
+            m_container->selectPage("import");
+            m_importPage->setUrl(url);
+            m_importPage->setExtraInfo(extraInfo);
+        }
     }
 
     updateDialogState();

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
@@ -344,8 +344,27 @@ void ModrinthPage::triggerSearch()
     m_ui->packDescription->clear();
     m_ui->versionSelectionBox->clear();
     bool filterChanged = m_filterWidget->changed();
-    m_model->searchWithTerm(m_ui->searchEdit->text(), m_ui->sortByBox->currentIndex(), m_filterWidget->getFilter(), filterChanged);
+    const auto searchTerm = m_ui->searchEdit->text();
+    m_model->searchWithTerm(searchTerm, m_ui->sortByBox->currentIndex(), m_filterWidget->getFilter(), filterChanged);
     m_fetch_progress.watch(m_model->activeSearchJob().get());
+
+    if (searchTerm.startsWith('#') && !searchTerm.mid(1).trimmed().isEmpty()) {
+        const auto selectProject = [this, searchTerm] {
+            if (m_ui->searchEdit->text() != searchTerm || m_model->rowCount({}) != 1) {
+                return;
+            }
+
+            const auto index = m_model->index(0, 0);
+            m_ui->packView->setCurrentIndex(index);
+            m_ui->packView->scrollTo(index);
+        };
+
+        if (m_model->hasActiveSearchJob()) {
+            connect(m_model->activeSearchJob().get(), &Task::finished, this, selectProject);
+        } else {
+            selectProject();
+        }
+    }
 }
 
 void ModrinthPage::onVersionSelectionChanged(int index)

--- a/program_info/org.prismlauncher.PrismLauncher.desktop.in
+++ b/program_info/org.prismlauncher.PrismLauncher.desktop.in
@@ -10,4 +10,4 @@ Icon=@Launcher_AppID@
 Categories=Game;ActionGame;AdventureGame;Simulation;PackageManager;
 Keywords=game;minecraft;mc;
 StartupWMClass=@Launcher_CommonName@
-MimeType=application/zip;application/x-modrinth-modpack+zip;x-scheme-handler/curseforge;x-scheme-handler/prismlauncher;x-scheme-handler/@Launcher_APP_BINARY_NAME@;
+MimeType=application/zip;application/x-modrinth-modpack+zip;x-scheme-handler/curseforge;x-scheme-handler/modrinth;x-scheme-handler/prismlauncher;x-scheme-handler/@Launcher_APP_BINARY_NAME@;

--- a/program_info/win_install.nsi.in
+++ b/program_info/win_install.nsi.in
@@ -394,6 +394,10 @@ Section "@Launcher_DisplayName@"
   WriteRegStr HKCU Software\Classes\curseforge "URL Protocol" ""
   WriteRegStr HKCU Software\Classes\curseforge\shell\open\command "" '"$INSTDIR\@Launcher_APP_BINARY_NAME@.exe" "%1"'
 
+  ; Write the URL Handler into registry for modrinth
+  WriteRegStr HKCU Software\Classes\modrinth "URL Protocol" ""
+  WriteRegStr HKCU Software\Classes\modrinth\shell\open\command "" '"$INSTDIR\@Launcher_APP_BINARY_NAME@.exe" "%1"'
+
   ; Write the URL Handler into registry for prismlauncher
   WriteRegStr HKCU Software\Classes\@Launcher_APP_BINARY_NAME@ "URL Protocol" ""
   WriteRegStr HKCU Software\Classes\@Launcher_APP_BINARY_NAME@\shell\open\command "" '"$INSTDIR\@Launcher_APP_BINARY_NAME@.exe" "%1"'

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -54,6 +54,9 @@ ecm_add_test(Index_test.cpp LINK_LIBRARIES Launcher_logic Qt${QT_VERSION_MAJOR}:
 ecm_add_test(Version_test.cpp LINK_LIBRARIES Launcher_logic Qt${QT_VERSION_MAJOR}::Test
     TEST_NAME Version)
 
+ecm_add_test(ModrinthUrl_test.cpp LINK_LIBRARIES Launcher_logic Qt${QT_VERSION_MAJOR}::Test
+    TEST_NAME ModrinthUrl)
+
 ecm_add_test(MetaComponentParse_test.cpp LINK_LIBRARIES Launcher_logic Qt${QT_VERSION_MAJOR}::Test
     TEST_NAME MetaComponentParse)
 

--- a/tests/ModrinthUrl_test.cpp
+++ b/tests/ModrinthUrl_test.cpp
@@ -1,0 +1,50 @@
+#include <QTest>
+
+#include <modplatform/modrinth/ModrinthAPI.h>
+
+class ModrinthUrlTest : public QObject {
+    Q_OBJECT
+
+   private slots:
+    void parseModpackLink_data()
+    {
+        QTest::addColumn<QString>("link");
+        QTest::addColumn<QString>("slug");
+
+        QTest::newRow("official") << "modrinth://modpack/fabulously-optimized"
+                                  << "fabulously-optimized";
+        QTest::newRow("trailing slash") << "modrinth://modpack/fabulously-optimized/"
+                                        << "fabulously-optimized";
+        QTest::newRow("case insensitive host") << "modrinth://MODPACK/fo"
+                                               << "fo";
+    }
+
+    void parseModpackLink()
+    {
+        QFETCH(QString, link);
+        QFETCH(QString, slug);
+
+        QCOMPARE(ModrinthAPI::getModpackIdFromUrl(QUrl(link)), slug);
+    }
+
+    void rejectInvalidLinks_data()
+    {
+        QTest::addColumn<QString>("link");
+
+        QTest::newRow("wrong scheme") << "https://modrinth.com/modpack/fabulously-optimized";
+        QTest::newRow("missing slug") << "modrinth://modpack/";
+        QTest::newRow("unsupported resource") << "modrinth://mod/sodium";
+        QTest::newRow("extra path") << "modrinth://modpack/fabulously-optimized/version/latest";
+    }
+
+    void rejectInvalidLinks()
+    {
+        QFETCH(QString, link);
+
+        QVERIFY(ModrinthAPI::getModpackIdFromUrl(QUrl(link)).isEmpty());
+    }
+};
+
+QTEST_GUILESS_MAIN(ModrinthUrlTest)
+
+#include "ModrinthUrl_test.moc"


### PR DESCRIPTION
Refs #3159

  ## Summary

  - add parsing for `modrinth://modpack/<slug>` links
  - open `New Instance` directly on the Modrinth page for supported links
  - prefill the slug search and auto-select the matching modpack when possible
  - register the `modrinth` protocol in the Windows, Linux, and macOS app metadata
  - add parser tests for accepted and rejected `modrinth://` URLs

  ## Why

  Prism already supports generic encoded URL imports via #4990, and it already has precedent for URI-based modpack flows
  via #4872.

  This change specifically covers the `modrinth://modpack/<slug>` links used by Modrinth's download button, so users can
  go directly from the browser to the Modrinth import flow in Prism without an intermediate encoded launcher URL.

  ## Testing

  - `ctest --preset local_windows_msvc --build-config Debug -R ModrinthUrl`
  - manually verified a positive system-level flow with `modrinth://modpack/fabulously-optimized`