### PR TITLE
Enable automatically enabling automatic merging on backport PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -27,6 +27,7 @@ jobs:
         uses: korthout/backport-action@v4.4
         with:
           # Config README: https://github.com/korthout/backport-action#backport-action
+          auto_merge_enabled: true
           pull_description: |-
             Bot-based backport to `${target_branch}`, triggered by a label in #${pull_number}.
 


### PR DESCRIPTION
* saves a few seconds of maintainer time (absolutely invaluable nowadays)
* helps reduce clutter in PR list??
* 99% (not accurate) of automatic backports are merged without further questions, only very few are closed/delayed
