### PR TITLE
Do not open account select dialog if there are no accounts

### DIFF
--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -109,7 +109,7 @@ void LaunchController::decideAccount()
         }
     }
 
-    if (!m_accountToUse) {
+    if (!m_accountToUse && accounts->anyAccountIsValid()) {
         // If no default account is set, ask the user which one to use.
         ProfileSelectDialog selectDialog(tr("Which account would you like to use?"), ProfileSelectDialog::GlobalDefaultCheckbox,
                                          m_parentWidget);


### PR DESCRIPTION
how to replicate bug (on develop/11.0.2):
- remove all accounts
- try to launch an instance
- press Yes to open the account manager
- close the manager without adding any accounts
- you get an account select window but you have no accounts