### PR TITLE
revert: "change: enable automatically enabling automatic merging on backport PRs"

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -27,7 +27,6 @@ jobs:
         uses: korthout/backport-action@v4.4
         with:
           # Config README: https://github.com/korthout/backport-action#backport-action
-          auto_merge_enabled: true
           pull_description: |-
             Bot-based backport to `${target_branch}`, triggered by a label in #${pull_number}.
 


### PR DESCRIPTION
This is currently a downright terrible idea as our release branches don't have any required checks. This will effectively cause PRs created by the workflow to instantly be merged regardless of build status - or not work at all, based on this note in [GitHub's docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/automatically-merging-a-pull-request#enabling-auto-merge):

> The option to enable auto-merge is shown only on pull requests that cannot be merged immediately.
