### PR TITLE
change(bug_report.yml): use input type where short answer is preferred

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -23,14 +23,14 @@ body:
     - macOS
     - Linux
     - Other
-- type: textarea
+- type: input
   attributes:
     label: Version of Prism Launcher
     description: The version of Prism Launcher used in the bug report.
     placeholder: Prism Launcher 5.0
   validations:
     required: true
-- type: textarea
+- type: input
   attributes:
     label: Version of Qt
     description: The version of Qt used in the bug report. You can find it in Help -> About Prism Launcher -> About Qt.


### PR DESCRIPTION
self-explanatory. `input` looks cleaner and i think version input areas doesn't use more than 1 line.