### PR TITLE
fix(nix): switch to KF6 ECM

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777578337,
-        "narHash": "sha256-fN6ynMvcdwPDB09LpWJNO5ogu+HFydrBWXJywoI/NNg=",
-        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+        "lastModified": 1778443072,
+        "narHash": "sha256-rNDJzV2JTV5SUTwv1cgKZYMdyoUYU9/YfegSaUf3QfY=",
+        "rev": "da5ad661ba4e5ef59ba743f0d112cbc30e474f32",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre990025.15f4ee454b1d/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixos/unstable/nixos-26.05pre995699.da5ad661ba4e/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",

--- a/nix/unwrapped.nix
+++ b/nix/unwrapped.nix
@@ -3,12 +3,12 @@
   stdenv,
   cmake,
   cmark,
-  extra-cmake-modules,
   gamemode,
   jdk17,
   kdePackages,
   libnbtplusplus,
   ninja,
+  pkg-config,
   qrencode,
   self,
   stripJavaArchivesHook,
@@ -35,6 +35,13 @@ let
       ]
     else
       "unknown";
+
+  # Remove once https://github.com/NixOS/nixpkgs/pull/518987 lands
+  extra-cmake-modules = kdePackages.extra-cmake-modules.overrideAttrs (prevAttrs: {
+    meta = prevAttrs.meta // {
+      platforms = lib.platforms.all;
+    };
+  });
 in
 
 stdenv.mkDerivation {
@@ -65,6 +72,7 @@ stdenv.mkDerivation {
     cmake
     ninja
     extra-cmake-modules
+    pkg-config
     jdk17
     stripJavaArchivesHook
   ];


### PR DESCRIPTION
Latest nixpkgs doesn't build due to the removal of the top-level ECM package