### PR TITLE
fix renovate using old label

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
         "config:recommended"
     ],
     "labels": [
-        "area: CI",
+        "area: actions",
         "complexity: low",
         "priority: low",
         "type: robot",


### PR DESCRIPTION
after merge https://github.com/PrismLauncher/PrismLauncher/labels and delete `area: CI`