### PR TITLE
Log components in instance logs

### DIFF
--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -893,6 +893,14 @@ QStringList MinecraftInstance::verboseDescription(AuthSessionPtr session, Minecr
 
     QStringList out;
 
+    out << "Components:";
+    for (int i = 0; i < m_components->rowCount(); ++i) {
+        const auto& component = m_components->getComponent(i);
+        out << indent +
+                   QString("%1) %2 (%3) %4").arg(QString::number(i + 1), component->getName(), component->getID(), component->getVersion());
+    }
+    out << emptyLine;
+
     out << "Launcher: " + getLauncher();
     out << "Main class: " + getMainClass() << emptyLine;
 


### PR DESCRIPTION
<img width="660" height="209" alt="image" src="https://github.com/user-attachments/assets/515d57f5-ea08-441f-bfe0-605958f2a019" />

maintainers pick the milestone (11.0.3 or 12)