### PR TITLE
Fix broken help links (for the ones that have a help page at least)

### DIFF
--- a/launcher/ui/pages/global/APIPage.h
+++ b/launcher/ui/pages/global/APIPage.h
@@ -55,7 +55,7 @@ class APIPage : public QWidget, public BasePage {
     QString displayName() const override { return tr("Services"); }
     QIcon icon() const override { return QIcon::fromTheme("worlds"); }
     QString id() const override { return "apis"; }
-    QString helpPage() const override { return "APIs"; }
+    QString helpPage() const override { return "apis"; }
     virtual bool apply() override;
     void retranslate() override;
 

--- a/launcher/ui/pages/global/AccountListPage.h
+++ b/launcher/ui/pages/global/AccountListPage.h
@@ -65,6 +65,7 @@ class AccountListPage : public QMainWindow, public BasePage {
         return icon;
     }
     QString id() const override { return "accounts"; }
+    /// Wiki is missing a page for accounts.
     QString helpPage() const override { return "getting-started/adding-an-account"; }
     void retranslate() override;
 

--- a/launcher/ui/pages/global/AccountListPage.h
+++ b/launcher/ui/pages/global/AccountListPage.h
@@ -66,7 +66,7 @@ class AccountListPage : public QMainWindow, public BasePage {
     }
     QString id() const override { return "accounts"; }
     /// Wiki is missing a page for accounts.
-    QString helpPage() const override { return "getting-started/adding-an-account"; }
+    QString helpPage() const override { return "adding-an-account"; }
     void retranslate() override;
 
    public slots:

--- a/launcher/ui/pages/global/AppearancePage.h
+++ b/launcher/ui/pages/global/AppearancePage.h
@@ -54,7 +54,7 @@ class AppearancePage : public AppearanceWidget, public BasePage {
     QString displayName() const override { return tr("Appearance"); }
     QIcon icon() const override { return QIcon::fromTheme("appearance"); }
     QString id() const override { return "appearance-settings"; }
-    QString helpPage() const override { return "Launcher-settings"; }
+    QString helpPage() const override { return "launcher-settings"; }
 
     bool apply() override
     {

--- a/launcher/ui/pages/global/ExternalToolsPage.h
+++ b/launcher/ui/pages/global/ExternalToolsPage.h
@@ -60,7 +60,7 @@ class ExternalToolsPage : public QWidget, public BasePage {
         return icon;
     }
     QString id() const override { return "external-tools"; }
-    QString helpPage() const override { return "Tools"; }
+    QString helpPage() const override { return "tools"; }
     virtual bool apply() override;
     void retranslate() override;
 

--- a/launcher/ui/pages/global/JavaPage.h
+++ b/launcher/ui/pages/global/JavaPage.h
@@ -58,7 +58,7 @@ class JavaPage : public QWidget, public BasePage {
     QString displayName() const override { return tr("Java"); }
     QIcon icon() const override { return QIcon::fromTheme("java"); }
     QString id() const override { return "java-settings"; }
-    QString helpPage() const override { return "Java-settings"; }
+    QString helpPage() const override { return "java-settings"; }
     void retranslate() override;
 
     bool apply() override;

--- a/launcher/ui/pages/global/LanguagePage.h
+++ b/launcher/ui/pages/global/LanguagePage.h
@@ -52,7 +52,7 @@ class LanguagePage : public QWidget, public BasePage {
     QString displayName() const override { return tr("Language"); }
     QIcon icon() const override { return QIcon::fromTheme("language"); }
     QString id() const override { return "language-settings"; }
-    QString helpPage() const override { return "Language-settings"; }
+    QString helpPage() const override { return "language-settings"; }
     bool apply() override;
 
     void retranslate() override;

--- a/launcher/ui/pages/global/LauncherPage.h
+++ b/launcher/ui/pages/global/LauncherPage.h
@@ -59,7 +59,7 @@ class LauncherPage : public QWidget, public BasePage {
     QString displayName() const override { return tr("General"); }
     QIcon icon() const override { return QIcon::fromTheme("settings"); }
     QString id() const override { return "launcher-settings"; }
-    QString helpPage() const override { return "Launcher-settings"; }
+    QString helpPage() const override { return "launcher-settings"; }
     bool apply() override;
     void retranslate() override;
 

--- a/launcher/ui/pages/global/MinecraftPage.h
+++ b/launcher/ui/pages/global/MinecraftPage.h
@@ -54,7 +54,7 @@ class MinecraftPage : public MinecraftSettingsWidget, public BasePage {
     QString displayName() const override { return tr("Minecraft"); }
     QIcon icon() const override { return QIcon::fromTheme("minecraft"); }
     QString id() const override { return "minecraft-settings"; }
-    QString helpPage() const override { return "Minecraft-settings"; }
+    QString helpPage() const override { return "minecraft-settings"; }
     bool apply() override
     {
         saveSettings();

--- a/launcher/ui/pages/global/ProxyPage.h
+++ b/launcher/ui/pages/global/ProxyPage.h
@@ -56,7 +56,7 @@ class ProxyPage : public QWidget, public BasePage {
     QString displayName() const override { return tr("Proxy"); }
     QIcon icon() const override { return QIcon::fromTheme("proxy"); }
     QString id() const override { return "proxy-settings"; }
-    QString helpPage() const override { return "Proxy-settings"; }
+    QString helpPage() const override { return "proxy-settings"; }
     bool apply() override;
     void retranslate() override;
 

--- a/launcher/ui/pages/instance/DataPackPage.h
+++ b/launcher/ui/pages/instance/DataPackPage.h
@@ -31,6 +31,7 @@ class DataPackPage : public ExternalResourcesPage {
     QString displayName() const override { return QObject::tr("Data Packs"); }
     QIcon icon() const override { return QIcon::fromTheme("datapacks"); }
     QString id() const override { return "datapacks"; }
+    /// Wiki is missing a page for data packs.
     QString helpPage() const override { return "Data-packs"; }
     bool shouldDisplay() const override { return true; }
 

--- a/launcher/ui/pages/instance/GameOptionsPage.h
+++ b/launcher/ui/pages/instance/GameOptionsPage.h
@@ -60,6 +60,7 @@ class GameOptionsPage : public QWidget, public BasePage {
     virtual QString displayName() const override { return tr("Game Options"); }
     virtual QIcon icon() const override { return QIcon::fromTheme("settings"); }
     virtual QString id() const override { return "gameoptions"; }
+    /// Wiki is missing a page for game options.
     virtual QString helpPage() const override { return "Game-Options-management"; }
     void retranslate() override;
 

--- a/launcher/ui/pages/instance/InstanceSettingsPage.h
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.h
@@ -58,5 +58,6 @@ class InstanceSettingsPage : public MinecraftSettingsWidget, public BasePage {
         saveSettings();
         return true;
     }
-    QString helpPage() const override { return "Instance-settings"; }
+    /// Wiki is missing a page for instance settings, using instance-version instead.
+    QString helpPage() const override { return "instance-version"; }
 };

--- a/launcher/ui/pages/instance/LogPage.h
+++ b/launcher/ui/pages/instance/LogPage.h
@@ -69,6 +69,7 @@ class LogPage : public QWidget, public BasePage {
     virtual QIcon icon() const override { return QIcon::fromTheme("log"); }
     virtual QString id() const override { return "console"; }
     virtual bool apply() override;
+    /// Wiki is missing a page for Minecraft logs.
     virtual QString helpPage() const override { return "Minecraft-Logs"; }
     virtual bool shouldDisplay() const override;
     void retranslate() override;

--- a/launcher/ui/pages/instance/ManagedPackPage.h
+++ b/launcher/ui/pages/instance/ManagedPackPage.h
@@ -122,7 +122,8 @@ class ModrinthManagedPackPage final : public ManagedPackPage {
 
     void parseManagedPack() override;
     QString url() const override;
-    QString helpPage() const override { return "modrinth-managed-pack"; }
+    /// Wiki is missing a page for Modrinth managed packs, using modrinth-platform instead.
+    QString helpPage() const override { return "modrinth-platform"; }
 
    public slots:
     void suggestVersion() override;
@@ -146,7 +147,8 @@ class FlameManagedPackPage final : public ManagedPackPage {
 
     void parseManagedPack() override;
     QString url() const override;
-    QString helpPage() const override { return "curseforge-managed-pack"; }
+    /// Wiki is missing a page for CurseForge managed packs, using flame-platform instead.
+    QString helpPage() const override { return "flame-platform"; }
 
    public slots:
     void suggestVersion() override;

--- a/launcher/ui/pages/instance/ModFolderPage.h
+++ b/launcher/ui/pages/instance/ModFolderPage.h
@@ -56,7 +56,7 @@ class ModFolderPage : public ExternalResourcesPage {
     virtual QString displayName() const override { return tr("Mods"); }
     virtual QIcon icon() const override { return QIcon::fromTheme("loadermods"); }
     virtual QString id() const override { return "mods"; }
-    virtual QString helpPage() const override { return "Loader-mods"; }
+    virtual QString helpPage() const override { return "loader-mods"; }
 
     virtual bool shouldDisplay() const override;
 
@@ -87,7 +87,8 @@ class CoreModFolderPage : public ModFolderPage {
     virtual QString displayName() const override { return tr("Core Mods"); }
     virtual QIcon icon() const override { return QIcon::fromTheme("coremods"); }
     virtual QString id() const override { return "coremods"; }
-    virtual QString helpPage() const override { return "Core-mods"; }
+    /// Wiki is missing a page for Core Mods, using loader-mods instead.
+    virtual QString helpPage() const override { return "loader-mods"; }
 
     virtual bool shouldDisplay() const override;
 };
@@ -101,7 +102,8 @@ class NilModFolderPage : public ModFolderPage {
     virtual QString displayName() const override { return tr("Nilmods"); }
     virtual QIcon icon() const override { return QIcon::fromTheme("coremods"); }
     virtual QString id() const override { return "nilmods"; }
-    virtual QString helpPage() const override { return "Nilmods"; }
+    /// Wiki is missing a page for Nilmods, using loader-mods instead.
+    virtual QString helpPage() const override { return "loader-mods"; }
 
     virtual bool shouldDisplay() const override;
 };

--- a/launcher/ui/pages/instance/NotesPage.h
+++ b/launcher/ui/pages/instance/NotesPage.h
@@ -60,7 +60,7 @@ class NotesPage : public QWidget, public BasePage {
     }
     virtual QString id() const override { return "notes"; }
     virtual bool apply() override;
-    virtual QString helpPage() const override { return "Notes"; }
+    virtual QString helpPage() const override { return "notes"; }
     void retranslate() override;
 
    private:

--- a/launcher/ui/pages/instance/OtherLogsPage.h
+++ b/launcher/ui/pages/instance/OtherLogsPage.h
@@ -58,6 +58,7 @@ class OtherLogsPage : public QWidget, public BasePage {
     QString id() const override { return m_id; }
     QString displayName() const override { return m_displayName; }
     QIcon icon() const override { return QIcon::fromTheme("log"); }
+    /// Wiki is missing a page for other logs.
     QString helpPage() const override { return m_helpPage; }
     void retranslate() override;
 

--- a/launcher/ui/pages/instance/ResourcePackPage.h
+++ b/launcher/ui/pages/instance/ResourcePackPage.h
@@ -53,6 +53,7 @@ class ResourcePackPage : public ExternalResourcesPage {
     QString displayName() const override { return tr("Resource Packs"); }
     QIcon icon() const override { return QIcon::fromTheme("resourcepacks"); }
     QString id() const override { return "resourcepacks"; }
+    /// Wiki is missing a page for resource packs.
     QString helpPage() const override { return "Resource-packs"; }
 
     virtual bool shouldDisplay() const override

--- a/launcher/ui/pages/instance/ScreenshotsPage.h
+++ b/launcher/ui/pages/instance/ScreenshotsPage.h
@@ -69,7 +69,7 @@ class ScreenshotsPage : public QMainWindow, public BasePage {
     virtual QString displayName() const override { return tr("Screenshots"); }
     virtual QIcon icon() const override { return QIcon::fromTheme("screenshots"); }
     virtual QString id() const override { return "screenshots"; }
-    virtual QString helpPage() const override { return "Screenshots-management"; }
+    virtual QString helpPage() const override { return "screenshots-management"; }
     virtual bool apply() override { return !m_uploadActive; }
     void retranslate() override;
 

--- a/launcher/ui/pages/instance/ServersPage.h
+++ b/launcher/ui/pages/instance/ServersPage.h
@@ -65,6 +65,7 @@ class ServersPage : public QMainWindow, public BasePage {
     virtual QString displayName() const override { return tr("Servers"); }
     virtual QIcon icon() const override { return QIcon::fromTheme("server"); }
     virtual QString id() const override { return "servers"; }
+    /// Wiki is missing a page for servers.
     virtual QString helpPage() const override { return "Servers-management"; }
     void retranslate() override;
 

--- a/launcher/ui/pages/instance/ShaderPackPage.h
+++ b/launcher/ui/pages/instance/ShaderPackPage.h
@@ -50,6 +50,7 @@ class ShaderPackPage : public ExternalResourcesPage {
     QString displayName() const override { return tr("Shader Packs"); }
     QIcon icon() const override { return QIcon::fromTheme("shaderpacks"); }
     QString id() const override { return "shaderpacks"; }
+    /// Wiki is missing a page for shader packs.
     QString helpPage() const override { return "shader-packs"; }
 
     bool shouldDisplay() const override { return true; }

--- a/launcher/ui/pages/instance/TexturePackPage.h
+++ b/launcher/ui/pages/instance/TexturePackPage.h
@@ -53,6 +53,7 @@ class TexturePackPage : public ExternalResourcesPage {
     QString displayName() const override { return tr("Texture packs"); }
     QIcon icon() const override { return QIcon::fromTheme("resourcepacks"); }
     QString id() const override { return "texturepacks"; }
+    /// Wiki is missing a page for texture packs.
     QString helpPage() const override { return "Texture-packs"; }
 
     virtual bool shouldDisplay() const override { return m_instance->traits().contains("texturepacks"); }

--- a/launcher/ui/pages/instance/VersionPage.h
+++ b/launcher/ui/pages/instance/VersionPage.h
@@ -60,7 +60,7 @@ class VersionPage : public QMainWindow, public BasePage {
     virtual QString displayName() const override { return tr("Version"); }
     virtual QIcon icon() const override;
     virtual QString id() const override { return "version"; }
-    virtual QString helpPage() const override { return "Instance-Version"; }
+    virtual QString helpPage() const override { return "instance-version"; }
     virtual bool shouldDisplay() const override;
     void retranslate() override;
 

--- a/launcher/ui/pages/instance/WorldListPage.h
+++ b/launcher/ui/pages/instance/WorldListPage.h
@@ -58,7 +58,7 @@ class WorldListPage : public QMainWindow, public BasePage {
     virtual QString displayName() const override { return tr("Worlds"); }
     virtual QIcon icon() const override { return QIcon::fromTheme("worlds"); }
     virtual QString id() const override { return "worlds"; }
-    virtual QString helpPage() const override { return "Worlds"; }
+    virtual QString helpPage() const override { return "worlds"; }
     virtual bool shouldDisplay() const override;
     void retranslate() override;
 

--- a/launcher/ui/pages/modplatform/CustomPage.h
+++ b/launcher/ui/pages/modplatform/CustomPage.h
@@ -56,7 +56,7 @@ class CustomPage : public QWidget, public BasePage {
     virtual QString displayName() const override { return tr("Custom"); }
     virtual QIcon icon() const override { return QIcon::fromTheme("minecraft"); }
     virtual QString id() const override { return "vanilla"; }
-    virtual QString helpPage() const override { return "Vanilla-platform"; }
+    virtual QString helpPage() const override { return "vanilla-platform"; }
     virtual bool shouldDisplay() const override;
     void retranslate() override;
 

--- a/launcher/ui/pages/modplatform/ImportPage.h
+++ b/launcher/ui/pages/modplatform/ImportPage.h
@@ -55,7 +55,7 @@ class ImportPage : public QWidget, public BasePage {
     virtual QString displayName() const override { return tr("Import"); }
     virtual QIcon icon() const override { return QIcon::fromTheme("viewfolder"); }
     virtual QString id() const override { return "import"; }
-    virtual QString helpPage() const override { return "Zip-import"; }
+    virtual QString helpPage() const override { return "zip-import"; }
     virtual bool shouldDisplay() const override;
     void retranslate() override;
 

--- a/launcher/ui/pages/modplatform/atlauncher/AtlPage.h
+++ b/launcher/ui/pages/modplatform/atlauncher/AtlPage.h
@@ -58,7 +58,7 @@ class AtlPage : public QWidget, public ModpackProviderBasePage {
     virtual QString displayName() const override { return "ATLauncher"; }
     virtual QIcon icon() const override { return QIcon::fromTheme("atlauncher"); }
     virtual QString id() const override { return "atl"; }
-    virtual QString helpPage() const override { return "ATL-platform"; }
+    virtual QString helpPage() const override { return "atl-platform"; }
     virtual bool shouldDisplay() const override;
     void retranslate() override;
 

--- a/launcher/ui/pages/modplatform/flame/FlamePage.h
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.h
@@ -62,7 +62,7 @@ class FlamePage : public QWidget, public ModpackProviderBasePage {
     virtual QString displayName() const override { return "CurseForge"; }
     virtual QIcon icon() const override { return QIcon::fromTheme("flame"); }
     virtual QString id() const override { return "flame"; }
-    virtual QString helpPage() const override { return "Flame-platform"; }
+    virtual QString helpPage() const override { return "flame-platform"; }
     virtual bool shouldDisplay() const override;
     void retranslate() override;
 

--- a/launcher/ui/pages/modplatform/ftb/FtbPage.h
+++ b/launcher/ui/pages/modplatform/ftb/FtbPage.h
@@ -60,7 +60,7 @@ class FtbPage : public QWidget, public ModpackProviderBasePage {
     virtual QString displayName() const override { return "FTB"; }
     virtual QIcon icon() const override { return QIcon::fromTheme("ftb_logo"); }
     virtual QString id() const override { return "ftb"; }
-    virtual QString helpPage() const override { return "FTB-platform"; }
+    virtual QString helpPage() const override { return "ftb-platform"; }
     virtual bool shouldDisplay() const override;
     void retranslate() override;
 

--- a/launcher/ui/pages/modplatform/import_ftb/ImportFTBPage.h
+++ b/launcher/ui/pages/modplatform/import_ftb/ImportFTBPage.h
@@ -43,7 +43,8 @@ class ImportFTBPage : public QWidget, public ModpackProviderBasePage {
     QString displayName() const override { return tr("FTB App Import"); }
     QIcon icon() const override { return QIcon::fromTheme("ftb_logo"); }
     QString id() const override { return "import_ftb"; }
-    QString helpPage() const override { return "FTB-import"; }
+    /// Wiki is missing a page for ftb import, using ftb-platform instead.
+    QString helpPage() const override { return "ftb-platform"; }
     bool shouldDisplay() const override { return true; }
     void openedImpl() override;
     void retranslate() override;
@@ -51,7 +52,7 @@ class ImportFTBPage : public QWidget, public ModpackProviderBasePage {
     /** Programatically set the term in the search bar. */
     virtual void setSearchTerm(QString) override;
     /** Get the current term in the search bar. */
-    virtual QString getSerachTerm() const override;
+    virtual QString getSearchTerm() const override;
 
    private:
     void suggestCurrent();

--- a/launcher/ui/pages/modplatform/legacy_ftb/Page.h
+++ b/launcher/ui/pages/modplatform/legacy_ftb/Page.h
@@ -65,7 +65,7 @@ class Page : public QWidget, public ModpackProviderBasePage {
     QString displayName() const override { return "FTB Legacy"; }
     QIcon icon() const override { return QIcon::fromTheme("ftb_logo"); }
     QString id() const override { return "legacy_ftb"; }
-    QString helpPage() const override { return "FTB-legacy"; }
+    QString helpPage() const override { return "ftb-platform"; }
     bool shouldDisplay() const override;
     void openedImpl() override;
     void retranslate() override;

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.h
@@ -65,7 +65,7 @@ class ModrinthPage : public QWidget, public ModpackProviderBasePage {
     QString displayName() const override { return tr("Modrinth"); }
     QIcon icon() const override { return QIcon::fromTheme("modrinth"); }
     QString id() const override { return "modrinth"; }
-    QString helpPage() const override { return "Modrinth-platform"; }
+    QString helpPage() const override { return "modrinth-platform"; }
 
     inline QString debugName() const { return "Modrinth"; }
     inline QString metaEntryBase() const { return "ModrinthModpacks"; };

--- a/launcher/ui/pages/modplatform/technic/TechnicPage.h
+++ b/launcher/ui/pages/modplatform/technic/TechnicPage.h
@@ -62,7 +62,7 @@ class TechnicPage : public QWidget, public ModpackProviderBasePage {
     virtual QString displayName() const override { return "Technic"; }
     virtual QIcon icon() const override { return QIcon::fromTheme("technic"); }
     virtual QString id() const override { return "technic"; }
-    virtual QString helpPage() const override { return "Technic-platform"; }
+    virtual QString helpPage() const override { return "technic-platform"; }
     virtual bool shouldDisplay() const override;
     void retranslate() override;
 


### PR DESCRIPTION
Wiki is missing pages for accounts, data packs, game options, instance settings, log page, managed pack page, mod folder, other logs, resource pack, servers, shader pack, texture pack, and importftb.

Help button is almost universally broken since urls were all swapped to lowercase with the new wiki.
<img width="694" height="712" alt="image" src="https://github.com/user-attachments/assets/2c7f14c4-d3aa-469d-8562-2a6b5fddb5f4" />
<img width="1286" height="1352" alt="image" src="https://github.com/user-attachments/assets/a2cd0883-7d4c-462b-aeec-f9cdee29c5c5" />


Signed-off-by: Hung Pham <hnpham02@gmail.com>