### PR TITLE
Move GPU detection out of the main process

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,6 +353,7 @@ add_subdirectory(program_info)
 
 set(Launcher_ENABLE_UPDATER NO)
 set(Launcher_BUILD_UPDATER NO)
+set(Launcher_BUILD_GPUDETECT YES)
 
 if (NOT APPLE AND (NOT Launcher_UPDATER_GITHUB_REPO STREQUAL "" AND NOT Launcher_BUILD_ARTIFACT STREQUAL ""))
     set(Launcher_BUILD_UPDATER YES)

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -666,11 +666,29 @@ set(PRISMUPDATER_SOURCES
 
 )
 
+set(GPUDETECT_SOURCES
+    gpudetect/Print.h
+    gpudetect/OpenGL.cpp
+    gpudetect/OpenGL.h
+    gpudetect/Vulkan.cpp
+    gpudetect/Vulkan.h
+    gpudetect/lspci.cpp
+    gpudetect/lspci.h
+)
+
 if(WIN32)
     set(PRISMUPDATER_SOURCES
         console/WindowsConsole.h
         console/WindowsConsole.cpp
         ${PRISMUPDATER_SOURCES}
+    )
+endif()
+
+if(WIN32)
+    set(GPUDETECT_SOURCES
+        console/WindowsConsole.h
+        console/WindowsConsole.cpp
+        ${GPUDETECT_SOURCES}
     )
 endif()
 
@@ -1475,6 +1493,51 @@ if (UNIX AND APPLE AND Launcher_ENABLE_UPDATER)
     install(DIRECTORY ${MACOSX_SPARKLE_DIR}/Sparkle.framework DESTINATION ${FRAMEWORK_DEST_DIR} USE_SOURCE_PERMISSIONS)
 endif()
 
+if(Launcher_BUILD_GPUDETECT)
+    # GPU detection executable
+    add_library(gpudetect_logic STATIC ${GPUDETECT_SOURCES})
+    target_include_directories(gpudetect_logic PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+    if(${Launcher_USE_PCH})
+        target_precompile_headers(gpudetect_logic PRIVATE ${PRECOMPILED_HEADERS})
+    endif()
+
+    target_link_libraries(gpudetect_logic
+        BuildConfig
+        Qt${QT_VERSION_MAJOR}::Widgets
+        Qt${QT_VERSION_MAJOR}::Core
+        Qt${QT_VERSION_MAJOR}::Network
+        ${Launcher_QT_LIBS}
+    )
+
+    add_executable("${Launcher_Name}_gpudetect" WIN32 gpudetect/gpudetect_main.cpp)
+    target_sources("${Launcher_Name}_gpudetect" PRIVATE gpudetect/gpudetect.exe.manifest)
+    target_link_libraries("${Launcher_Name}_gpudetect" gpudetect_logic)
+
+    if(${Launcher_USE_PCH})
+        target_precompile_headers("${Launcher_Name}_gpudetect" REUSE_FROM gpudetect_logic)
+    endif()
+
+    if(DEFINED Launcher_APP_BINARY_NAME)
+        set_target_properties("${Launcher_Name}_gpudetect" PROPERTIES OUTPUT_NAME "${Launcher_APP_BINARY_NAME}_gpudetect")
+    endif()
+    if(DEFINED Launcher_BINARY_RPATH)
+        set_target_properties("${Launcher_Name}_gpudetect" PROPERTIES INSTALL_RPATH "${Launcher_BINARY_RPATH}")
+    endif()
+
+    install(TARGETS "${Launcher_Name}_gpudetect"
+            BUNDLE DESTINATION "." COMPONENT Runtime
+            LIBRARY DESTINATION ${LIBRARY_DEST_DIR} COMPONENT Runtime
+            RUNTIME DESTINATION ${BINARY_DEST_DIR} COMPONENT Runtime
+            FRAMEWORK DESTINATION ${FRAMEWORK_DEST_DIR} COMPONENT Runtime
+    )
+
+    # Deploy PDBs
+    if(CMAKE_CXX_LINKER_SUPPORTS_PDB)
+        install(FILES $<TARGET_PDB_FILE:${Launcher_Name}_gpudetect> DESTINATION ${BINARY_DEST_DIR} OPTIONAL)
+    endif()
+endif()
+
 # Set basic compiler warning/error flags for all targets
 get_property(Launcher_TARGETS DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY BUILDSYSTEM_TARGETS)
 foreach(target ${Launcher_TARGETS})
@@ -1608,7 +1671,7 @@ if(CLANG_FORMAT)
     message(STATUS "Creating clang-format target")
     add_custom_target(
         clang-format
-        COMMAND ${CLANG_FORMAT} -i --style=file:${CMAKE_SOURCE_DIR}/.clang-format ${LOGIC_SOURCES} ${LAUNCHER_SOURCES} ${PRISMUPDATER_SOURCES} ${LINKEXE_SOURCES} ${PRECOMPILED_HEADERS}
+        COMMAND ${CLANG_FORMAT} -i --style=file:${CMAKE_SOURCE_DIR}/.clang-format ${LOGIC_SOURCES} ${LAUNCHER_SOURCES} ${PRISMUPDATER_SOURCES} ${LINKEXE_SOURCES} ${GPUDETECT_SOURCES} ${PRECOMPILED_HEADERS}
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
     )
 else()

--- a/launcher/HardwareInfo.cpp
+++ b/launcher/HardwareInfo.cpp
@@ -18,85 +18,69 @@
 
 #include "HardwareInfo.h"
 
-#include <QCoreApplication>
-#include <QOffscreenSurface>
-#include <QOpenGLFunctions>
+#include <QDir>
 #include <QProcessEnvironment>
+
+#include "Application.h"
 #include "BuildConfig.h"
 
-#ifndef Q_OS_MACOS
-#include <QVulkanInstance>
-#include <QVulkanWindow>
-#endif
-
-namespace {
-bool vulkanInfo(QStringList& out)
-{
-    if (!QProcessEnvironment::systemEnvironment()
-             .value(QStringLiteral("%1_DISABLE_GLVULKAN").arg(BuildConfig.LAUNCHER_ENVNAME))
-             .isEmpty()) {
-        return false;
-    }
-#ifndef Q_OS_MACOS
-    QVulkanInstance inst;
-    if (!inst.create()) {
-        qWarning() << "Vulkan instance creation failed, VkResult:" << inst.errorCode();
-        out << "Couldn't get Vulkan device information";
-        return false;
-    }
-
-    QVulkanWindow window;
-    window.setVulkanInstance(&inst);
-
-    for (auto device : window.availablePhysicalDevices()) {
-        const auto supportedVulkanVersion = QVersionNumber(VK_API_VERSION_MAJOR(device.apiVersion), VK_API_VERSION_MINOR(device.apiVersion),
-                                                           VK_API_VERSION_PATCH(device.apiVersion));
-        out << QString("Found Vulkan device: %1 (API version %2)").arg(device.deviceName).arg(supportedVulkanVersion.toString());
-    }
-#endif
-
-    return true;
-}
-
-bool openGlInfo(QStringList& out)
-{
-    if (!QProcessEnvironment::systemEnvironment()
-             .value(QStringLiteral("%1_DISABLE_GLVULKAN").arg(BuildConfig.LAUNCHER_ENVNAME))
-             .isEmpty()) {
-        return false;
-    }
-    QOpenGLContext ctx;
-    if (!ctx.create()) {
-        qWarning() << "OpenGL context creation failed";
-        out << "Couldn't get OpenGL device information";
-        return false;
-    }
-
-    QOffscreenSurface surface;
-    surface.create();
-    ctx.makeCurrent(&surface);
-
-    auto* f = ctx.functions();
-    f->initializeOpenGLFunctions();
-
-    auto toQString = [](const GLubyte* str) { return QString(reinterpret_cast<const char*>(str)); };
-    out << "OpenGL driver vendor: " + toQString(f->glGetString(GL_VENDOR));
-    out << "OpenGL renderer: " + toQString(f->glGetString(GL_RENDERER));
-    out << "OpenGL driver version: " + toQString(f->glGetString(GL_VERSION));
-
-    return true;
-}
-}  // namespace
-
-#ifndef Q_OS_LINUX
 QStringList HardwareInfo::gpuInfo()
 {
-    QStringList info;
-    vulkanInfo(info);
-    openGlInfo(info);
-    return info;
-}
+    QProcess process;
+
+    auto exeName = QStringLiteral("%1_gpudetect").arg(BuildConfig.LAUNCHER_APP_BINARY_NAME);
+#ifdef Q_OS_WIN32
+    exeName.append(".exe");
+
+    auto env = QProcessEnvironment::systemEnvironment();
+    env.insert("__COMPAT_LAYER", "RUNASINVOKER");
+    process.setProcessEnvironment(env);
 #endif
+
+    const QDir appExePath(APPLICATION->applicationDirPath());
+    const QString pathToExe = appExePath.absoluteFilePath(exeName);
+
+    process.setProgram(pathToExe);
+
+    QStringList methods;
+    if (QProcessEnvironment::systemEnvironment().value(QStringLiteral("%1_DISABLE_GLVULKAN").arg(BuildConfig.LAUNCHER_ENVNAME)).isEmpty()) {
+        methods << "opengl";
+#ifndef Q_OS_MACOS
+        methods << "vulkan";
+#endif
+    }
+
+#ifdef Q_OS_LINUX
+    methods << "lspci";
+#endif
+
+    QStringList out;
+
+    for (const auto& method : methods) {
+        qInfo() << "Attempting GPU detection using" << method;
+
+        process.setArguments({ method });
+        process.start();
+        if (!process.waitForFinished(1000)) {
+            process.kill();
+            qWarning() << "GPU detection process exited with code:" << process.exitCode() << process.errorString();
+            continue;
+        }
+
+        for (const auto& str : process.readAllStandardOutput().split('\n')) {
+            if (const auto line = str.trimmed(); !line.isEmpty()) {
+                out << line;
+            }
+        }
+        for (const auto& str : process.readAllStandardError().split('\n')) {
+            if (const auto line = str.trimmed(); !line.isEmpty()) {
+                qWarning() << line;
+            }
+        }
+    }
+
+    return out;
+}
 
 #ifdef Q_OS_WINDOWS
 #ifndef WIN32_LEAN_AND_MEAN
@@ -252,56 +236,6 @@ uint64_t HardwareInfo::totalRamMiB()
 uint64_t HardwareInfo::availableRamMiB()
 {
     return readMemInfo("MemAvailable");
-}
-
-QStringList HardwareInfo::gpuInfo()
-{
-    QStringList list;
-    const bool vulkanSuccess = vulkanInfo(list);
-    const bool openGlSuccess = openGlInfo(list);
-    if (vulkanSuccess || openGlSuccess) {
-        return list;
-    }
-
-    std::array<char, 512> buffer;
-    FILE* lspci = popen("lspci -k", "r");
-
-    if (!lspci) {
-        return { "Could not detect GPUs: lspci is not present" };
-    }
-
-    bool readingGpuInfo = false;
-    QString currentModel = "";
-    while (fgets(buffer.data(), 512, lspci) != nullptr) {
-        QString str(buffer.data());
-        // clang-format off
-        // 04:00.0 VGA compatible controller: Advanced Micro Devices, Inc. [AMD/ATI] Ellesmere [Radeon RX 470/480/570/570X/580/580X/590] (rev e7)
-        // Subsystem: Sapphire Technology Limited Radeon RX 580 Pulse 4GB
-        // Kernel driver in use: amdgpu
-        // Kernel modules: amdgpu
-        // clang-format on
-        if (str.contains("VGA compatible controller")) {
-            readingGpuInfo = true;
-        } else if (!str.startsWith('\t')) {
-            readingGpuInfo = false;
-        }
-        if (!readingGpuInfo) {
-            continue;
-        }
-
-        if (str.contains("Subsystem")) {
-            currentModel = "Found GPU: " + afterColon(str);
-        }
-        if (str.contains("Kernel driver in use")) {
-            currentModel += " (using driver " + afterColon(str);
-        }
-        if (str.contains("Kernel modules")) {
-            currentModel += ", available drivers: " + afterColon(str) + ")";
-            list.append(currentModel);
-        }
-    }
-    pclose(lspci);
-    return list;
 }
 
 #else

--- a/launcher/gpudetect/OpenGL.cpp
+++ b/launcher/gpudetect/OpenGL.cpp
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2026 Octol1ttle <l1ttleofficial@outlook.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "OpenGL.h"
+
+#include <QOffscreenSurface>
+#include <QOpenGLContext>
+#include <QOpenGLFunctions>
+
+#include "Print.h"
+
+void OpenGL::print()
+{
+    QOpenGLContext ctx;
+    if (!ctx.create()) {
+        Print::err("OpenGL context creation failed");
+        return;
+    }
+
+    QOffscreenSurface surface;
+    surface.create();
+    ctx.makeCurrent(&surface);
+
+    auto* f = ctx.functions();
+    f->initializeOpenGLFunctions();
+
+    auto toQString = [](const GLubyte* str) { return QString(reinterpret_cast<const char*>(str)); };  // NOLINT(*-pro-type-reinterpret-cast)
+    Print::info("OpenGL driver vendor: " + toQString(f->glGetString(GL_VENDOR)));
+    Print::info("OpenGL renderer: " + toQString(f->glGetString(GL_RENDERER)));
+    Print::info("OpenGL driver version: " + toQString(f->glGetString(GL_VERSION)));
+}

--- a/launcher/gpudetect/OpenGL.h
+++ b/launcher/gpudetect/OpenGL.h
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2026 Octol1ttle <l1ttleofficial@outlook.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace OpenGL {
+void print();
+}

--- a/launcher/gpudetect/Print.h
+++ b/launcher/gpudetect/Print.h
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2026 Octol1ttle <l1ttleofficial@outlook.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QString>
+#include <iostream>
+
+namespace Print {
+inline void info(const char* message)
+{
+    std::cout << message << '\n';
+}
+
+inline void info(const QString& message)
+{
+    info(qPrintable(message));
+}
+
+inline void err(const char* message)
+{
+    std::cerr << message << '\n';
+}
+
+inline void err(const QString& message)
+{
+    err(qPrintable(message));
+}
+}  // namespace Print

--- a/launcher/gpudetect/Vulkan.cpp
+++ b/launcher/gpudetect/Vulkan.cpp
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2026 Octol1ttle <l1ttleofficial@outlook.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "Vulkan.h"
+
+#include "Print.h"
+
+#ifdef Q_OS_MACOS
+void Vulkan::print()
+{
+    Print::err("Vulkan is not supported on macOS");
+}
+#else
+#include <QVulkanWindow>
+
+void Vulkan::print()
+{
+    QVulkanInstance inst;
+    if (!inst.create()) {
+        Print::err("Vulkan instance creation failed, VkResult: " + QString::number(inst.errorCode()));
+        return;
+    }
+
+    QVulkanWindow window;
+    window.setVulkanInstance(&inst);
+
+    for (auto device : window.availablePhysicalDevices()) {
+        const auto supportedVulkanVersion = QVersionNumber(VK_API_VERSION_MAJOR(device.apiVersion), VK_API_VERSION_MINOR(device.apiVersion),
+                                                           VK_API_VERSION_PATCH(device.apiVersion));
+        Print::info(QString("Found Vulkan device: %1 (API version %2)").arg(device.deviceName, supportedVulkanVersion.toString()));
+    }
+}
+#endif

--- a/launcher/gpudetect/Vulkan.h
+++ b/launcher/gpudetect/Vulkan.h
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2026 Octol1ttle <l1ttleofficial@outlook.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace Vulkan {
+void print();
+}

--- a/launcher/gpudetect/gpudetect.exe.manifest
+++ b/launcher/gpudetect/gpudetect.exe.manifest
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+    </windowsSettings>
+  </application>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10, Windows 11 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
+      <!-- Windows 8 -->
+      <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
+      <!-- Windows 7 -->
+      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
+    </application>
+  </compatibility>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges>
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+       </requestedPrivileges>
+    </security>
+  </trustInfo>
+</assembly>

--- a/launcher/gpudetect/gpudetect_main.cpp
+++ b/launcher/gpudetect/gpudetect_main.cpp
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2026 Octol1ttle <l1ttleofficial@outlook.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <QGuiApplication>
+
+#include "OpenGL.h"
+#include "Print.h"
+#include "Vulkan.h"
+#include "lspci.h"
+
+#ifdef Q_OS_WIN32
+#include "console/WindowsConsole.h"
+#endif
+
+int main(int argc, char* argv[])
+{
+#ifdef Q_OS_WIN32
+    // attach the parent console
+    console::WindowsConsoleGuard _consoleGuard;
+#endif
+
+    const QGuiApplication app(argc, argv);
+
+    const auto args = std::span{ argv, static_cast<size_t>(argc) };
+    for (const std::string_view arg : args.subspan(1)) {
+        if (arg == "vulkan") {
+            Vulkan::print();
+        } else if (arg == "opengl") {
+            OpenGL::print();
+        } else if (arg == "lspci") {
+            lspci::print();
+        } else {
+            Print::err(QString("Ignoring unknown method: %1").arg(arg));
+        }
+    }
+}

--- a/launcher/gpudetect/lspci.cpp
+++ b/launcher/gpudetect/lspci.cpp
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2026 Octol1ttle <l1ttleofficial@outlook.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "lspci.h"
+
+#include "Print.h"
+
+#ifndef Q_OS_LINUX
+void lspci::print()
+{
+    Print::err("lspci is supported only for Linux");
+}
+#else
+#include <array>
+#include <cstdio>
+
+namespace {
+QString afterColon(QString str)
+{
+    return str.remove(0, str.indexOf(':') + 2).trimmed();
+}
+}  // namespace
+
+void lspci::print()
+{
+    std::array<char, 512> buffer{};
+    FILE* lspci = popen("lspci -k", "r");  // NOLINT(*-command-processor)
+
+    if (!lspci) {
+        Print::err("lspci is not present");
+        return;
+    }
+
+    bool readingGpuInfo = false;
+    QString gpu;
+    QString driverInUse = "NONE";
+    QString driversAvailable;
+    while (fgets(buffer.data(), 512, lspci) != nullptr) {
+        const QString str(buffer.data());
+        // clang-format off
+        // 04:00.0 VGA compatible controller: Advanced Micro Devices, Inc. [AMD/ATI] Ellesmere [Radeon RX 470/480/570/570X/580/580X/590] (rev e7)
+        // Subsystem: Sapphire Technology Limited Radeon RX 580 Pulse 4GB
+        // Kernel driver in use: amdgpu
+        // Kernel modules: amdgpu
+        // clang-format on
+        if (str.contains("VGA compatible controller")) {
+            readingGpuInfo = true;
+        } else if (!str.startsWith('\t')) {
+            if (readingGpuInfo) {
+                Print::info(QString("Found VGA compatible controller: %1 (using driver %2, available drivers: %3)")
+                                .arg(gpu, driverInUse, driversAvailable));
+            }
+            readingGpuInfo = false;
+        }
+
+        if (!readingGpuInfo) {
+            continue;
+        }
+
+        const QString value = afterColon(str);
+        if (str.contains("Subsystem")) {
+            gpu = value;
+        }
+        if (str.contains("Kernel driver in use")) {
+            driverInUse = value;
+        }
+        if (str.contains("Kernel modules")) {
+            driversAvailable = value;
+        }
+    }
+
+    pclose(lspci);
+}
+#endif

--- a/launcher/gpudetect/lspci.h
+++ b/launcher/gpudetect/lspci.h
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2026 Octol1ttle <l1ttleofficial@outlook.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+namespace lspci {
+void print();
+}

--- a/launcher/updater/prismupdater/PrismUpdater.cpp
+++ b/launcher/updater/prismupdater/PrismUpdater.cpp
@@ -978,6 +978,7 @@ void PrismUpdaterApp::backupAppDir()
                 "prismlauncher.exe",
                 "prismlauncher_filelink.exe",
                 "prismlauncher_updater.exe",
+                "prismlauncher_gpudetect.exe",
                 "qtlogging.ini",
                 "imageformats",
                 "iconengines",

--- a/program_info/win_install.nsi.in
+++ b/program_info/win_install.nsi.in
@@ -377,6 +377,7 @@ Section "@Launcher_DisplayName@"
   File "@Launcher_APP_BINARY_NAME@.exe"
   File "@Launcher_APP_BINARY_NAME@_filelink.exe"
   File "@Launcher_APP_BINARY_NAME@_updater.exe"
+  File "@Launcher_APP_BINARY_NAME@_gpudetect.exe"
   File "qt.conf"
   File "qtlogging.ini"
   File *.dll
@@ -474,6 +475,7 @@ Section "Uninstall"
   Delete $INSTDIR\@Launcher_APP_BINARY_NAME@.exe
   Delete $INSTDIR\@Launcher_APP_BINARY_NAME@_filelink.exe
   Delete $INSTDIR\@Launcher_APP_BINARY_NAME@_updater.exe
+  Delete $INSTDIR\@Launcher_APP_BINARY_NAME@_gpudetect.exe
   Delete $INSTDIR\qt.conf
   Delete $INSTDIR\*.dll
 


### PR DESCRIPTION
Closes #5525

Doing it in process is not ideal because:
1) If OpenGL fails, Qt will throw a fatal error and the launcher will die
2) If Vulkan fails, nothing bad happens. If there's a poorly written Vulkan graphics hook, it may throw a segfault and the launcher will die. If there's a poorly written Vulkan driver (say hi, AMD), it may also throw a segfault and the launcher will also die.

These are not "catchable" by regular means, so having separate processes is what we have to do. Note that a new process is started for each of the three available methods (`vulkan`, `opengl` and `lspci`), so that failure of one of the methods doesn't impact the others

Tested on: Linux AppImage, Linux Portable, macOS, Windows Setup, Windows Portable