### PR TITLE
fix(UI): Set active window as parent for NetworkJobFailedDialog

### DIFF
--- a/launcher/net/NetJob.cpp
+++ b/launcher/net/NetJob.cpp
@@ -40,6 +40,7 @@
 #include "net/NetRequest.h"
 #include "tasks/ConcurrentTask.h"
 #if defined(LAUNCHER_APPLICATION)
+#include <QApplication>
 #include "Application.h"
 #include "settings/SettingsObject.h"
 #include "ui/dialogs/NetworkJobFailedDialog.h"
@@ -174,7 +175,8 @@ void NetJob::emitFailed(QString reason)
     if (APPLICATION_DYN && m_ask_retry && m_manual_try < APPLICATION->settings()->get("NumberOfManualRetries").toInt() && isOnline()) {
         m_manual_try++;
         auto failed = getFailedActions();
-        auto dialog = new NetworkJobFailedDialog(objectName(), m_try, m_done.size(), failed.size(), nullptr);
+        QWidget* activeWindow = QApplication::activeWindow();
+        auto dialog = new NetworkJobFailedDialog(objectName(), m_try, m_done.size(), failed.size(), activeWindow);
         dialog->setAttribute(Qt::WA_DeleteOnClose);
 
         for (const auto& request : failed) {


### PR DESCRIPTION
Issue #5595

Fixed an issue where the launcher completely freezes if a modpack download hits a network error.

When a download fails the error popup is created without a parent window. Since the launcher already has a modal Please Wait progress bar active the OS slides the new error box behind the progress bar.

Changed the parent argument from nullptr to QApplication::activeWindow(). Now is stacks the error dialog on top of the active progress screen allowing you to actually click OK or retry the download without any problems.

`area: ui`, `type: bugfix`