### PR TITLE
Update README packaging status image alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@
 - All downloads and instructions for Prism Launcher can be found on our [Website](https://prismlauncher.org/download).
 - Last build status can be found in the [GitHub Actions](https://github.com/PrismLauncher/PrismLauncher/actions) tab (this also includes the pull requests status).
 
+<p align="center">
 <a href="https://repology.org/project/prismlauncher/versions">
     <img src="https://repology.org/badge/vertical-allrepos/prismlauncher.svg?columns=3" alt="Packaging status">
 </a>
+</p>
 
 ### Development Builds
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@
 
 ## Installation
 
-<a href="https://repology.org/project/prismlauncher/versions">
-    <img src="https://repology.org/badge/vertical-allrepos/prismlauncher.svg" alt="Packaging status" align="right">
-</a>
-
 - All downloads and instructions for Prism Launcher can be found on our [Website](https://prismlauncher.org/download).
 - Last build status can be found in the [GitHub Actions](https://github.com/PrismLauncher/PrismLauncher/actions) tab (this also includes the pull requests status).
+
+<a href="https://repology.org/project/prismlauncher/versions">
+    <img src="https://repology.org/badge/vertical-allrepos/prismlauncher.svg?columns=3" alt="Packaging status">
+</a>
 
 ### Development Builds
 


### PR DESCRIPTION
Currently, the use of `align="right"` in the packaging status image in the Install section of the README, causes a portion of the text to be unreadable on mobile form factors.

Changing the image to a 3 column version using `?columns=3` and making it center aligned allows readability while not significantly increasing the length of the README.

Before on mobile
<img width="1080" height="2424" alt="Screenshot_20260531-150830" src="https://github.com/user-attachments/assets/3f7b402c-f807-491c-8835-b8f9f10d9d32" />

Now on mobile
<img width="1080" height="2424" alt="Screenshot_20260531-150904" src="https://github.com/user-attachments/assets/1983237c-1b5c-42b2-913e-690f199ad64a" />

Before on desktop
<img width="1080" height="2424" alt="Screenshot_20260531-150844" src="https://github.com/user-attachments/assets/4a7bce27-436a-47f8-8d9e-ef1a05562de5" />

Now on desktop
<img width="1080" height="2424" alt="Screenshot_20260531-151508" src="https://github.com/user-attachments/assets/faa74d75-6f37-4635-ab1f-938116f80646" />
