### PR TITLE
AccountList: Skip refresh when !shouldRefresh

### DIFF
--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -648,9 +648,17 @@ void AccountList::tryNext()
     while (m_refreshQueue.length()) {
         auto accountId = m_refreshQueue.front();
         m_refreshQueue.pop_front();
+        bool found = false;
         for (int i = 0; i < count(); i++) {
             auto account = at(i);
             if (account->internalId() == accountId) {
+                found = true;
+                if (!account->shouldRefresh()) {
+                    // Account no longer needs refreshing, skip it.
+                    qDebug() << "RefreshSchedule: Skipping account" << account->profileName() << "with internal ID"
+                             << accountId << "(no longer needs refresh)";
+                    break;
+                }
                 m_currentTask = account->refresh();
                 if (m_currentTask) {
                     connect(m_currentTask.get(), &Task::succeeded, this, &AccountList::authSucceeded);
@@ -660,9 +668,12 @@ void AccountList::tryNext()
                              << accountId;
                     return;
                 }
+                break;
             }
         }
-        qDebug() << "RefreshSchedule: Account with internal ID" << accountId << "not found.";
+        if (!found) {
+            qDebug() << "RefreshSchedule: Account with internal ID" << accountId << "not found.";
+        }
     }
     // if we get here, no account needed refreshing. Schedule refresh in an hour.
     m_refreshTimer->start(1000 * 3600);


### PR DESCRIPTION
I was encountering a problem where after I launched the 26.2 pre-release, after a while, my friends list would start reporting errors. After looking into this, it seems that if the launcher is open in the background it calls the refresh endpoint after around 10 minutes on all the accounts in the list, which then invalidates the token I'm using in my running session. I tested with this patch, and the issue is resolved by it.