### PR TITLE
fix: abort device code properly

### DIFF
--- a/launcher/minecraft/auth/AuthFlow.cpp
+++ b/launcher/minecraft/auth/AuthFlow.cpp
@@ -23,7 +23,6 @@ AuthFlow::AuthFlow(AccountData* data, Action action) : Task(), m_data(data)
         if (action == Action::DeviceCode) {
             auto oauthStep = makeShared<MSADeviceCodeStep>(m_data);
             connect(oauthStep.get(), &MSADeviceCodeStep::authorizeWithBrowser, this, &AuthFlow::authorizeWithBrowserWithExtra);
-            connect(this, &Task::aborted, oauthStep.get(), &MSADeviceCodeStep::abort);
             m_steps.append(oauthStep);
         } else {
             auto oauthStep = makeShared<MSAStep>(m_data, action == Action::Refresh);

--- a/launcher/minecraft/auth/steps/MSADeviceCodeStep.cpp
+++ b/launcher/minecraft/auth/steps/MSADeviceCodeStep.cpp
@@ -153,7 +153,6 @@ void MSADeviceCodeStep::abort()
         m_request->abort();
     }
     m_is_aborted = true;
-    emit finished(AccountTaskState::STATE_FAILED_HARD, tr("Task aborted"));
 }
 
 void MSADeviceCodeStep::startPoolTimer()


### PR DESCRIPTION
`MSADeviceCodeStep::abort` gets called in `AuthFlow::abort` (`m_currentStep->abort()`). the `emit finished` will trigger `AuthFlow::changeState`, causing `AuthFlow` to `emitFailed`. but after `m_currentStep->abort()` there's `emitAborted` which causes assertion error because the `emitFailed` already stopped the `AuthFlow`.

none of this affects users because assertions are disabled in release