### PR TITLE
Don't remove old Microsoft accounts until they're successfully reauthenticated

### DIFF
--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -333,11 +333,11 @@ bool LaunchController::reauthenticateAccount(const MinecraftAccountPtr& account,
     if (button == QMessageBox::StandardButton::Yes) {
         auto* accounts = APPLICATION->accounts();
         const bool isDefault = accounts->defaultAccount() == account;
-        accounts->removeAccount(accounts->index(accounts->findAccountByProfileId(account->profileId())));
         if (account->accountType() == AccountType::MSA) {
             auto newAccount = MSALoginDialog::newAccount(m_parentWidget);
 
             if (newAccount != nullptr) {
+                accounts->removeAccount(accounts->index(accounts->findAccountByProfileId(account->profileId())));
                 accounts->addAccount(newAccount);
 
                 if (isDefault) {


### PR DESCRIPTION
Closes #5616 

recent outage caused authentication errors, if the user accepted to re-add their account the existing account would be removed before the new one could be added (but because of the outage the user couldn't add any accounts), so even if they try playing offline they can't (no accounts)

fix: move the account removal to after the new account is available, if its not available then nothing happens (the account remains)