### PR TITLE
ci: pin actions versions with hashes

### DIFF
--- a/.github/actions/package/linux/action.yml
+++ b/.github/actions/package/linux/action.yml
@@ -135,19 +135,19 @@ runs:
         tar -czf ../PrismLauncher-portable.tar.gz *
 
     - name: Upload binary tarball
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: PrismLauncher-${{ inputs.artifact-name }}-Qt6-Portable-${{ inputs.version }}-${{ inputs.build-type }}
         path: PrismLauncher-portable.tar.gz
 
     - name: Upload AppImage
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: PrismLauncher-${{ runner.os }}-${{ inputs.version }}-${{ inputs.build-type }}-${{ env.APPIMAGE_ARCH }}.AppImage
         path: PrismLauncher-${{ runner.os }}-*${{ env.APPIMAGE_ARCH }}.AppImage
 
     - name: Upload AppImage Zsync
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: PrismLauncher-${{ runner.os }}-${{ inputs.version }}-${{ inputs.build-type }}-${{ env.APPIMAGE_ARCH }}.AppImage.zsync
         path: PrismLauncher-${{ runner.os }}-*${{ env.APPIMAGE_ARCH }}.AppImage.zsync

--- a/.github/actions/package/macos/action.yml
+++ b/.github/actions/package/macos/action.yml
@@ -135,13 +135,13 @@ runs:
         fi
 
     - name: Upload binary tarball
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: PrismLauncher-${{ inputs.artifact-name }}-${{ inputs.version }}-${{ inputs.build-type }}
         path: PrismLauncher.zip
 
     - name: Upload disk image
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: PrismLauncher-${{ inputs.artifact-name }}-${{ inputs.version }}-${{ inputs.build-type }}.dmg
         path: PrismLauncher.dmg

--- a/.github/actions/package/windows/action.yml
+++ b/.github/actions/package/windows/action.yml
@@ -61,7 +61,7 @@ runs:
 
     - name: Login to Azure
       if: ${{ env.CI_HAS_ACCESS_TO_AZURE != '' && inputs.azure-client-id != '' }}
-      uses: azure/login@v3
+      uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
       with:
         client-id: ${{ inputs.azure-client-id }}
         tenant-id: ${{ inputs.azure-tenant-id }}
@@ -69,7 +69,7 @@ runs:
 
     - name: Sign executables
       if: ${{ env.CI_HAS_ACCESS_TO_AZURE != '' && inputs.azure-client-id != '' }}
-      uses: azure/artifact-signing-action@v2
+      uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
       with:
         endpoint: https://eus.codesigning.azure.net/
         trusted-signing-account-name: PrismLauncher
@@ -142,7 +142,7 @@ runs:
 
     - name: Sign installer
       if: ${{ env.CI_HAS_ACCESS_TO_AZURE != '' && inputs.azure-client-id != '' }}
-      uses: azure/artifact-signing-action@v2
+      uses: azure/artifact-signing-action@c7ab2a863ab5f9a846ddb8265964877ef296ee82 # v2.0.0
       with:
         endpoint: https://eus.codesigning.azure.net/
         trusted-signing-account-name: PrismLauncher
@@ -168,19 +168,19 @@ runs:
         exclude-interactive-browser-credential: true
 
     - name: Upload binary zip
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: PrismLauncher-${{ inputs.artifact-name }}-${{ inputs.version }}-${{ inputs.build-type }}
         path: install/**
 
     - name: Upload portable zip
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: PrismLauncher-${{ inputs.artifact-name }}-Portable-${{ inputs.version }}-${{ inputs.build-type }}
         path: install-portable/**
 
     - name: Upload installer
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: PrismLauncher-${{ inputs.artifact-name }}-Setup-${{ inputs.version }}-${{ inputs.build-type }}
         path: PrismLauncher-Setup.exe

--- a/.github/actions/setup-dependencies/action.yml
+++ b/.github/actions/setup-dependencies/action.yml
@@ -55,7 +55,7 @@ runs:
     # TODO(@getchoo): Get this working on MSYS2!
     - name: Setup ccache
       if: ${{ (runner.os != 'Windows' || inputs.msystem == '') && inputs.build-type == 'Debug' }}
-      uses: hendrikmuhs/ccache-action@v1.2.23
+      uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
       with:
         variant: sccache
         create-symlink: ${{ runner.os != 'Windows' }}
@@ -73,7 +73,7 @@ runs:
 
     - name: Install Qt
       if: ${{ inputs.msystem == '' }}
-      uses: jurplel/install-qt-action@v4
+      uses: jurplel/install-qt-action@48d3ad6db93f3627c8ee7a0454bc6f3744f7e730 # v4.3.1
       with:
         aqtversion: "==3.1.*"
         version: ${{ inputs.qt-version }}

--- a/.github/actions/setup-dependencies/windows/action.yml
+++ b/.github/actions/setup-dependencies/windows/action.yml
@@ -21,13 +21,13 @@ runs:
     # NOTE: Installed on MinGW as well for SignTool
     - name: Enter VS Developer shell
       if: ${{ runner.os == 'Windows' }}
-      uses: ilammy/msvc-dev-cmd@v1
+      uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
       with:
         arch: ${{ inputs.vcvars-arch }}
         vsversion: 2022
 
     - name: Setup Java (MSVC)
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
       with:
         # NOTE(@getchoo): We should probably stay on Zulu.
         # Temurin doesn't have Java 17 builds for WoA
@@ -62,7 +62,7 @@ runs:
 
     - name: Setup MSYS2 (MinGW)
       if: ${{ inputs.msystem != '' }}
-      uses: msys2/setup-msys2@v2
+      uses: msys2/setup-msys2@e9898307ac31d1a803454791be09ab9973336e1c # v2.31.1
       with:
         msystem: ${{ inputs.msystem }}
         update: true
@@ -91,7 +91,7 @@ runs:
 
     - name: Retrieve ccache cache (MinGW)
       if: ${{ inputs.msystem != '' && inputs.build-type == 'Debug' }}
-      uses: actions/cache@v5.0.5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: '${{ github.workspace }}\.ccache'
         key: ${{ runner.os }}-mingw-w64-ccache-${{ github.run_id }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -20,11 +20,11 @@ jobs:
     if: github.repository_owner == 'PrismLauncher' && github.event.pull_request.merged == true && (github.event_name != 'labeled' || startsWith('backport', github.event.label.name))
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Create backport PRs
-        uses: korthout/backport-action@v4.5
+        uses: korthout/backport-action@66065406958f46e82238fd59546f5a99e69e22aa #v4.5.2
         with:
           # Config README: https://github.com/korthout/backport-action#backport-action
           pull_description: |-

--- a/.github/workflows/blocked-prs.yml
+++ b/.github/workflows/blocked-prs.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: Generate token
         id: generate-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.PULL_REQUEST_APP_ID }}
           private-key: ${{ secrets.PULL_REQUEST_APP_PRIVATE_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,7 @@ jobs:
       ##
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: true
 

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -23,13 +23,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0 # Required for diffing later on
           submodules: "true"
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
 
       - name: Run source generators
         # TODO(@getchoo): Figure out how to make this work with PCH

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,12 +22,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: "true"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1
         with:
           config-file: ./.github/codeql/codeql-config.yml
           queries: security-and-quality
@@ -49,4 +49,4 @@ jobs:
           ctest --preset linux --build-config Debug --extra-verbose --output-on-failure
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@87557b9c84dde89fdd9b10e88954ac2f4248e463 # v4.36.1

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -44,18 +44,18 @@ jobs:
           echo "image-name=${REGISTRY}/${GITHUB_REPOSITORY_OWNER,,}/devcontainer" >> "$GITHUB_OUTPUT"
 
       - name: Install Podman
-        uses: redhat-actions/podman-install@main
+        uses: redhat-actions/podman-install@aea6ff44f2a4a82da13d22061ce73443a125925d # commit-aea6ff4
         # TODO(@getchoo): Always use this when the action properly supports ARM
         if: ${{ runner.arch == 'X64' || runner.arch == 'X86' }}
         with:
           github-token: ${{ github.token }}
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Determine metadata for image
         id: image-metadata
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: |
             ${{ steps.image-name.outputs.image-name }}
@@ -71,7 +71,7 @@ jobs:
 
       - name: Build image
         id: build-image
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2.13
         with:
           containerfiles: |
             ./Containerfile
@@ -81,7 +81,7 @@ jobs:
       - name: Push image
         id: push-image
         if: ${{ github.event_name != 'pull_request' }}
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
         with:
           tags: ${{ steps.build-image.outputs.tags }}
           username: ${{ github.repository_owner }}
@@ -98,7 +98,7 @@ jobs:
 
       - name: Upload digest artifact
         if: ${{ github.event_name != 'pull_request' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: digests-${{ matrix.arch }}
           path: ${{ runner.temp }}/digests/*
@@ -119,7 +119,7 @@ jobs:
 
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*
@@ -128,12 +128,12 @@ jobs:
       - name: Install Podman
         # TODO(@getchoo): Always use this when the action properly supports ARM
         if: ${{ runner.arch == 'X64' || runner.arch == 'X86' }}
-        uses: redhat-actions/podman-install@main
+        uses: redhat-actions/podman-install@aea6ff44f2a4a82da13d22061ce73443a125925d # commit-aea6ff4
         with:
           github-token: ${{ github.token }}
 
       - name: Login to registry
-        uses: redhat-actions/podman-login@v1
+        uses: redhat-actions/podman-login@4934294ad0449894bcd1e9f191899d7292469603 # v1.7
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.repository_owner }}
@@ -141,7 +141,7 @@ jobs:
 
       - name: Determine metadata for manifest
         id: manifest-metadata
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: |
             ${{ needs.build.outputs.image-name }}
@@ -166,7 +166,7 @@ jobs:
           done <<< "$DOCKER_METADATA_OUTPUT_TAGS"
 
       - name: Push manifest
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2.8
         with:
           tags: ${{ steps.manifest-metadata.outputs.tags }}
           username: ${{ github.repository_owner }}

--- a/.github/workflows/merge-blocking-pr.yml
+++ b/.github/workflows/merge-blocking-pr.yml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: Generate token
         id: generate-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.PULL_REQUEST_APP_ID }}
           private-key: ${{ secrets.PULL_REQUEST_APP_PRIVATE_KEY }}

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -95,15 +95,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v31
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
 
         # For PRs
       - name: Setup Nix Magic Cache
         if: ${{ github.event_name == 'pull_request' }}
-        uses: DeterminateSystems/magic-nix-cache-action@v14
+        uses: DeterminateSystems/magic-nix-cache-action@908b263ff629f4cc17666315b7fd3ec127c6244d # v14
         with:
           diagnostic-endpoint: ""
           use-flakehub: false
@@ -111,7 +111,7 @@ jobs:
         # For in-tree builds
       - name: Setup Cachix
         if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
-        uses: cachix/cachix-action@v17
+        uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
         with:
           name: prismlauncher
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Publish on Winget
-        uses: vedantmgoyal2009/winget-releaser@v2
+        uses: vedantmgoyal2009/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
         with:
           identifier: PrismLauncher.PrismLauncher
           version: ${{ github.event.release.tag_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,12 +31,12 @@ jobs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           submodules: "true"
           path: "PrismLauncher-source"
       - name: Download artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       - name: Grab and store version
         run: |
           tag_name=$(echo ${{ github.ref }} | grep -oE "[^/]+$")
@@ -94,7 +94,7 @@ jobs:
 
       - name: Create release
         id: create_release
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: ${{ github.ref }}

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-slim
 
     steps:
-      - uses: actions/checkout@v6
-      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
 
-      - uses: DeterminateSystems/update-flake-lock@v28
+      - uses: DeterminateSystems/update-flake-lock@834c491b2ece4de0bbd00d85214bb5e83b4da5c6 # v28
         with:
           commit-msg: "chore(nix): update lockfile"
           pr-title: "chore(nix): update lockfile"


### PR DESCRIPTION
# ci: pin actions versions with hashes

I have pinned the versions of the actions used in the workflows with hashes.

Pinning GitHub Actions to a commit hash is an effective safeguard against supply chain attacks. By referencing a specific and immutable version of an action, you prevent compromised versions from being automatically integrated into your pipelines.

All the hashed versions match the previously specified versions, since the specified versions were generic and I just specified exactly which version to use.

Here is the link to the tags for the actions I've pinned, if you want to check the hashes:

- https://github.com/actions/upload-artifact/releases/tag/v7.0.1
- https://github.com/Azure/login/releases/tag/v3.0.0
- https://github.com/Azure/artifact-signing-action/releases/tag/v2.0.0
- https://github.com/hendrikmuhs/ccache-action/releases/tag/v1.2.23
- https://github.com/jurplel/install-qt-action/releases/tag/v4.3.1
- https://github.com/ilammy/msvc-dev-cmd/releases/tag/v1.13.0
- https://github.com/actions/setup-java/releases/tag/v5.2.0
- https://github.com/msys2/setup-msys2/releases/tag/v2.31.1
- https://github.com/actions/cache/releases/tag/v5.0.5
- https://github.com/actions/checkout/releases/tag/v6.0.3
- https://github.com/korthout/backport-action/releases/tag/v4.5.2
- https://github.com/actions/create-github-app-token/releases/tag/v3.2.0
- https://github.com/cachix/install-nix-action/releases/tag/v31.10.6
- https://github.com/github/codeql-action/releases/tag/v4.36.1
- https://github.com/redhat-actions/podman-install/releases/tag/commit-aea6ff4
- https://github.com/docker/metadata-action/releases/tag/v6.1.0
- https://github.com/redhat-actions/buildah-build/releases/tag/v2.13
- https://github.com/redhat-actions/push-to-registry/releases/tag/v2.8
- https://github.com/actions/download-artifact/releases/tag/v8.0.1
- https://github.com/redhat-actions/podman-login/releases/tag/v1.7
- https://github.com/DeterminateSystems/magic-nix-cache-action/releases/tag/v14
- https://github.com/cachix/cachix-action/releases/tag/v17
- https://github.com/vedantmgoyal9/winget-releaser/releases/tag/v2
- https://github.com/softprops/action-gh-release/releases/tag/v3.0.0
- https://github.com/DeterminateSystems/update-flake-lock/releases/tag/v28

Pinning versions requires a bit of maintenance, since you have to perform manual upgrades regularly, but in your case, with workflows that handle secrets (such as `secrets.GPG_PRIVATE_KEY` or `secrets.PULL_REQUEST_APP_PRIVATE_KEY`), it’s a best practice to avoid troubles.