### PR TITLE
Show process start error string in logs

### DIFF
--- a/launcher/LoggedProcess.cpp
+++ b/launcher/LoggedProcess.cpp
@@ -114,7 +114,7 @@ void LoggedProcess::on_error(QProcess::ProcessError error)
 {
     switch (error) {
         case QProcess::FailedToStart: {
-            emit log({ tr("The process failed to start.") }, MessageLevel::Fatal);
+            emit log({ tr("The process failed to start: %1").arg(errorString()) }, MessageLevel::Fatal);
             changeState(LoggedProcess::FailedToStart);
             break;
         }

--- a/launcher/java/JavaChecker.cpp
+++ b/launcher/java/JavaChecker.cpp
@@ -179,13 +179,20 @@ void JavaChecker::finished(int exitcode, QProcess::ExitStatus status)
 void JavaChecker::error(QProcess::ProcessError err)
 {
     if (err == QProcess::FailedToStart) {
-        qDebug() << "Java checker has failed to start.";
+        qDebug() << "Java checker has failed to start:" << process->errorString();
         qDebug() << "Process environment:";
         qDebug() << process->environment();
         qDebug() << "Native environment:";
         qDebug() << QProcessEnvironment::systemEnvironment().toStringList();
         killTimer.stop();
-        emit checkFinished({ m_path, m_id });
+
+        Result result = {
+            m_path,
+            m_id,
+        };
+        result.errorLog = process->errorString();
+        result.validity = Result::Validity::Errored;
+        emit checkFinished(result);
     }
     emitSucceeded();
 }

--- a/launcher/minecraft/launch/LauncherPartLaunch.cpp
+++ b/launcher/minecraft/launch/LauncherPartLaunch.cpp
@@ -164,9 +164,9 @@ void LauncherPartLaunch::on_state(LoggedProcess::State state)
     switch (state) {
         case LoggedProcess::FailedToStart: {
             //: Error message displayed if instace can't start
-            const char* reason = QT_TR_NOOP("Could not launch Minecraft!");
-            emit logLine(reason, MessageLevel::Fatal);
-            emitFailed(tr(reason));
+            const char* reason = QT_TR_NOOP("Could not launch Minecraft: %1");
+            emit logLine(QString(reason).arg(m_process.errorString()), MessageLevel::Fatal);
+            emitFailed(tr(reason).arg(m_process.errorString()));
             return;
         }
         case LoggedProcess::Aborted:


### PR DESCRIPTION
Qt sets errorString on start failure but we never propagate it to the user, so if they encounter process start errors no one can help (this happened today in the discord so not a theoretical issue)