### PR TITLE
Add restart button to instance window

### DIFF
--- a/launcher/ui/InstanceWindow.cpp
+++ b/launcher/ui/InstanceWindow.cpp
@@ -100,6 +100,8 @@ InstanceWindow::InstanceWindow(BaseInstance* instance, QWidget* parent) : QMainW
         horizontalLayout->addWidget(m_restartButton);
         connect(m_restartButton, &QPushButton::clicked, this, &InstanceWindow::restartInstance);
 
+        m_restartButton->hide();
+
         m_killButton = new QPushButton(this);
         m_killButton->setText(tr("&Kill"));
         m_killButton->setToolTip(tr("Kill the running instance"));
@@ -160,6 +162,9 @@ void InstanceWindow::on_instanceStatusChanged(BaseInstance::Status, BaseInstance
 void InstanceWindow::updateButtons()
 {
     const bool running = m_instance->isRunning();
+
+    m_launchButton->setVisible(!running);
+    m_restartButton->setVisible(running);
 
     m_launchButton->setEnabled(m_instance->canLaunch());
     m_restartButton->setEnabled(running && !m_restartQueued);

--- a/launcher/ui/InstanceWindow.cpp
+++ b/launcher/ui/InstanceWindow.cpp
@@ -42,6 +42,7 @@
 #include <QMessageBox>
 #include <QPushButton>
 #include <QScrollBar>
+#include <QTimer>
 
 #include "ui/widgets/PageContainer.h"
 
@@ -92,6 +93,12 @@ InstanceWindow::InstanceWindow(BaseInstance* instance, QWidget* parent) : QMainW
         m_launchButton->setMinimumWidth(80);  // HACK!!
         horizontalLayout->addWidget(m_launchButton);
         connect(m_launchButton, &QPushButton::clicked, this, [this] { APPLICATION->launch(m_instance); });
+
+        m_restartButton = new QPushButton(this);
+        m_restartButton->setText(tr("&Restart"));
+        m_restartButton->setToolTip(tr("Restart the running instance"));
+        horizontalLayout->addWidget(m_restartButton);
+        connect(m_restartButton, &QPushButton::clicked, this, &InstanceWindow::restartInstance);
 
         m_killButton = new QPushButton(this);
         m_killButton->setText(tr("&Kill"));
@@ -152,8 +159,11 @@ void InstanceWindow::on_instanceStatusChanged(BaseInstance::Status, BaseInstance
 
 void InstanceWindow::updateButtons()
 {
+    const bool running = m_instance->isRunning();
+
     m_launchButton->setEnabled(m_instance->canLaunch());
-    m_killButton->setEnabled(m_instance->isRunning());
+    m_restartButton->setEnabled(running && !m_restartQueued);
+    m_killButton->setEnabled(running);
 
     QMenu* launchMenu = m_launchButton->menu();
     if (launchMenu)
@@ -175,7 +185,24 @@ void InstanceWindow::runningStateChanged(bool running)
     m_container->refreshContainer();
     if (running) {
         selectPage("log");
+    } else if (m_restartQueued) {
+        m_restartQueued = false;
+        // Wait until the current launch controller has handled the stopped instance before launching again.
+        QTimer::singleShot(0, this, [this] {
+            APPLICATION->launch(m_instance);
+            updateButtons();
+        });
     }
+}
+
+void InstanceWindow::restartInstance()
+{
+    if (!m_instance->isRunning()) {
+        return;
+    }
+
+    m_restartQueued = APPLICATION->kill(m_instance);
+    updateButtons();
 }
 
 void InstanceWindow::closeEvent(QCloseEvent* event)

--- a/launcher/ui/InstanceWindow.h
+++ b/launcher/ui/InstanceWindow.h
@@ -74,6 +74,7 @@ class InstanceWindow : public QMainWindow, public BasePageContainer {
    private slots:
     void instanceLaunchTaskChanged(LaunchTask* proc);
     void runningStateChanged(bool running);
+    void restartInstance();
     void on_instanceStatusChanged(BaseInstance::Status, BaseInstance::Status newStatus);
 
    protected:
@@ -86,8 +87,10 @@ class InstanceWindow : public QMainWindow, public BasePageContainer {
     LaunchTask* m_proc;
     BaseInstance* m_instance;
     bool m_doNotSave = false;
+    bool m_restartQueued = false;
     PageContainer* m_container = nullptr;
     QPushButton* m_closeButton = nullptr;
     QToolButton* m_launchButton = nullptr;
+    QPushButton* m_restartButton = nullptr;
     QPushButton* m_killButton = nullptr;
 };


### PR DESCRIPTION
Closes #1834

Adds a Restart button to the instance window next to Launch and Kill.

The button is only enabled while the instance is running. When clicked, it kills the running instance through the existing kill path and relaunches it after the instance reports that it has stopped.