### PR TITLE
When auth is down, launch into offline mode

### DIFF
--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -182,6 +182,33 @@ LaunchDecision LaunchController::decideLaunchMode()
 
     QString reauthReason;
     switch (state) {
+        case AccountState::Offline: {
+            if (m_wantedLaunchMode == LaunchMode::Normal) {
+                QMessageBox msg(m_parentWidget);
+                msg.setWindowTitle(tr("Auth servers offline"));
+                msg.setText(tr("The Minecraft authentication servers are currently unavailable."));
+                msg.setIcon(QMessageBox::Warning);
+
+                auto* launchOfflineButton = msg.addButton(tr("Launch Offline"), QMessageBox::AcceptRole);
+                auto* retryButton = msg.addButton(tr("Retry"), QMessageBox::ActionRole);
+                msg.addButton(tr("Cancel"), QMessageBox::RejectRole);
+                msg.setDefaultButton(launchOfflineButton);
+
+                msg.exec();
+
+                if (msg.clickedButton() == launchOfflineButton) {
+                    m_actualLaunchMode = LaunchMode::Offline;
+                    return LaunchDecision::Continue;
+                }
+                if (msg.clickedButton() == retryButton) {
+                    return LaunchDecision::Undecided;
+                }
+                return LaunchDecision::Abort;
+            }
+
+            m_actualLaunchMode = LaunchMode::Offline;
+            return LaunchDecision::Continue;
+        }
         case AccountState::Errored:
             reauthReason = tr("An error occurred while refreshing '%1'").arg(accountToCheck->profileName());
             break;

--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -41,6 +41,7 @@
 #include "minecraft/auth/AccountList.h"
 
 #include "ui/InstanceWindow.h"
+#include "net/NetUtils.h"
 #include "ui/dialogs/CustomMessageBox.h"
 #include "ui/dialogs/MSALoginDialog.h"
 #include "ui/dialogs/ProfileSelectDialog.h"
@@ -185,8 +186,16 @@ LaunchDecision LaunchController::decideLaunchMode()
         case AccountState::Offline: {
             if (m_wantedLaunchMode == LaunchMode::Normal) {
                 QMessageBox msg(m_parentWidget);
-                msg.setWindowTitle(tr("Auth servers offline"));
-                msg.setText(tr("The Minecraft authentication servers are currently unavailable."));
+
+                auto netErr = accountToCheck->accountData()->networkError;
+                if (Net::isServerError(netErr)) {
+                    msg.setWindowTitle(tr("Auth servers offline"));
+                    msg.setText(tr("The Minecraft authentication servers are currently unavailable.\n\n%1").arg(accountToCheck->lastError()));
+                } else {
+                    msg.setWindowTitle(tr("No internet connection"));
+                    msg.setText(tr("Unable to connect to the internet.\n\n%1").arg(accountToCheck->lastError()));
+                }
+
                 msg.setIcon(QMessageBox::Warning);
 
                 auto* launchOfflineButton = msg.addButton(tr("Launch Offline"), QMessageBox::AcceptRole);

--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -40,8 +40,8 @@
 #include "minecraft/auth/AccountData.h"
 #include "minecraft/auth/AccountList.h"
 
-#include "ui/InstanceWindow.h"
 #include "net/NetUtils.h"
+#include "ui/InstanceWindow.h"
 #include "ui/dialogs/CustomMessageBox.h"
 #include "ui/dialogs/MSALoginDialog.h"
 #include "ui/dialogs/ProfileSelectDialog.h"
@@ -183,41 +183,6 @@ LaunchDecision LaunchController::decideLaunchMode()
 
     QString reauthReason;
     switch (state) {
-        case AccountState::Offline: {
-            if (m_wantedLaunchMode == LaunchMode::Normal) {
-                QMessageBox msg(m_parentWidget);
-
-                auto netErr = accountToCheck->accountData()->networkError;
-                if (Net::isServerError(netErr)) {
-                    msg.setWindowTitle(tr("Auth servers offline"));
-                    msg.setText(tr("The Minecraft authentication servers are currently unavailable.\n\n%1").arg(accountToCheck->lastError()));
-                } else {
-                    msg.setWindowTitle(tr("No internet connection"));
-                    msg.setText(tr("Unable to connect to the internet.\n\n%1").arg(accountToCheck->lastError()));
-                }
-
-                msg.setIcon(QMessageBox::Warning);
-
-                auto* launchOfflineButton = msg.addButton(tr("Launch Offline"), QMessageBox::AcceptRole);
-                auto* retryButton = msg.addButton(tr("Retry"), QMessageBox::ActionRole);
-                msg.addButton(tr("Cancel"), QMessageBox::RejectRole);
-                msg.setDefaultButton(launchOfflineButton);
-
-                msg.exec();
-
-                if (msg.clickedButton() == launchOfflineButton) {
-                    m_actualLaunchMode = LaunchMode::Offline;
-                    return LaunchDecision::Continue;
-                }
-                if (msg.clickedButton() == retryButton) {
-                    return LaunchDecision::Undecided;
-                }
-                return LaunchDecision::Abort;
-            }
-
-            m_actualLaunchMode = LaunchMode::Offline;
-            return LaunchDecision::Continue;
-        }
         case AccountState::Errored:
             reauthReason = tr("An error occurred while refreshing '%1'").arg(accountToCheck->profileName());
             break;
@@ -261,13 +226,14 @@ bool LaunchController::askPlayDemo() const
     return box.clickedButton() == demoButton;
 }
 
-QString LaunchController::askOfflineName(const QString& playerName, bool* ok) const
+QString LaunchController::askOfflineName(const QString& playerName, bool* ok)
 {
     if (ok != nullptr) {
         *ok = false;
     }
 
-    QString message;
+    QString title, message;
+    title = tr("Player name");
     switch (m_actualLaunchMode) {
         case LaunchMode::Normal:
             Q_ASSERT(false);
@@ -277,7 +243,14 @@ QString LaunchController::askOfflineName(const QString& playerName, bool* ok) co
             break;
         case LaunchMode::Offline:
             if (m_wantedLaunchMode == LaunchMode::Normal) {
-                message = tr("You are not connected to the Internet, launching in offline mode\n\n");
+                auto netErr = m_accountToUse->accountData()->networkError;
+                if (Net::isServerError(netErr)) {
+                    title = tr("Auth servers offline");
+                    message = tr("The Minecraft authentication servers are currently unavailable, launching in offline mode.\n\n");
+                } else {
+                    title = tr("No internet connection");
+                    message = tr("You are not connected to the Internet, launching in offline mode.\n\n");
+                }
             }
             message += tr("Choose your offline mode player name");
             break;
@@ -287,7 +260,7 @@ QString LaunchController::askOfflineName(const QString& playerName, bool* ok) co
     QString usedname = lastOfflinePlayerName.isEmpty() ? playerName : lastOfflinePlayerName;
 
     ChooseOfflineNameDialog dialog(message, m_parentWidget);
-    dialog.setWindowTitle(tr("Player name"));
+    dialog.setWindowTitle(title);
     dialog.setUsername(usedname);
     if (dialog.exec() != QDialog::Accepted) {
         return {};

--- a/launcher/LaunchController.h
+++ b/launcher/LaunchController.h
@@ -78,7 +78,7 @@ class LaunchController : public Task {
     void decideAccount();
     LaunchDecision decideLaunchMode();
     bool askPlayDemo() const;
-    QString askOfflineName(const QString& playerName, bool* ok = nullptr) const;
+    QString askOfflineName(const QString& playerName, bool* ok = nullptr);
     bool reauthenticateAccount(const MinecraftAccountPtr& account, const QString& reason);
 
    private slots:

--- a/launcher/minecraft/auth/AccountData.h
+++ b/launcher/minecraft/auth/AccountData.h
@@ -41,6 +41,7 @@
 
 #include <QDateTime>
 #include <QMap>
+#include <QNetworkReply>
 #include <QVariantMap>
 
 enum class Validity { None, Assumed, Certain };
@@ -118,5 +119,6 @@ struct AccountData {
     // runtime only information (not saved with the account)
     QString internalId;
     QString errorString;
+    QNetworkReply::NetworkError networkError = QNetworkReply::NoError;
     AccountState accountState = AccountState::Unchecked;
 };

--- a/launcher/minecraft/auth/steps/LauncherLoginStep.cpp
+++ b/launcher/minecraft/auth/steps/LauncherLoginStep.cpp
@@ -60,6 +60,7 @@ void LauncherLoginStep::onRequestDone(QByteArray* response)
             emit finished(AccountTaskState::STATE_FAILED_SOFT,
                           tr("Failed to get Minecraft access token: %1").arg(m_request->errorString()));
         } else {
+            m_data->networkError = m_request->error();
             emit finished(AccountTaskState::STATE_OFFLINE, tr("Failed to get Minecraft access token: %1").arg(m_request->errorString()));
         }
         return;

--- a/launcher/minecraft/auth/steps/LauncherLoginStep.cpp
+++ b/launcher/minecraft/auth/steps/LauncherLoginStep.cpp
@@ -56,7 +56,7 @@ void LauncherLoginStep::onRequestDone(QByteArray* response)
     qCDebug(authCredentials()) << *response;
     if (m_request->error() != QNetworkReply::NoError) {
         qWarning() << "Reply error:" << m_request->error();
-        if (Net::isApplicationError(m_request->error())) {
+        if (Net::isApplicationError(m_request->error()) && !Net::isServerError(m_request->error())) {
             emit finished(AccountTaskState::STATE_FAILED_SOFT,
                           tr("Failed to get Minecraft access token: %1").arg(m_request->errorString()));
         } else {

--- a/launcher/minecraft/auth/steps/MinecraftProfileStep.cpp
+++ b/launcher/minecraft/auth/steps/MinecraftProfileStep.cpp
@@ -56,6 +56,7 @@ void MinecraftProfileStep::onRequestDone(QByteArray* response)
             emit finished(AccountTaskState::STATE_FAILED_SOFT,
                           tr("Minecraft Java profile acquisition failed: %1").arg(m_request->errorString()));
         } else {
+            m_data->networkError = m_request->error();
             emit finished(AccountTaskState::STATE_OFFLINE,
                           tr("Minecraft Java profile acquisition failed: %1").arg(m_request->errorString()));
         }

--- a/launcher/minecraft/auth/steps/MinecraftProfileStep.cpp
+++ b/launcher/minecraft/auth/steps/MinecraftProfileStep.cpp
@@ -52,7 +52,7 @@ void MinecraftProfileStep::onRequestDone(QByteArray* response)
         qWarning() << " Response:";
         qWarning() << QString::fromUtf8(*response);
 
-        if (Net::isApplicationError(m_request->error())) {
+        if (Net::isApplicationError(m_request->error()) && !Net::isServerError(m_request->error())) {
             emit finished(AccountTaskState::STATE_FAILED_SOFT,
                           tr("Minecraft Java profile acquisition failed: %1").arg(m_request->errorString()));
         } else {

--- a/launcher/minecraft/auth/steps/XboxAuthorizationStep.cpp
+++ b/launcher/minecraft/auth/steps/XboxAuthorizationStep.cpp
@@ -60,7 +60,7 @@ void XboxAuthorizationStep::onRequestDone(QByteArray* response)
     qCDebug(authCredentials()) << *response;
     if (m_request->error() != QNetworkReply::NoError) {
         qWarning() << "Reply error:" << m_request->error();
-        if (Net::isApplicationError(m_request->error())) {
+        if (Net::isApplicationError(m_request->error()) && !Net::isServerError(m_request->error())) {
             if (processSTSError(*response)) {
                 return;
             }

--- a/launcher/minecraft/auth/steps/XboxAuthorizationStep.cpp
+++ b/launcher/minecraft/auth/steps/XboxAuthorizationStep.cpp
@@ -67,6 +67,7 @@ void XboxAuthorizationStep::onRequestDone(QByteArray* response)
             emit finished(AccountTaskState::STATE_FAILED_SOFT,
                           tr("Unknown STS error for %1 services: %2").arg(m_authorizationKind, m_request->errorString()));
         } else {
+            m_data->networkError = m_request->error();
             emit finished(AccountTaskState::STATE_OFFLINE,
                           tr("Failed to get authorization for %1 services: %2").arg(m_authorizationKind, m_request->errorString()));
         }

--- a/launcher/minecraft/auth/steps/XboxUserStep.cpp
+++ b/launcher/minecraft/auth/steps/XboxUserStep.cpp
@@ -59,6 +59,7 @@ void XboxUserStep::onRequestDone(QByteArray* response)
         if (Net::isApplicationError(m_request->error()) && !Net::isServerError(m_request->error())) {
             emit finished(AccountTaskState::STATE_FAILED_SOFT, tr("Xbox user authentication failed: %1").arg(m_request->errorString()));
         } else {
+            m_data->networkError = m_request->error();
             emit finished(AccountTaskState::STATE_OFFLINE, tr("Xbox user authentication failed: %1").arg(m_request->errorString()));
         }
         return;

--- a/launcher/minecraft/auth/steps/XboxUserStep.cpp
+++ b/launcher/minecraft/auth/steps/XboxUserStep.cpp
@@ -56,7 +56,7 @@ void XboxUserStep::onRequestDone(QByteArray* response)
 {
     if (m_request->error() != QNetworkReply::NoError) {
         qWarning() << "Reply error:" << m_request->error();
-        if (Net::isApplicationError(m_request->error())) {
+        if (Net::isApplicationError(m_request->error()) && !Net::isServerError(m_request->error())) {
             emit finished(AccountTaskState::STATE_FAILED_SOFT, tr("Xbox user authentication failed: %1").arg(m_request->errorString()));
         } else {
             emit finished(AccountTaskState::STATE_OFFLINE, tr("Xbox user authentication failed: %1").arg(m_request->errorString()));

--- a/launcher/net/NetUtils.h
+++ b/launcher/net/NetUtils.h
@@ -40,4 +40,18 @@ inline bool isApplicationError(QNetworkReply::NetworkError x)
                                                         QNetworkReply::UnknownContentError };
     return errors.contains(x);
 }
+
+// 500 class errors, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/500
+// microsoft may send these error codes when services (auth) are down.
+// We treat this as a reason to launch in offline mode.
+inline bool isServerError(QNetworkReply::NetworkError x)
+{
+    static QSet<QNetworkReply::NetworkError> errors = { QNetworkReply::InternalServerError,
+                                                        QNetworkReply::OperationNotImplementedError,
+                                                        QNetworkReply::ServiceUnavailableError,     // 503 | seen in logs in 2026
+                                                        //QNetworkReply::GatewayTimeoutError,       // 504 | seen in logs in 2024
+                                                        // Qt doesn't have it mapped. Unknown covers it
+                                                        QNetworkReply::UnknownServerError };
+    return errors.contains(x);
+}
 }  // namespace Net


### PR DESCRIPTION
when the auth request on launch returns a 5xx error (500, 501, 503, 504 or anything not mapped by Qt), then the launcher asks if you want to launch offline.

~~Right now it just jumps straight in, I think it should probably ask to retry, or launch offline. 
opinions? Suggestions on implementation? (feel free to push to this branch)~~