### PR TITLE
Include Flame API key in CDN downloads

### DIFF
--- a/buildconfig/BuildConfig.h
+++ b/buildconfig/BuildConfig.h
@@ -194,8 +194,10 @@ class Config {
     QString MODRINTH_STAGING_URL = "https://staging-api.modrinth.com/v2";
     QString MODRINTH_PROD_URL = "https://api.modrinth.com/v2";
     QStringList MODRINTH_MRPACK_HOSTS{ "cdn.modrinth.com", "github.com", "raw.githubusercontent.com", "gitlab.com" };
+    QString MODRINTH_DOWNLOAD_HOST = "cdn.modrinth.com";
 
     QString FLAME_BASE_URL = "https://api.curseforge.com/v1";
+    QString FLAME_DOWNLOAD_HOST = "edge.forgecdn.net";
 
     QString versionString() const;
     /**

--- a/launcher/net/ApiHeaderProxy.h
+++ b/launcher/net/ApiHeaderProxy.h
@@ -61,17 +61,19 @@ class ApiHeaderProxy : public HeaderProxy {
     QList<HeaderPair> headers(const QNetworkRequest& request) const override
     {
         QList<HeaderPair> hdrs;
-        if (APPLICATION->capabilities() & Application::SupportsFlame && request.url().host() == QUrl(BuildConfig.FLAME_BASE_URL).host()) {
+        const auto host = request.url().host();
+
+        if (APPLICATION->capabilities() & Application::SupportsFlame &&
+            (host == QUrl(BuildConfig.FLAME_BASE_URL).host() || host == BuildConfig.FLAME_DOWNLOAD_HOST)) {
             hdrs.append({ .headerName = "x-api-key", .headerValue = APPLICATION->getFlameAPIKey().toUtf8() });
-        } else if (request.url().host() == QUrl(BuildConfig.MODRINTH_PROD_URL).host() ||
-                   request.url().host() == QUrl(BuildConfig.MODRINTH_STAGING_URL).host()) {
+        } else if (host == QUrl(BuildConfig.MODRINTH_PROD_URL).host() || host == QUrl(BuildConfig.MODRINTH_STAGING_URL).host()) {
             QString token = APPLICATION->getModrinthAPIToken();
             if (!token.isNull()) {
                 hdrs.append({ .headerName = "Authorization", .headerValue = token.toUtf8() });
             }
         }
 
-        if (request.url().host() == "cdn.modrinth.com" && !m_meta.isEmpty()) {
+        if (host == BuildConfig.MODRINTH_DOWNLOAD_HOST && !m_meta.isEmpty()) {
             hdrs.append({ .headerName = "modrinth-download-meta", .headerValue = m_meta.toJson() });
         }
         return hdrs;


### PR DESCRIPTION
https://blog.curseforge.com/introducing-api-key-authentication-for-curseforge-file-downloads/

<img width="715" height="91" alt="image" src="https://github.com/user-attachments/assets/ac5aad0f-5efc-4643-8ff5-26abd82ac9a9" />
