### PR TITLE
Trim whitespace from environment variables

### DIFF
--- a/launcher/ui/widgets/EnvironmentVariables.cpp
+++ b/launcher/ui/widgets/EnvironmentVariables.cpp
@@ -104,7 +104,7 @@ QMap<QString, QVariant> EnvironmentVariables::value() const
     QMap<QString, QVariant> result;
     QTreeWidgetItem* item = ui->list->topLevelItem(0);
     for (int i = 1; item != nullptr; item = ui->list->topLevelItem(i++))
-        result[item->text(0)] = item->text(1);
+        result[item->text(0).trimmed()] = item->text(1).trimmed();
 
     return result;
 }


### PR DESCRIPTION
Fixes #5698

Trims leading and trailing whitespace from environment variable names and values to avoid silently creating invalid variables.