### PR TITLE
Sort mod Minecraft versions as version lists

### DIFF
--- a/launcher/minecraft/mod/Mod.cpp
+++ b/launcher/minecraft/mod/Mod.cpp
@@ -40,6 +40,7 @@
 #include <QDir>
 #include <QRegularExpression>
 #include <QString>
+#include <algorithm>
 
 #include "MTPixmapCache.h"
 #include "MetadataHandler.h"
@@ -48,6 +49,34 @@
 #include "minecraft/mod/ModDetails.h"
 #include "minecraft/mod/tasks/LocalModParseTask.h"
 #include "modplatform/ModIndex.h"
+
+namespace {
+
+int compareVersionLists(const QStringList& leftVersions, const QStringList& rightVersions)
+{
+    const qsizetype commonSize = std::min(leftVersions.size(), rightVersions.size());
+
+    for (qsizetype i = 0; i < commonSize; i++) {
+        const auto leftVersion = Version(leftVersions.at(i).trimmed());
+        const auto rightVersion = Version(rightVersions.at(i).trimmed());
+
+        if (leftVersion > rightVersion)
+            return 1;
+
+        if (leftVersion < rightVersion)
+            return -1;
+    }
+
+    if (leftVersions.size() > rightVersions.size())
+        return 1;
+
+    if (leftVersions.size() < rightVersions.size())
+        return -1;
+
+    return 0;
+}
+
+}  // namespace
 
 Mod::Mod(const QFileInfo& file) : Resource(file), m_local_details()
 {
@@ -88,7 +117,7 @@ int Mod::compare(const Resource& other, SortType type) const
             break;
         }
         case SortType::McVersions: {
-            auto compare_result = QString::compare(mcVersions(), cast_other->mcVersions(), Qt::CaseInsensitive);
+            auto compare_result = compareVersionLists(mcVersions(), cast_other->mcVersions());
             if (compare_result != 0)
                 return compare_result;
             break;
@@ -197,12 +226,17 @@ auto Mod::side() const -> QString
     return ModPlatform::SideUtils::toString(ModPlatform::Side::UniversalSide);
 }
 
-auto Mod::mcVersions() const -> QString
+auto Mod::mcVersions() const -> QStringList
 {
     if (metadata())
-        return metadata()->mcVersions.join(", ");
+        return metadata()->mcVersions;
 
     return {};
+}
+
+auto Mod::mcVersionsString() const -> QString
+{
+    return mcVersions().join(", ");
 }
 
 auto Mod::releaseType() const -> QString

--- a/launcher/minecraft/mod/Mod.h
+++ b/launcher/minecraft/mod/Mod.h
@@ -68,7 +68,8 @@ class Mod : public Resource {
     auto issueTracker() const -> QString;
     auto side() const -> QString;
     auto loaders() const -> QString;
-    auto mcVersions() const -> QString;
+    auto mcVersions() const -> QStringList;
+    auto mcVersionsString() const -> QString;
     auto releaseType() const -> QString;
     QStringList dependencies() const;
 

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -110,7 +110,7 @@ QVariant ModFolderModel::data(const QModelIndex& index, int role) const
                     return at(row).loaders();
                 }
                 case McVersionsColumn: {
-                    return at(row).mcVersions();
+                    return at(row).mcVersionsString();
                 }
                 case ReleaseTypeColumn: {
                     return at(row).releaseType();


### PR DESCRIPTION
Fixes #4217

Compare Minecraft version lists using the existing Version comparator instead of sorting the joined display string.

This fixes incorrect ordering for versions such as 1.21.10, which were previously sorted as plain text. Multi-version entries are compared in display order, matching how they are shown in the Minecraft Versions column.

Tested by creating a mod list with Minecraft versions including 1.21.1, 1.21.2, 1.21.5, 1.21.9, and 1.21.10, and then sorting the Minecraft Versions column.

Screenshot after the fix:
<img width="590" height="434" alt="Screenshot_7" src="https://github.com/user-attachments/assets/e775c6db-a954-491a-9ac0-6f8795d8f621" />
