### PR TITLE
Add the option to sort instances by total playtime

### DIFF
--- a/launcher/ui/instanceview/InstanceProxyModel.cpp
+++ b/launcher/ui/instanceview/InstanceProxyModel.cpp
@@ -62,6 +62,12 @@ bool InstanceProxyModel::subSortLessThan(const QModelIndex& left, const QModelIn
     QString sortMode = APPLICATION->settings()->get("InstSortMode").toString();
     if (sortMode == "LastLaunch") {
         return pdataLeft->lastLaunch() > pdataRight->lastLaunch();
+    } else if (sortMode == "Playtime") {
+        if (pdataLeft->totalTimePlayed() == pdataRight->totalTimePlayed()) {
+            // fallback to name sorting if playtime is equal
+            return m_naturalSort.compare(pdataLeft->name(), pdataRight->name()) < 0;
+        }
+        return pdataLeft->totalTimePlayed() > pdataRight->totalTimePlayed();
     } else {
         return m_naturalSort.compare(pdataLeft->name(), pdataRight->name()) < 0;
     }

--- a/launcher/ui/instanceview/InstanceProxyModel.cpp
+++ b/launcher/ui/instanceview/InstanceProxyModel.cpp
@@ -64,7 +64,6 @@ bool InstanceProxyModel::subSortLessThan(const QModelIndex& left, const QModelIn
         return pdataLeft->lastLaunch() > pdataRight->lastLaunch();
     } else if (sortMode == "Playtime") {
         if (pdataLeft->totalTimePlayed() == pdataRight->totalTimePlayed()) {
-            // fallback to name sorting if playtime is equal
             return m_naturalSort.compare(pdataLeft->name(), pdataRight->name()) < 0;
         }
         return pdataLeft->totalTimePlayed() > pdataRight->totalTimePlayed();

--- a/launcher/ui/pages/global/LauncherPage.cpp
+++ b/launcher/ui/pages/global/LauncherPage.cpp
@@ -62,7 +62,9 @@ enum InstSortMode {
     // Sort alphabetically by name.
     Sort_Name,
     // Sort by which instance was launched most recently.
-    Sort_LastLaunch
+    Sort_LastLaunch,
+    // Sort by which instance has the most playtime.
+    Sort_Playtime,
 };
 
 LauncherPage::LauncherPage(QWidget* parent) : QWidget(parent), ui(new Ui::LauncherPage)
@@ -71,6 +73,7 @@ LauncherPage::LauncherPage(QWidget* parent) : QWidget(parent), ui(new Ui::Launch
 
     ui->sortingModeGroup->setId(ui->sortByNameBtn, Sort_Name);
     ui->sortingModeGroup->setId(ui->sortLastLaunchedBtn, Sort_LastLaunch);
+    ui->sortingModeGroup->setId(ui->sortByPlaytimeBtn, Sort_Playtime);
 
     loadSettings();
 
@@ -227,6 +230,9 @@ void LauncherPage::applySettings()
         case Sort_LastLaunch:
             s->set("InstSortMode", "LastLaunch");
             break;
+        case Sort_Playtime:
+            s->set("InstSortMode", "Playtime");
+            break;
         case Sort_Name:
         default:
             s->set("InstSortMode", "Name");
@@ -282,6 +288,8 @@ void LauncherPage::loadSettings()
     QString sortMode = s->get("InstSortMode").toString();
     if (sortMode == "LastLaunch") {
         ui->sortLastLaunchedBtn->setChecked(true);
+    } else if (sortMode == "Playtime"){
+        ui->sortByPlaytimeBtn->setChecked(true);
     } else {
         ui->sortByNameBtn->setChecked(true);
     }

--- a/launcher/ui/pages/global/LauncherPage.ui
+++ b/launcher/ui/pages/global/LauncherPage.ui
@@ -84,6 +84,16 @@
            </widget>
           </item>
           <item>
+           <widget class="QRadioButton" name="sortByPlaytimeBtn">
+            <property name="text">
+             <string>By &amp;playtime</string>
+            </property>
+            <attribute name="buttonGroup">
+             <string notr="true">sortingModeGroup</string>
+            </attribute>
+           </widget>
+          </item>
+          <item>
            <spacer name="verticalSpacer">
             <property name="orientation">
              <enum>Qt::Orientation::Vertical</enum>
@@ -675,6 +685,7 @@
   <tabstop>scrollArea</tabstop>
   <tabstop>sortByNameBtn</tabstop>
   <tabstop>sortLastLaunchedBtn</tabstop>
+  <tabstop>sortByPlaytimeBtn</tabstop>
   <tabstop>askToRenameDirBtn</tabstop>
   <tabstop>alwaysRenameDirBtn</tabstop>
   <tabstop>neverRenameDirBtn</tabstop>

--- a/launcher/ui/pages/global/LauncherPage.ui
+++ b/launcher/ui/pages/global/LauncherPage.ui
@@ -86,7 +86,7 @@
           <item>
            <widget class="QRadioButton" name="sortByPlaytimeBtn">
             <property name="text">
-             <string>By &amp;playtime</string>
+             <string>By total time &amp;played</string>
             </property>
             <attribute name="buttonGroup">
              <string notr="true">sortingModeGroup</string>


### PR DESCRIPTION
Fixes #5701 

Adds the option "By playtime" to the Instance Sorting menu.

When selected, instances are sorted by their total playtime. If two instances total playtimes are equal, sorting falls back to ordering by name.

<img width="632" height="704" alt="image" src="https://github.com/user-attachments/assets/0a77a012-75ad-46f8-93b3-3fa620b71129" />