### PR TITLE
feat: add manual group reordering with drag-and-drop

### DIFF
--- a/launcher/InstanceList.cpp
+++ b/launcher/InstanceList.cpp
@@ -144,6 +144,30 @@ QStringList InstanceList::getLinkedInstancesById(const QString& id) const
     return linkedInstances;
 }
 
+QStringList InstanceList::groupOrder() const
+{
+    return m_groupOrder;
+}
+
+void InstanceList::moveGroup(const QString& group, int toIndex)
+{
+    int fromIndex = m_groupOrder.indexOf(group);
+    if (fromIndex < 0)
+        return;
+
+    int size = m_groupOrder.size();
+    toIndex = qBound(0, toIndex, size);
+    if (fromIndex == toIndex)
+        return;
+
+    QString name = m_groupOrder.takeAt(fromIndex);
+    // After takeAt, insert position shifts if target was after the removed position
+    int insertAt = (fromIndex < toIndex) ? (toIndex - 1) : toIndex;
+    m_groupOrder.insert(insertAt, name);
+    emit groupOrderChanged();
+    saveGroupList();
+}
+
 int InstanceList::rowCount(const QModelIndex& parent) const
 {
     Q_UNUSED(parent);
@@ -296,6 +320,8 @@ void InstanceList::deleteGroup(const GroupId& name)
     if (removed) {
         saveGroupList();
     }
+    m_groupOrder.removeAll(name);
+    emit groupOrderChanged();
 }
 
 void InstanceList::renameGroup(const QString& src, const QString& dst)
@@ -324,6 +350,14 @@ void InstanceList::renameGroup(const QString& src, const QString& dst)
     if (modified) {
         saveGroupList();
     }
+    if (src != dst) {
+        m_groupOrder.removeAll(dst);
+        const int idx = static_cast<int>(m_groupOrder.indexOf(src));
+        if (idx >= 0) {
+            m_groupOrder[idx] = dst;
+        }
+    }
+    emit groupOrderChanged();
 }
 
 bool InstanceList::isGroupCollapsed(const QString& group)
@@ -731,7 +765,11 @@ void InstanceList::increaseGroupCount(const QString& group)
         return;
     }
 
+    bool wasNew = !m_groupNameCache.contains(group);
     ++m_groupNameCache[group];
+    if (wasNew && !m_groupOrder.contains(group)) {
+        m_groupOrder.append(group);
+    }
 }
 
 void InstanceList::decreaseGroupCount(const QString& group)
@@ -743,6 +781,7 @@ void InstanceList::decreaseGroupCount(const QString& group)
     if (--m_groupNameCache[group] < 1) {
         m_groupNameCache.remove(group);
         m_collapsedGroups.remove(group);
+        m_groupOrder.removeAll(group);
     }
 }
 
@@ -788,6 +827,16 @@ void InstanceList::saveGroupList()
         ungrouped.insert("hidden", QJsonValue(true));
         toplevel.insert("ungrouped", ungrouped);
     }
+    // Save group order (deduplicate to prevent silent corruption)
+    QJsonArray orderArr;
+    QStringList savedOrder;
+    for (const auto& name : m_groupOrder) {
+        if (!savedOrder.contains(name) && (name.isEmpty() || m_groupNameCache.contains(name))) {
+            savedOrder.append(name);
+            orderArr.append(name);
+        }
+    }
+    toplevel.insert("groupOrder", orderArr);
     QJsonDocument doc(toplevel);
     try {
         FS::write(groupFileName, doc.toJson());
@@ -813,6 +862,10 @@ void InstanceList::loadGroupList()
     if (!QFileInfo::exists(groupFileName)) {
         QString legacyGroupFileName = FS::PathCombine(primaryDir(), "instgroups.json");
         if (!QFileInfo::exists(legacyGroupFileName)) {
+            // No group file at all: set up the default state
+            m_groupOrder.clear();
+            m_groupOrder.append("");
+            m_groupsLoaded = true;
             return;
         }
         qInfo() << "Migrating instance groups from legacy location" << legacyGroupFileName;
@@ -858,6 +911,18 @@ void InstanceList::loadGroupList()
         return;
     }
 
+    m_groupOrder.clear();
+
+    // Load saved group order FIRST, so increaseGroupCount won't re-add groups out of order
+    if (rootObj.value("groupOrder").isArray()) {
+        const QJsonArray orderArr = rootObj.value("groupOrder").toArray();
+        for (const auto& val : orderArr) {
+            const QString name = val.toString();
+            m_groupOrder.append(name);
+        }
+    }
+
+    // Iterate through all the groups.
     QJsonObject groupMapping = rootObj.value("groups").toObject();
     for (QJsonObject::iterator iter = groupMapping.begin(); iter != groupMapping.end(); iter++) {
         QString groupName = iter.key();
@@ -898,6 +963,23 @@ void InstanceList::loadGroupList()
         // empty string represents ungrouped "group"
         m_collapsedGroups.insert("");
     }
+
+    // Deduplicate group order (defense against previously-corrupted data)
+    QStringList uniqueOrder;
+    for (const auto& name : m_groupOrder) {
+        if (!uniqueOrder.contains(name))
+            uniqueOrder.append(name);
+    }
+    m_groupOrder = uniqueOrder;
+
+    // Treat ungrouped group (empty string) as a regular group for ordering
+    if (m_groupOrder.isEmpty()) {
+        m_groupOrder = m_groupNameCache.keys();
+        m_groupOrder.sort();
+    }
+    if (!m_groupOrder.contains(""))
+        m_groupOrder.append("");
+
     m_groupsLoaded = true;
     qDebug() << "Group list loaded.";
 

--- a/launcher/InstanceList.h
+++ b/launcher/InstanceList.h
@@ -151,10 +151,13 @@ class InstanceList : public QAbstractListModel {
     QMimeData* mimeData(const QModelIndexList& indexes) const override;
 
     QStringList getLinkedInstancesById(const QString& id) const;
+    QStringList groupOrder() const;
+    void moveGroup(const QString& group, int toIndex);
 
     QString primaryDir() const { return m_instDirs.isEmpty() ? QString() : m_instDirs.first(); }
 
    signals:
+    void groupOrderChanged();
     void dataIsInvalid();
     void instancesChanged();
     void instanceSelectRequest(QString instanceId);
@@ -189,6 +192,7 @@ class InstanceList : public QAbstractListModel {
     std::vector<std::unique_ptr<MinecraftInstance>> m_instances;
     // id -> refs
     QMap<QString, int> m_groupNameCache;
+    QStringList m_groupOrder;
 
     SettingsObject* m_globalSettings;
     QStringList m_instDirs;

--- a/launcher/ui/instanceview/InstanceView.cpp
+++ b/launcher/ui/instanceview/InstanceView.cpp
@@ -38,6 +38,7 @@
 #include <QAccessible>
 #include <QApplication>
 #include <QCache>
+
 #include <QDrag>
 #include <QFont>
 #include <QListView>
@@ -46,6 +47,7 @@
 #include <QPainter>
 #include <QPersistentModelIndex>
 #include <QScrollBar>
+#include <QSet>
 #include <QtMath>
 
 #include "VisualGroup.h"
@@ -202,7 +204,23 @@ void InstanceView::updateGeometries()
     }
 
     qDeleteAll(m_groups);
-    m_groups = cats.values();
+    m_groups.clear();
+
+    // Build ordered group list from custom group order
+    auto instanceList = APPLICATION->instances();
+    auto groupOrder = instanceList->groupOrder();
+    QSet<QString> placed;
+    for (const auto& groupName : groupOrder) {
+        if (cats.contains(groupName)) {
+            m_groups.append(cats.take(groupName));
+            placed.insert(groupName);
+        }
+    }
+    // Append remaining groups (not in order) alphabetically
+    auto remaining = cats.values();
+    std::sort(remaining.begin(), remaining.end(), [](VisualGroup* a, VisualGroup* b) { return a->text.localeAwareCompare(b->text) < 0; });
+    m_groups.append(remaining);
+
     updateScrollbar();
     viewport()->update();
 }
@@ -283,12 +301,20 @@ void InstanceView::mousePressEvent(QMouseEvent* event)
     m_pressedIndex = index;
     m_pressedAlreadySelected = selectionModel()->isSelected(m_pressedIndex);
     m_pressedPosition = geometryPos;
+    m_draggingGroup = false;
+    m_draggedGroupName.clear();
+    m_groupDragTargetIndex = -1;
 
     if (event->button() == Qt::LeftButton) {
         VisualGroup::HitResults hitResult;
         m_pressedCategory = categoryAt(geometryPos, hitResult);
-        if (m_pressedCategory && hitResult & VisualGroup::CheckboxHit) {
-            setState(m_pressedCategory->collapsed ? ExpandingState : CollapsingState);
+        if (m_pressedCategory && hitResult & VisualGroup::HeaderHit) {
+            // Always allow drag from header, collapse also possible on click
+            m_draggingGroup = true;
+            m_draggedGroupName = m_pressedCategory->text;
+            if (hitResult & VisualGroup::CheckboxHit) {
+                setState(m_pressedCategory->collapsed ? ExpandingState : CollapsingState);
+            }
             event->accept();
             return;
         }
@@ -324,6 +350,39 @@ void InstanceView::mouseMoveEvent(QMouseEvent* event)
     QPoint topLeft;
     QPoint visualPos = event->pos();
     QPoint geometryPos = event->pos() + offset();
+
+    if (m_draggingGroup) {
+        topLeft = m_pressedPosition - offset();
+        qreal dist = (topLeft - event->pos()).manhattanLength();
+        qreal threshold = QApplication::startDragDistance();
+        if (dist > threshold) {
+            // Drag preview: compute visual target index and show indicator
+            setState(NoState);
+            QPoint cursorPos = geometryPos;
+            m_groupDragTargetIndex = -1;
+            for (int i = 0; i < m_groups.size(); i++) {
+                if (m_groups[i]->text == m_draggedGroupName)
+                    continue;
+                int gTop = m_groups[i]->verticalPosition();
+                int gBot = gTop + m_groups[i]->totalHeight();
+                int hMid = gTop + VisualGroup::headerHeight() / 2;
+                if (cursorPos.y() < hMid) {
+                    m_groupDragTargetIndex = i;
+                    break;
+                } else if (cursorPos.y() < gBot) {
+                    m_groupDragTargetIndex = i + 1;
+                    break;
+                }
+            }
+            if (m_groupDragTargetIndex < 0)
+                m_groupDragTargetIndex = m_groups.size();
+            if (m_groupDragTargetIndex > m_groups.size())
+                m_groupDragTargetIndex = m_groups.size();
+            viewport()->update();
+            return;
+        }
+        return;
+    }
 
     if (state() == ExpandingState || state() == CollapsingState) {
         return;
@@ -367,6 +426,35 @@ void InstanceView::mouseMoveEvent(QMouseEvent* event)
 void InstanceView::mouseReleaseEvent(QMouseEvent* event)
 {
     executeDelayedItemsLayout();
+
+    // Commit group drag reorder on release
+    if (m_draggingGroup && m_groupDragTargetIndex >= 0) {
+        auto groupOrder = APPLICATION->instances()->groupOrder();
+        int currentOrderIdx = groupOrder.indexOf(m_draggedGroupName);
+        if (currentOrderIdx >= 0) {
+            // Convert visual target index to groupOrder index
+            int orderTarget = 0;
+            for (int i = 0; i < m_groupDragTargetIndex && i < m_groups.size(); i++) {
+                if (m_groups[i]->text == m_draggedGroupName)
+                    continue;
+                int orderPos = groupOrder.indexOf(m_groups[i]->text);
+                if (orderPos >= 0 && orderPos >= orderTarget)
+                    orderTarget = orderPos + 1;
+            }
+            // Clamp to valid range
+            if (orderTarget > groupOrder.size())
+                orderTarget = groupOrder.size();
+            if (orderTarget != currentOrderIdx) {
+                APPLICATION->instances()->moveGroup(m_draggedGroupName, orderTarget);
+                updateGeometries();
+            }
+        }
+        viewport()->update();
+    }
+
+    m_draggingGroup = false;
+    m_draggedGroupName.clear();
+    m_groupDragTargetIndex = -1;
 
     QPoint visualPos = event->pos();
     QPoint geometryPos = event->pos() + offset();
@@ -522,6 +610,21 @@ void InstanceView::paintEvent([[maybe_unused]] QPaintEvent* event)
         option.rect.setRight(wpWidth - m_rightMargin);
         category->drawHeader(&painter, option);
         option.rect = backup;
+    }
+
+    // Draw group drag drop indicator
+    if (m_groupDragTargetIndex >= 0) {
+        int indicatorY = 0;
+        if (m_groupDragTargetIndex < m_groups.size()) {
+            indicatorY = m_groups[m_groupDragTargetIndex]->verticalPosition() - verticalOffset();
+        } else if (!m_groups.isEmpty()) {
+            auto* last = m_groups.last();
+            indicatorY = last->verticalPosition() + last->totalHeight() - verticalOffset();
+        }
+        painter.save();
+        painter.setPen(QPen(Qt::white, 1));
+        painter.drawLine(m_leftMargin, indicatorY, wpWidth - m_rightMargin, indicatorY);
+        painter.restore();
     }
 
     for (int i = 0; i < model()->rowCount(); ++i) {

--- a/launcher/ui/instanceview/InstanceView.cpp
+++ b/launcher/ui/instanceview/InstanceView.cpp
@@ -348,36 +348,38 @@ void InstanceView::mouseMoveEvent(QMouseEvent* event)
     executeDelayedItemsLayout();
 
     QPoint topLeft;
-    QPoint visualPos = event->pos();
-    QPoint geometryPos = event->pos() + offset();
+    const QPoint visualPos = event->pos();
+    const QPoint geometryPos = event->pos() + offset();
 
     if (m_draggingGroup) {
         topLeft = m_pressedPosition - offset();
-        qreal dist = (topLeft - event->pos()).manhattanLength();
-        qreal threshold = QApplication::startDragDistance();
+        const qreal dist = (topLeft - event->pos()).manhattanLength();
+        const qreal threshold = QApplication::startDragDistance();
         if (dist > threshold) {
             // Drag preview: compute visual target index and show indicator
             setState(NoState);
-            QPoint cursorPos = geometryPos;
+            const QPoint cursorPos = geometryPos;
             m_groupDragTargetIndex = -1;
             for (int i = 0; i < m_groups.size(); i++) {
-                if (m_groups[i]->text == m_draggedGroupName)
+                if (m_groups[i]->text == m_draggedGroupName) {
                     continue;
-                int gTop = m_groups[i]->verticalPosition();
-                int gBot = gTop + m_groups[i]->totalHeight();
-                int hMid = gTop + VisualGroup::headerHeight() / 2;
+                }
+                const int gTop = m_groups[i]->verticalPosition();
+                const int gBot = gTop + m_groups[i]->totalHeight();
+                const int hMid = gTop + (VisualGroup::headerHeight() / 2);
                 if (cursorPos.y() < hMid) {
                     m_groupDragTargetIndex = i;
                     break;
-                } else if (cursorPos.y() < gBot) {
+                }
+                if (cursorPos.y() < gBot) {
                     m_groupDragTargetIndex = i + 1;
                     break;
                 }
             }
-            if (m_groupDragTargetIndex < 0)
-                m_groupDragTargetIndex = m_groups.size();
-            if (m_groupDragTargetIndex > m_groups.size())
-                m_groupDragTargetIndex = m_groups.size();
+            if (m_groupDragTargetIndex < 0) {
+                m_groupDragTargetIndex = static_cast<int>(m_groups.size());
+            }
+            m_groupDragTargetIndex = std::min(m_groupDragTargetIndex, static_cast<int>(m_groups.size()));
             viewport()->update();
             return;
         }
@@ -429,21 +431,22 @@ void InstanceView::mouseReleaseEvent(QMouseEvent* event)
 
     // Commit group drag reorder on release
     if (m_draggingGroup && m_groupDragTargetIndex >= 0) {
-        auto groupOrder = APPLICATION->instances()->groupOrder();
-        int currentOrderIdx = groupOrder.indexOf(m_draggedGroupName);
+        const auto groupOrder = APPLICATION->instances()->groupOrder();
+        const int currentOrderIdx = static_cast<int>(groupOrder.indexOf(m_draggedGroupName));
         if (currentOrderIdx >= 0) {
             // Convert visual target index to groupOrder index
             int orderTarget = 0;
             for (int i = 0; i < m_groupDragTargetIndex && i < m_groups.size(); i++) {
-                if (m_groups[i]->text == m_draggedGroupName)
+                if (m_groups[i]->text == m_draggedGroupName) {
                     continue;
-                int orderPos = groupOrder.indexOf(m_groups[i]->text);
-                if (orderPos >= 0 && orderPos >= orderTarget)
+                }
+                const int orderPos = static_cast<int>(groupOrder.indexOf(m_groups[i]->text));
+                if (orderPos >= 0 && orderPos >= orderTarget) {
                     orderTarget = orderPos + 1;
+                }
             }
             // Clamp to valid range
-            if (orderTarget > groupOrder.size())
-                orderTarget = groupOrder.size();
+            orderTarget = std::min(orderTarget, static_cast<int>(groupOrder.size()));
             if (orderTarget != currentOrderIdx) {
                 APPLICATION->instances()->moveGroup(m_draggedGroupName, orderTarget);
                 updateGeometries();
@@ -616,13 +619,16 @@ void InstanceView::paintEvent([[maybe_unused]] QPaintEvent* event)
     if (m_groupDragTargetIndex >= 0) {
         int indicatorY = 0;
         if (m_groupDragTargetIndex < m_groups.size()) {
-            indicatorY = m_groups[m_groupDragTargetIndex]->verticalPosition() - verticalOffset();
+            indicatorY = m_groups[m_groupDragTargetIndex]->verticalPosition() - verticalOffset() + 5;
         } else if (!m_groups.isEmpty()) {
             auto* last = m_groups.last();
-            indicatorY = last->verticalPosition() + last->totalHeight() - verticalOffset();
+            indicatorY = last->verticalPosition() + last->totalHeight() - verticalOffset() + 10;
         }
         painter.save();
-        painter.setPen(QPen(Qt::white, 1));
+        {
+            const QColor indicatorColor = option.palette.color(QPalette::Highlight);
+            painter.setPen(QPen(indicatorColor, 2));
+        }
         painter.drawLine(m_leftMargin, indicatorY, wpWidth - m_rightMargin, indicatorY);
         painter.restore();
     }

--- a/launcher/ui/instanceview/InstanceView.h
+++ b/launcher/ui/instanceview/InstanceView.h
@@ -139,6 +139,11 @@ class InstanceView : public QAbstractItemView {
     QItemSelectionModel::SelectionFlag m_ctrlDragSelectionFlag;
     QPoint m_lastDragPosition;
 
+    // group drag-reorder state
+    bool m_draggingGroup = false;
+    QString m_draggedGroupName;
+    int m_groupDragTargetIndex = -1;
+
     VisualGroup* category(const QModelIndex& index) const;
     VisualGroup* category(const QString& cat) const;
     VisualGroup* categoryAt(const QPoint& pos, VisualGroup::HitResults& result) const;


### PR DESCRIPTION

## Summary

Add drag-and-drop group reordering with a real-time indicator line, persisted via a new `groupOrder` array in `instgroups.json`.

### Data model (`InstanceList`)

- `groupOrder()` / `moveGroup()` API backed by `m_groupOrder` member
- `groupOrderChanged` signal emitted on order changes
- Save/load `groupOrder` as a JSON array in `instgroups.json` (format-compatible addition, absent on old files falls back to alphabetical order)
- New groups auto-appended to the order via `increaseGroupCount`; deleted groups removed; renamed groups updated in-place
- The "Ungrouped" section (empty-string group) is included in the ordering by default

### View (`InstanceView`)

- **Drag gesture**: Press on any group header starts group-drag mode; crossing the drag threshold computes a visual target index based on cursor Y relative to adjacent group boundaries
- **Indicator**: A horizontal line is drawn at the computed drop position in `paintEvent` (white, 1px)
- **Commit**: On `mouseReleaseEvent`, the visual target index is converted to an order-list index, and `moveGroup` is called. The order is saved and `updateGeometries` rebuilds the group list respecting the new order
- `updateGeometries` now places groups from `groupOrder` first (in order), then appends remaining groups alphabetically

> Parts of this PR were generated with AI assistance (opencode + deepseek-v4-flash-free). All changes were reviewed and verified manually.

screenshots
<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/68af68e4-b251-4ca8-9010-165bdf0c667a" />
<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/8bf8b21e-2226-473c-82eb-15069bf4fe95" />

sorry for the previous pr with wrong format

Assisted-by: opencode:deepseek-v4-flash-free