### PR TITLE
Fixed dependencies not enabling/disabling other dependencies

### DIFF
--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -342,7 +342,6 @@ QSet<Mod*> collectMods(const QSet<Mod*>& mods, QHash<QString, QSet<Mod*>> relati
                 auto affectedId = affected->mod_id();
 
                 if (findById(mods, affectedId) == nullptr && !seen.contains(affectedId)) {
-                    seen.insert(affectedId);
                     if (shouldBeEnabled != affected->enabled()) {
                         affectedList << affected;
                     }


### PR DESCRIPTION
Fixes #5668

Problem: in the collectMods() function, seen.insert(affectedId) was called inside of the inner loop before the recursive call. As a result, the mod is marked as seen before its dependencies are examined recursively. 

Changes: I just removed the seen.insert(affectedId) within the inner loop. This function still prevents infinite loops because the outer loop will mark each mod as seen (at line 340).

Tests: I reproduced both the steps in the original issue and the alternate steps in the comments.

Download BetterEndCities and dependencies (BetterEnd, BCLib, and FabricAPI)
Enabling BetterEndCities will enable BetterEnd, BCLib, and Fabric API
Disabing Fabric API will disable BetterEndCities, BetterEnd, and BCLib

Download FlightAssistant and dependencies (Architectury, Fabric API, Fabric Language Kotlin, YACL)
Disabling Fabric API will disable FlightAssistant, Architectury, and YACL
Enabling FlightAssistant will enable Architectury, Fabric API, Fabric Language Kotlin, and YACL


https://github.com/user-attachments/assets/a4f869ee-dce6-43ef-a2fa-604eaa673ada

https://github.com/user-attachments/assets/1bc33414-4721-4036-88bb-e7f0ed924e9c

