### PR TITLE
Naively turn Discrete and Zink checkbox mutually exclusive

### DIFF
--- a/launcher/ui/widgets/MinecraftSettingsWidget.ui
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.ui
@@ -929,5 +929,38 @@ It is most likely you will need to change the path - please refer to the mod's w
   <tabstop>useZink</tabstop>
  </tabstops>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>useDiscreteGpuCheck</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>useZink</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>useZink</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>useDiscreteGpuCheck</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>


### PR DESCRIPTION
solves #3760

Makes the `Use Discrete GPU` and `Use Zink` checkboxes into mutually exclusive by disabling the other when checked, this will prevent the user from enabling both and getting weird behavior.
