### PR TITLE
Add explicit macOS Game Mode support

### DIFF
--- a/cmake/MacOSXBundleInfo.plist.in
+++ b/cmake/MacOSXBundleInfo.plist.in
@@ -46,6 +46,10 @@
     <true/>
     <key>LSApplicationCategoryType</key>
     <string>public.app-category.games</string>
+    <key>GCSupportsGameMode</key>
+    <true/>
+    <key>LSSupportsGameMode</key>
+    <true/>
     <key>NSHumanReadableCopyright</key>
     <string>${MACOSX_BUNDLE_COPYRIGHT}</string>
     <key>SUPublicEDKey</key>


### PR DESCRIPTION
﻿## Summary

This adds explicit macOS Game Mode support keys to Prism Launcher's macOS bundle plist template:

- `GCSupportsGameMode`
- `LSSupportsGameMode`

Prism Launcher already declares:

- `LSApplicationCategoryType = public.app-category.games`

That is useful, but in local testing it was not sufficient to make macOS Game Mode activate reliably for Minecraft launched through Prism.

## Motivation

Prism Launcher does not render the Minecraft game window itself. It starts Minecraft through a child Java process, and the fullscreen game window belongs to that process rather than to the launcher's main UI.

Because of that, relying only on `LSApplicationCategoryType = public.app-category.games` can be unreliable. macOS may classify Prism Launcher as a game-category app, but still fail to activate Game Mode when the actual Minecraft fullscreen window appears.

Adding the explicit Game Mode support keys made Game Mode activate in the same local setup where the category-only plist did not.

## Local testing

Tested locally on macOS with Minecraft launched through Prism Launcher.

Observed behavior:

1. With only `LSApplicationCategoryType = public.app-category.games`, Game Mode did not activate reliably.
2. After adding `GCSupportsGameMode` and `LSSupportsGameMode`, macOS Game Mode activated when Minecraft entered fullscreen mode.

## Notes

This change is macOS-only and only affects the generated app bundle `Info.plist`.

It should be safe for other platforms because the changed file is the macOS bundle plist template.
