### PR TITLE
Add support for importing CurseForge's 7-day share links

### DIFF
--- a/launcher/ui/pages/modplatform/ImportPage.cpp
+++ b/launcher/ui/pages/modplatform/ImportPage.cpp
@@ -180,6 +180,11 @@ void ImportPage::updateState()
                 input.append("/file");
                 url = QUrl::fromUserInput(input);
             }
+            if (input.startsWith("https://www.curseforge.com/minecraft/share/")) {
+                input.remove(0, 43);
+                input.prepend("http://api.curseforge.com/v1/shared-profile/");
+                url = QUrl::fromUserInput(input);
+            }
             // hook, line and sinker.
             QFileInfo fi(url.fileName());
             auto extra_info = QMap(m_extra_info);

--- a/launcher/ui/pages/modplatform/ImportPage.cpp
+++ b/launcher/ui/pages/modplatform/ImportPage.cpp
@@ -182,7 +182,7 @@ void ImportPage::updateState()
             }
             if (input.startsWith("https://www.curseforge.com/minecraft/share/")) {
                 input.remove(0, 43);
-                input.prepend("http://api.curseforge.com/v1/shared-profile/");
+                input.prepend("https://api.curseforge.com/v1/shared-profile/");
                 url = QUrl::fromUserInput(input);
             }
             // hook, line and sinker.


### PR DESCRIPTION
CurseForge allows users to create share codes for their custom modpacks (valid for 7 days), which are the easiest way to share a custom CurseForge modpack. Unfortunately, Prism cannot import these share code links. They look like this: 

https://www.curseforge.com/minecraft/share/Cd77OhpJ

It turns out that the CurseForge App's heavy lifting is literally just redirecting to an API link.

https://api.curseforge.com/v1/shared-profile/Cd77OhpJ  (plus an API key)

The link even ended up working without an API key, and is a direct download to the custom modpack ZIP.  
So, I allowed Prism to do the same link conversion. Only caveats I found is that the instance name becomes the share code and there's a quick message about missing an overrides folder, probably because the system isn't expecting this to be a CF zip. It works fine though.  

Relevant GH discussion: https://github.com/orgs/PrismLauncher/discussions/3502