### PR TITLE
Move world import, copy and delete actions to tasks

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -321,6 +321,8 @@ set(MINECRAFT_SOURCES
     minecraft/World.cpp
     minecraft/WorldList.h
     minecraft/WorldList.cpp
+    minecraft/WorldTasks.h
+    minecraft/WorldTasks.cpp
 
     minecraft/mod/MetadataHandler.h
     minecraft/mod/Mod.h

--- a/launcher/minecraft/WorldList.cpp
+++ b/launcher/minecraft/WorldList.cpp
@@ -34,6 +34,7 @@
  */
 
 #include "WorldList.h"
+#include "WorldTasks.h"
 
 #include <FileSystem.h>
 #include <QDebug>
@@ -123,18 +124,23 @@ QString WorldList::instDirPath() const
     return QFileInfo(m_instance->instanceRoot()).absoluteFilePath();
 }
 
-bool WorldList::deleteWorld(int index)
+bool WorldList::removeWorldFromModel(const QFileInfo& sourceFile)
 {
-    if (index >= m_worlds.size() || index < 0)
-        return false;
-    World& m = m_worlds[index];
-    if (m.destroy()) {
-        beginRemoveRows(QModelIndex(), index, index);
-        m_worlds.removeAt(index);
+    const auto sourcePath = sourceFile.absoluteFilePath();
+
+    for (int row = 0; row < m_worlds.size(); ++row) {
+        if (m_worlds.at(row).container().absoluteFilePath() != sourcePath) {
+            continue;
+        }
+
+        beginRemoveRows(QModelIndex(), row, row);
+        m_worlds.removeAt(row);
         endRemoveRows();
+
         emit changed();
         return true;
     }
+
     return false;
 }
 
@@ -358,6 +364,46 @@ void WorldList::installWorld(QFileInfo filename)
         return;
     }
     w.install(m_dir.absolutePath());
+}
+
+std::unique_ptr<Task> WorldList::createInstallWorldTask(QFileInfo filename)
+{
+    return std::make_unique<InstallWorldTask>(InstallWorldTask::Args{
+        .worlds = this,
+        .sourceFile = filename,
+        .targetDir = m_dir.absolutePath(),
+    });
+}
+
+std::unique_ptr<Task> WorldList::createCopyWorldTask(int index, const QString& name)
+{
+    if (index >= m_worlds.size() || index < 0) {
+        return nullptr;
+    }
+
+    const auto& world = m_worlds.at(index);
+
+    return std::make_unique<CopyWorldTask>(CopyWorldTask::Args{
+        .worlds = this,
+        .sourceFile = world.container(),
+        .targetDir = m_dir.absolutePath(),
+        .targetName = name,
+    });
+}
+
+std::unique_ptr<Task> WorldList::createDeleteWorldTask(int index)
+{
+    if (index >= m_worlds.size() || index < 0) {
+        return nullptr;
+    }
+
+    const auto& world = m_worlds.at(index);
+
+    return std::make_unique<DeleteWorldTask>(DeleteWorldTask::Args{
+        .worlds = this,
+        .sourceFile = world.container(),
+        .displayName = world.name(),
+    });
 }
 
 bool WorldList::dropMimeData(const QMimeData* data,

--- a/launcher/minecraft/WorldList.h
+++ b/launcher/minecraft/WorldList.h
@@ -20,10 +20,12 @@
 #include <QList>
 #include <QMimeData>
 #include <QString>
+#include <memory>
 #include "BaseInstance.h"
 #include "minecraft/World.h"
 
 class QFileSystemWatcher;
+class Task;
 
 class WorldList : public QAbstractListModel {
     Q_OBJECT
@@ -50,8 +52,17 @@ class WorldList : public QAbstractListModel {
     /// Install a world from location
     void installWorld(QFileInfo filename);
 
-    /// Deletes the mod at the given index.
-    virtual bool deleteWorld(int index);
+    /// Create a task to install a world from location
+    std::unique_ptr<Task> createInstallWorldTask(QFileInfo filename);
+
+    /// Create a task to copy the world at the given index.
+    std::unique_ptr<Task> createCopyWorldTask(int index, const QString& name);
+
+    /// Create a task to delete the world at the given index.
+    std::unique_ptr<Task> createDeleteWorldTask(int index);
+
+    /// Remove an already deleted world from the model.
+    bool removeWorldFromModel(const QFileInfo& sourceFile);
 
     /// Removes the world icon, if any
     virtual bool resetIcon(int index);

--- a/launcher/minecraft/WorldTasks.cpp
+++ b/launcher/minecraft/WorldTasks.cpp
@@ -1,0 +1,130 @@
+#include "WorldTasks.h"
+
+#include "World.h"
+#include "WorldList.h"
+
+#include <QCoreApplication>
+#include <QMetaObject>
+#include <QThreadPool>
+
+#include <utility>
+
+namespace {
+
+template <typename Func>
+void invokeOnMainThread(Func&& func)
+{
+    auto app = QCoreApplication::instance();
+    if (!app) {
+        return;
+    }
+
+    QMetaObject::invokeMethod(app, std::forward<Func>(func), Qt::QueuedConnection);
+}
+
+}  // namespace
+
+InstallWorldTask::InstallWorldTask(Args args) : m_args(std::move(args)) {}
+
+void InstallWorldTask::executeTask()
+{
+    setStatus(tr("Importing world..."));
+    setDetails(m_args.sourceFile.fileName());
+    setProgress(0, 0);
+
+    QPointer<InstallWorldTask> self(this);
+    auto args = m_args;
+
+    QThreadPool::globalInstance()->start([self, args]() mutable {
+        World world(args.sourceFile);
+        const bool ok = world.isValid() && world.install(args.targetDir);
+
+        invokeOnMainThread([self, worlds = args.worlds, ok]() {
+            if (!self) {
+                return;
+            }
+
+            if (!ok) {
+                self->emitFailed(self->tr("Failed to import world."));
+                return;
+            }
+
+            if (worlds) {
+                worlds->update();
+            }
+
+            self->setProgress(1, 1);
+            self->emitSucceeded();
+        });
+    });
+}
+
+CopyWorldTask::CopyWorldTask(Args args) : m_args(std::move(args)) {}
+
+void CopyWorldTask::executeTask()
+{
+    setStatus(tr("Copying world..."));
+    setDetails(m_args.targetName);
+    setProgress(0, 0);
+
+    QPointer<CopyWorldTask> self(this);
+    auto args = m_args;
+
+    QThreadPool::globalInstance()->start([self, args]() mutable {
+        World world(args.sourceFile);
+        const bool ok = world.isValid() && world.install(args.targetDir, args.targetName);
+
+        invokeOnMainThread([self, worlds = args.worlds, ok]() {
+            if (!self) {
+                return;
+            }
+
+            if (!ok) {
+                self->emitFailed(self->tr("Failed to copy world."));
+                return;
+            }
+
+            if (worlds) {
+                worlds->update();
+            }
+
+            self->setProgress(1, 1);
+            self->emitSucceeded();
+        });
+    });
+}
+
+DeleteWorldTask::DeleteWorldTask(Args args) : m_args(std::move(args)) {}
+
+void DeleteWorldTask::executeTask()
+{
+    setStatus(tr("Deleting world..."));
+    setDetails(m_args.displayName);
+    setProgress(0, 0);
+
+    QPointer<DeleteWorldTask> self(this);
+    auto args = m_args;
+
+    QThreadPool::globalInstance()->start([self, args]() mutable {
+        World world(args.sourceFile);
+        const bool ok = world.destroy();
+
+        invokeOnMainThread([self, worlds = args.worlds, sourceFile = args.sourceFile, ok]() {
+            if (!self) {
+                return;
+            }
+
+            if (!ok) {
+                self->emitFailed(self->tr("Failed to delete world."));
+                return;
+            }
+
+            if (worlds) {
+                worlds->removeWorldFromModel(sourceFile);
+            }
+
+            self->setProgress(1, 1);
+            self->emitSucceeded();
+        });
+    });
+}

--- a/launcher/minecraft/WorldTasks.h
+++ b/launcher/minecraft/WorldTasks.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <memory>
+
+#include <QFileInfo>
+#include <QPointer>
+#include <QString>
+
+#include "tasks/Task.h"
+
+class WorldList;
+
+class InstallWorldTask : public Task {
+   public:
+    struct Args {
+        QPointer<WorldList> worlds;
+        QFileInfo sourceFile;
+        QString targetDir;
+    };
+
+    explicit InstallWorldTask(Args args);
+
+   protected:
+    void executeTask() override;
+
+   private:
+    Args m_args;
+};
+
+class CopyWorldTask : public Task {
+   public:
+    struct Args {
+        QPointer<WorldList> worlds;
+        QFileInfo sourceFile;
+        QString targetDir;
+        QString targetName;
+    };
+
+    explicit CopyWorldTask(Args args);
+
+   protected:
+    void executeTask() override;
+
+   private:
+    Args m_args;
+};
+
+class DeleteWorldTask : public Task {
+   public:
+    struct Args {
+        QPointer<WorldList> worlds;
+        QFileInfo sourceFile;
+        QString displayName;
+    };
+
+    explicit DeleteWorldTask(Args args);
+
+   protected:
+    void executeTask() override;
+
+   private:
+    Args m_args;
+};

--- a/launcher/ui/pages/instance/WorldListPage.cpp
+++ b/launcher/ui/pages/instance/WorldListPage.cpp
@@ -38,6 +38,7 @@
 #include "WorldListPage.h"
 #include "minecraft/WorldList.h"
 #include "ui/dialogs/CustomMessageBox.h"
+#include "ui/dialogs/ProgressDialog.h"
 #include "ui_WorldListPage.h"
 
 #include <ui/widgets/PageContainer.h>
@@ -187,23 +188,34 @@ bool WorldListPage::eventFilter(QObject* obj, QEvent* ev)
 void WorldListPage::on_actionRemove_triggered()
 {
     auto proxiedIndex = getSelectedWorld();
-
-    if (!proxiedIndex.isValid())
+    if (!proxiedIndex.isValid()) {
         return;
+    }
+
+    const auto& world = m_worlds->allWorlds().at(proxiedIndex.row());
 
     auto result = CustomMessageBox::selectable(this, tr("Confirm Deletion"),
                                                tr("You are about to delete \"%1\".\n"
                                                   "The world may be gone forever (A LONG TIME).\n\n"
                                                   "Are you sure?")
-                                                   .arg(m_worlds->allWorlds().at(proxiedIndex.row()).name()),
+                                                   .arg(world.name()),
                                                QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No, QMessageBox::No)
                       ->exec();
 
     if (result != QMessageBox::Yes) {
         return;
     }
+
+    auto task = m_worlds->createDeleteWorldTask(proxiedIndex.row());
+    if (!task) {
+        return;
+    }
+
     m_worlds->stopWatching();
-    m_worlds->deleteWorld(proxiedIndex.row());
+
+    ProgressDialog dialog(this);
+    dialog.execWithTask(std::move(task));
+
     m_worlds->startWatching();
 }
 
@@ -393,13 +405,20 @@ void WorldListPage::on_actionAdd_triggered()
 {
     auto list = GuiUtil::BrowseForFiles(displayName(), tr("Select a Minecraft world zip"), tr("Minecraft World Zip File") + " (*.zip)",
                                         QString(), this->parentWidget());
-    if (!list.empty()) {
-        m_worlds->stopWatching();
-        for (auto filename : list) {
-            m_worlds->installWorld(QFileInfo(filename));
-        }
-        m_worlds->startWatching();
+    if (list.empty()) {
+        return;
     }
+
+    m_worlds->stopWatching();
+    for (auto filename : list) {
+        auto task = m_worlds->createInstallWorldTask(QFileInfo(filename));
+        if (!task) {
+            continue;
+        }
+        ProgressDialog dialog(this);
+        dialog.execWithTask(std::move(task));
+    }
+    m_worlds->startWatching();
 }
 
 bool WorldListPage::isWorldSafe(QModelIndex)
@@ -426,18 +445,31 @@ void WorldListPage::on_actionCopy_triggered()
         return;
     }
 
-    if (!worldSafetyNagQuestion(tr("Copy World")))
+    if (!worldSafetyNagQuestion(tr("Copy World"))) {
         return;
+    }
 
-    auto worldVariant = m_worlds->data(index, WorldList::ObjectRole);
-    auto world = (World*)worldVariant.value<void*>();
+    const auto world = m_worlds->allWorlds().at(index.row());
+
     bool ok = false;
     QString name =
-        QInputDialog::getText(this, tr("World name"), tr("Enter a new name for the copy."), QLineEdit::Normal, world->name(), &ok);
+        QInputDialog::getText(this, tr("World name"), tr("Enter a new name for the copy."), QLineEdit::Normal, world.name(), &ok);
 
-    if (ok && name.length() > 0) {
-        world->install(m_worlds->dir().absolutePath(), name);
+    if (!ok || name.isEmpty()) {
+        return;
     }
+
+    auto task = m_worlds->createCopyWorldTask(index.row(), name);
+    if (!task) {
+        return;
+    }
+
+    m_worlds->stopWatching();
+
+    ProgressDialog dialog(this);
+    dialog.execWithTask(std::move(task));
+
+    m_worlds->startWatching();
 }
 
 void WorldListPage::on_actionRename_triggered()


### PR DESCRIPTION
Addresses #4384

## Summary

This moves world import, copy and delete actions to task-based execution with a progress dialog.

The filesystem operations are now performed through dedicated world operation tasks instead of running directly from `WorldListPage`. This gives users visible feedback while long-running world operations are in progress.

## Changes

* Add task classes for world install, copy and delete operations.
* Show `ProgressDialog` for world import, copy and delete actions.
* Run filesystem work on `QThreadPool`.
* Apply `WorldList` model updates back on the main thread.
* Remove deleted worlds from the model through `removeWorldFromModel()` instead of resetting the whole list.

## Notes

The progress dialog currently uses indeterminate progress because the underlying world install/copy/delete operations do not expose file-level progress yet.

## Testing

* Imported a world from a `.zip` file.
* Copied an existing world.
* Deleted an existing world.
* Confirmed that the world list updates after each operation.

## Demo

### Import world

https://github.com/user-attachments/assets/1c307af0-fa53-4d3e-8fa9-4a33ad630cea

### Copy world

https://github.com/user-attachments/assets/4c1fbd29-2276-4748-96e3-aa3fcb1a9861

### Delete world

https://github.com/user-attachments/assets/9d66d5e2-23b8-453f-bb51-52ae8a1192b2
