### PR TITLE
Backport explicit macOS Game Mode support to 11.x

### DIFF
--- a/cmake/MacOSXBundleInfo.plist.in
+++ b/cmake/MacOSXBundleInfo.plist.in
@@ -46,6 +46,10 @@
     <true/>
     <key>LSApplicationCategoryType</key>
     <string>public.app-category.games</string>
+    <key>GCSupportsGameMode</key>
+    <true/>
+    <key>LSSupportsGameMode</key>
+    <true/>
     <key>NSHumanReadableCopyright</key>
     <string>${MACOSX_BUNDLE_COPYRIGHT}</string>
     <key>SUPublicEDKey</key>


### PR DESCRIPTION
﻿## Summary

Backport of the explicit macOS Game Mode support change to the 11.x release branch, so it can be included and tested during the 11.0.3 pre-release cycle.

This adds the following macOS bundle plist keys:

- `GCSupportsGameMode`
- `LSSupportsGameMode`

The branch already has:

- `LSApplicationCategoryType = public.app-category.games`

## Motivation

The game-category declaration is useful, but local testing showed that it was not sufficient to make macOS Game Mode activate reliably for Minecraft launched through Prism.

Prism starts Minecraft through a child Java process, and the fullscreen game window belongs to that process rather than to the launcher's main UI. Adding the explicit Game Mode support keys made Game Mode activate in the same setup where the category-only plist did not.

## Notes

This is macOS-only and only affects the generated app bundle `Info.plist`.

The change should be safe for 11.0.3 because it only adds explicit metadata for macOS Game Mode support and does not affect launch behavior or gameplay logic.
