### PR TITLE
[Nix] Use final launcher wrapper in instance shortcuts

### DIFF
--- a/nix/unwrapped.nix
+++ b/nix/unwrapped.nix
@@ -68,6 +68,11 @@ stdenv.mkDerivation {
     ln -s ${libnbtplusplus} source/libraries/libnbtplusplus
   '';
 
+  postPatch = ''
+    substituteInPlace launcher/minecraft/ShortcutUtils.cpp \
+      --replace-fail 'QApplication::applicationFilePath()' 'QProcessEnvironment::systemEnvironment().value("NIX_LAUNCHER_WRAPPER", "${placeholder "out"}/bin/prismlauncher")'
+  '';
+
   nativeBuildInputs = [
     cmake
     ninja

--- a/nix/wrapper.nix
+++ b/nix/wrapper.nix
@@ -115,7 +115,10 @@ symlinkJoin {
       ++ additionalPrograms;
 
     in
-    [ "--prefix PRISMLAUNCHER_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks}" ]
+    [
+      "--set NIX_LAUNCHER_WRAPPER ${placeholder "out"}/bin/prismlauncher"
+      "--prefix PRISMLAUNCHER_JAVA_PATHS : ${lib.makeSearchPath "bin/java" jdks}"
+    ]
     ++ lib.optionals stdenv.hostPlatform.isLinux [
       "--set LD_LIBRARY_PATH ${addDriverRunpath.driverLink}/lib:${lib.makeLibraryPath runtimeLibs}"
       "--prefix PATH : ${lib.makeBinPath runtimePrograms}"


### PR DESCRIPTION
Previously the unwrapped binary of Prism would be used in the `Exec`
line of desktop files, leading to Weird behavior - like the instance
hanging with no window created
