### PR TITLE
Add conflict prompt to the Install Loader dialog

### DIFF
--- a/launcher/ui/dialogs/InstallLoaderDialog.cpp
+++ b/launcher/ui/dialogs/InstallLoaderDialog.cpp
@@ -25,8 +25,10 @@
 #include "BuildConfig.h"
 #include "DesktopServices.h"
 #include "meta/Index.h"
+#include "meta/Version.h"
 #include "minecraft/MinecraftInstance.h"
 #include "minecraft/PackProfile.h"
+#include "ui/dialogs/CustomMessageBox.h"
 #include "ui/widgets/PageContainer.h"
 #include "ui/widgets/VersionSelectWidget.h"
 
@@ -84,22 +86,28 @@ static InstallLoaderPage* pageCast(BasePage* page)
     return result;
 }
 
+static bool askYesNo(QWidget* parent, const QString& title, const QString& text, QMessageBox::Icon icon)
+{
+    return CustomMessageBox::selectable(parent, title, text, icon, QMessageBox::Yes | QMessageBox::No, QMessageBox::No)->exec() ==
+           QMessageBox::Yes;
+}
+
 InstallLoaderDialog::InstallLoaderDialog(PackProfile* profile, const QString& uid, QWidget* parent)
     : QDialog(parent), profile(profile), container(new PageContainer(this, QString(), this)), buttons(new QDialogButtonBox(this))
 {
     auto layout = new QVBoxLayout(this);
-    // small margins look ugly on macOS on modal windows
-    #ifndef Q_OS_MACOS
+// small margins look ugly on macOS on modal windows
+#ifndef Q_OS_MACOS
     layout->setContentsMargins(0, 0, 0, 0);
-    #endif
+#endif
     container->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
     layout->addWidget(container);
 
     auto buttonLayout = new QHBoxLayout(this);
-    // small margins look ugly on macOS on modal windows
-    #ifndef Q_OS_MACOS
+// small margins look ugly on macOS on modal windows
+#ifndef Q_OS_MACOS
     buttonLayout->setContentsMargins(0, 0, 6, 6);
-    #endif
+#endif
     auto refreshButton = new QPushButton(tr("&Refresh"), this);
     connect(refreshButton, &QPushButton::clicked, this, [this] { pageCast(container->selectedPage())->loadList(true); });
     buttonLayout->addWidget(refreshButton);
@@ -157,11 +165,133 @@ void InstallLoaderDialog::validate(BasePage* page)
     buttons->button(QDialogButtonBox::Ok)->setEnabled(pageCast(page)->selectedVersion() != nullptr);
 }
 
+QString InstallLoaderDialog::describeVersionChange(InstallLoaderPage* page, const QString& installedVersion, const QString& selectedVersion)
+{
+    auto list = APPLICATION->metadataIndex()->get(page->id());
+    auto installedMetaVersion = std::dynamic_pointer_cast<Meta::Version>(list->findVersion(installedVersion));
+    auto selectedMetaVersion = std::dynamic_pointer_cast<Meta::Version>(page->selectedVersion());
+
+    if (installedMetaVersion && selectedMetaVersion && installedMetaVersion->rawTime() != selectedMetaVersion->rawTime()) {
+        if (installedMetaVersion->rawTime() < selectedMetaVersion->rawTime())
+            return tr("update it to %1").arg(selectedVersion);
+        return tr("downgrade it to %1").arg(selectedVersion);
+    }
+    return tr("switch it to %1").arg(selectedVersion);
+}
+
+bool InstallLoaderDialog::resolveLoaderConflicts(InstallLoaderPage* page)
+{
+    QList<ComponentPtr> conflicts;
+    auto knownLoader = Component::KNOWN_MODLOADERS.find(page->id());
+    if (knownLoader != Component::KNOWN_MODLOADERS.cend()) {
+        for (const QString& conflictId : knownLoader->knownConflictingComponents) {
+            const ComponentPtr conflictComponent = profile->getComponent(conflictId);
+            if (conflictComponent && conflictComponent->isEnabled() && !conflictComponent->isCustom())
+                conflicts.append(conflictComponent);
+        }
+    }
+
+    const QString targetVersion = tr("%1 %2").arg(page->displayName(), page->selectedVersion()->descriptor());
+
+    for (const ComponentPtr& conflict : conflicts) {
+        const QString conflictVersion = tr("%1 %2").arg(conflict->getName(), conflict->getVersion());
+        auto* msgBox = CustomMessageBox::selectable(
+            this, tr("Installing a second loader"),
+            tr("%1 is known to conflict with %2, which is already enabled on this instance. Having both enabled at the same time will "
+               "likely break the instance.\n\nWhat would you like to do with %2?")
+                .arg(targetVersion, conflictVersion),
+            QMessageBox::Warning, QMessageBox::Cancel);
+        QAbstractButton* keepButton = msgBox->addButton(tr("Keep it"), QMessageBox::AcceptRole);
+        QAbstractButton* disableButton = conflict->canBeDisabled() ? msgBox->addButton(tr("Disable it"), QMessageBox::ActionRole) : nullptr;
+        QAbstractButton* uninstallButton =
+            conflict->isRemovable() ? msgBox->addButton(tr("Uninstall it"), QMessageBox::DestructiveRole) : nullptr;
+        msgBox->exec();
+
+        auto* clicked = msgBox->clickedButton();
+        if (clicked == keepButton)
+            continue;
+        if (disableButton && clicked == disableButton) {
+            conflict->setEnabled(false);
+            profile->resolve(Net::Mode::Online);
+            continue;
+        }
+        if (uninstallButton && clicked == uninstallButton) {
+            profile->remove(conflict->getID());
+            profile->resolve(Net::Mode::Online);
+            continue;
+        }
+        return false;
+    }
+    return true;
+}
+
+bool InstallLoaderDialog::confirmReinstall(InstallLoaderPage* page, Component* component)
+{
+    const QString installedVersion = component->getVersion();
+    const QString selectedVersion = page->selectedVersion()->descriptor();
+    const bool sameVersion = installedVersion == selectedVersion;
+
+    if (component->isEnabled() && sameVersion) {
+        if (askYesNo(this, tr("Loader already installed"),
+                     tr("%1 %2 is already installed. Do you want to reinstall it?").arg(page->displayName(), installedVersion),
+                     QMessageBox::Warning))
+            return true;
+        QDialog::done(Accepted);
+        return false;
+    }
+
+    if (component->isEnabled()) {
+        return askYesNo(this, tr("Loader already installed"),
+                        tr("%1 %2 is currently installed. Do you want to %3?")
+                            .arg(page->displayName(), installedVersion, describeVersionChange(page, installedVersion, selectedVersion)),
+                        QMessageBox::Warning);
+    }
+
+    if (sameVersion) {
+        auto* msgBox = CustomMessageBox::selectable(
+            this, tr("Loader already installed"),
+            tr("%1 %2 is already installed, but disabled. Do you want to enable it?").arg(page->displayName(), installedVersion),
+            QMessageBox::Question, QMessageBox::No);
+        QAbstractButton* enableButton = msgBox->addButton(tr("Enable"), QMessageBox::AcceptRole);
+        QAbstractButton* reinstallButton = msgBox->addButton(tr("Reinstall"), QMessageBox::DestructiveRole);
+        msgBox->exec();
+
+        auto* clicked = msgBox->clickedButton();
+        if (clicked == enableButton) {
+            component->setEnabled(true);
+            profile->resolve(Net::Mode::Online);
+            QDialog::done(Accepted);
+            return false;
+        }
+        if (clicked != reinstallButton) {
+            QDialog::done(Rejected);
+            return false;
+        }
+        component->setEnabled(true);
+        return true;
+    }
+
+    if (!askYesNo(this, tr("Loader already installed"),
+                  tr("%1 %2 is currently installed, but disabled. Do you want to %3 and enable it?")
+                      .arg(page->displayName(), installedVersion, describeVersionChange(page, installedVersion, selectedVersion)),
+                  QMessageBox::Question))
+        return false;
+    component->setEnabled(true);
+    return true;
+}
+
 void InstallLoaderDialog::done(int result)
 {
     if (result == Accepted) {
         auto* page = pageCast(container->selectedPage());
         if (page->selectedVersion()) {
+            if (!resolveLoaderConflicts(page))
+                return;
+
+            const ComponentPtr component = profile->getComponent(page->id());
+            if (component && !confirmReinstall(page, component.get()))
+                return;
+
             profile->setComponentVersion(page->id(), page->selectedVersion()->descriptor());
             profile->resolve(Net::Mode::Online);
         }

--- a/launcher/ui/dialogs/InstallLoaderDialog.cpp
+++ b/launcher/ui/dialogs/InstallLoaderDialog.cpp
@@ -176,7 +176,7 @@ bool InstallLoaderDialog::resolveLoaderConflicts(InstallLoaderPage* page)
         const QString conflictVersion = QString("%1 %2").arg(conflict->getName(), conflict->getVersion());
         auto* msgBox = CustomMessageBox::selectable(
             this, tr("Installing a second loader"),
-            tr("%1 is known to conflict with %2, which is already enabled on this instance. Having both enabled at the same time will "
+            tr("%1 is known to conflict with %2, which is enabled on this instance. Having both enabled at the same time will "
                "likely break the instance.\n\nWhat would you like to do with %2?")
                 .arg(targetVersion, conflictVersion),
             QMessageBox::Warning, QMessageBox::Cancel);

--- a/launcher/ui/dialogs/InstallLoaderDialog.cpp
+++ b/launcher/ui/dialogs/InstallLoaderDialog.cpp
@@ -96,18 +96,18 @@ InstallLoaderDialog::InstallLoaderDialog(PackProfile* profile, const QString& ui
     : QDialog(parent), profile(profile), container(new PageContainer(this, QString(), this)), buttons(new QDialogButtonBox(this))
 {
     auto layout = new QVBoxLayout(this);
-// small margins look ugly on macOS on modal windows
-#ifndef Q_OS_MACOS
+    // small margins look ugly on macOS on modal windows
+    #ifndef Q_OS_MACOS
     layout->setContentsMargins(0, 0, 0, 0);
-#endif
+    #endif
     container->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Expanding);
     layout->addWidget(container);
 
     auto buttonLayout = new QHBoxLayout(this);
-// small margins look ugly on macOS on modal windows
-#ifndef Q_OS_MACOS
+    // small margins look ugly on macOS on modal windows
+    #ifndef Q_OS_MACOS
     buttonLayout->setContentsMargins(0, 0, 6, 6);
-#endif
+    #endif
     auto refreshButton = new QPushButton(tr("&Refresh"), this);
     connect(refreshButton, &QPushButton::clicked, this, [this] { pageCast(container->selectedPage())->loadList(true); });
     buttonLayout->addWidget(refreshButton);

--- a/launcher/ui/dialogs/InstallLoaderDialog.cpp
+++ b/launcher/ui/dialogs/InstallLoaderDialog.cpp
@@ -25,7 +25,6 @@
 #include "BuildConfig.h"
 #include "DesktopServices.h"
 #include "meta/Index.h"
-#include "meta/Version.h"
 #include "minecraft/MinecraftInstance.h"
 #include "minecraft/PackProfile.h"
 #include "ui/dialogs/CustomMessageBox.h"
@@ -84,12 +83,6 @@ static InstallLoaderPage* pageCast(BasePage* page)
     auto result = dynamic_cast<InstallLoaderPage*>(page);
     Q_ASSERT(result != nullptr);
     return result;
-}
-
-static bool askYesNo(QWidget* parent, const QString& title, const QString& text, QMessageBox::Icon icon)
-{
-    return CustomMessageBox::selectable(parent, title, text, icon, QMessageBox::Yes | QMessageBox::No, QMessageBox::No)->exec() ==
-           QMessageBox::Yes;
 }
 
 InstallLoaderDialog::InstallLoaderDialog(PackProfile* profile, const QString& uid, QWidget* parent)
@@ -165,20 +158,6 @@ void InstallLoaderDialog::validate(BasePage* page)
     buttons->button(QDialogButtonBox::Ok)->setEnabled(pageCast(page)->selectedVersion() != nullptr);
 }
 
-QString InstallLoaderDialog::describeVersionChange(InstallLoaderPage* page, const QString& installedVersion, const QString& selectedVersion)
-{
-    auto list = APPLICATION->metadataIndex()->get(page->id());
-    auto installedMetaVersion = std::dynamic_pointer_cast<Meta::Version>(list->findVersion(installedVersion));
-    auto selectedMetaVersion = std::dynamic_pointer_cast<Meta::Version>(page->selectedVersion());
-
-    if (installedMetaVersion && selectedMetaVersion && installedMetaVersion->rawTime() != selectedMetaVersion->rawTime()) {
-        if (installedMetaVersion->rawTime() < selectedMetaVersion->rawTime())
-            return tr("update it to %1").arg(selectedVersion);
-        return tr("downgrade it to %1").arg(selectedVersion);
-    }
-    return tr("switch it to %1").arg(selectedVersion);
-}
-
 bool InstallLoaderDialog::resolveLoaderConflicts(InstallLoaderPage* page)
 {
     QList<ComponentPtr> conflicts;
@@ -225,61 +204,6 @@ bool InstallLoaderDialog::resolveLoaderConflicts(InstallLoaderPage* page)
     return true;
 }
 
-bool InstallLoaderDialog::confirmReinstall(InstallLoaderPage* page, Component* component)
-{
-    const QString installedVersion = component->getVersion();
-    const QString selectedVersion = page->selectedVersion()->descriptor();
-    const bool sameVersion = installedVersion == selectedVersion;
-
-    if (component->isEnabled() && sameVersion) {
-        if (askYesNo(this, tr("Loader already installed"),
-                     tr("%1 %2 is already installed. Do you want to reinstall it?").arg(page->displayName(), installedVersion),
-                     QMessageBox::Warning))
-            return true;
-        QDialog::done(Accepted);
-        return false;
-    }
-
-    if (component->isEnabled()) {
-        return askYesNo(this, tr("Loader already installed"),
-                        tr("%1 %2 is currently installed. Do you want to %3?")
-                            .arg(page->displayName(), installedVersion, describeVersionChange(page, installedVersion, selectedVersion)),
-                        QMessageBox::Warning);
-    }
-
-    if (sameVersion) {
-        auto* msgBox = CustomMessageBox::selectable(
-            this, tr("Loader already installed"),
-            tr("%1 %2 is already installed, but disabled. Do you want to enable it?").arg(page->displayName(), installedVersion),
-            QMessageBox::Question, QMessageBox::No);
-        QAbstractButton* enableButton = msgBox->addButton(tr("Enable"), QMessageBox::AcceptRole);
-        QAbstractButton* reinstallButton = msgBox->addButton(tr("Reinstall"), QMessageBox::DestructiveRole);
-        msgBox->exec();
-
-        auto* clicked = msgBox->clickedButton();
-        if (clicked == enableButton) {
-            component->setEnabled(true);
-            profile->resolve(Net::Mode::Online);
-            QDialog::done(Accepted);
-            return false;
-        }
-        if (clicked != reinstallButton) {
-            QDialog::done(Rejected);
-            return false;
-        }
-        component->setEnabled(true);
-        return true;
-    }
-
-    if (!askYesNo(this, tr("Loader already installed"),
-                  tr("%1 %2 is currently installed, but disabled. Do you want to %3 and enable it?")
-                      .arg(page->displayName(), installedVersion, describeVersionChange(page, installedVersion, selectedVersion)),
-                  QMessageBox::Question))
-        return false;
-    component->setEnabled(true);
-    return true;
-}
-
 void InstallLoaderDialog::done(int result)
 {
     if (result == Accepted) {
@@ -288,9 +212,8 @@ void InstallLoaderDialog::done(int result)
             if (!resolveLoaderConflicts(page))
                 return;
 
-            const ComponentPtr component = profile->getComponent(page->id());
-            if (component && !confirmReinstall(page, component.get()))
-                return;
+            if (const ComponentPtr component = profile->getComponent(page->id()); component && !component->isEnabled())
+                component->setEnabled(true);
 
             profile->setComponentVersion(page->id(), page->selectedVersion()->descriptor());
             profile->resolve(Net::Mode::Online);

--- a/launcher/ui/dialogs/InstallLoaderDialog.cpp
+++ b/launcher/ui/dialogs/InstallLoaderDialog.cpp
@@ -170,10 +170,10 @@ bool InstallLoaderDialog::resolveLoaderConflicts(InstallLoaderPage* page)
         }
     }
 
-    const QString targetVersion = tr("%1 %2").arg(page->displayName(), page->selectedVersion()->descriptor());
+    const QString targetVersion = QString("%1 %2").arg(page->displayName(), page->selectedVersion()->descriptor());
 
     for (const ComponentPtr& conflict : conflicts) {
-        const QString conflictVersion = tr("%1 %2").arg(conflict->getName(), conflict->getVersion());
+        const QString conflictVersion = QString("%1 %2").arg(conflict->getName(), conflict->getVersion());
         auto* msgBox = CustomMessageBox::selectable(
             this, tr("Installing a second loader"),
             tr("%1 is known to conflict with %2, which is already enabled on this instance. Having both enabled at the same time will "

--- a/launcher/ui/dialogs/InstallLoaderDialog.h
+++ b/launcher/ui/dialogs/InstallLoaderDialog.h
@@ -21,7 +21,6 @@
 #include <QDialog>
 #include "ui/pages/BasePageProvider.h"
 
-class Component;
 class InstallLoaderPage;
 class MinecraftInstance;
 class PageContainer;
@@ -41,9 +40,7 @@ class InstallLoaderDialog final : public QDialog, protected BasePageProvider {
     void done(int result) override;
 
    private:
-    static QString describeVersionChange(InstallLoaderPage* page, const QString& installedVersion, const QString& selectedVersion);
     bool resolveLoaderConflicts(InstallLoaderPage* page);
-    bool confirmReinstall(InstallLoaderPage* page, Component* component);
 
     PackProfile* profile;
     PageContainer* container;

--- a/launcher/ui/dialogs/InstallLoaderDialog.h
+++ b/launcher/ui/dialogs/InstallLoaderDialog.h
@@ -21,6 +21,8 @@
 #include <QDialog>
 #include "ui/pages/BasePageProvider.h"
 
+class Component;
+class InstallLoaderPage;
 class MinecraftInstance;
 class PageContainer;
 class PackProfile;
@@ -39,6 +41,10 @@ class InstallLoaderDialog final : public QDialog, protected BasePageProvider {
     void done(int result) override;
 
    private:
+    static QString describeVersionChange(InstallLoaderPage* page, const QString& installedVersion, const QString& selectedVersion);
+    bool resolveLoaderConflicts(InstallLoaderPage* page);
+    bool confirmReinstall(InstallLoaderPage* page, Component* component);
+
     PackProfile* profile;
     PageContainer* container;
     QDialogButtonBox* buttons;


### PR DESCRIPTION
his PR adds a warning when the user attempts to install a mod loader that conflicts with another enabled loader in the instance.

Instead of silently allowing incompatible loaders to coexist, the dialog informs the user that the selected loader conflicts with an already enabled one and lets them choose whether to:
- keep the conflicting loader enabled,
- disable it, or
- uninstall it

before continuing with the installation.

This change aims to prevent accidental invalid configurations while avoiding unnecessary prompts for non-conflicting operations.


<img width="992" height="308" alt="swappy-20260706_031855" src="https://github.com/user-attachments/assets/e544df82-7124-46e4-bf72-ec667de40280" />
