### PR TITLE
fix: do not fallback on native env vars with switcheroo is available

### DIFF
--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -137,11 +137,14 @@
             for (int i = 0; i + 1 < envList.size(); i += 2) {
                 env.insert(envList[i], envList[i + 1]);
             }
-            return true;
+            break;
         }
     }
-#endif
+
+    return true;
+#else
     return false;
+#endif
 }
 
 // all of this because keeping things compatible with deprecated old settings


### PR DESCRIPTION
The Discrete GPU logic checks if `switcherooSetupGPU` returns true and if not naively assigns env vars to select the "next" GPU.

If switcheroo is available and no valid GPU can be found then it is better to return true and not set env vars that do nothing useful i.e. setting DRI_PRIME on a single GPU system.