### PR TITLE
Add option whether to count instance in total playtime

### DIFF
--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -94,6 +94,7 @@ BaseInstance::BaseInstance(SettingsObject* globalSettings, std::unique_ptr<Setti
     auto gameTimeOverride = m_settings->registerSetting("OverrideGameTime", false);
     m_settings->registerOverride(globalSettings->getSetting("ShowGameTime"), gameTimeOverride);
     m_settings->registerOverride(globalSettings->getSetting("RecordGameTime"), gameTimeOverride);
+    m_settings->registerSetting("CountGameTime", true);
 
     // NOTE: Sometimees InstanceType is already registered, as it was used to identify the type of
     // a locally stored instance
@@ -321,6 +322,11 @@ int64_t BaseInstance::lastTimePlayed() const
         return m_timeStarted.secsTo(timeNow);
     }
     return m_settings->get("lastTimePlayed").toLongLong();
+}
+
+bool BaseInstance::countTimePlayed() const
+{
+    return m_settings->get("CountGameTime").toBool();
 }
 
 void BaseInstance::resetTimePlayed()

--- a/launcher/BaseInstance.h
+++ b/launcher/BaseInstance.h
@@ -121,6 +121,7 @@ class BaseInstance : public QObject {
     bool isRunning() const;
     int64_t totalTimePlayed() const;
     int64_t lastTimePlayed() const;
+    bool countTimePlayed() const;
     void resetTimePlayed();
 
     /// get the type of this instance

--- a/launcher/InstanceList.cpp
+++ b/launcher/InstanceList.cpp
@@ -561,7 +561,9 @@ void InstanceList::updateTotalPlayTime()
 {
     totalPlayTime = 0;
     for (const auto& itr : m_instances) {
-        totalPlayTime += itr->totalTimePlayed();
+        if (itr->countTimePlayed()) {
+            totalPlayTime += itr->totalTimePlayed();
+        }
     }
 }
 

--- a/launcher/ui/widgets/MinecraftSettingsWidget.cpp
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.cpp
@@ -61,6 +61,7 @@ MinecraftSettingsWidget::MinecraftSettingsWidget(MinecraftInstance* instance, QW
         m_ui->serverJoinGroupBox->hide();
         m_ui->globalDataPacksGroupBox->hide();
         m_ui->loaderGroup->hide();
+        m_ui->countGameTime->hide();
     } else {
         m_javaSettings = new JavaSettingsWidget(m_instance, this);
         m_ui->javaScrollArea->setWidget(m_javaSettings);
@@ -174,6 +175,7 @@ void MinecraftSettingsWidget::loadSettings()
     m_ui->gameTimeGroupBox->setChecked(m_instance == nullptr || settings->get("OverrideGameTime").toBool());
     m_ui->showGameTime->setChecked(settings->get("ShowGameTime").toBool());
     m_ui->recordGameTime->setChecked(settings->get("RecordGameTime").toBool());
+    m_ui->countGameTime->setChecked(settings->get("CountGameTime").toBool());
     m_ui->showGlobalGameTime->setChecked(m_instance == nullptr && settings->get("ShowGlobalGameTime").toBool());
     m_ui->showGameTimeWithoutDays->setChecked(m_instance == nullptr && settings->get("ShowGameTimeWithoutDays").toBool());
 
@@ -422,8 +424,15 @@ void MinecraftSettingsWidget::saveSettings()
         // Game time
         bool gameTime = m_instance == nullptr || m_ui->gameTimeGroupBox->isChecked();
 
-        if (m_instance != nullptr)
+        if (m_instance != nullptr) {
             settings->set("OverrideGameTime", gameTime);
+
+            if (gameTime) {
+                settings->set("CountGameTime", m_ui->countGameTime->isChecked());
+            } else {
+                settings->reset("CountGameTime");
+            }
+        }
 
         if (gameTime) {
             settings->set("ShowGameTime", m_ui->showGameTime->isChecked());

--- a/launcher/ui/widgets/MinecraftSettingsWidget.ui
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.ui
@@ -346,6 +346,13 @@ It is most likely you will need to change the path - please refer to the mod's w
                </widget>
               </item>
               <item>
+               <widget class="QCheckBox" name="countGameTime">
+                <property name="text">
+                 <string>&amp;Count time playing this instance into total time played</string>
+                </property>
+               </widget>
+              </item>
+              <item>
                <widget class="QCheckBox" name="showGlobalGameTime">
                 <property name="text">
                  <string>Show the &amp;total time played across instances</string>


### PR DESCRIPTION
The use case here is making a copy of your instance as a backup (say, when migrating to a new modpack version) and wanting to keep the old copy displayed in Prism. In that case, the old instance can now be configured to not count towards total playtime. This way, the instance, including its playtime, can be fully preserved and displayed in Prism, but the total playtime statistic stays accurate.

Closes #4937.