### PR TITLE
build(cmake): add path hints for qt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -292,8 +292,25 @@ set(Launcher_BUILD_TIMESTAMP "${TODAY}")
 # Find the required Qt parts
 if(Launcher_QT_VERSION_MAJOR EQUAL 6)
     set(QT_VERSION_MAJOR 6)
-    find_package(Qt6 6.4 REQUIRED COMPONENTS Core CoreTools Widgets Concurrent Network Test Xml NetworkAuth OpenGL)
-    find_package(Qt6 COMPONENTS DBus)
+    find_package(
+        Qt6 6.4
+        REQUIRED
+        COMPONENTS
+            Concurrent
+            Core
+            CoreTools
+            Network
+            NetworkAuth
+            OpenGL
+            Test
+            Widgets
+            Xml
+        HINTS
+            C:/Qt/*/*/lib/cmake
+            /opt/qt/*/*/lib/cmake
+            $ENV{MINGW_PREFIX}/opt/qt/*/*/li/cmake
+    )
+    find_package(Qt6 COMPONENTS DBus HINTS /opt/qt/*/*/lib/cmake)
     list(APPEND Launcher_QT_DBUS Qt6::DBus)
 else()
     message(FATAL_ERROR "Qt version ${Launcher_QT_VERSION_MAJOR} is not supported")


### PR DESCRIPTION
This makes the build experience work a bit more OOTB - assuming a
standard output directory for `aqt`