### PR TITLE
Support using vcpkg with MinGW

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -68,6 +68,11 @@
                 "type": "equals",
                 "lhs": "${hostSystemName}",
                 "rhs": "Windows"
+            },
+            "cacheVariables": {
+                "CMAKE_TOOLCHAIN_FILE": "$penv{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+                "VCPKG_HOST_TRIPLET": "x64-mingw-static-release",
+                "VCPKG_TARGET_TRIPLET": "x64-mingw-static-release"
             }
         },
         {

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -1528,6 +1528,7 @@ if(WIN32 OR (UNIX AND APPLE))
         COMPONENT bundle
         DIRECTORIES
             ${CMAKE_SYSTEM_LIBRARY_PATH}
+            $ENV{PATH}
             ${QT_LIBS_DIR}
             ${QT_LIBEXECS_DIR}
         PRE_EXCLUDE_REGEXES
@@ -1547,7 +1548,7 @@ if(WIN32 OR (UNIX AND APPLE))
         COMPONENT bundle
     )
     # FIXME: remove this crap once we stop using msys2
-    if(MINGW)
+    if(MINGW AND NOT VCPKG_MANIFEST_INSTALL)
         # i've not found a solution better than injecting the config vars like this...
         # with install(CODE" for everything everything just breaks
         install(CODE "

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "2d6a6cf3ac9a7cc93942c3d289a2f9c661a6f4a7",
+    "baseline": "301856f5f2824f788a3ffa6332293861cccd23b4",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [


### PR DESCRIPTION
## This doesn't switch from MSYS2 in CI yet!!!

Previously we only used MSYS2 to source dependencies due to weird issues between it and vcpkg (which bundles its own MSYS2 install). When using standalone distributions of MinGW like llvm-mingw though, it appears to mostly work fine!

The only gotcha is that Qt doesn't yet support llvm-mingw for Windows on ARM yet, so we'll still have to keep MSYS2 support around for that at least

To try this for yourself, do the following

```
# This assumes a working vcpkg as well
winget install MartinStorsjo.LLVM-MinGW.UCRT Kitware.CMake Ninja-build.Ninja miurahr.aqtinstall
aqt install-qt windows desktop 6.10 win64_llvm_mingw -m qtimageformats qtnetworkauth -O C:\aqt
# Delete bundled dlls that conflict with our llvm-mingw toolchain
rm C:\aqt\6.10.3\llvm-mingw_64\bin\libc++.dll
rm C:\aqt\6.10.3\llvm-mingw_64\bin\libunwind.dll
# Build as normal
cmake --preset windows_mingw
cmake --build --preset windows_mingw --config Debug
cmake --install build --config Debug
```