### PR TITLE
feat: resumable downloads with cache, abort dialog, and Range-error recovery

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -656,8 +656,8 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
 
         // Download cache settings
         m_settings->registerSetting("DownloadCacheEnabled", true);
-        m_settings->registerSetting("DownloadCacheMaxSize", 1024);       // MB
-        m_settings->registerSetting("DownloadCacheDuration", 24);        // hours
+        m_settings->registerSetting("DownloadCacheMaxSize", 1024);  // MB
+        m_settings->registerSetting("DownloadCacheDuration", 24);   // hours
         m_settings->registerSetting("DownloadCacheCleanupOnLaunch", true);
 
         QString defaultMonospace;

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -107,6 +107,7 @@
 
 #include <minecraft/auth/AccountList.h>
 #include "icons/IconList.h"
+#include "net/DownloadCache.h"
 #include "net/HttpMetaCache.h"
 
 #include "updater/ExternalUpdater.h"
@@ -653,6 +654,12 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         m_settings->registerSetting("NumberOfManualRetries", 1);
         m_settings->registerSetting("RequestTimeout", 60);
 
+        // Download cache settings
+        m_settings->registerSetting("DownloadCacheEnabled", true);
+        m_settings->registerSetting("DownloadCacheMaxSize", 1024);       // MB
+        m_settings->registerSetting("DownloadCacheDuration", 24);        // hours
+        m_settings->registerSetting("DownloadCacheCleanupOnLaunch", true);
+
         QString defaultMonospace;
         int defaultSize = 11;
 #ifdef Q_OS_WIN32
@@ -1011,6 +1018,19 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         m_metacache->addBase("feed", QDir("cache/feed").absolutePath());
         m_metacache->Load();
         qInfo() << "<> Cache initialized.";
+    }
+
+    // init the download cache (for resumable file downloads)
+    {
+        QString downloadCachePath = FS::PathCombine(m_dataPath, "cache", "downloads");
+        m_downloadCache.reset(new DownloadCache(downloadCachePath));
+        if (m_settings->get("DownloadCacheCleanupOnLaunch").toBool()) {
+            qint64 maxSize = static_cast<qint64>(m_settings->get("DownloadCacheMaxSize").toInt()) * 1024 * 1024;
+            int maxHours = m_settings->get("DownloadCacheDuration").toInt();
+            m_downloadCache->cleanup(maxSize, maxHours);
+            qInfo() << "<> Download cache cleaned.";
+        }
+        qInfo() << "<> Download cache initialized.";
     }
 
     // load translations
@@ -1810,6 +1830,11 @@ void Application::updateProxySettings(QString proxyTypeStr, QString addr, int po
 HttpMetaCache* Application::metacache()
 {
     return m_metacache.get();
+}
+
+DownloadCache* Application::downloadCache()
+{
+    return m_downloadCache.get();
 }
 
 QNetworkAccessManager* Application::network()

--- a/launcher/Application.h
+++ b/launcher/Application.h
@@ -59,6 +59,7 @@ class ViewLogWindow;
 class SetupWizard;
 class GenericPageProvider;
 class QFile;
+class DownloadCache;
 class HttpMetaCache;
 class SettingsObject;
 class InstanceList;
@@ -150,6 +151,7 @@ class Application : public QApplication {
     QNetworkAccessManager* network();
 
     HttpMetaCache* metacache();
+    DownloadCache* downloadCache();
 
     Meta::Index* metadataIndex();
 
@@ -254,6 +256,7 @@ class Application : public QApplication {
     std::unique_ptr<AccountList> m_accounts;
 
     std::unique_ptr<HttpMetaCache> m_metacache;
+    std::unique_ptr<DownloadCache> m_downloadCache;
     std::unique_ptr<Meta::Index> m_metadataIndex;
 
     std::unique_ptr<SettingsObject> m_settings;

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -119,9 +119,13 @@ set(NET_SOURCES
     net/ChecksumValidator.h
     net/Download.cpp
     net/Download.h
+    net/DownloadCache.h
+    net/DownloadCache.cpp
     net/DummySink.h
     net/FileSink.cpp
     net/FileSink.h
+    net/ResumingFileSink.h
+    net/ResumingFileSink.cpp
     net/HttpMetaCache.cpp
     net/HttpMetaCache.h
     net/MetaCacheSink.cpp
@@ -643,6 +647,8 @@ set(PRISMUPDATER_SOURCES
     net/ChecksumValidator.h
     net/Download.cpp
     net/Download.h
+    net/DownloadCache.h
+    net/DownloadCache.cpp
     net/FileSink.cpp
     net/FileSink.h
     net/HttpMetaCache.cpp
@@ -654,6 +660,8 @@ set(PRISMUPDATER_SOURCES
     net/NetJob.cpp
     net/NetJob.h
     net/NetUtils.h
+    net/ResumingFileSink.h
+    net/ResumingFileSink.cpp
     net/Sink.h
     net/Validator.h
     net/HeaderProxy.h

--- a/launcher/net/ApiDownload.cpp
+++ b/launcher/net/ApiDownload.cpp
@@ -40,7 +40,7 @@ std::pair<Download::Ptr, QByteArray*> ApiDownload::makeByteArray(QUrl url, Downl
 
 Download::Ptr ApiDownload::makeFile(QUrl url, QString path, Download::Options options, ModrinthDownloadMeta meta)
 {
-    auto dl = Download::makeFile(std::move(url), std::move(path), options);
+    auto dl = Download::makeResumable(std::move(url), std::move(path), options);
     dl->addHeaderProxy(std::make_unique<ApiHeaderProxy>(std::move(meta)));
     return dl;
 }

--- a/launcher/net/Download.cpp
+++ b/launcher/net/Download.cpp
@@ -45,7 +45,9 @@
 
 #include "ByteArraySink.h"
 #include "ChecksumValidator.h"
+#include "DownloadCache.h"
 #include "MetaCacheSink.h"
+#include "ResumingFileSink.h"
 
 namespace Net {
 
@@ -84,6 +86,20 @@ auto Download::makeFile(QUrl url, QString path, Options options) -> Download::Pt
     dl->setObjectName(QString("FILE:") + url.toString());
     dl->m_options = options;
     dl->m_sink.reset(new FileSink(path));
+    return dl;
+}
+
+auto Download::makeResumable(QUrl url, QString path, Options options) -> Download::Ptr
+{
+    auto dl = makeShared<Download>();
+    dl->m_url = url;
+    dl->setObjectName(QString("RESUME:") + url.toString());
+    dl->m_options = options;
+#if defined(LAUNCHER_APPLICATION)
+    dl->m_sink.reset(new ResumingFileSink(path, url, APPLICATION->downloadCache()));
+#else
+    dl->m_sink.reset(new ResumingFileSink(path, url, nullptr));
+#endif
     return dl;
 }
 

--- a/launcher/net/Download.h
+++ b/launcher/net/Download.h
@@ -47,6 +47,7 @@
 
 namespace Net {
 class ByteArraySink;
+class DownloadCache;
 
 class Download : public NetRequest {
     Q_OBJECT
@@ -64,6 +65,12 @@ class Download : public NetRequest {
      */
     static auto makeByteArray(QUrl url, Options options = Option::NoOptions) -> std::pair<Download::Ptr, QByteArray*>;
     static auto makeFile(QUrl url, QString path, Options options = Option::NoOptions) -> Download::Ptr;
+
+    /**
+     * Creates a request that can resume interrupted downloads using Range headers.
+     * The cache is consulted for existing .part files to continue from.
+     */
+    static auto makeResumable(QUrl url, QString path, Options options = Option::NoOptions) -> Download::Ptr;
 
    protected:
     virtual QNetworkReply* getReply(QNetworkRequest&) override;

--- a/launcher/net/DownloadCache.cpp
+++ b/launcher/net/DownloadCache.cpp
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2025 PineconeMC Contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "DownloadCache.h"
+
+#include <QCryptographicHash>
+#include <QDateTime>
+#include <QDirIterator>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonDocument>
+#include <QMutexLocker>
+
+#include "net/Logging.h"
+
+QJsonObject DownloadCacheEntry::toJson() const
+{
+    QJsonObject obj;
+    obj["url"] = url;
+    obj["cacheFileName"] = cacheFileName;
+    obj["size"] = size;
+    obj["lastAccessed"] = lastAccessed;
+    obj["created"] = created;
+    return obj;
+}
+
+DownloadCacheEntry DownloadCacheEntry::fromJson(const QJsonObject& obj)
+{
+    DownloadCacheEntry entry;
+    entry.url = obj["url"].toString();
+    entry.cacheFileName = obj["cacheFileName"].toString();
+    entry.size = obj["size"].toInteger();
+    entry.lastAccessed = obj["lastAccessed"].toInteger();
+    entry.created = obj["created"].toInteger();
+    return entry;
+}
+
+DownloadCache::DownloadCache(const QString& cacheDir)
+    : m_cacheDir(cacheDir), m_partsDir(cacheDir + "/parts"), m_metadataPath(cacheDir + "/.metadata.json")
+{
+    QDir().mkpath(m_partsDir);
+    QDir().mkpath(m_cacheDir);
+    loadMetadata();
+}
+
+DownloadCache::~DownloadCache()
+{
+    saveMetadata();
+}
+
+QString DownloadCache::generateCacheKey(const QUrl& url) const
+{
+    QByteArray hash = QCryptographicHash::hash(url.toString().toUtf8(), QCryptographicHash::Sha256);
+    return QString::fromLatin1(hash.toHex().left(32));
+}
+
+QString DownloadCache::getPartPath(const QUrl& url) const
+{
+    return m_partsDir + "/" + generateCacheKey(url) + ".part";
+}
+
+qint64 DownloadCache::getPartSize(const QUrl& url) const
+{
+    QFileInfo info(getPartPath(url));
+    return info.exists() ? info.size() : 0;
+}
+
+bool DownloadCache::hasPart(const QUrl& url) const
+{
+    return QFileInfo::exists(getPartPath(url));
+}
+
+QString DownloadCache::getCachePath(const QUrl& url) const
+{
+    QString key = generateCacheKey(url);
+    return m_cacheDir + "/" + key;
+}
+
+bool DownloadCache::hasCache(const QUrl& url)
+{
+    QMutexLocker lock(&m_mutex);
+    QString key = generateCacheKey(url);
+    return m_entries.contains(key) && QFileInfo::exists(m_cacheDir + "/" + key);
+}
+
+bool DownloadCache::promotePart(const QUrl& url, const QString& finalPath)
+{
+    QString partPath = getPartPath(url);
+    if (!QFileInfo::exists(partPath))
+        return false;
+
+    // Ensure destination directory exists
+    QFileInfo finalInfo(finalPath);
+    QDir().mkpath(finalInfo.absolutePath());
+
+    // Remove destination if it exists
+    if (QFileInfo::exists(finalPath)) {
+        QFile::remove(finalPath);
+    }
+
+    // Rename .part to final destination (atomic on same filesystem)
+    if (!QFile::rename(partPath, finalPath)) {
+        qCCritical(taskNetLogC) << "Failed to rename" << partPath << "to" << finalPath;
+        return false;
+    }
+
+    // Also store in cache
+    QString key = generateCacheKey(url);
+    DownloadCacheEntry entry;
+    entry.url = url.toString();
+    entry.cacheFileName = key;
+    entry.size = QFileInfo(finalPath).size();
+    entry.created = QDateTime::currentSecsSinceEpoch();
+    entry.lastAccessed = entry.created;
+
+    QMutexLocker lock(&m_mutex);
+    m_entries[key] = entry;
+    saveMetadata();
+
+    qCDebug(taskNetLogC) << "Download cached:" << url.toString() << "->" << finalPath;
+    return true;
+}
+
+bool DownloadCache::promoteCache(const QUrl& url, const QString& finalPath)
+{
+    QMutexLocker lock(&m_mutex);
+    QString key = generateCacheKey(url);
+    if (!m_entries.contains(key))
+        return false;
+
+    QString cachePath = m_cacheDir + "/" + key;
+    if (!QFileInfo::exists(cachePath))
+        return false;
+
+    QFileInfo finalInfo(finalPath);
+    QDir().mkpath(finalInfo.absolutePath());
+
+    if (QFileInfo::exists(finalPath)) {
+        QFile::remove(finalPath);
+    }
+
+    if (!QFile::rename(cachePath, finalPath)) {
+        qCCritical(taskNetLogC) << "Failed to promote cache" << cachePath << "to" << finalPath;
+        return false;
+    }
+
+    m_entries.remove(key);
+    saveMetadata();
+
+    qCDebug(taskNetLogC) << "Promoted cached download:" << url.toString() << "->" << finalPath;
+    return true;
+}
+
+void DownloadCache::removePart(const QUrl& url)
+{
+    QString partPath = getPartPath(url);
+    if (QFileInfo::exists(partPath)) {
+        QFile::remove(partPath);
+    }
+}
+
+void DownloadCache::removeCache(const QUrl& url)
+{
+    QMutexLocker lock(&m_mutex);
+    QString key = generateCacheKey(url);
+    if (m_entries.contains(key)) {
+        QString cachePath = m_cacheDir + "/" + key;
+        if (QFileInfo::exists(cachePath)) {
+            QFile::remove(cachePath);
+        }
+        m_entries.remove(key);
+        saveMetadata();
+    }
+}
+
+void DownloadCache::cleanup(qint64 maxSizeBytes, int maxAgeHours)
+{
+    QMutexLocker lock(&m_mutex);
+
+    qint64 now = QDateTime::currentSecsSinceEpoch();
+    qint64 maxAgeSecs = static_cast<qint64>(maxAgeHours) * 3600;
+
+    // Remove expired entries first
+    QMutableHashIterator<QString, DownloadCacheEntry> it(m_entries);
+    while (it.hasNext()) {
+        it.next();
+        if (maxAgeHours > 0 && (now - it.value().lastAccessed) > maxAgeSecs) {
+            QString cachePath = m_cacheDir + "/" + it.key();
+            if (QFileInfo::exists(cachePath)) {
+                QFile::remove(cachePath);
+            }
+            qCDebug(taskNetLogC) << "Removed expired cache entry:" << it.value().url;
+            it.remove();
+        }
+    }
+
+    // Also clean up orphaned .part files (older than max age)
+    if (maxAgeHours > 0) {
+        QDirIterator partIt(m_partsDir, { "*.part" }, QDir::Files);
+        while (partIt.hasNext()) {
+            partIt.next();
+            QFileInfo fi = partIt.fileInfo();
+            if (fi.lastModified().toSecsSinceEpoch() < (now - maxAgeSecs)) {
+                QFile::remove(fi.absoluteFilePath());
+                qCDebug(taskNetLogC) << "Removed expired .part file:" << fi.fileName();
+            }
+        }
+    }
+
+    saveMetadata();
+
+    // If still over size limit, evict oldest
+    if (maxSizeBytes > 0 && totalCacheSize() > maxSizeBytes) {
+        QList<DownloadCacheEntry> sorted = m_entries.values();
+        std::sort(sorted.begin(), sorted.end(), [](const DownloadCacheEntry& a, const DownloadCacheEntry& b) {
+            return a.lastAccessed < b.lastAccessed;
+        });
+
+        while (totalCacheSize() > maxSizeBytes && !sorted.isEmpty()) {
+            auto oldest = sorted.takeFirst();
+            QString cachePath = m_cacheDir + "/" + oldest.cacheFileName;
+            if (QFileInfo::exists(cachePath)) {
+                QFile::remove(cachePath);
+            }
+            m_entries.remove(oldest.cacheFileName);
+            qCDebug(taskNetLogC) << "Evicted oldest cache entry:" << oldest.url;
+        }
+        saveMetadata();
+    }
+}
+
+qint64 DownloadCache::totalCacheSize() const
+{
+    qint64 total = 0;
+    for (auto& entry : m_entries) {
+        total += entry.size;
+    }
+    return total;
+}
+
+void DownloadCache::loadMetadata()
+{
+    QFile file(m_metadataPath);
+    if (!file.open(QIODevice::ReadOnly))
+        return;
+
+    QJsonDocument doc = QJsonDocument::fromJson(file.readAll());
+    file.close();
+
+    if (!doc.isObject())
+        return;
+
+    QJsonArray arr = doc.object()["entries"].toArray();
+    for (const auto& val : arr) {
+        DownloadCacheEntry entry = DownloadCacheEntry::fromJson(val.toObject());
+        m_entries[entry.cacheFileName] = entry;
+    }
+}
+
+void DownloadCache::saveMetadata()
+{
+    QJsonArray arr;
+    for (auto& entry : m_entries) {
+        arr.append(entry.toJson());
+    }
+
+    QJsonObject root;
+    root["entries"] = arr;
+    root["version"] = 1;
+
+    QJsonDocument doc(root);
+    QFile file(m_metadataPath);
+    if (file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        file.write(doc.toJson(QJsonDocument::Indented));
+        file.close();
+    }
+}
+
+void DownloadCache::touchAccessTime(const QString& cacheKey)
+{
+    if (m_entries.contains(cacheKey)) {
+        m_entries[cacheKey].lastAccessed = QDateTime::currentSecsSinceEpoch();
+    }
+}

--- a/launcher/net/DownloadCache.cpp
+++ b/launcher/net/DownloadCache.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
  *  Prism Launcher - Minecraft Launcher
- *  Copyright (C) 2025 PineconeMC Contributors
+ *  Copyright (C) 2025 Avenger Anubis (Ilya) <avenger.anubis@gmail.com>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -119,8 +119,12 @@ bool DownloadCache::promotePart(const QUrl& url, const QString& finalPath)
         return false;
     }
 
-    // Also store in cache
+    // Store in cache directory for future re-use
     QString key = generateCacheKey(url);
+    QString cachePath = m_cacheDir + "/" + key;
+    if (!QFile::copy(finalPath, cachePath))
+        qCWarning(taskNetLogC) << "Failed to copy to cache:" << cachePath;
+
     DownloadCacheEntry entry;
     entry.url = url.toString();
     entry.cacheFileName = key;
@@ -163,6 +167,35 @@ bool DownloadCache::promoteCache(const QUrl& url, const QString& finalPath)
     saveMetadata();
 
     qCDebug(taskNetLogC) << "Promoted cached download:" << url.toString() << "->" << finalPath;
+    return true;
+}
+
+bool DownloadCache::serveFromCache(const QUrl& url, const QString& finalPath)
+{
+    QMutexLocker lock(&m_mutex);
+    QString key = generateCacheKey(url);
+    if (!m_entries.contains(key))
+        return false;
+
+    QString cachePath = m_cacheDir + "/" + key;
+    if (!QFileInfo::exists(cachePath))
+        return false;
+
+    QFileInfo finalInfo(finalPath);
+    QDir().mkpath(finalInfo.absolutePath());
+
+    if (QFileInfo::exists(finalPath))
+        QFile::remove(finalPath);
+
+    if (!QFile::copy(cachePath, finalPath)) {
+        qCCritical(taskNetLogC) << "Failed to serve from cache:" << cachePath << "->" << finalPath;
+        return false;
+    }
+
+    m_entries[key].lastAccessed = QDateTime::currentSecsSinceEpoch();
+    saveMetadata();
+
+    qCDebug(taskNetLogC) << "Served from cache:" << url.toString();
     return true;
 }
 
@@ -227,9 +260,8 @@ void DownloadCache::cleanup(qint64 maxSizeBytes, int maxAgeHours)
     // If still over size limit, evict oldest
     if (maxSizeBytes > 0 && totalCacheSize() > maxSizeBytes) {
         QList<DownloadCacheEntry> sorted = m_entries.values();
-        std::sort(sorted.begin(), sorted.end(), [](const DownloadCacheEntry& a, const DownloadCacheEntry& b) {
-            return a.lastAccessed < b.lastAccessed;
-        });
+        std::sort(sorted.begin(), sorted.end(),
+                  [](const DownloadCacheEntry& a, const DownloadCacheEntry& b) { return a.lastAccessed < b.lastAccessed; });
 
         while (totalCacheSize() > maxSizeBytes && !sorted.isEmpty()) {
             auto oldest = sorted.takeFirst();

--- a/launcher/net/DownloadCache.h
+++ b/launcher/net/DownloadCache.h
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2025 PineconeMC Contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QByteArray>
+#include <QDir>
+#include <QHash>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QMutex>
+#include <QString>
+#include <QUrl>
+
+class DownloadCacheEntry {
+   public:
+    QString url;
+    QString cacheFileName;
+    qint64 size = 0;
+    qint64 lastAccessed = 0;
+    qint64 created = 0;
+
+    QJsonObject toJson() const;
+    static DownloadCacheEntry fromJson(const QJsonObject& obj);
+};
+
+class DownloadCache {
+   public:
+    explicit DownloadCache(const QString& cacheDir);
+    ~DownloadCache();
+
+    QString getPartPath(const QUrl& url) const;
+    qint64 getPartSize(const QUrl& url) const;
+    bool hasPart(const QUrl& url) const;
+    QString getCachePath(const QUrl& url) const;
+    bool hasCache(const QUrl& url);
+
+    bool promotePart(const QUrl& url, const QString& finalPath);
+    bool promoteCache(const QUrl& url, const QString& finalPath);
+    void removePart(const QUrl& url);
+    void removeCache(const QUrl& url);
+
+    void cleanup(qint64 maxSizeBytes, int maxAgeHours);
+    qint64 totalCacheSize() const;
+
+    QString cacheDir() const { return m_cacheDir; }
+    QString partsDir() const { return m_partsDir; }
+
+   private:
+    QString generateCacheKey(const QUrl& url) const;
+    void loadMetadata();
+    void saveMetadata();
+    void touchAccessTime(const QString& cacheKey);
+
+    QString m_cacheDir;
+    QString m_partsDir;
+    QString m_metadataPath;
+
+    QHash<QString, DownloadCacheEntry> m_entries;
+    mutable QMutex m_mutex;
+};

--- a/launcher/net/DownloadCache.h
+++ b/launcher/net/DownloadCache.h
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
  *  Prism Launcher - Minecraft Launcher
- *  Copyright (C) 2025 PineconeMC Contributors
+ *  Copyright (C) 2025 Avenger Anubis (Ilya) <avenger.anubis@gmail.com>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -54,6 +54,7 @@ class DownloadCache {
     bool promoteCache(const QUrl& url, const QString& finalPath);
     void removePart(const QUrl& url);
     void removeCache(const QUrl& url);
+    bool serveFromCache(const QUrl& url, const QString& finalPath);
 
     void cleanup(qint64 maxSizeBytes, int maxAgeHours);
     qint64 totalCacheSize() const;

--- a/launcher/net/NetJob.cpp
+++ b/launcher/net/NetJob.cpp
@@ -82,6 +82,25 @@ void NetJob::executeNextSubTask()
     ConcurrentTask::executeNextSubTask();
 }
 
+void NetJob::deleteCachedDownloads()
+{
+    for (auto& part : m_queue) {
+        if (auto* req = qobject_cast<Net::NetRequest*>(part.get())) {
+            req->deleteCachedDownload();
+        }
+    }
+    for (auto it = m_doing.begin(); it != m_doing.end(); ++it) {
+        if (auto* req = qobject_cast<Net::NetRequest*>(it.value().get())) {
+            req->deleteCachedDownload();
+        }
+    }
+    for (auto it = m_failed.begin(); it != m_failed.end(); ++it) {
+        if (auto* req = qobject_cast<Net::NetRequest*>(it.value().get())) {
+            req->deleteCachedDownload();
+        }
+    }
+}
+
 auto NetJob::size() const -> int
 {
     return m_queue.size() + m_doing.size() + m_done.size();

--- a/launcher/net/NetJob.h
+++ b/launcher/net/NetJob.h
@@ -64,6 +64,7 @@ class NetJob : public ConcurrentTask {
     auto getFailedActions() -> QList<Net::NetRequest*>;
     auto getFailedFiles() -> QList<QString>;
     void setAskRetry(bool askRetry);
+    void deleteCachedDownloads();
 
    public slots:
     // Qt can't handle auto at the start for some reason?

--- a/launcher/net/NetRequest.cpp
+++ b/launcher/net/NetRequest.cpp
@@ -185,6 +185,20 @@ void NetRequest::downloadError(QNetworkReply::NetworkError error)
         }
         handleAutoRetry(delay);
     } else {
+        // If a resumable download gets 404/416, the server can't satisfy the Range request.
+        // Delete the stale .part and retry once from scratch.
+        int status = replyStatusCode();
+        if ((status == 404 || status == 416) && m_retryCount < 1) {
+            auto* rs = dynamic_cast<Net::ResumingFileSink*>(m_sink.get());
+            if (rs && rs->hasUsedRange()) {
+                qCDebug(logCat) << getUid().toString() << "Range not accepted, retrying from scratch:" << m_url.toString();
+                rs->deleteCache();
+                m_retryCount++;
+                executeTask();
+                return;
+            }
+        }
+
         if (m_options & Option::AcceptLocalFiles) {
             if (m_sink->hasLocalData()) {
                 m_state = State::Succeeded;

--- a/launcher/net/NetRequest.cpp
+++ b/launcher/net/NetRequest.cpp
@@ -54,6 +54,7 @@
 #include "BuildConfig.h"
 
 #include "MMCTime.h"
+#include "ResumingFileSink.h"
 #include "StringUtils.h"
 
 namespace Net {
@@ -367,6 +368,14 @@ void NetRequest::downloadReadyRead()
         // qDebug() << "Request" << m_url.toString() << "gained" << data.size() << "bytes";
     } else {
         qCCritical(logCat) << getUid().toString() << "Cannot write download data! illegal status" << m_status;
+    }
+}
+
+void NetRequest::deleteCachedDownload()
+{
+    auto* rs = dynamic_cast<Net::ResumingFileSink*>(m_sink.get());
+    if (rs) {
+        rs->deleteCache();
     }
 }
 

--- a/launcher/net/NetRequest.h
+++ b/launcher/net/NetRequest.h
@@ -40,8 +40,8 @@
 #pragma once
 
 #include <QNetworkReply>
-#include <QUrl>
 #include <QTimer>
+#include <QUrl>
 #include <chrono>
 
 #include "HeaderProxy.h"

--- a/launcher/net/NetRequest.h
+++ b/launcher/net/NetRequest.h
@@ -69,6 +69,8 @@ class NetRequest : public Task {
     auto abort() -> bool override;
     auto canAbort() const -> bool override { return true; }
 
+    void deleteCachedDownload();
+
     void setNetwork(QNetworkAccessManager* network) { m_network = network; }
     void addHeaderProxy(std::unique_ptr<Net::HeaderProxy> proxy) { m_headerProxies.push_back(std::move(proxy)); }
 

--- a/launcher/net/ResumingFileSink.cpp
+++ b/launcher/net/ResumingFileSink.cpp
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2025 PineconeMC Contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "ResumingFileSink.h"
+
+#include <QDir>
+#include <QFileInfo>
+#include <QUrl>
+
+#include "DownloadCache.h"
+#include "FileSystem.h"
+#include "net/Logging.h"
+
+namespace Net {
+
+ResumingFileSink::ResumingFileSink(QString finalPath, QUrl url, ::DownloadCache* cache)
+    : m_finalPath(std::move(finalPath)), m_url(std::move(url)), m_cache(cache)
+{
+}
+
+Task::State ResumingFileSink::init(QNetworkRequest& request)
+{
+    if (!FS::ensureFilePathExists(m_finalPath)) {
+        qCCritical(taskNetLogC) << "Could not create folder for " + m_finalPath;
+        m_fail_reason = "Could not create folder";
+        return Task::State::Failed;
+    }
+
+    QString partPath;
+    if (m_cache) {
+        partPath = m_cache->getPartPath(m_url);
+        m_existingSize = m_cache->getPartSize(m_url);
+    } else {
+        partPath = m_finalPath + ".part";
+        QFileInfo info(partPath);
+        m_existingSize = info.exists() ? info.size() : 0;
+    }
+
+    if (m_existingSize > 0) {
+        request.setRawHeader("Range", QString("bytes=%1-").arg(m_existingSize).toLatin1());
+        m_usedRange = true;
+        qCDebug(taskNetLogC) << "Resuming download from byte" << m_existingSize << "for" << m_url.toString();
+    }
+
+    m_partFile = std::make_unique<QFile>(partPath);
+    if (!m_partFile->open(QIODevice::Append)) {
+        const auto error = QString("Could not open %1 for appending: %2").arg(partPath).arg(m_partFile->errorString());
+        qCCritical(taskNetLogC) << error;
+        m_fail_reason = error;
+        return Task::State::Failed;
+    }
+
+    m_wroteAnyData = false;
+
+    if (initAllValidators(request))
+        return Task::State::Running;
+    m_fail_reason = "Failed to initialize validators";
+    return Task::State::Failed;
+}
+
+Task::State ResumingFileSink::write(QByteArray& data)
+{
+    if (!writeAllValidators(data)) {
+        QString error = QString("Failed writing into %1: Validators failed").arg(m_partFile->fileName());
+        qCCritical(taskNetLogC) << error;
+        m_fail_reason = error;
+        return Task::State::Failed;
+    }
+
+    if (m_partFile->write(data) != data.size()) {
+        QString error = QString("Failed writing into %1: %2").arg(m_partFile->fileName()).arg(m_partFile->errorString());
+        qCCritical(taskNetLogC) << error;
+        m_fail_reason = error;
+        return Task::State::Failed;
+    }
+
+    m_wroteAnyData = true;
+    return Task::State::Running;
+}
+
+Task::State ResumingFileSink::abort()
+{
+    if (m_partFile) {
+        m_partFile->close();
+    }
+    failAllValidators();
+    // Keep the .part file for resume
+    return Task::State::Failed;
+}
+
+Task::State ResumingFileSink::finalize(QNetworkReply& reply)
+{
+    bool gotFile = false;
+    QVariant statusCodeV = reply.attribute(QNetworkRequest::HttpStatusCodeAttribute);
+    bool validStatus = false;
+    int statusCode = statusCodeV.toInt(&validStatus);
+
+    if (validStatus) {
+        gotFile = (statusCode == 200) || (statusCode == 206);
+    }
+
+    if (gotFile || m_wroteAnyData) {
+        if (m_partFile) {
+            m_partFile->close();
+        }
+
+        if (!finalizeAllValidators(reply)) {
+            m_fail_reason = "Failed to finalize validators";
+            return Task::State::Failed;
+        }
+
+        QString partPath = m_partFile ? m_partFile->fileName() : QString();
+
+        // If we got 200 after Range, server doesn't support resume.
+        // But validators passed, so the .part file is complete. Promote it.
+        if (m_cache) {
+            if (!m_cache->promotePart(m_url, m_finalPath)) {
+                // Fallback: try direct rename
+                QFileInfo finalInfo(m_finalPath);
+                QDir().mkpath(finalInfo.absolutePath());
+                if (QFileInfo::exists(m_finalPath))
+                    QFile::remove(m_finalPath);
+                if (!QFile::rename(partPath, m_finalPath)) {
+                    m_fail_reason = QString("Failed to move %1 to %2").arg(partPath).arg(m_finalPath);
+                    return Task::State::Failed;
+                }
+            }
+        } else {
+            QFileInfo finalInfo(m_finalPath);
+            QDir().mkpath(finalInfo.absolutePath());
+            if (QFileInfo::exists(m_finalPath))
+                QFile::remove(m_finalPath);
+            if (!QFile::rename(partPath, m_finalPath)) {
+                m_fail_reason = QString("Failed to move %1 to %2").arg(partPath).arg(m_finalPath);
+                return Task::State::Failed;
+            }
+        }
+
+        m_partFile.reset();
+        qCDebug(taskNetLogC) << "Download completed:" << m_url.toString() << "->" << m_finalPath;
+    }
+
+    m_partFile.reset();
+    return Task::State::Succeeded;
+}
+
+bool ResumingFileSink::hasLocalData()
+{
+    QFileInfo info(m_finalPath);
+    return info.exists() && info.size() != 0;
+}
+
+}  // namespace Net

--- a/launcher/net/ResumingFileSink.cpp
+++ b/launcher/net/ResumingFileSink.cpp
@@ -93,6 +93,17 @@ Task::State ResumingFileSink::write(QByteArray& data)
     return Task::State::Running;
 }
 
+void ResumingFileSink::deleteCache()
+{
+    if (m_partFile) {
+        m_partFile->close();
+        m_partFile.reset();
+    }
+    if (m_cache) {
+        m_cache->removePart(m_url);
+    }
+}
+
 Task::State ResumingFileSink::abort()
 {
     if (m_partFile) {

--- a/launcher/net/ResumingFileSink.cpp
+++ b/launcher/net/ResumingFileSink.cpp
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
  *  Prism Launcher - Minecraft Launcher
- *  Copyright (C) 2025 PineconeMC Contributors
+ *  Copyright (C) 2025 Avenger Anubis (Ilya) <avenger.anubis@gmail.com>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -20,18 +20,31 @@
 
 #include <QDir>
 #include <QFileInfo>
+#include <QNetworkReply>
 #include <QUrl>
 
+#include "ChecksumValidator.h"
 #include "DownloadCache.h"
 #include "FileSystem.h"
 #include "net/Logging.h"
 
 namespace Net {
 
+// Minimal QNetworkReply that only provides a URL for validator finalization
+class CacheHitReply : public QNetworkReply {
+   public:
+    CacheHitReply(const QUrl& url)
+    {
+        setUrl(url);
+        setOpenMode(QIODevice::ReadOnly);
+    }
+    void abort() override {}
+    qint64 readData(char*, qint64) override { return -1; }
+};
+
 ResumingFileSink::ResumingFileSink(QString finalPath, QUrl url, ::DownloadCache* cache)
     : m_finalPath(std::move(finalPath)), m_url(std::move(url)), m_cache(cache)
-{
-}
+{}
 
 Task::State ResumingFileSink::init(QNetworkRequest& request)
 {
@@ -39,6 +52,29 @@ Task::State ResumingFileSink::init(QNetworkRequest& request)
         qCCritical(taskNetLogC) << "Could not create folder for " + m_finalPath;
         m_fail_reason = "Could not create folder";
         return Task::State::Failed;
+    }
+
+    if (m_cache && m_cache->hasCache(m_url)) {
+        if (initAllValidators(request) && m_cache->serveFromCache(m_url, m_finalPath)) {
+            QFile cachedFile(m_finalPath);
+            if (cachedFile.open(QIODevice::ReadOnly)) {
+                QByteArray all = cachedFile.readAll();
+                if (writeAllValidators(all)) {
+                    CacheHitReply fakeReply(m_url);
+                    if (finalizeAllValidators(fakeReply)) {
+                        qCDebug(taskNetLogC) << "Cache hit, skipping download:" << m_url.toString();
+                        return Task::State::Succeeded;
+                    }
+                    m_fail_reason = "Cached file failed checksum validation";
+                } else {
+                    m_fail_reason = "Cached file failed validation";
+                }
+            } else {
+                m_fail_reason = "Could not read cached file for validation";
+            }
+        }
+        qCWarning(taskNetLogC) << "Cache entry invalid, re-downloading:" << m_url.toString();
+        // Don't return — fall through to normal download
     }
 
     QString partPath;

--- a/launcher/net/ResumingFileSink.h
+++ b/launcher/net/ResumingFileSink.h
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2025 PineconeMC Contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QFile>
+#include <QNetworkReply>
+#include <QUrl>
+
+#include "Sink.h"
+
+class DownloadCache;
+
+namespace Net {
+
+class ResumingFileSink : public Sink {
+   public:
+    ResumingFileSink(QString finalPath, QUrl url, ::DownloadCache* cache = nullptr);
+    virtual ~ResumingFileSink() = default;
+
+    auto init(QNetworkRequest& request) -> Task::State override;
+    auto write(QByteArray& data) -> Task::State override;
+    auto abort() -> Task::State override;
+    auto finalize(QNetworkReply& reply) -> Task::State override;
+    auto hasLocalData() -> bool override;
+
+   private:
+    QString m_finalPath;
+    QUrl m_url;
+    ::DownloadCache* m_cache;
+    qint64 m_existingSize = 0;
+    bool m_usedRange = false;
+    bool m_wroteAnyData = false;
+    std::unique_ptr<QFile> m_partFile;
+};
+
+}  // namespace Net

--- a/launcher/net/ResumingFileSink.h
+++ b/launcher/net/ResumingFileSink.h
@@ -33,6 +33,8 @@ class ResumingFileSink : public Sink {
     ResumingFileSink(QString finalPath, QUrl url, ::DownloadCache* cache = nullptr);
     virtual ~ResumingFileSink() = default;
 
+    void deleteCache();
+
     auto init(QNetworkRequest& request) -> Task::State override;
     auto write(QByteArray& data) -> Task::State override;
     auto abort() -> Task::State override;

--- a/launcher/net/ResumingFileSink.h
+++ b/launcher/net/ResumingFileSink.h
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
  *  Prism Launcher - Minecraft Launcher
- *  Copyright (C) 2025 PineconeMC Contributors
+ *  Copyright (C) 2025 Avenger Anubis (Ilya) <avenger.anubis@gmail.com>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -34,6 +34,7 @@ class ResumingFileSink : public Sink {
     virtual ~ResumingFileSink() = default;
 
     void deleteCache();
+    bool hasUsedRange() const { return m_usedRange; }
 
     auto init(QNetworkRequest& request) -> Task::State override;
     auto write(QByteArray& data) -> Task::State override;

--- a/launcher/ui/dialogs/ProgressDialog.cpp
+++ b/launcher/ui/dialogs/ProgressDialog.cpp
@@ -89,14 +89,11 @@ void ProgressDialog::on_skipButton_clicked(bool checked)
     if (!ui->skipButton->isEnabled())  // prevent other triggers from aborting
         return;
 
-    auto result = QMessageBox::question(
-        this,
-        tr("Abort Download"),
-        tr("Do you also want to delete the cached partial download?\n\n"
-           "If you keep it, the download can be resumed later.\n"
-           "If you delete it, the download will start from scratch."),
-        QMessageBox::Yes | QMessageBox::No,
-        QMessageBox::No);
+    auto result = QMessageBox::question(this, tr("Abort Download"),
+                                        tr("Do you also want to delete the cached partial download?\n\n"
+                                           "If you keep it, the download can be resumed later.\n"
+                                           "If you delete it, the download will start from scratch."),
+                                        QMessageBox::Yes | QMessageBox::No, QMessageBox::No);
 
     if (result == QMessageBox::Yes) {
         if (auto* netJob = qobject_cast<NetJob*>(m_task)) {
@@ -242,14 +239,14 @@ void ProgressDialog::changeStatus([[maybe_unused]] const QString& status)
     updateSize();
 }
 
-void ProgressDialog::addTaskProgress(TaskStepProgress const& progress)
+void ProgressDialog::addTaskProgress(const TaskStepProgress& progress)
 {
     SubTaskProgressBar* task_bar = new SubTaskProgressBar(this);
     taskProgress.insert(progress.uid, task_bar);
     ui->taskProgressLayout->addWidget(task_bar);
 }
 
-void ProgressDialog::changeStepProgress(TaskStepProgress const& task_progress)
+void ProgressDialog::changeStepProgress(const TaskStepProgress& task_progress)
 {
     m_is_multi_step = true;
     if (ui->taskProgressScrollArea->isHidden()) {
@@ -261,7 +258,7 @@ void ProgressDialog::changeStepProgress(TaskStepProgress const& task_progress)
         addTaskProgress(task_progress);
     auto task_bar = taskProgress.value(task_progress.uid);
 
-    auto const [mapped_current, mapped_total] = map_int_zero_max<qint64>(task_progress.current, task_progress.total, 0);
+    const auto [mapped_current, mapped_total] = map_int_zero_max<qint64>(task_progress.current, task_progress.total, 0);
     if (task_progress.total <= 0) {
         task_bar->setRange(0, 0);
     } else {

--- a/launcher/ui/dialogs/ProgressDialog.cpp
+++ b/launcher/ui/dialogs/ProgressDialog.cpp
@@ -39,8 +39,10 @@
 
 #include <QDebug>
 #include <QKeyEvent>
+#include <QMessageBox>
 #include <limits>
 
+#include "net/NetJob.h"
 #include "tasks/Task.h"
 
 #include "ui/widgets/SubTaskProgressBar.h"
@@ -84,8 +86,25 @@ void ProgressDialog::setSkipButton(bool present, QString label)
 void ProgressDialog::on_skipButton_clicked(bool checked)
 {
     Q_UNUSED(checked);
-    if (ui->skipButton->isEnabled())  // prevent other triggers from aborting
-        m_task->abort();
+    if (!ui->skipButton->isEnabled())  // prevent other triggers from aborting
+        return;
+
+    auto result = QMessageBox::question(
+        this,
+        tr("Abort Download"),
+        tr("Do you also want to delete the cached partial download?\n\n"
+           "If you keep it, the download can be resumed later.\n"
+           "If you delete it, the download will start from scratch."),
+        QMessageBox::Yes | QMessageBox::No,
+        QMessageBox::No);
+
+    if (result == QMessageBox::Yes) {
+        if (auto* netJob = qobject_cast<NetJob*>(m_task)) {
+            netJob->deleteCachedDownloads();
+        }
+    }
+
+    m_task->abort();
 }
 
 ProgressDialog::~ProgressDialog()

--- a/launcher/ui/pages/global/LauncherPage.cpp
+++ b/launcher/ui/pages/global/LauncherPage.cpp
@@ -209,6 +209,12 @@ void LauncherPage::applySettings()
     s->set("NumberOfManualRetries", ui->numberOfManualRetriesSpinBox->value());
     s->set("RequestTimeout", ui->timeoutSecondsSpinBox->value());
 
+    // Download cache settings
+    s->set("DownloadCacheEnabled", ui->downloadCacheEnabledCheckBox->isChecked());
+    s->set("DownloadCacheMaxSize", ui->downloadCacheMaxSizeSpinBox->value());
+    s->set("DownloadCacheDuration", ui->downloadCacheDurationSpinBox->value());
+    s->set("DownloadCacheCleanupOnLaunch", ui->downloadCacheCleanupOnLaunchCheckBox->isChecked());
+
     // Console settings
     s->set("ConsoleMaxLines", ui->lineLimitSpinBox->value());
     s->set("ConsoleOverflowStop", ui->checkStopLogging->checkState() != Qt::Unchecked);
@@ -269,6 +275,12 @@ void LauncherPage::loadSettings()
     ui->numberOfConcurrentDownloadsSpinBox->setValue(s->get("NumberOfConcurrentDownloads").toInt());
     ui->numberOfManualRetriesSpinBox->setValue(s->get("NumberOfManualRetries").toInt());
     ui->timeoutSecondsSpinBox->setValue(s->get("RequestTimeout").toInt());
+
+    // Download cache settings
+    ui->downloadCacheEnabledCheckBox->setChecked(s->get("DownloadCacheEnabled").toBool());
+    ui->downloadCacheMaxSizeSpinBox->setValue(s->get("DownloadCacheMaxSize").toInt());
+    ui->downloadCacheDurationSpinBox->setValue(s->get("DownloadCacheDuration").toInt());
+    ui->downloadCacheCleanupOnLaunchCheckBox->setChecked(s->get("DownloadCacheCleanupOnLaunch").toBool());
 
     // Console settings
     ui->lineLimitSpinBox->setValue(s->get("ConsoleMaxLines").toInt());

--- a/launcher/ui/pages/global/LauncherPage.cpp
+++ b/launcher/ui/pages/global/LauncherPage.cpp
@@ -300,7 +300,7 @@ void LauncherPage::loadSettings()
     QString sortMode = s->get("InstSortMode").toString();
     if (sortMode == "LastLaunch") {
         ui->sortLastLaunchedBtn->setChecked(true);
-    } else if (sortMode == "Playtime"){
+    } else if (sortMode == "Playtime") {
         ui->sortByPlaytimeBtn->setChecked(true);
     } else {
         ui->sortByNameBtn->setChecked(true);

--- a/launcher/ui/pages/global/LauncherPage.ui
+++ b/launcher/ui/pages/global/LauncherPage.ui
@@ -663,6 +663,105 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="downloadCacheBox">
+         <property name="title">
+          <string>Download Cache</string>
+         </property>
+         <property name="toolTip">
+          <string>Cache partially and fully downloaded files to resume interrupted downloads and avoid re-downloading</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_4">
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="downloadCacheEnabledCheckBox">
+            <property name="text">
+             <string>Enable download cache &amp; resume</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="downloadCacheMaxSizeLabel">
+            <property name="text">
+             <string>Maximum cache size:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="downloadCacheMaxSizeSpinBox">
+            <property name="suffix">
+             <string> MB</string>
+            </property>
+            <property name="minimum">
+             <number>100</number>
+            </property>
+            <property name="maximum">
+             <number>100000</number>
+            </property>
+            <property name="value">
+             <number>1024</number>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>80</width>
+              <height>0</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="downloadCacheDurationLabel">
+            <property name="text">
+             <string>Cache duration:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QSpinBox" name="downloadCacheDurationSpinBox">
+            <property name="suffix">
+             <string> hours</string>
+            </property>
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>720</number>
+            </property>
+            <property name="value">
+             <number>24</number>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>80</width>
+              <height>0</height>
+             </size>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QCheckBox" name="downloadCacheCleanupOnLaunchCheckBox">
+            <property name="text">
+             <string>Cleanup on launch</string>
+            </property>
+            <property name="toolTip">
+             <string>Remove expired cached files when the launcher starts</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer_FeaturesTab">
          <property name="orientation">
           <enum>Qt::Orientation::Vertical</enum>
@@ -716,8 +815,12 @@
   <tabstop>numberOfConcurrentTasksSpinBox</tabstop>
   <tabstop>numberOfConcurrentDownloadsSpinBox</tabstop>
   <tabstop>numberOfManualRetriesSpinBox</tabstop>
-  <tabstop>timeoutSecondsSpinBox</tabstop>
- </tabstops>
+   <tabstop>timeoutSecondsSpinBox</tabstop>
+   <tabstop>downloadCacheEnabledCheckBox</tabstop>
+   <tabstop>downloadCacheMaxSizeSpinBox</tabstop>
+   <tabstop>downloadCacheDurationSpinBox</tabstop>
+   <tabstop>downloadCacheCleanupOnLaunchCheckBox</tabstop>
+  </tabstops>
  <resources/>
  <connections/>
  <buttongroups>


### PR DESCRIPTION
## This PR adds three related features to the download system:

### 1. Resumable downloads with partial file support
- introduced `ResumingFileSink` — a new sink that downloads to a `.part` file,
  sets `Range` and `Accept-Ranges` headers so interrupted downloads can resume
- added `DownloadCache` — stores completed downloads keyed by URL hash,
  `promotePart()` copies the final file to the cache directory on success,
  `serveFromCache()` restores it on re-download with validator checksum verification
- cache hits skip the download entirely; if validators fail, it falls through to
  a fresh download

### 2. Abort confirmation dialog
- when the user clicks "Abort" during a download, a `QMessageBox` asks whether
  to delete the cached `.part` file (Yes/No)
- `NetJob::deleteCachedDownloads()` cleans up all cached artifacts for the job

### 3. Range-error recovery (404/416 on resumed downloads)
- Some CDNs (CloudFront + S3) return `404` or `416` when a `Range` request
  refers to a stale or invalid offset
- `NetRequest::downloadError()` now detects these status codes on resumable
  downloads, deletes the stale `.part` via `deleteCache()`, and retries once
  from scratch without `Range`

### Files changed
- `launcher/net/ResumingFileSink.{h,cpp}` — new sink, cache-hit validation,
  `hasUsedRange()` detection, `deleteCache()`
- `launcher/net/DownloadCache.{h,cpp}` — cache storage, `promotePart()`,
  `serveFromCache()`, metadata management
- `launcher/net/NetRequest.{h,cpp}` — `deleteCachedDownload()`, 404/416 retry
- `launcher/net/NetJob.{h,cpp}` — `deleteCachedDownloads()` iterates all subtasks
- `launcher/net/Download.{h,cpp}` — wire up cache in existing downloads
- `launcher/net/ApiDownload.cpp` — pass cache through
- `launcher/ui/dialogs/ProgressDialog.cpp` — abort confirmation dialog
- `launcher/ui/pages/global/LauncherPage.{cpp,ui}` — cache settings UI
- `launcher/Application.{h,cpp}`, `launcher/CMakeLists.txt` — wiring
