### PR TITLE
fix: crash when trying to install a disabled modloader

### DIFF
--- a/launcher/minecraft/mod/tasks/GetModDependenciesTask.cpp
+++ b/launcher/minecraft/mod/tasks/GetModDependenciesTask.cpp
@@ -37,7 +37,7 @@ static Version mcVersion(BaseInstance* inst)
 
 static ModPlatform::ModLoaderTypes mcLoaders(BaseInstance* inst)
 {
-    return static_cast<MinecraftInstance*>(inst)->getPackProfile()->getSupportedModLoaders().value();
+    return static_cast<MinecraftInstance*>(inst)->getPackProfile()->getSupportedModLoaders().value_or(ModPlatform::ModLoaderTypes(0));
 }
 
 static bool checkDependencies(std::shared_ptr<GetModDependenciesTask::PackDependency> sel,

--- a/launcher/ui/dialogs/InstallLoaderDialog.cpp
+++ b/launcher/ui/dialogs/InstallLoaderDialog.cpp
@@ -163,6 +163,9 @@ void InstallLoaderDialog::done(int result)
         auto* page = pageCast(container->selectedPage());
         if (page->selectedVersion()) {
             profile->setComponentVersion(page->id(), page->selectedVersion()->descriptor());
+            if (auto component = profile->getComponent(page->id())) {
+                component->setEnabled(true);
+            }
             profile->resolve(Net::Mode::Online);
         }
     }

--- a/launcher/ui/dialogs/ResourceDownloadDialog.cpp
+++ b/launcher/ui/dialogs/ResourceDownloadDialog.cpp
@@ -305,7 +305,7 @@ QList<BasePage*> ModDownloadDialog::getPages()
 {
     QList<BasePage*> pages;
 
-    auto loaders = static_cast<MinecraftInstance*>(m_instance)->getPackProfile()->getSupportedModLoaders().value();
+    auto loaders = static_cast<MinecraftInstance*>(m_instance)->getPackProfile()->getSupportedModLoaders().value_or(ModPlatform::ModLoaderTypes(0));
 
     if (ModrinthAPI::validateModLoaders(loaders)) {
         auto* page = ModrinthModPage::create(this, *m_instance);

--- a/launcher/ui/pages/instance/ModFolderPage.cpp
+++ b/launcher/ui/pages/instance/ModFolderPage.cpp
@@ -167,10 +167,8 @@ void ModFolderPage::downloadMods()
     }
 
     auto* profile = static_cast<MinecraftInstance*>(m_instance)->getPackProfile();
-    if (!profile->getModLoaders().has_value()) {
-        if (handleNoModLoader()) {
-            return;
-        }
+    if (!profile->getModLoaders().has_value() && handleNoModLoader()) {
+        return;
     }
 
     m_downloadDialog = new ResourceDownload::ModDownloadDialog(this, m_model, m_instance);
@@ -227,10 +225,8 @@ void ModFolderPage::updateMods(bool includeDeps)
     }
 
     auto* profile = static_cast<MinecraftInstance*>(m_instance)->getPackProfile();
-    if (!profile->getModLoaders().has_value()) {
-        if (handleNoModLoader()) {
-            return;
-        }
+    if (!profile->getModLoaders().has_value() && handleNoModLoader()) {
+        return;
     }
     if (APPLICATION->settings()->get("ModMetadataDisabled").toBool()) {
         QMessageBox::critical(this, tr("Error"), tr("Mod updates are unavailable when metadata is disabled!"));
@@ -337,10 +333,8 @@ void ModFolderPage::changeModVersion()
     }
 
     auto* profile = static_cast<MinecraftInstance*>(m_instance)->getPackProfile();
-    if (!profile->getModLoaders().has_value()) {
-        if (handleNoModLoader()) {
-            return;
-        }
+    if (!profile->getModLoaders().has_value() && handleNoModLoader()) {
+        return;
     }
     if (APPLICATION->settings()->get("ModMetadataDisabled").toBool()) {
         QMessageBox::critical(this, tr("Error"), tr("Mod updates are unavailable when metadata is disabled!"));
@@ -434,12 +428,21 @@ inline bool ModFolderPage::handleNoModLoader()
         // Should be safe
         auto* profile = static_cast<MinecraftInstance*>(this->m_instance)->getPackProfile();
         InstallLoaderDialog dialog(profile, QString(), this);
-        bool ret = dialog.exec() != 0;
+        // true if the user went through the install loader dialog
+        // false if the dialog got canceled/closed
+        bool dialogAccepted = dialog.exec() != 0;
         this->m_container->refreshContainer();
 
-        // returning negation of dialog.exec which'll be true if the install loader dialog got canceled/closed
-        // and false if the user went through and installed a loader
-        return !ret;
+        if (!dialogAccepted) {
+            return true;
+        }
+        if (!profile->getModLoaders().has_value()) {
+            CustomMessageBox::selectable(
+                this, tr("Error"), tr("No mod loader was installed. Please try again."), QMessageBox::Warning)
+                ->show();
+            return true;
+        }
+        return false;
     }
     // Nothing happens the dialog is already closing
     // returning true so the caller doesn't go and continue with opening it's dialog without a mod loader

--- a/launcher/ui/widgets/ModFilterWidget.cpp
+++ b/launcher/ui/widgets/ModFilterWidget.cpp
@@ -234,7 +234,7 @@ void ModFilterWidget::prepareBasicFilter()
                 loaders |= ModPlatform::getModLoaderFromString(loader);
             }
         } else {
-            loaders = m_instance->getPackProfile()->getSupportedModLoaders().value();
+            loaders = m_instance->getPackProfile()->getSupportedModLoaders().value_or(ModPlatform::ModLoaderTypes(0));
         }
         ui->neoForge->setChecked(loaders & ModPlatform::NeoForge);
         ui->forge->setChecked(loaders & ModPlatform::Forge);


### PR DESCRIPTION
fixes #5753

so this happens because the InstallLoaderDialog refuses to install the same modloader twice (even if the current one is disabled). Because of this the code doesn't exit early and the optional value is retrieved, but it crashes because the value is never set.

The perfect solution for this would be to actually install the modloader selected(maybe even enabling it if is disabled)