### PR TITLE
chore: add warning for unknown sources

### DIFF
--- a/launcher/ui/pages/instance/ManagedPackPage.ui
+++ b/launcher/ui/pages/instance/ManagedPackPage.ui
@@ -120,6 +120,16 @@
       </widget>
      </item>
      <item>
+      <widget class="QLabel" name="warningLabel">
+       <property name="text">
+        <string>&lt;p style=&quot;color: #e67e22; font-weight: bold;&quot;&gt;⚠ Warning: Only install modpacks from sources you trust.&lt;/p&gt;</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
         <widget class="QLabel" name="updateToVersionLabel">

--- a/launcher/ui/pages/modplatform/ImportPage.ui
+++ b/launcher/ui/pages/modplatform/ImportPage.ui
@@ -99,6 +99,16 @@
      </property>
     </widget>
    </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QLabel" name="warningLabel">
+     <property name="text">
+      <string>&lt;p style=&quot;color: #e67e22; font-weight: bold;&quot;&gt;⚠ Warning: Only install modpacks from sources you trust.&lt;/p&gt;</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>


### PR DESCRIPTION
I'm sure somebody requested this, but I'm unsure when and where.
This is just a basic warning on import page and on update pack page.
This can be extended on so it also catches mods on the pack file that are not on the installed source. But at that point I expect either to be from a trusted source CurseForge/Modrinth( and that means it is not our fault) or installed through the Import Page(meaning they saw this warning).
