### PR TITLE
Fix Windows instance export permissions

### DIFF
--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -210,7 +210,7 @@ void InstanceImportTask::extractFinished()
     QDir extractDir(m_stagingPath);
 
     qDebug() << "Fixing permissions for extracted pack files...";
-    QDirIterator it(extractDir, QDirIterator::Subdirectories);
+    QDirIterator it(extractDir.absolutePath(), QDir::AllEntries | QDir::NoDotAndDotDot | QDir::Hidden, QDirIterator::Subdirectories);
     while (it.hasNext()) {
         auto filepath = it.next();
         QFileInfo file(filepath);

--- a/launcher/archive/ArchiveWriter.cpp
+++ b/launcher/archive/ArchiveWriter.cpp
@@ -128,6 +128,11 @@ bool ArchiveWriter::addFile(const QString& fileName, const QString& fileDest)
         }
 
         archive_entry_copy_bhfi(entry, &file_info);
+        if (fileInfo.isFile() && !fileInfo.isSymLink()) {
+            // archive_entry_copy_bhfi() does not populate POSIX permissions. ZIP archives written by libarchive are marked as
+            // originating on Unix, so leaving the mode unset makes other Unix systems extract these files with mode 000.
+            archive_entry_set_perm(entry, file_info.dwFileAttributes & FILE_ATTRIBUTE_READONLY ? 0444 : 0644);
+        }
         CloseHandle(file_handle);
     }
 #else

--- a/tests/Archive_test.cpp
+++ b/tests/Archive_test.cpp
@@ -1,0 +1,60 @@
+#include <archive.h>
+#include <archive_entry.h>
+
+#include <QFile>
+#include <QTemporaryDir>
+#include <QTest>
+
+#include <archive/ArchiveWriter.h>
+
+#include <memory>
+
+class ArchiveTest : public QObject {
+    Q_OBJECT
+
+    static int archivePermissions(const QString& archivePath)
+    {
+        std::unique_ptr<archive, decltype(&archive_read_free)> input(archive_read_new(), &archive_read_free);
+        if (!input) {
+            return 0;
+        }
+        archive_read_support_format_all(input.get());
+        archive_read_support_filter_all(input.get());
+
+        auto archivePathWide = archivePath.toStdWString();
+        if (archive_read_open_filename_w(input.get(), archivePathWide.data(), 10240) != ARCHIVE_OK) {
+            return 0;
+        }
+
+        archive_entry* entry = nullptr;
+        if (archive_read_next_header(input.get(), &entry) != ARCHIVE_OK) {
+            return 0;
+        }
+        return archive_entry_perm(entry);
+    }
+
+   private slots:
+    void test_ExportedFileHasPermissions()
+    {
+        QTemporaryDir tempDir;
+        QVERIFY(tempDir.isValid());
+
+        auto sourcePath = tempDir.filePath("source.txt");
+        QFile source(sourcePath);
+        QVERIFY(source.open(QIODevice::WriteOnly));
+        QCOMPARE(source.write("contents"), qint64(8));
+        source.close();
+
+        auto archivePath = tempDir.filePath("export.zip");
+        MMCZip::ArchiveWriter output(archivePath);
+        QVERIFY(output.open());
+        QVERIFY(output.addFile(sourcePath, QStringLiteral("source.txt")));
+        QVERIFY(output.close());
+
+        QVERIFY(archivePermissions(archivePath) != 0);
+    }
+};
+
+QTEST_GUILESS_MAIN(ArchiveTest)
+
+#include "Archive_test.moc"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,8 @@
 project(tests)
 
+ecm_add_test(Archive_test.cpp LINK_LIBRARIES Launcher_logic Qt${QT_VERSION_MAJOR}::Test
+    TEST_NAME Archive)
+
 ecm_add_test(FileSystem_test.cpp LINK_LIBRARIES Launcher_logic Qt${QT_VERSION_MAJOR}::Test
     TEST_NAME FileSystem)
 


### PR DESCRIPTION
## Summary

- write portable Unix permission bits for regular files added to instance archives on Windows
- include hidden entries in the existing post-import permission repair, matching how the same instance contents are traversed on Windows
- add a regression test that verifies exported files have non-zero archive permissions

Fixes #5580

## Root cause

`archive_entry_copy_bhfi()` copies Windows file metadata but does not populate POSIX permission bits. The resulting ZIP entries can be identified as Unix entries with mode `000`, so importing a Windows-exported instance on Linux can leave files under hidden directories such as `.minecraft` unreadable and unwritable. The existing post-import repair did not traverse hidden entries on Linux.

## User impact

New instance archives exported on Windows carry usable file permissions. Previously exported archives are repaired during instance import, including files below hidden directories.

## Testing

- targeted `Archive_test` build with MSVC, Qt 6.11.1, and libarchive 3.8.2: 3 passed, 0 failed
- `git diff --check`
