### PR TITLE
fix: suppress GCC 14 array-bounds false positive

### DIFF
--- a/launcher/ui/pages/modplatform/ftb/FtbPage.cpp
+++ b/launcher/ui/pages/modplatform/ftb/FtbPage.cpp
@@ -163,7 +163,8 @@ void FtbPage::onSelectionChanged(QModelIndex first, QModelIndex /*second*/)
         return;
     }
 
-    m_selected = m_filterModel->data(first, Qt::UserRole).value<FTB::Modpack>();
+    auto vdata = m_filterModel->data(first, Qt::UserRole);
+    m_selected = vdata.value<FTB::Modpack>();
 
     QString output = markdownToHTML(m_selected.description.toUtf8());
     m_ui->packDescription->setHtml(output);


### PR DESCRIPTION
GCC 14.3.0's -Werror=array-bounds triggers a false positive when QVariant::valueFTB::Modpack() is called on an rvalue.

Splitting into a local variable prevents the inlining path that triggers the false positive.