### PR TITLE
Bump winget-releaser to fix autopublishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Publish on Winget
-        uses: vedantmgoyal2009/winget-releaser@v2
+        uses: vedantmgoyal2009/winget-releaser@7bd472be23763def6e16bd06cc8b1cdfab0e2fd5 # docs: add description to inputs (#335)
         with:
           identifier: PrismLauncher.PrismLauncher
           version: ${{ github.event.release.tag_name }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,7 @@ jobs:
 
     steps:
       - name: Publish on Winget
+        # @Octol1ttle: Pinned to a commit because no release has been published that works on ubuntu-slim
         uses: vedantmgoyal2009/winget-releaser@7bd472be23763def6e16bd06cc8b1cdfab0e2fd5 # docs: add description to inputs (#335)
         with:
           identifier: PrismLauncher.PrismLauncher


### PR DESCRIPTION
The workflow was switched to the `ubuntu-slim` runner in #4863 but winget-releaser did not support it. This was fixed in https://github.com/vedantmgoyal9/winget-releaser/commit/a43926ed822e5a076ac8a81e0a794915cbad51d1, however no release has been published, so this PR uses the latest commit hash instead