### PR TITLE
Fix instance shortcuts breaking when the instance is renamed

### DIFF
--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -91,8 +91,9 @@ BaseInstance::BaseInstance(SettingsObject* globalSettings, std::unique_ptr<Setti
     m_settings->registerSetting("linkedInstances", "[]");
     m_settings->registerSetting("shortcuts", QString());
     m_settings->registerSetting("uuid", QString());
-    if (m_settings->get("uuid").toString().isEmpty())
+    if (m_settings->get("uuid").toString().isEmpty()) {
         m_settings->set("uuid", QUuid::createUuid().toString(QUuid::Id128));
+    }
 
     // Game time override
     auto gameTimeOverride = m_settings->registerSetting("OverrideGameTime", false);
@@ -276,6 +277,11 @@ QString BaseInstance::id() const
 QString BaseInstance::uuid() const
 {
     return m_settings->get("uuid").toString();
+}
+
+void BaseInstance::regenerateUuid()
+{
+    m_settings->set("uuid", QUuid::createUuid().toString(QUuid::Id128));
 }
 
 bool BaseInstance::isRunning() const

--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -42,6 +42,7 @@
 #include <QFileInfo>
 #include <QJsonDocument>
 #include <QJsonObject>
+#include <QUuid>
 
 #include "Application.h"
 #include "Json.h"
@@ -89,6 +90,9 @@ BaseInstance::BaseInstance(SettingsObject* globalSettings, std::unique_ptr<Setti
 
     m_settings->registerSetting("linkedInstances", "[]");
     m_settings->registerSetting("shortcuts", QString());
+    m_settings->registerSetting("uuid", QString());
+    if (m_settings->get("uuid").toString().isEmpty())
+        m_settings->set("uuid", QUuid::createUuid().toString(QUuid::Id128));
 
     // Game time override
     auto gameTimeOverride = m_settings->registerSetting("OverrideGameTime", false);
@@ -267,6 +271,11 @@ BaseInstance::Status BaseInstance::currentStatus() const
 QString BaseInstance::id() const
 {
     return QFileInfo(instanceRoot()).fileName();
+}
+
+QString BaseInstance::uuid() const
+{
+    return m_settings->get("uuid").toString();
 }
 
 bool BaseInstance::isRunning() const

--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -92,7 +92,7 @@ BaseInstance::BaseInstance(SettingsObject* globalSettings, std::unique_ptr<Setti
     m_settings->registerSetting("shortcuts", QString());
     m_settings->registerSetting("uuid", QString());
     if (m_settings->get("uuid").toString().isEmpty()) {
-        m_settings->set("uuid", QUuid::createUuid().toString(QUuid::Id128));
+        regenerateUuid();
     }
 
     // Game time override

--- a/launcher/BaseInstance.h
+++ b/launcher/BaseInstance.h
@@ -116,6 +116,7 @@ class BaseInstance : public QObject {
     /// be unique.
     virtual QString id() const;
     virtual QString uuid() const;
+    void regenerateUuid();
 
     void setMinecraftRunning(bool running);
     void setRunning(bool running);

--- a/launcher/BaseInstance.h
+++ b/launcher/BaseInstance.h
@@ -115,6 +115,7 @@ class BaseInstance : public QObject {
     /// The instance's ID. The ID SHALL be determined by LAUNCHER internally. The ID IS guaranteed to
     /// be unique.
     virtual QString id() const;
+    virtual QString uuid() const;
 
     void setMinecraftRunning(bool running);
     void setRunning(bool running);

--- a/launcher/InstanceCopyTask.cpp
+++ b/launcher/InstanceCopyTask.cpp
@@ -151,6 +151,7 @@ void InstanceCopyTask::copyFinished()
     BaseInstance* inst(new NullInstance(m_globalSettings, std::move(instanceSettings), m_stagingPath));
     inst->setName(name());
     inst->setIconKey(m_instIcon);
+    inst->regenerateUuid();
     if (!m_keepPlaytime) {
         inst->resetTimePlayed();
     }

--- a/launcher/InstanceList.cpp
+++ b/launcher/InstanceList.cpp
@@ -612,7 +612,7 @@ BaseInstance* InstanceList::getInstanceById(QString instId) const
     if (instId.isEmpty())
         return nullptr;
     for (auto& inst : m_instances) {
-        if (inst->id() == instId) {
+        if (inst->id() == instId || inst->uuid() == instId) {
             return inst.get();
         }
     }

--- a/launcher/minecraft/ShortcutUtils.cpp
+++ b/launcher/minecraft/ShortcutUtils.cpp
@@ -146,7 +146,7 @@ bool createInstanceShortcut(const Shortcut& shortcut, const QString& filePath)
     QMessageBox::critical(shortcut.parent, QObject::tr("Create Shortcut"), QObject::tr("Not supported on your platform!"));
     return false;
 #endif
-    args.append({ "--launch", shortcut.instance->id() });
+    args.append({ "--launch", shortcut.instance->uuid() });
     args.append(shortcut.extraArgs);
 
     QString shortcutPath = FS::createShortcut(filePath, appPath, args, shortcut.name, iconPath);


### PR DESCRIPTION
Taking a jab at #5457

Shortcuts bake the instance's folder-derived `id()` into the `.desktop` file's `--launch` arg at creation time. Renaming an instance renames its folder, so `id()` changes and the shortcut points at nothing.

- Added a persisted `uuid` setting on `BaseInstance`, generated once via `QUuid::createUuid()`.
- `uuid()` is embedded instead of `id()` in `ShortcutUtils::createInstanceShortcut`
- `InstanceList::getInstanceById` now matches on `id()` or `uuid()`, so shortcuts made before this patch still resolve.

Closes #5457 