### PR TITLE
Fix existing instance shortcuts not being detected

### DIFF
--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -446,7 +446,7 @@ QList<ShortcutData> BaseInstance::shortcuts() const
 
         QString shortcutName = dict["name"].toString();
         QString filePath = dict["filePath"].toString();
-        if (!QDir(filePath).exists()) {
+        if (!QFileInfo::exists(filePath)) {
             qWarning() << "Shortcut" << shortcutName << "for instance" << name() << "have non-existent path" << filePath;
             continue;
         }


### PR DESCRIPTION
Due to wrong check (as a directory instead of a file) after deleting an instance its shortcuts are not automatically deleted. This PR fixes the issue:
<img width="426" height="154" alt="image" src="https://github.com/user-attachments/assets/9994c6fc-8adf-44c5-8f82-83816a9575b9" />
