### PR TITLE
Prevent renaming instance folder while instance is running

### DIFF
--- a/launcher/InstanceDirUpdate.cpp
+++ b/launcher/InstanceDirUpdate.cpp
@@ -66,6 +66,13 @@ QString askToUpdateInstanceDirName(BaseInstance* instance, const QString& oldNam
         return QString();
     }
 
+    if (instance->isRunning()) {
+        QMessageBox::warning(parent, QObject::tr("Cannot rename instance folder"),
+                             QObject::tr("The instance folder cannot be renamed while the instance is running.\n\n"
+                                         "Only the instance name will be changed. The folder will keep its current name."));
+        return QString();
+    }
+
     // Ask if we should rename
     if (renamingMode == "AskEverytime") {
         auto checkBox = new QCheckBox(QObject::tr("&Remember my choice"), parent);


### PR DESCRIPTION
Renaming an instance while it's running would also rename the folder on disk, which could break things.

This adds an `isRunning()` check in `askToUpdateInstanceDirName()`. If the user tries to rename the instance while it is running, a warning is shown and only the instance is renamed, not the instance folder.

## Testing
Tested locally.
If i try to rename the instance while it is running the following warning is shown and only the instance is renamed and not the folder
<img width="540" height="200" alt="image" src="https://github.com/user-attachments/assets/ae0f4969-ea39-4161-9bfe-7ab01f5b0125" />

Closes #5670