### PR TITLE
Add support for multiple instance directories

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -686,6 +686,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
 
         // Folders
         m_settings->registerSetting("InstanceDir", "instances");
+        m_settings->registerSetting("AdditionalInstanceDirs", QVariant(QStringList()));
         m_settings->registerSetting({ "CentralModsDir", "ModsDir" }, "mods");
         m_settings->registerSetting("IconsDir", "icons");
         m_settings->registerSetting("DownloadsDir", QStandardPaths::writableLocation(QStandardPaths::DownloadLocation));
@@ -967,6 +968,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
     // initialize and load all instances
     {
         auto InstDirSetting = m_settings->getSetting("InstanceDir");
+        auto AdditionalInstanceDirsSetting = m_settings->getSetting("AdditionalInstanceDirs");
         // instance path: check for problems with '!' in instance path and warn the user in the log
         // and remember that we have to show him a dialog when the gui starts (if it does so)
         QString instDir = m_settings->get("InstanceDir").toString();
@@ -974,8 +976,17 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         if (FS::checkProblemticPathJava(QDir(instDir))) {
             qWarning() << "Your instance path contains \'!\' and this is known to cause java problems!";
         }
-        m_instances.reset(new InstanceList(m_settings.get(), instDir, this));
+        QStringList additionalDirs = m_settings->get("AdditionalInstanceDirs").toStringList();
+        QStringList allInstDirs;
+        allInstDirs << instDir;
+        for (const auto& dir : additionalDirs) {
+            if (!dir.isEmpty() && !allInstDirs.contains(dir))
+                allInstDirs << dir;
+        }
+
+        m_instances.reset(new InstanceList(m_settings.get(), allInstDirs, this));
         connect(InstDirSetting.get(), &Setting::SettingChanged, m_instances.get(), &InstanceList::on_InstFolderChanged);
+        connect(AdditionalInstanceDirsSetting.get(), &Setting::SettingChanged, m_instances.get(), &InstanceList::on_InstFolderChanged);
         qInfo() << "Loading Instances...";
         m_instances->loadList();
         qInfo() << "<> Instances loaded.";

--- a/launcher/InstanceList.cpp
+++ b/launcher/InstanceList.cpp
@@ -64,22 +64,28 @@
 
 const static int GROUP_FILE_FORMAT_VERSION = 1;
 
-InstanceList::InstanceList(SettingsObject* settings, const QString& instDir, QObject* parent)
+InstanceList::InstanceList(SettingsObject* settings, const QStringList& instDirs, QObject* parent)
     : QAbstractListModel(parent), m_globalSettings(settings)
 {
     resumeWatch();
-    // Create aand normalize path
-    if (!QDir::current().exists(instDir)) {
-        QDir::current().mkpath(instDir);
-    }
 
     connect(this, &InstanceList::instancesChanged, this, &InstanceList::providerUpdated);
 
-    // NOTE: canonicalPath requires the path to exist. Do not move this above the creation block!
-    m_instDir = QDir(instDir).canonicalPath();
     m_watcher = new QFileSystemWatcher(this);
     connect(m_watcher, &QFileSystemWatcher::directoryChanged, this, &InstanceList::instanceDirContentsChanged);
-    m_watcher->addPath(m_instDir);
+
+    for (const auto& dir : instDirs) {
+        // Create and normalize path
+        if (!QDir::current().exists(dir)) {
+            QDir::current().mkpath(dir);
+        }
+        // NOTE: canonicalPath requires the path to exist. Do not move this above the creation block!
+        QString canonical = QDir(dir).canonicalPath();
+        if (!canonical.isEmpty() && !m_instDirs.contains(canonical)) {
+            m_instDirs << canonical;
+            m_watcher->addPath(canonical);
+        }
+    }
 }
 
 InstanceList::~InstanceList() {}
@@ -469,30 +475,44 @@ static QMap<InstanceId, InstanceLocator> getIdMapping(const std::vector<std::uni
 
 QList<InstanceId> InstanceList::discoverInstances()
 {
-    qInfo() << "Discovering instances in" << m_instDir;
     QList<InstanceId> out;
-    QDirIterator iter(m_instDir, QDir::Dirs | QDir::NoDot | QDir::NoDotDot | QDir::Readable | QDir::Hidden, QDirIterator::FollowSymlinks);
-    while (iter.hasNext()) {
-        QString subDir = iter.next();
-        QFileInfo dirInfo(subDir);
-        if (!QFileInfo(FS::PathCombine(subDir, "instance.cfg")).exists())
-            continue;
-        // if it is a symlink, ignore it if it goes to the instance folder
-        if (dirInfo.isSymLink()) {
-            QFileInfo targetInfo(dirInfo.symLinkTarget());
-            QFileInfo instDirInfo(m_instDir);
-            if (targetInfo.canonicalPath() == instDirInfo.canonicalFilePath()) {
-                qDebug() << "Ignoring symlink" << subDir << "that leads into the instances folder";
+    m_instanceRootDir.clear();
+    for (const auto& rootDir : m_instDirs) {
+        qInfo() << "Discovering instances in" << rootDir;
+        QDirIterator iter(rootDir, QDir::Dirs | QDir::NoDot | QDir::NoDotDot | QDir::Readable | QDir::Hidden, QDirIterator::FollowSymlinks);
+        while (iter.hasNext()) {
+            QString subDir = iter.next();
+            QFileInfo dirInfo(subDir);
+            if (!QFileInfo(FS::PathCombine(subDir, "instance.cfg")).exists())
+                continue;
+            // if it is a symlink, ignore it if it goes to the instance folder
+            if (dirInfo.isSymLink()) {
+                QFileInfo targetInfo(dirInfo.symLinkTarget());
+                QFileInfo instDirInfo(rootDir);
+                if (targetInfo.canonicalPath() == instDirInfo.canonicalFilePath()) {
+                    qDebug() << "Ignoring symlink" << subDir << "that leads into the instances folder";
+                    continue;
+                }
+            }
+            auto id = dirInfo.fileName();
+            if (m_instanceRootDir.contains(id)) {
+                qWarning() << "Duplicate instance ID" << id << "found in" << rootDir << "- already claimed by"
+                           << m_instanceRootDir.value(id) << ". Skipping.";
                 continue;
             }
+            m_instanceRootDir[id] = rootDir;
+            out.append(id);
+            qInfo() << "Found instance ID" << id << "in" << rootDir;
         }
-        auto id = dirInfo.fileName();
-        out.append(id);
-        qInfo() << "Found instance ID" << id;
     }
     instanceSet = QSet<QString>(out.begin(), out.end());
     m_instancesProbed = true;
     return out;
+}
+
+QString InstanceList::rootDirOf(const InstanceId& id) const
+{
+    return m_instanceRootDir.value(id, primaryDir());
 }
 
 InstanceList::InstListError InstanceList::loadList()
@@ -663,7 +683,7 @@ std::unique_ptr<BaseInstance> InstanceList::loadInstance(const InstanceId& id)
         loadGroupList();
     }
 
-    auto instanceRoot = FS::PathCombine(m_instDir, id);
+    auto instanceRoot = FS::PathCombine(rootDirOf(id), id);
     auto instanceSettings = std::make_unique<INISettingsObject>(FS::PathCombine(instanceRoot, "instance.cfg"));
     std::unique_ptr<BaseInstance> inst;
 
@@ -713,28 +733,18 @@ void InstanceList::saveGroupList()
         qDebug() << "Group saving prevented because we don't know the full list of instances yet.";
         return;
     }
-    WatchLock foo(m_watcher, m_instDir);
-    QString groupFileName = m_instDir + "/instgroups.json";
+
+    QString groupFileName = QDir::current().filePath("instgroups.json");
+
     QMap<QString, QSet<QString>> reverseGroupMap;
     for (auto iter = m_instanceGroupIndex.begin(); iter != m_instanceGroupIndex.end(); iter++) {
         const QString& id = iter.key();
         QString group = iter.value();
         if (group.isEmpty())
             continue;
-        if (!instanceSet.contains(id)) {
-            qDebug() << "Skipping saving missing instance" << id << "to groups list.";
-            continue;
-        }
-
-        if (!reverseGroupMap.count(group)) {
-            QSet<QString> set;
-            set.insert(id);
-            reverseGroupMap[group] = set;
-        } else {
-            QSet<QString>& set = reverseGroupMap[group];
-            set.insert(id);
-        }
+        reverseGroupMap[group].insert(id);
     }
+
     QJsonObject toplevel;
     toplevel.insert("formatVersion", QJsonValue(QString("1")));
     QJsonObject groupsArr;
@@ -770,9 +780,12 @@ void InstanceList::loadGroupList()
 {
     qDebug() << "Will load group list now.";
 
-    QString groupFileName = m_instDir + "/instgroups.json";
+    QString groupFileName = QDir::current().filePath("instgroups.json");
 
-    // if there's no group file, fail
+    m_instanceGroupIndex.clear();
+    m_groupNameCache.clear();
+    m_collapsedGroups.clear();
+
     if (!QFileInfo(groupFileName).exists())
         return;
 
@@ -813,20 +826,13 @@ void InstanceList::loadGroupList()
         return;
     }
 
-    m_instanceGroupIndex.clear();
-    m_groupNameCache.clear();
-
-    // Iterate through all the groups.
     QJsonObject groupMapping = rootObj.value("groups").toObject();
     for (QJsonObject::iterator iter = groupMapping.begin(); iter != groupMapping.end(); iter++) {
         QString groupName = iter.key();
-
-        if (iter.key().isEmpty()) {
+        if (groupName.isEmpty()) {
             qWarning() << "Redundant empty group found";
             continue;
         }
-
-        // If not an object, complain and skip to the next one.
         if (!iter.value().isObject()) {
             qWarning() << QString("Group '%1' in the group list should be an object").arg(groupName).toUtf8();
             continue;
@@ -839,14 +845,10 @@ void InstanceList::loadGroupList()
                               .toUtf8();
             continue;
         }
-
-        auto hidden = groupObj.value("hidden").toBool(false);
-        if (hidden)
+        if (groupObj.value("hidden").toBool(false))
             m_collapsedGroups.insert(groupName);
 
-        // Iterate through the list of instances in the group.
         QJsonArray instancesArray = groupObj.value("instances").toArray();
-
         for (auto value : instancesArray) {
             m_instanceGroupIndex[value.toString()] = groupName;
             increaseGroupCount(groupName);
@@ -855,8 +857,7 @@ void InstanceList::loadGroupList()
 
     bool ungroupedHidden = false;
     if (rootObj.value("ungrouped").isObject()) {
-        QJsonObject ungrouped = rootObj.value("ungrouped").toObject();
-        ungroupedHidden = ungrouped.value("hidden").toBool(false);
+        ungroupedHidden = rootObj.value("ungrouped").toObject().value("hidden").toBool(false);
     }
     if (ungroupedHidden) {
         // empty string represents ungrouped "group"
@@ -872,14 +873,33 @@ void InstanceList::instanceDirContentsChanged(const QString& path)
     emit instancesChanged();
 }
 
-void InstanceList::on_InstFolderChanged([[maybe_unused]] const Setting& setting, QVariant value)
+void InstanceList::on_InstFolderChanged([[maybe_unused]] const Setting& setting, [[maybe_unused]] QVariant value)
 {
-    QString newInstDir = QDir(value.toString()).canonicalPath();
-    if (newInstDir != m_instDir) {
+    QString instDir = m_globalSettings->get("InstanceDir").toString();
+    QStringList additionalDirs = m_globalSettings->get("AdditionalInstanceDirs").toStringList();
+
+    QStringList newDirs;
+    QStringList candidates;
+    candidates << instDir << additionalDirs;
+    for (const auto& dir : candidates) {
+        if (dir.isEmpty())
+            continue;
+        if (!QDir::current().exists(dir))
+            QDir::current().mkpath(dir);
+        QString canonical = QDir(dir).canonicalPath();
+        if (!canonical.isEmpty() && !newDirs.contains(canonical))
+            newDirs << canonical;
+    }
+
+    if (newDirs != m_instDirs) {
         if (m_groupsLoaded) {
             saveGroupList();
         }
-        m_instDir = newInstDir;
+        for (const auto& dir : m_instDirs)
+            m_watcher->removePath(dir);
+        m_instDirs = newDirs;
+        for (const auto& dir : m_instDirs)
+            m_watcher->addPath(dir);
         m_groupsLoaded = false;
         beginRemoveRows(QModelIndex(), 0, count());
         m_instances.erase(m_instances.begin(), m_instances.end());
@@ -1003,7 +1023,7 @@ Task* InstanceList::wrapInstanceTask(InstanceTask* task)
 
 QString InstanceList::getStagedInstancePath()
 {
-    const QString tempRoot = FS::PathCombine(m_instDir, ".tmp");
+    const QString tempRoot = FS::PathCombine(primaryDir(), ".tmp");
 
     QString result;
     int tries = 0;
@@ -1039,14 +1059,14 @@ bool InstanceList::commitStagedInstance(const QString& path,
     if (should_override) {
         instID = commiting.originalInstanceID();
     } else {
-        instID = FS::DirNameFromString(instanceName.modifiedName(), m_instDir);
+        instID = FS::DirNameFromString(instanceName.modifiedName(), primaryDir());
     }
 
     Q_ASSERT(!instID.isEmpty());
 
     {
-        WatchLock lock(m_watcher, m_instDir);
-        QString destination = FS::PathCombine(m_instDir, instID);
+        WatchLock lock(m_watcher, primaryDir());
+        QString destination = FS::PathCombine(primaryDir(), instID);
 
         if (should_override) {
             if (!FS::overrideFolder(destination, path)) {
@@ -1061,6 +1081,7 @@ bool InstanceList::commitStagedInstance(const QString& path,
 
             m_instanceGroupIndex[instID] = groupName;
             increaseGroupCount(groupName);
+            m_instanceRootDir[instID] = primaryDir();
         }
 
         instanceSet.insert(instID);

--- a/launcher/InstanceList.cpp
+++ b/launcher/InstanceList.cpp
@@ -477,6 +477,7 @@ QList<InstanceId> InstanceList::discoverInstances()
 {
     QList<InstanceId> out;
     m_instanceRootDir.clear();
+    QSet<QString> visitedCanonicalPaths;
     for (const auto& rootDir : m_instDirs) {
         qInfo() << "Discovering instances in" << rootDir;
         QDirIterator iter(rootDir, QDir::Dirs | QDir::NoDot | QDir::NoDotDot | QDir::Readable | QDir::Hidden, QDirIterator::FollowSymlinks);
@@ -485,14 +486,22 @@ QList<InstanceId> InstanceList::discoverInstances()
             QFileInfo dirInfo(subDir);
             if (!QFileInfo(FS::PathCombine(subDir, "instance.cfg")).exists())
                 continue;
-            // if it is a symlink, ignore it if it goes to the instance folder
+            // if it is a symlink, ignore it if it goes to ANY configured instance
             if (dirInfo.isSymLink()) {
                 QFileInfo targetInfo(dirInfo.symLinkTarget());
-                QFileInfo instDirInfo(rootDir);
-                if (targetInfo.canonicalPath() == instDirInfo.canonicalFilePath()) {
-                    qDebug() << "Ignoring symlink" << subDir << "that leads into the instances folder";
+                QString targetCanonical = targetInfo.canonicalFilePath();
+                bool pointsIntoAnyRoot = false;
+                for (const auto& otherRoot : m_instDirs) {
+                    if (targetCanonical.startsWith(QFileInfo(otherRoot).canonicalFilePath())) {
+                        pointsIntoAnyRoot = true;
+                        break;
+                    }
+                }
+                if (pointsIntoAnyRoot || visitedCanonicalPaths.contains(targetCanonical)) {
+                    qDebug() << "Ignoring symlink" << subDir << "that leads into a configured instance root or was already visited";
                     continue;
                 }
+                visitedCanonicalPaths.insert(targetCanonical);
             }
             auto id = dirInfo.fileName();
             if (m_instanceRootDir.contains(id)) {

--- a/launcher/InstanceList.cpp
+++ b/launcher/InstanceList.cpp
@@ -47,6 +47,7 @@
 #include <QStack>
 #include <QTimer>
 #include <QUuid>
+#include <algorithm>
 
 #include "BaseInstance.h"
 #include "ExponentialSeries.h"
@@ -76,9 +77,7 @@ InstanceList::InstanceList(SettingsObject* settings, const QStringList& instDirs
 
     for (const auto& dir : instDirs) {
         // Create and normalize path
-        if (!QDir::current().exists(dir)) {
-            QDir::current().mkpath(dir);
-        }
+        QDir::current().mkpath(dir);
         // NOTE: canonicalPath requires the path to exist. Do not move this above the creation block!
         QString canonical = QDir(dir).canonicalPath();
         if (!canonical.isEmpty() && !m_instDirs.contains(canonical)) {
@@ -476,8 +475,7 @@ static QMap<InstanceId, InstanceLocator> getIdMapping(const std::vector<std::uni
 QList<InstanceId> InstanceList::discoverInstances()
 {
     QList<InstanceId> out;
-    m_instanceRootDir.clear();
-    QSet<QString> visitedCanonicalPaths;
+    m_instanceRootDirMap.clear();
     for (const auto& rootDir : m_instDirs) {
         qInfo() << "Discovering instances in" << rootDir;
         QDirIterator iter(rootDir, QDir::Dirs | QDir::NoDot | QDir::NoDotDot | QDir::Readable | QDir::Hidden, QDirIterator::FollowSymlinks);
@@ -490,26 +488,21 @@ QList<InstanceId> InstanceList::discoverInstances()
             if (dirInfo.isSymLink()) {
                 QFileInfo targetInfo(dirInfo.symLinkTarget());
                 QString targetCanonical = targetInfo.canonicalFilePath();
-                bool pointsIntoAnyRoot = false;
-                for (const auto& otherRoot : m_instDirs) {
-                    if (targetCanonical.startsWith(QFileInfo(otherRoot).canonicalFilePath())) {
-                        pointsIntoAnyRoot = true;
-                        break;
-                    }
-                }
-                if (pointsIntoAnyRoot || visitedCanonicalPaths.contains(targetCanonical)) {
-                    qDebug() << "Ignoring symlink" << subDir << "that leads into a configured instance root or was already visited";
+                bool pointsIntoAnyRoot = std::ranges::any_of(m_instDirs, [&targetCanonical](const QString& otherRoot) {
+                    return targetCanonical.startsWith(QFileInfo(otherRoot).canonicalFilePath());
+                });
+                if (pointsIntoAnyRoot) {
+                    qDebug() << "Ignoring symlink" << subDir << "that leads into a configured instance root";
                     continue;
                 }
-                visitedCanonicalPaths.insert(targetCanonical);
             }
             auto id = dirInfo.fileName();
-            if (m_instanceRootDir.contains(id)) {
+            if (m_instanceRootDirMap.contains(id)) {
                 qWarning() << "Duplicate instance ID" << id << "found in" << rootDir << "- already claimed by"
-                           << m_instanceRootDir.value(id) << ". Skipping.";
+                           << m_instanceRootDirMap.value(id) << ". Skipping.";
                 continue;
             }
-            m_instanceRootDir[id] = rootDir;
+            m_instanceRootDirMap[id] = rootDir;
             out.append(id);
             qInfo() << "Found instance ID" << id << "in" << rootDir;
         }
@@ -521,7 +514,7 @@ QList<InstanceId> InstanceList::discoverInstances()
 
 QString InstanceList::rootDirOf(const InstanceId& id) const
 {
-    return m_instanceRootDir.value(id, primaryDir());
+    return m_instanceRootDirMap.value(id, primaryDir());
 }
 
 InstanceList::InstListError InstanceList::loadList()
@@ -893,8 +886,7 @@ void InstanceList::on_InstFolderChanged([[maybe_unused]] const Setting& setting,
     for (const auto& dir : candidates) {
         if (dir.isEmpty())
             continue;
-        if (!QDir::current().exists(dir))
-            QDir::current().mkpath(dir);
+        QDir::current().mkpath(dir);
         QString canonical = QDir(dir).canonicalPath();
         if (!canonical.isEmpty() && !newDirs.contains(canonical))
             newDirs << canonical;
@@ -1090,7 +1082,7 @@ bool InstanceList::commitStagedInstance(const QString& path,
 
             m_instanceGroupIndex[instID] = groupName;
             increaseGroupCount(groupName);
-            m_instanceRootDir[instID] = primaryDir();
+            m_instanceRootDirMap[instID] = primaryDir();
         }
 
         instanceSet.insert(instID);

--- a/launcher/InstanceList.h
+++ b/launcher/InstanceList.h
@@ -36,6 +36,7 @@
 #pragma once
 
 #include <QAbstractListModel>
+#include <QHash>
 #include <QList>
 #include <QObject>
 #include <QPair>
@@ -73,7 +74,7 @@ class InstanceList : public QAbstractListModel {
     Q_OBJECT
 
    public:
-    explicit InstanceList(SettingsObject* settings, const QString& instDir, QObject* parent = 0);
+    explicit InstanceList(SettingsObject* settings, const QStringList& instDirs, QObject* parent = 0);
     virtual ~InstanceList();
 
    public:
@@ -159,6 +160,8 @@ class InstanceList : public QAbstractListModel {
 
     QStringList getLinkedInstancesById(const QString& id) const;
 
+    QString primaryDir() const { return m_instDirs.isEmpty() ? QString() : m_instDirs.first(); }
+
    signals:
     void dataIsInvalid();
     void instancesChanged();
@@ -197,7 +200,9 @@ class InstanceList : public QAbstractListModel {
     QMap<QString, int> m_groupNameCache;
 
     SettingsObject* m_globalSettings;
-    QString m_instDir;
+    QStringList m_instDirs;
+    QHash<InstanceId, QString> m_instanceRootDir;
+    QString rootDirOf(const InstanceId& id) const;
     QFileSystemWatcher* m_watcher;
     // FIXME: this is so inefficient that looking at it is almost painful.
     QSet<QString> m_collapsedGroups;

--- a/launcher/InstanceList.h
+++ b/launcher/InstanceList.h
@@ -201,7 +201,7 @@ class InstanceList : public QAbstractListModel {
 
     SettingsObject* m_globalSettings;
     QStringList m_instDirs;
-    QHash<InstanceId, QString> m_instanceRootDir;
+    QHash<InstanceId, QString> m_instanceRootDirMap;
     QString rootDirOf(const InstanceId& id) const;
     QFileSystemWatcher* m_watcher;
     // FIXME: this is so inefficient that looking at it is almost painful.

--- a/launcher/ui/pages/global/LauncherPage.cpp
+++ b/launcher/ui/pages/global/LauncherPage.cpp
@@ -91,70 +91,8 @@ bool LauncherPage::apply()
     return true;
 }
 
-void LauncherPage::on_instDirBrowseBtn_clicked()
+bool LauncherPage::confirmInstanceDirPath(const QString& rawDir, const QString& cookedDir)
 {
-    QString rawDir = QFileDialog::getExistingDirectory(this, tr("Instance Folder"), ui->instDirTextBox->text());
-
-    // do not allow current dir - it's dirty. Do not allow dirs that don't exist
-    if (!rawDir.isEmpty() && QDir(rawDir).exists()) {
-        QString cookedDir = FS::NormalizePath(rawDir);
-        if (FS::checkProblemticPathJava(QDir(cookedDir))) {
-            QMessageBox warning;
-            warning.setText(
-                tr("You're trying to specify an instance folder which\'s path "
-                   "contains at least one \'!\'. "
-                   "Java is known to cause problems if that is the case, your "
-                   "instances (probably) won't start!"));
-            warning.setInformativeText(
-                tr("Do you really want to use this path? "
-                   "Selecting \"No\" will close this and not alter your instance path."));
-            warning.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
-            int result = warning.exec();
-            if (result == QMessageBox::Ok) {
-                ui->instDirTextBox->setText(cookedDir);
-            }
-        } else if (DesktopServices::isFlatpak() && rawDir.startsWith("/run/user")) {
-            QMessageBox warning;
-            warning.setText(tr("You're trying to specify an instance folder "
-                               "which was granted temporarily via Flatpak.\n"
-                               "This is known to cause problems. "
-                               "After a restart the launcher might break, "
-                               "because it will no longer have access to that directory.\n\n"
-                               "Granting %1 access to it via Flatseal is recommended.")
-                                .arg(BuildConfig.LAUNCHER_DISPLAYNAME));
-            warning.setInformativeText(tr("Do you want to proceed anyway?"));
-            warning.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
-            int result = warning.exec();
-            if (result == QMessageBox::Ok) {
-                ui->instDirTextBox->setText(cookedDir);
-            }
-        } else {
-            ui->instDirTextBox->setText(cookedDir);
-        }
-    }
-}
-
-void LauncherPage::on_addInstDirBtn_clicked()
-{
-    QString rawDir = QFileDialog::getExistingDirectory(this, tr("Additional Instance Folder"));
-
-    if (rawDir.isEmpty() || !QDir(rawDir).exists())
-        return;
-
-    QString cookedDir = FS::NormalizePath(rawDir);
-
-    // don't allow duplicates of the primary dir or of an already-added additional dir
-    if (cookedDir == FS::NormalizePath(ui->instDirTextBox->text())) {
-        QMessageBox::warning(this, tr("Duplicate directory"), tr("This is already your primary instance directory."));
-        return;
-    }
-    for (int i = 0; i < ui->additionalInstDirsList->count(); ++i) {
-        if (FS::NormalizePath(ui->additionalInstDirsList->item(i)->text()) == cookedDir) {
-            QMessageBox::warning(this, tr("Duplicate directory"), tr("This directory has already been added."));
-            return;
-        }
-    }
-
     if (FS::checkProblemticPathJava(QDir(cookedDir))) {
         QMessageBox warning;
         warning.setText(
@@ -167,7 +105,7 @@ void LauncherPage::on_addInstDirBtn_clicked()
                "Selecting \"No\" will close this and not alter your instance path."));
         warning.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
         if (warning.exec() != QMessageBox::Ok)
-            return;
+            return false;
     } else if (DesktopServices::isFlatpak() && rawDir.startsWith("/run/user")) {
         QMessageBox warning;
         warning.setText(tr("You're trying to specify an instance folder "
@@ -180,8 +118,40 @@ void LauncherPage::on_addInstDirBtn_clicked()
         warning.setInformativeText(tr("Do you want to proceed anyway?"));
         warning.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
         if (warning.exec() != QMessageBox::Ok)
-            return;
+            return false;
     }
+    return true;
+}
+
+void LauncherPage::on_instDirBrowseBtn_clicked()
+{
+    QString rawDir = QFileDialog::getExistingDirectory(this, tr("Instance Folder"), ui->instDirTextBox->text());
+    if (!rawDir.isEmpty() && QDir(rawDir).exists()) {
+        QString cookedDir = FS::NormalizePath(rawDir);
+        if (confirmInstanceDirPath(rawDir, cookedDir))
+            ui->instDirTextBox->setText(cookedDir);
+    }
+}
+
+void LauncherPage::on_addInstDirBtn_clicked()
+{
+    QString rawDir = QFileDialog::getExistingDirectory(this, tr("Additional Instance Folder"));
+    if (rawDir.isEmpty() || !QDir(rawDir).exists())
+        return;
+
+    QString cookedDir = FS::NormalizePath(rawDir);
+    if (cookedDir == FS::NormalizePath(ui->instDirTextBox->text())) {
+        QMessageBox::warning(this, tr("Duplicate directory"), tr("This is already your primary instance directory."));
+        return;
+    }
+
+    if (!ui->additionalInstDirsList->findItems(cookedDir, Qt::MatchFixedString).isEmpty()) {
+        QMessageBox::warning(this, tr("Duplicate directory"), tr("This directory has already been added."));
+        return;
+    }
+
+    if (!confirmInstanceDirPath(rawDir, cookedDir))
+        return;
 
     ui->additionalInstDirsList->addItem(cookedDir);
 }
@@ -275,8 +245,9 @@ void LauncherPage::applySettings()
     s->set("InstanceDir", ui->instDirTextBox->text());
     {
         QStringList additionalDirs;
-        for (int i = 0; i < ui->additionalInstDirsList->count(); ++i)
+        for (int i = 0; i < ui->additionalInstDirsList->count(); ++i) {
             additionalDirs << ui->additionalInstDirsList->item(i)->text();
+        }
         s->set("AdditionalInstanceDirs", additionalDirs);
     }
     s->set("CentralModsDir", ui->modsDirTextBox->text());

--- a/launcher/ui/pages/global/LauncherPage.cpp
+++ b/launcher/ui/pages/global/LauncherPage.cpp
@@ -134,6 +134,63 @@ void LauncherPage::on_instDirBrowseBtn_clicked()
     }
 }
 
+void LauncherPage::on_addInstDirBtn_clicked()
+{
+    QString rawDir = QFileDialog::getExistingDirectory(this, tr("Additional Instance Folder"));
+
+    if (rawDir.isEmpty() || !QDir(rawDir).exists())
+        return;
+
+    QString cookedDir = FS::NormalizePath(rawDir);
+
+    // don't allow duplicates of the primary dir or of an already-added additional dir
+    if (cookedDir == FS::NormalizePath(ui->instDirTextBox->text())) {
+        QMessageBox::warning(this, tr("Duplicate directory"), tr("This is already your primary instance directory."));
+        return;
+    }
+    for (int i = 0; i < ui->additionalInstDirsList->count(); ++i) {
+        if (FS::NormalizePath(ui->additionalInstDirsList->item(i)->text()) == cookedDir) {
+            QMessageBox::warning(this, tr("Duplicate directory"), tr("This directory has already been added."));
+            return;
+        }
+    }
+
+    if (FS::checkProblemticPathJava(QDir(cookedDir))) {
+        QMessageBox warning;
+        warning.setText(
+            tr("You're trying to specify an instance folder which\'s path "
+               "contains at least one \'!\'. "
+               "Java is known to cause problems if that is the case, your "
+               "instances (probably) won't start!"));
+        warning.setInformativeText(
+            tr("Do you really want to use this path? "
+               "Selecting \"No\" will close this and not alter your instance path."));
+        warning.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
+        if (warning.exec() != QMessageBox::Ok)
+            return;
+    } else if (DesktopServices::isFlatpak() && rawDir.startsWith("/run/user")) {
+        QMessageBox warning;
+        warning.setText(tr("You're trying to specify an instance folder "
+                           "which was granted temporarily via Flatpak.\n"
+                           "This is known to cause problems. "
+                           "After a restart the launcher might break, "
+                           "because it will no longer have access to that directory.\n\n"
+                           "Granting %1 access to it via Flatseal is recommended.")
+                            .arg(BuildConfig.LAUNCHER_DISPLAYNAME));
+        warning.setInformativeText(tr("Do you want to proceed anyway?"));
+        warning.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
+        if (warning.exec() != QMessageBox::Ok)
+            return;
+    }
+
+    ui->additionalInstDirsList->addItem(cookedDir);
+}
+
+void LauncherPage::on_removeInstDirBtn_clicked()
+{
+    qDeleteAll(ui->additionalInstDirsList->selectedItems());
+}
+
 void LauncherPage::on_iconsDirBrowseBtn_clicked()
 {
     QString rawDir = QFileDialog::getExistingDirectory(this, tr("Icons Folder"), ui->iconsDirTextBox->text());
@@ -216,6 +273,12 @@ void LauncherPage::applySettings()
     // Folders
     // TODO: Offer to move instances to new instance folder.
     s->set("InstanceDir", ui->instDirTextBox->text());
+    {
+        QStringList additionalDirs;
+        for (int i = 0; i < ui->additionalInstDirsList->count(); ++i)
+            additionalDirs << ui->additionalInstDirsList->item(i)->text();
+        s->set("AdditionalInstanceDirs", additionalDirs);
+    }
     s->set("CentralModsDir", ui->modsDirTextBox->text());
     s->set("IconsDir", ui->iconsDirTextBox->text());
     s->set("DownloadsDir", ui->downloadsDirTextBox->text());
@@ -276,6 +339,8 @@ void LauncherPage::loadSettings()
 
     // Folders
     ui->instDirTextBox->setText(s->get("InstanceDir").toString());
+    ui->additionalInstDirsList->clear();
+    ui->additionalInstDirsList->addItems(s->get("AdditionalInstanceDirs").toStringList());
     ui->modsDirTextBox->setText(s->get("CentralModsDir").toString());
     ui->iconsDirTextBox->setText(s->get("IconsDir").toString());
     ui->downloadsDirTextBox->setText(s->get("DownloadsDir").toString());
@@ -288,7 +353,7 @@ void LauncherPage::loadSettings()
     QString sortMode = s->get("InstSortMode").toString();
     if (sortMode == "LastLaunch") {
         ui->sortLastLaunchedBtn->setChecked(true);
-    } else if (sortMode == "Playtime"){
+    } else if (sortMode == "Playtime") {
         ui->sortByPlaytimeBtn->setChecked(true);
     } else {
         ui->sortByNameBtn->setChecked(true);

--- a/launcher/ui/pages/global/LauncherPage.h
+++ b/launcher/ui/pages/global/LauncherPage.h
@@ -69,6 +69,8 @@ class LauncherPage : public QWidget, public BasePage {
 
    private slots:
     void on_instDirBrowseBtn_clicked();
+    void on_addInstDirBtn_clicked();
+    void on_removeInstDirBtn_clicked();
     void on_modsDirBrowseBtn_clicked();
     void on_iconsDirBrowseBtn_clicked();
     void on_downloadsDirBrowseBtn_clicked();

--- a/launcher/ui/pages/global/LauncherPage.h
+++ b/launcher/ui/pages/global/LauncherPage.h
@@ -66,6 +66,7 @@ class LauncherPage : public QWidget, public BasePage {
    private:
     void applySettings();
     void loadSettings();
+    bool confirmInstanceDirPath(const QString& rawDir, const QString& cookedDir);
 
    private slots:
     void on_instDirBrowseBtn_clicked();

--- a/launcher/ui/pages/global/LauncherPage.ui
+++ b/launcher/ui/pages/global/LauncherPage.ui
@@ -739,11 +739,11 @@
   <tabstop>javaDirBrowseBtn</tabstop>
   <tabstop>skinsDirTextBox</tabstop>
   <tabstop>skinsDirBrowseBtn</tabstop>
+  <tabstop>downloadsDirTextBox</tabstop>
+  <tabstop>downloadsDirBrowseBtn</tabstop>
   <tabstop>additionalInstDirsList</tabstop>
   <tabstop>addInstDirBtn</tabstop>
   <tabstop>removeInstDirBtn</tabstop>
-  <tabstop>downloadsDirTextBox</tabstop>
-  <tabstop>downloadsDirBrowseBtn</tabstop>
   <tabstop>downloadsDirWatchRecursiveCheckBox</tabstop>
   <tabstop>downloadsDirMoveCheckBox</tabstop>
   <tabstop>metadataEnableBtn</tabstop>

--- a/launcher/ui/pages/global/LauncherPage.ui
+++ b/launcher/ui/pages/global/LauncherPage.ui
@@ -346,6 +346,43 @@
             </property>
            </widget>
           </item>
+          <item row="6" column="0" colspan="3">
+           <widget class="QGroupBox" name="additionalInstDirsGroupBox">
+            <property name="title">
+             <string>Additional instance directories</string>
+            </property>
+            <layout class="QVBoxLayout" name="additionalInstDirsLayout">
+             <item>
+              <widget class="QListWidget" name="additionalInstDirsList"/>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="additionalInstDirsBtnLayout">
+               <item>
+                <widget class="QPushButton" name="addInstDirBtn">
+                 <property name="text">
+                  <string>Add</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="removeInstDirBtn">
+                 <property name="text">
+                  <string>Remove</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <spacer name="additionalInstDirsSpacer">
+                 <property name="orientation">
+                  <enum>Qt::Orientation::Horizontal</enum>
+                 </property>
+                </spacer>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </widget>
+          </item>
           <item row="0" column="1">
            <widget class="QLineEdit" name="instDirTextBox"/>
           </item>
@@ -694,6 +731,9 @@
   <tabstop>updateIntervalSpinBox</tabstop>
   <tabstop>instDirTextBox</tabstop>
   <tabstop>instDirBrowseBtn</tabstop>
+  <tabstop>additionalInstDirsList</tabstop>
+  <tabstop>addInstDirBtn</tabstop>
+  <tabstop>removeInstDirBtn</tabstop>
   <tabstop>modsDirTextBox</tabstop>
   <tabstop>modsDirBrowseBtn</tabstop>
   <tabstop>iconsDirTextBox</tabstop>

--- a/launcher/ui/pages/global/LauncherPage.ui
+++ b/launcher/ui/pages/global/LauncherPage.ui
@@ -731,9 +731,6 @@
   <tabstop>updateIntervalSpinBox</tabstop>
   <tabstop>instDirTextBox</tabstop>
   <tabstop>instDirBrowseBtn</tabstop>
-  <tabstop>additionalInstDirsList</tabstop>
-  <tabstop>addInstDirBtn</tabstop>
-  <tabstop>removeInstDirBtn</tabstop>
   <tabstop>modsDirTextBox</tabstop>
   <tabstop>modsDirBrowseBtn</tabstop>
   <tabstop>iconsDirTextBox</tabstop>
@@ -742,6 +739,9 @@
   <tabstop>javaDirBrowseBtn</tabstop>
   <tabstop>skinsDirTextBox</tabstop>
   <tabstop>skinsDirBrowseBtn</tabstop>
+  <tabstop>additionalInstDirsList</tabstop>
+  <tabstop>addInstDirBtn</tabstop>
+  <tabstop>removeInstDirBtn</tabstop>
   <tabstop>downloadsDirTextBox</tabstop>
   <tabstop>downloadsDirBrowseBtn</tabstop>
   <tabstop>downloadsDirWatchRecursiveCheckBox</tabstop>


### PR DESCRIPTION
Closes #4358 

## What this PR does
- New "Additional instance directories" list in Settings -> General with Add/Remove buttons.
- `InstanceList` scans all configured directories and merges discovered instances into one unified list.
- New instances are still created in the primary directory.
- Removing a directory from the list safely detaches its instances from the running list. Re-adding it restores them, including group membership.

## Further Scope
- No option to select the directory where the user want to create it (Like how steam does)
- Icons folder for each directory

## What I tested
-  The group entry lands in the single root `instgroups.json`, with groups for instances from the primary directory.
- After restarting, group assignments across directories persisted correctly.
- Removed a directory from settings and the instance disappeared from the list but the instance files are still on the disk.
<img width="814" height="436" alt="image" src="https://github.com/user-attachments/assets/787c1833-34e4-415e-b46b-ff97c53f2e37" />
