### PR TITLE
Fix Forge WARN/ERROR lines not being colored in the Other Logs tab

### DIFF
--- a/launcher/logs/LogParser.cpp
+++ b/launcher/logs/LogParser.cpp
@@ -322,11 +322,10 @@ std::optional<LogParser::ParsedItem> LogParser::parseLog4J()
 
 MessageLevel LogParser::guessLevel(const QString& line, MessageLevel previous)
 {
-    static const QRegularExpression LINE_WITH_LEVEL("^\\[(?<timestamp>[0-9:]+)\\] \\[[^/]+/(?<level>[^\\]]+)\\]");
+    static const QRegularExpression LINE_WITH_LEVEL("^\\[[^\\]]+\\] \\[[^/]+/(?<level>[^\\]]+)\\]");
     auto match = LINE_WITH_LEVEL.match(line);
     if (match.hasMatch()) {
         // New style logs from log4j
-        QString timestamp = match.captured("timestamp");
         QString levelStr = match.captured("level");
 
         return MessageLevel::fromName(levelStr);

--- a/tests/XmlLogs_test.cpp
+++ b/tests/XmlLogs_test.cpp
@@ -38,6 +38,18 @@ class XmlLogParseTest : public QObject {
 
    private slots:
 
+    void guessLevel_timestampFormats()
+    {
+        QCOMPARE(LogParser::guessLevel("[21:16:07] [Server thread/WARN]: short timestamp", MessageLevel::Unknown), MessageLevel::Warning);
+        QCOMPARE(LogParser::guessLevel("[23Jul2026 18:12:07.877] [main/WARN] [Sodium-Workarounds/]: date and millis timestamp",
+                                       MessageLevel::Unknown),
+                 MessageLevel::Warning);
+        QCOMPARE(LogParser::guessLevel(
+                     "[25Jul2026 14:10:58.723] [main/ERROR] [net.minecraftforge.fml.loading.moddiscovery.ModFileParser/LOADING]: error",
+                     MessageLevel::Unknown),
+                 MessageLevel::Error);
+    }
+
     void parseXml_data()
     {
         QString source = QFINDTESTDATA("testdata/TestLogs");


### PR DESCRIPTION
guessLevel() required the log line's timestamp bracket to contain only digits and colons, so it never matched real log4j output that includes a full date and milliseconds (e.g. "[23Jul2026 18:12:07.877] [main/WARN] [...]"). Lines fell through to Unknown level and were left uncolored, even with "Color lines" enabled. The live "Minecraft Log" console tab wasn't affected since it gets levels from log4j's XML event stream instead of this text heuristic.

Signed-off-by: desvaters dev@messmann.me
