### PR TITLE
Allow editing auto generated instance name

### DIFF
--- a/launcher/ui/dialogs/NewInstanceDialog.cpp
+++ b/launcher/ui/dialogs/NewInstanceDialog.cpp
@@ -201,7 +201,8 @@ void NewInstanceDialog::setSuggestedPack(const QString& name, InstanceTask* task
 {
     creationTask.reset(task);
 
-    ui->instNameTextBox->setPlaceholderText(name);
+    m_suggestedName = name;
+    ui->instNameTextBox->setPlaceholderText(name.isEmpty() ? name : tr("%1  (tip: use * to insert this name)").arg(name));
     importVersion.clear();
 
     if (!task) {
@@ -217,7 +218,8 @@ void NewInstanceDialog::setSuggestedPack(const QString& name, QString version, I
 {
     creationTask.reset(task);
 
-    ui->instNameTextBox->setPlaceholderText(name);
+    m_suggestedName = name;
+    ui->instNameTextBox->setPlaceholderText(name.isEmpty() ? name : tr("%1  (tip: use * to insert this name)").arg(name));
     importVersion = std::move(version);
 
     if (!task) {
@@ -254,7 +256,7 @@ InstanceTask* NewInstanceDialog::extractTask()
 {
     InstanceTask* extracted = creationTask.release();
 
-    InstanceName inst_name(ui->instNameTextBox->placeholderText().trimmed(), importVersion);
+    InstanceName inst_name(m_suggestedName.trimmed(), importVersion);
     inst_name.setName(resolveWildcardName(ui->instNameTextBox->text().trimmed()));
     extracted->setName(inst_name);
 
@@ -278,7 +280,7 @@ QString NewInstanceDialog::instName() const
     if (result.size()) {
         return resolveWildcardName(result);
     }
-    result = ui->instNameTextBox->placeholderText().trimmed();
+    result = m_suggestedName.trimmed();
     if (result.size()) {
         return result;
     }
@@ -291,9 +293,8 @@ QString NewInstanceDialog::resolveWildcardName(const QString& typed) const
         return typed;
     }
 
-    auto suggested = ui->instNameTextBox->placeholderText().trimmed();
     QString result = typed;
-    return result.replace('*', suggested);
+    return result.replace('*', m_suggestedName.trimmed());
 }
 
 QString NewInstanceDialog::instGroup() const

--- a/launcher/ui/dialogs/NewInstanceDialog.cpp
+++ b/launcher/ui/dialogs/NewInstanceDialog.cpp
@@ -205,8 +205,13 @@ void NewInstanceDialog::setSuggestedPack(const QString& name, InstanceTask* task
     creationTask.reset(task);
 
     m_suggestedName = name;
-    ui->instNameTextBox->setText(name);
-    m_nameFieldSelectedOnce = false;
+
+    if (!m_nameFieldEditedByUser) {
+        m_settingTextProgrammatically = true;
+        ui->instNameTextBox->setText(name);
+        m_settingTextProgrammatically = false;
+        m_nameFieldSelectedOnce = false;
+    }
     importVersion.clear();
 
     if (!task) {
@@ -223,8 +228,13 @@ void NewInstanceDialog::setSuggestedPack(const QString& name, QString version, I
     creationTask.reset(task);
 
     m_suggestedName = name;
-    ui->instNameTextBox->setText(name);
-    m_nameFieldSelectedOnce = false;
+
+    if (!m_nameFieldEditedByUser) {
+        m_settingTextProgrammatically = true;
+        ui->instNameTextBox->setText(name);
+        m_settingTextProgrammatically = false;
+        m_nameFieldSelectedOnce = false;
+    }
     importVersion = std::move(version);
 
     if (!task) {
@@ -316,6 +326,9 @@ void NewInstanceDialog::on_iconButton_clicked()
 
 void NewInstanceDialog::on_instNameTextBox_textChanged([[maybe_unused]] const QString& arg1)
 {
+    if (!m_settingTextProgrammatically) {
+        m_nameFieldEditedByUser = true;
+    }
     updateDialogState();
 }
 

--- a/launcher/ui/dialogs/NewInstanceDialog.cpp
+++ b/launcher/ui/dialogs/NewInstanceDialog.cpp
@@ -54,6 +54,7 @@
 #include <QLayout>
 #include <QPushButton>
 #include <QScreen>
+#include <QTimer>
 #include <QValidator>
 #include <utility>
 
@@ -74,6 +75,8 @@ NewInstanceDialog::NewInstanceDialog(const QString& initialGroup,
     : QDialog(parent), ui(new Ui::NewInstanceDialog)
 {
     ui->setupUi(this);
+
+    ui->instNameTextBox->installEventFilter(this);
 
     setWindowIcon(QIcon::fromTheme("new"));
 
@@ -202,7 +205,8 @@ void NewInstanceDialog::setSuggestedPack(const QString& name, InstanceTask* task
     creationTask.reset(task);
 
     m_suggestedName = name;
-    ui->instNameTextBox->setPlaceholderText(name.isEmpty() ? name : tr("%1  (tip: use * to insert this name)").arg(name));
+    ui->instNameTextBox->setText(name);
+    m_nameFieldSelectedOnce = false;
     importVersion.clear();
 
     if (!task) {
@@ -219,7 +223,8 @@ void NewInstanceDialog::setSuggestedPack(const QString& name, QString version, I
     creationTask.reset(task);
 
     m_suggestedName = name;
-    ui->instNameTextBox->setPlaceholderText(name.isEmpty() ? name : tr("%1  (tip: use * to insert this name)").arg(name));
+    ui->instNameTextBox->setText(name);
+    m_nameFieldSelectedOnce = false;
     importVersion = std::move(version);
 
     if (!task) {
@@ -257,7 +262,7 @@ InstanceTask* NewInstanceDialog::extractTask()
     InstanceTask* extracted = creationTask.release();
 
     InstanceName inst_name(m_suggestedName.trimmed(), importVersion);
-    inst_name.setName(resolveWildcardName(ui->instNameTextBox->text().trimmed()));
+    inst_name.setName(ui->instNameTextBox->text().trimmed());
     extracted->setName(inst_name);
 
     extracted->setGroup(instGroup());
@@ -278,23 +283,13 @@ QString NewInstanceDialog::instName() const
 {
     auto result = ui->instNameTextBox->text().trimmed();
     if (result.size()) {
-        return resolveWildcardName(result);
+        return result;
     }
     result = m_suggestedName.trimmed();
     if (result.size()) {
         return result;
     }
     return QString();
-}
-
-QString NewInstanceDialog::resolveWildcardName(const QString& typed) const
-{
-    if (!typed.contains('*')) {
-        return typed;
-    }
-
-    QString result = typed;
-    return result.replace('*', m_suggestedName.trimmed());
 }
 
 QString NewInstanceDialog::instGroup() const
@@ -332,6 +327,15 @@ void NewInstanceDialog::importIconNow()
         importIcon = false;
     }
     APPLICATION->settings()->set("NewInstanceGeometry", QString::fromUtf8(saveGeometry().toBase64()));
+}
+
+bool NewInstanceDialog::eventFilter(QObject* watched, QEvent* event)
+{
+    if (watched == ui->instNameTextBox && event->type() == QEvent::FocusIn && !m_nameFieldSelectedOnce) {
+        m_nameFieldSelectedOnce = true;
+        QTimer::singleShot(0, ui->instNameTextBox, &QLineEdit::selectAll);
+    }
+    return QDialog::eventFilter(watched, event);
 }
 
 void NewInstanceDialog::selectedPageChanged(BasePage* previous, BasePage* selected)

--- a/launcher/ui/dialogs/NewInstanceDialog.cpp
+++ b/launcher/ui/dialogs/NewInstanceDialog.cpp
@@ -207,9 +207,10 @@ void NewInstanceDialog::setSuggestedPack(const QString& name, InstanceTask* task
     m_suggestedName = name;
 
     if (!m_nameFieldEditedByUser) {
-        m_settingTextProgrammatically = true;
+        ui->instNameTextBox->blockSignals(true);
         ui->instNameTextBox->setText(name);
-        m_settingTextProgrammatically = false;
+        updateDialogState();
+        ui->instNameTextBox->blockSignals(false);
         m_nameFieldSelectedOnce = false;
     }
     importVersion.clear();
@@ -230,9 +231,10 @@ void NewInstanceDialog::setSuggestedPack(const QString& name, QString version, I
     m_suggestedName = name;
 
     if (!m_nameFieldEditedByUser) {
-        m_settingTextProgrammatically = true;
+        ui->instNameTextBox->blockSignals(true);
         ui->instNameTextBox->setText(name);
-        m_settingTextProgrammatically = false;
+        updateDialogState();
+        ui->instNameTextBox->blockSignals(false);
         m_nameFieldSelectedOnce = false;
     }
     importVersion = std::move(version);
@@ -326,9 +328,7 @@ void NewInstanceDialog::on_iconButton_clicked()
 
 void NewInstanceDialog::on_instNameTextBox_textChanged([[maybe_unused]] const QString& arg1)
 {
-    if (!m_settingTextProgrammatically) {
-        m_nameFieldEditedByUser = true;
-    }
+    m_nameFieldEditedByUser = true;
     updateDialogState();
 }
 

--- a/launcher/ui/dialogs/NewInstanceDialog.cpp
+++ b/launcher/ui/dialogs/NewInstanceDialog.cpp
@@ -255,7 +255,7 @@ InstanceTask* NewInstanceDialog::extractTask()
     InstanceTask* extracted = creationTask.release();
 
     InstanceName inst_name(ui->instNameTextBox->placeholderText().trimmed(), importVersion);
-    inst_name.setName(ui->instNameTextBox->text().trimmed());
+    inst_name.setName(resolveWildcardName(ui->instNameTextBox->text().trimmed()));
     extracted->setName(inst_name);
 
     extracted->setGroup(instGroup());
@@ -276,13 +276,24 @@ QString NewInstanceDialog::instName() const
 {
     auto result = ui->instNameTextBox->text().trimmed();
     if (result.size()) {
-        return result;
+        return resolveWildcardName(result);
     }
     result = ui->instNameTextBox->placeholderText().trimmed();
     if (result.size()) {
         return result;
     }
     return QString();
+}
+
+QString NewInstanceDialog::resolveWildcardName(const QString& typed) const
+{
+    if (!typed.contains('*')) {
+        return typed;
+    }
+
+    auto suggested = ui->instNameTextBox->placeholderText().trimmed();
+    QString result = typed;
+    return result.replace('*', suggested);
 }
 
 QString NewInstanceDialog::instGroup() const

--- a/launcher/ui/dialogs/NewInstanceDialog.h
+++ b/launcher/ui/dialogs/NewInstanceDialog.h
@@ -102,7 +102,6 @@ class NewInstanceDialog : public QDialog, public BasePageProvider {
     QString m_suggestedName;
     bool m_nameFieldSelectedOnce = false;
     bool m_nameFieldEditedByUser = false;
-    bool m_settingTextProgrammatically = false;
 
     QString m_searchTerm;
 

--- a/launcher/ui/dialogs/NewInstanceDialog.h
+++ b/launcher/ui/dialogs/NewInstanceDialog.h
@@ -75,6 +75,8 @@ class NewInstanceDialog : public QDialog, public BasePageProvider {
     QString instGroup() const;
     QString iconKey() const;
 
+    QString resolveWildcardName(const QString& typed) const;
+
    public slots:
     void accept() override;
     void reject() override;

--- a/launcher/ui/dialogs/NewInstanceDialog.h
+++ b/launcher/ui/dialogs/NewInstanceDialog.h
@@ -75,8 +75,6 @@ class NewInstanceDialog : public QDialog, public BasePageProvider {
     QString instGroup() const;
     QString iconKey() const;
 
-    QString resolveWildcardName(const QString& typed) const;
-
    public slots:
     void accept() override;
     void reject() override;
@@ -102,8 +100,10 @@ class NewInstanceDialog : public QDialog, public BasePageProvider {
     QString importVersion;
 
     QString m_suggestedName;
+    bool m_nameFieldSelectedOnce = false;
 
     QString m_searchTerm;
 
     void importIconNow();
+    bool eventFilter(QObject* watched, QEvent* event) override;
 };

--- a/launcher/ui/dialogs/NewInstanceDialog.h
+++ b/launcher/ui/dialogs/NewInstanceDialog.h
@@ -101,6 +101,8 @@ class NewInstanceDialog : public QDialog, public BasePageProvider {
 
     QString importVersion;
 
+    QString m_suggestedName;
+
     QString m_searchTerm;
 
     void importIconNow();

--- a/launcher/ui/dialogs/NewInstanceDialog.h
+++ b/launcher/ui/dialogs/NewInstanceDialog.h
@@ -101,6 +101,8 @@ class NewInstanceDialog : public QDialog, public BasePageProvider {
 
     QString m_suggestedName;
     bool m_nameFieldSelectedOnce = false;
+    bool m_nameFieldEditedByUser = false;
+    bool m_settingTextProgrammatically = false;
 
     QString m_searchTerm;
 

--- a/launcher/ui/pages/modplatform/CustomPage.cpp
+++ b/launcher/ui/pages/modplatform/CustomPage.cpp
@@ -184,6 +184,26 @@ QString CustomPage::selectedLoader() const
     return m_selectedLoader;
 }
 
+QString CustomPage::selectedLoaderName() const
+{
+    if (ui->neoForgeFilter->isChecked()) {
+        return ui->neoForgeFilter->text();
+    }
+    if (ui->forgeFilter->isChecked()) {
+        return ui->forgeFilter->text();
+    }
+    if (ui->fabricFilter->isChecked()) {
+        return ui->fabricFilter->text();
+    }
+    if (ui->quiltFilter->isChecked()) {
+        return ui->quiltFilter->text();
+    }
+    if (ui->liteLoaderFilter->isChecked()) {
+        return ui->liteLoaderFilter->text();
+    }
+    return QString();
+}
+
 void CustomPage::suggestCurrent()
 {
     if (!isOpened) {
@@ -199,8 +219,8 @@ void CustomPage::suggestCurrent()
     if (ui->loaderVersionList->selectedVersion() == nullptr)
         dialog->setSuggestedPack(m_selectedVersion->descriptor(), new VanillaCreationTask(m_selectedVersion));
     else {
-        dialog->setSuggestedPack(m_selectedVersion->descriptor(),
-                                 new VanillaCreationTask(m_selectedVersion, m_selectedLoader, m_selectedLoaderVersion));
+        QString suggestedName = QString("%1 %2").arg(m_selectedVersion->descriptor(), selectedLoaderName());
+        dialog->setSuggestedPack(suggestedName, new VanillaCreationTask(m_selectedVersion, m_selectedLoader, m_selectedLoaderVersion));
     }
     dialog->setSuggestedIcon("default");
 }

--- a/launcher/ui/pages/modplatform/CustomPage.h
+++ b/launcher/ui/pages/modplatform/CustomPage.h
@@ -65,6 +65,7 @@ class CustomPage : public QWidget, public BasePage {
     BaseVersion::Ptr selectedVersion() const;
     BaseVersion::Ptr selectedLoaderVersion() const;
     QString selectedLoader() const;
+    QString selectedLoaderName() const;
 
    public slots:
     void setSelectedVersion(BaseVersion::Ptr version);


### PR DESCRIPTION
Instead of a `*` wildcard character, the instance name field now shows the suggested name as real, editable text.
The full name is auto-selected the first time you click into the field, so typing replaces it entirely. Clicking a second time just positions the cursor, so you can add or remove the text.

## What I tested

- Opening the dialog auto-fills the name field
- First click selects the whole name and typing replaces it
- Second click positions the cursor normally, so prepending/appending works
- Changing version or loader afterward resets the field to the new suggested name
- Naming works correctly for other mod loaders too (Forge, Fabric, Quilt)