### PR TITLE
Load world metadata asynchronously to avoid blocking UI thread

### DIFF
--- a/launcher/minecraft/World.cpp
+++ b/launcher/minecraft/World.cpp
@@ -220,16 +220,32 @@ void World::repath(const QFileInfo& file)
 {
     m_containerFile = file;
     m_folderName = file.fileName();
+    m_metadataLoaded = false;
     if (file.isFile() && file.suffix() == "zip") {
         m_iconFile = QString();
-        readFromZip(file);
+        m_isValid = true;
     } else if (file.isDir()) {
         QFileInfo assumedIconPath(file.absoluteFilePath() + "/icon.png");
         if (assumedIconPath.exists()) {
             m_iconFile = assumedIconPath.absoluteFilePath();
         }
-        readFromFS(file);
+        m_isValid = QFileInfo(file.absoluteFilePath() + "/level.dat").exists();
+    } else {
+        m_isValid = false;
     }
+}
+
+void World::loadMetadata()
+{
+    if (m_metadataLoaded) {
+        return;
+    }
+    if (m_containerFile.isFile() && m_containerFile.suffix() == "zip") {
+        readFromZip(m_containerFile);
+    } else if (m_containerFile.isDir()) {
+        readFromFS(m_containerFile);
+    }
+    m_metadataLoaded = true;
 }
 
 bool World::resetIcon()

--- a/launcher/minecraft/World.h
+++ b/launcher/minecraft/World.h
@@ -48,6 +48,8 @@ class World {
     bool replace(World& with);
     // change the world's filesystem path (used by world lists for *MAGIC* purposes)
     void repath(const QFileInfo& file);
+    void loadMetadata();
+    bool isMetadataLoaded() const { return m_metadataLoaded; }
     // remove the icon file, if any
     bool resetIcon();
 
@@ -78,6 +80,7 @@ class World {
     void readFromZip(const QFileInfo& file);
     void readFromFS(const QFileInfo& file);
     void loadFromLevelDat(QByteArray data);
+    bool m_metadataLoaded = false;
 
    protected:
     QFileInfo m_containerFile;

--- a/launcher/minecraft/WorldList.cpp
+++ b/launcher/minecraft/WorldList.cpp
@@ -464,17 +464,17 @@ void WorldList::loadWorldsAsync()
         auto file = m_worlds.at(i).container();
         int row = i;
         QThreadPool::globalInstance()->start([this, file, row]() mutable {
-            auto size = calculateWorldSize(file);
+            World w(file);
+            w.loadMetadata();
+            w.setSize(calculateWorldSize(file));
 
             QMetaObject::invokeMethod(
                 this,
-                [this, size, row, file]() {
+                [this, w, row, file]() {
                     if (row < m_worlds.size() && m_worlds[row].container() == file) {
-                        m_worlds[row].setSize(size);
+                        m_worlds[row] = w;
 
-                        // Notify views
-                        QModelIndex modelIndex = index(row, SizeColumn);
-                        emit dataChanged(modelIndex, modelIndex, { SizeRole });
+                        emit dataChanged(index(row, 0), index(row, columnCount(QModelIndex()) - 1));
                     }
                 },
                 Qt::QueuedConnection);


### PR DESCRIPTION
Fixes #2721.

`WorldList::update()` currently parses each world's `level.dat` or the NBT synchronously on the UI thread both the times when the Worlds tab is opened and when the instance settings dialog opens so it blocks the UI regardless of which one triggers it.
This PR moves the NBT parsing into the existing `QThreadPool` pattern that `loadWorldsAsync()` already uses for calculating world size.

## Testing
Tested locally with 82 real world folders

| Trigger | Before | After |
|---|---|---|
| Opening instance settings dialog | 109ms | 26ms |
| Opening Worlds tab | 95ms | 24ms |

Could not test with a much larger world count due to local hardware limits. But should scale further since the work is parallelized across cores rather than sequential, but I have not verified that directly. Maybe a speed runner or a maintainer can test that if required.

For zip worlds, `m_isValid` is now true until `loadMetadata()` confirms it. A corrupt zip will briefly show as valid before correcting itself.