### PR TITLE
Save account credentials on the system keychain

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,6 +341,7 @@ endif()
 
 find_package(ZLIB REQUIRED)
 
+find_package(Qt6Keychain 0.15.0 REQUIRED)
 
 include(ECMQtDeclareLoggingCategory)
 

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -84,6 +84,7 @@
 #include "ApplicationMessage.h"
 
 #include <iostream>
+#include <memory>
 #include <mutex>
 
 #include <QAccessible>
@@ -983,11 +984,48 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
 
     // and accounts
     {
-        m_accounts.reset(new AccountList(this));
+        m_accounts = std::make_unique<AccountList>(this);
         qInfo() << "Loading accounts...";
         m_accounts->setListFilePath("accounts.json", true);
         m_accounts->loadList();
+
+        auto secretsTask = m_accounts->loadSecrets();
+        while (secretsTask != nullptr) {
+            QEventLoop loop;
+            connect(secretsTask.get(), &Task::finished, &loop, &QEventLoop::quit);
+            secretsTask->start();
+            loop.exec();
+
+            if (secretsTask->wasSuccessful()) {
+                break;
+            }
+
+            const auto title = tr("Failed to load credentials");
+            const auto msg = tr("Account credentials could not be retrieved from the system keychain.");
+            auto* dialog =
+                CustomMessageBox::selectable(nullptr, title, msg, QMessageBox::Warning, QMessageBox::Ok | QMessageBox::Retry);
+            dialog->setDetailedText(secretsTask->failReason());
+            if (dialog->exec() == QMessageBox::Ok) {
+                break;
+            }
+
+            secretsTask = m_accounts->loadSecrets();
+        }
+
         m_accounts->fillQueue();
+
+        connect(m_accounts.get(), &AccountList::saveSecretsFailed, [](const QString& profileName, const QString& error) {
+            const auto title = tr("Failed to save account credentials");
+            const auto msg = tr("The account credentials for user %1 could not be saved: %2.").arg(profileName, error);
+            CustomMessageBox::selectable(nullptr, title, msg, QMessageBox::Warning)->open();
+        });
+
+        connect(m_accounts.get(), &AccountList::deleteSecretsFailed, [](const QString& profileName, const QString& error) {
+            const auto title = tr("Failed to delete account credentials");
+            const auto msg = tr("The account credentials for user %1 could not be deleted: %2.").arg(profileName, error);
+            CustomMessageBox::selectable(nullptr, title, msg, QMessageBox::Warning)->open();
+        });
+
         qInfo() << "<> Accounts loaded.";
     }
 

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -1300,6 +1300,7 @@ target_link_libraries(Launcher_logic
     cmark::cmark
     LocalPeer
     Launcher_rainbow
+    Qt6Keychain::Qt6Keychain
 )
 if (TARGET ${Launcher_QT_DBUS})
     add_compile_definitions(WITH_QTDBUS)

--- a/launcher/QObjectPtr.h
+++ b/launcher/QObjectPtr.h
@@ -46,8 +46,8 @@ class shared_qobject_ptr : public QSharedPointer<T> {
 };
 
 template <typename T, typename... Args>
-shared_qobject_ptr<T> makeShared(Args... args)
+shared_qobject_ptr<T> makeShared(Args&&... args)
 {
-    auto obj = new T(args...);
+    auto obj = new T(std::forward<Args>(args)...);
     return shared_qobject_ptr<T>(obj);
 }

--- a/launcher/minecraft/auth/AccountData.cpp
+++ b/launcher/minecraft/auth/AccountData.cpp
@@ -39,6 +39,8 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QUuid>
+#include "Application.h"
+#include "settings/SettingsObject.h"
 
 namespace {
 void tokenToJSONV3(QJsonObject& parent, const Token& t, const char* tokenName)
@@ -279,7 +281,7 @@ bool entitlementFromJSONV3(const QJsonObject& parent, MinecraftEntitlement& out)
 
 }  // namespace
 
-bool AccountData::resumeStateFromV3(QJsonObject data)
+bool AccountData::loadStateV3(const QJsonObject& data)
 {
     auto typeV = data.value("type");
     if (!typeV.isString()) {
@@ -301,15 +303,7 @@ bool AccountData::resumeStateFromV3(QJsonObject data)
         if (clientIDV.isString()) {
             msaClientID = clientIDV.toString();
         }  // leave msaClientID empty if it doesn't exist or isn't a string
-        msaToken = tokenFromJSONV3(data, "msa");
-        userToken = tokenFromJSONV3(data, "utoken");
-        mojangservicesToken = tokenFromJSONV3(data, "xrp-mc");
     }
-
-    yggdrasilToken = tokenFromJSONV3(data, "ygg");
-    // versions before 7.2 used "offline" as the offline token
-    if (yggdrasilToken.token == "offline")
-        yggdrasilToken.token = "0";
 
     minecraftProfile = profileFromJSONV3(data, "profile");
     if (!entitlementFromJSONV3(data, minecraftEntitlement)) {
@@ -327,19 +321,46 @@ bool AccountData::resumeStateFromV3(QJsonObject data)
 QJsonObject AccountData::saveState() const
 {
     QJsonObject output;
+
     if (type == AccountType::MSA) {
         output["type"] = "MSA";
         output["msa-client-id"] = msaClientID;
-        tokenToJSONV3(output, msaToken, "msa");
-        tokenToJSONV3(output, userToken, "utoken");
-        tokenToJSONV3(output, mojangservicesToken, "xrp-mc");
     } else if (type == AccountType::Offline) {
         output["type"] = "Offline";
     }
 
-    tokenToJSONV3(output, yggdrasilToken, "ygg");
     profileToJSONV3(output, minecraftProfile, "profile");
     entitlementToJSONV3(output, minecraftEntitlement);
+
+    return output;
+}
+
+void AccountData::loadSecrets(const QJsonObject& data)
+{
+    if (type == AccountType::MSA) {
+        msaToken = tokenFromJSONV3(data, "msa");
+        userToken = tokenFromJSONV3(data, "utoken");
+        mojangservicesToken = tokenFromJSONV3(data, "xrp-mc");
+    }
+
+    yggdrasilToken = tokenFromJSONV3(data, "ygg");
+    // versions before 7.2 used "offline" as the offline token
+    if (yggdrasilToken.token == "offline") {
+        yggdrasilToken.token = "0";
+    }
+}
+
+QJsonObject AccountData::saveSecrets() const
+{
+    QJsonObject output;
+
+    if (type == AccountType::MSA) {
+        tokenToJSONV3(output, msaToken, "msa");
+        tokenToJSONV3(output, userToken, "utoken");
+        tokenToJSONV3(output, mojangservicesToken, "xrp-mc");
+    }
+
+    tokenToJSONV3(output, yggdrasilToken, "ygg");
     return output;
 }
 

--- a/launcher/minecraft/auth/AccountData.h
+++ b/launcher/minecraft/auth/AccountData.h
@@ -94,7 +94,10 @@ enum class AccountState { Unchecked, Offline, Working, Online, Disabled, Errored
 
 struct AccountData {
     QJsonObject saveState() const;
-    bool resumeStateFromV3(QJsonObject data);
+    bool loadStateV3(const QJsonObject& data);
+
+    QJsonObject saveSecrets() const;
+    void loadSecrets(const QJsonObject& data);
 
     //! Yggdrasil access token, as passed to the game.
     QString accessToken() const;

--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -495,7 +495,7 @@ bool AccountList::loadV3(QJsonObject& root)
     QJsonArray accounts = root.value("accounts").toArray();
     for (QJsonValue accountVal : accounts) {
         QJsonObject accountObj = accountVal.toObject();
-        MinecraftAccountPtr account = MinecraftAccount::loadFromJsonV3(accountObj);
+        MinecraftAccountPtr account = MinecraftAccount::loadFromJsonV3(accountObj, accountObj);
         if (account.get() != nullptr) {
             auto profileId = account->profileId();
             if (profileId.size()) {
@@ -546,8 +546,8 @@ bool AccountList::saveList()
     // Build a list of accounts.
     qDebug() << "Building account array.";
     QJsonArray accounts;
-    for (MinecraftAccountPtr account : m_accounts) {
-        QJsonObject accountObj = account->saveToJson();
+    for (const auto& account : m_accounts) {
+        const QJsonObject accountObj = account->saveState();
         if (m_defaultAccount == account) {
             accountObj["active"] = true;
         }

--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -35,12 +35,17 @@
 
 #include "AccountList.h"
 #include "AccountData.h"
+#include "Application.h"
+#include "BuildConfig.h"
+#include "settings/SettingsObject.h"
+#include "tasks/SequentialTask.h"
 #include "tasks/Task.h"
 
+#include <qt6keychain/keychain.h>
 #include <QDir>
 #include <QFile>
-#include <QIcon>
 #include <QIODevice>
+#include <QIcon>
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -52,6 +57,8 @@
 
 #include <FileSystem.h>
 #include <QSaveFile>
+
+using namespace Qt::Literals;
 
 enum AccountListVersion { MojangMSA = 3 };
 
@@ -118,6 +125,7 @@ void AccountList::addAccount(const MinecraftAccountPtr account)
 
     // hook up notifications for changes in the account
     connect(account.get(), &MinecraftAccount::changed, this, &AccountList::accountChanged);
+    connect(account.get(), &MinecraftAccount::secretsChanged, this, [this, account = account.get()] { saveSecrets(*account); });
     connect(account.get(), &MinecraftAccount::activityChanged, this, &AccountList::accountActivityChanged);
 
     // override/replace existing account with the same profileId
@@ -136,6 +144,7 @@ void AccountList::addAccount(const MinecraftAccountPtr account)
             existingAccountPtr->disconnect(this);
             emit dataChanged(index(existingAccount), index(existingAccount, columnCount(QModelIndex()) - 1));
             onListChanged();
+            saveSecrets(*existingAccountPtr);
             return;
         }
     }
@@ -149,6 +158,7 @@ void AccountList::addAccount(const MinecraftAccountPtr account)
     endInsertRows();
 
     onListChanged();
+    saveSecrets(*account);
 }
 
 void AccountList::removeAccount(QModelIndex index)
@@ -166,6 +176,7 @@ void AccountList::removeAccount(QModelIndex index)
         m_accounts.removeAt(index.row());
         endRemoveRows();
         onListChanged();
+        deleteSecrets(*account);
     }
 }
 
@@ -480,7 +491,7 @@ bool AccountList::loadList()
     // Make sure the format version matches.
     auto listVersion = root.value("formatVersion").toVariant().toInt();
     if (listVersion == AccountListVersion::MojangMSA)
-        return loadV3(root);
+        return loadListV3(root);
 
     QString newName = "accounts-old.json";
     qWarning() << "Unknown format version when loading account list. Existing one will be renamed to" << newName;
@@ -489,13 +500,13 @@ bool AccountList::loadList()
     return false;
 }
 
-bool AccountList::loadV3(QJsonObject& root)
+bool AccountList::loadListV3(QJsonObject& root)
 {
     beginResetModel();
     QJsonArray accounts = root.value("accounts").toArray();
     for (QJsonValue accountVal : accounts) {
         QJsonObject accountObj = accountVal.toObject();
-        MinecraftAccountPtr account = MinecraftAccount::loadFromJsonV3(accountObj, accountObj);
+        MinecraftAccountPtr account = MinecraftAccount::loadFromJsonV3(accountObj);
         if (account.get() != nullptr) {
             auto profileId = account->profileId();
             if (profileId.size()) {
@@ -504,6 +515,7 @@ bool AccountList::loadV3(QJsonObject& root)
                 }
             }
             connect(account.get(), &MinecraftAccount::changed, this, &AccountList::accountChanged);
+            connect(account.get(), &MinecraftAccount::secretsChanged, this, [this, account = account.get()] { saveSecrets(*account); });
             connect(account.get(), &MinecraftAccount::activityChanged, this, &AccountList::accountActivityChanged);
             m_accounts.append(account);
             if (accountObj.value("active").toBool(false)) {
@@ -515,6 +527,68 @@ bool AccountList::loadV3(QJsonObject& root)
     }
     endResetModel();
     return true;
+}
+
+namespace {
+QString makeKeychainKey(const MinecraftAccount& account)
+{
+    return u"account:"_s + account.profileId();
+}
+
+class ReadAccountSecretsTask : public Task {
+    Q_OBJECT
+   public:
+    explicit ReadAccountSecretsTask(MinecraftAccount& account) : m_account{ &account }, m_job{ BuildConfig.LAUNCHER_APPID }
+    {
+        m_job.setAutoDelete(false);
+        m_job.setKey(makeKeychainKey(account));
+        connect(&m_job, &QKeychain::Job::finished, this, &ReadAccountSecretsTask::handleFinish);
+    }
+
+    void executeTask() override { m_job.start(); }
+
+   private:
+    MinecraftAccount* m_account;
+    QKeychain::ReadPasswordJob m_job;
+
+    void handleFinish()
+    {
+        if (m_job.error() == QKeychain::EntryNotFound) {
+            logWarning(u"Entry '%1' not found"_s.arg(m_job.key()));
+            emitSucceeded();
+            return;
+        }
+
+        if (m_job.error() != QKeychain::NoError) {
+            emitFailed(u"Could not read '%1': %2"_s.arg(m_job.key(), m_job.errorString()));
+            return;
+        }
+
+        const QByteArray secretsJson = m_job.textData().toUtf8();
+        QJsonParseError jsonErr;
+        const auto secretsObj = QJsonDocument::fromJson(secretsJson, &jsonErr).object();
+        if (jsonErr.error != QJsonParseError::NoError) {
+            emitFailed(u"Could not parse '%1': %2"_s.arg(m_job.key(), jsonErr.errorString()));
+            return;
+        }
+
+        m_account->loadSecrets(secretsObj);
+        emitSucceeded();
+    }
+};
+}  // namespace
+
+std::unique_ptr<Task> AccountList::loadSecrets()
+{
+    auto task = std::make_unique<SequentialTask>("AccountList::loadSecrets");
+
+    for (const auto& account : m_accounts) {
+        if (account->accountType() != AccountType::Offline) {
+            task->addTask(makeShared<ReadAccountSecretsTask>(*account));
+        }
+    }
+
+    return task;
 }
 
 bool AccountList::saveList()
@@ -547,7 +621,7 @@ bool AccountList::saveList()
     qDebug() << "Building account array.";
     QJsonArray accounts;
     for (const auto& account : m_accounts) {
-        const QJsonObject accountObj = account->saveState();
+        QJsonObject accountObj = account->saveState();
         if (m_defaultAccount == account) {
             accountObj["active"] = true;
         }
@@ -581,6 +655,58 @@ bool AccountList::saveList()
         qDebug() << "Failed to save accounts to" << m_listFilePath << "error:" << file.errorString();
         return false;
     }
+}
+
+void AccountList::saveSecrets(const MinecraftAccount& account)
+{
+    if (account.accountType() == AccountType::Offline) {
+        return;
+    }
+
+    qDebug() << u"Saving secrets for account" << account.profileId();
+
+    auto* job = new QKeychain::WritePasswordJob{ BuildConfig.LAUNCHER_APPID };
+    job->setAutoDelete(true);
+    job->setKey(makeKeychainKey(account));
+
+    const QJsonObject secretsObj = account.saveSecrets();
+    const auto secretsJson = QString::fromUtf8(QJsonDocument{ secretsObj }.toJson(QJsonDocument::Compact));
+    job->setTextData(secretsJson);
+
+    connect(job, &QKeychain::Job::finished, this, [this, job, profileId = account.profileId(), profileName = account.profileName()] {
+        if (job->error() != QKeychain::NoError) {
+            qWarning() << u"Failed to save secrets for account" << profileId;
+            emit saveSecretsFailed(profileName, job->errorString());
+        } else {
+            qDebug() << u"Saved secrets for account" << profileId;
+        }
+    });
+
+    job->start();
+}
+
+void AccountList::deleteSecrets(const MinecraftAccount& account)
+{
+    if (account.accountType() == AccountType::Offline) {
+        return;
+    }
+
+    qDebug() << u"Deleting secrets for account" << account.profileId();
+
+    auto* job = new QKeychain::DeletePasswordJob{ BuildConfig.LAUNCHER_APPID };
+    job->setAutoDelete(true);
+    job->setKey(makeKeychainKey(account));
+
+    connect(job, &QKeychain::Job::finished, this, [this, job, profileId = account.profileId(), profileName = account.profileName()] {
+        if (job->error() != QKeychain::NoError) {
+            qWarning() << u"Failed to delete secrets for account" << profileId;
+            emit deleteSecretsFailed(profileName, job->errorString());
+        } else {
+            qDebug() << u"Deleted secrets for account" << profileId;
+        }
+    });
+
+    job->start();
 }
 
 void AccountList::setListFilePath(QString path, bool autosave)
@@ -655,8 +781,8 @@ void AccountList::tryNext()
                 found = true;
                 if (!account->shouldRefresh()) {
                     // Account no longer needs refreshing, skip it.
-                    qDebug() << "RefreshSchedule: Skipping account" << account->profileName() << "with internal ID"
-                             << accountId << "(no longer needs refresh)";
+                    qDebug() << "RefreshSchedule: Skipping account" << account->profileName() << "with internal ID" << accountId
+                             << "(no longer needs refresh)";
                     break;
                 }
                 m_currentTask = account->refresh();
@@ -664,8 +790,7 @@ void AccountList::tryNext()
                     connect(m_currentTask.get(), &Task::succeeded, this, &AccountList::authSucceeded);
                     connect(m_currentTask.get(), &Task::failed, this, &AccountList::authFailed);
                     m_currentTask->start();
-                    qDebug() << "RefreshSchedule: Processing account" << account->profileName() << "with internal ID"
-                             << accountId;
+                    qDebug() << "RefreshSchedule: Processing account" << account->profileName() << "with internal ID" << accountId;
                     return;
                 }
                 break;
@@ -719,3 +844,5 @@ void AccountList::endActivity()
         emit activityChanged(false);
     }
 }
+
+#include "AccountList.moc"

--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -541,6 +541,7 @@ class ReadAccountSecretsTask : public Task {
     explicit ReadAccountSecretsTask(MinecraftAccount& account) : m_account{ &account }, m_job{ BuildConfig.LAUNCHER_APPID }
     {
         m_job.setAutoDelete(false);
+        m_job.setInsecureFallback(true);
         m_job.setKey(makeKeychainKey(account));
         connect(&m_job, &QKeychain::Job::finished, this, &ReadAccountSecretsTask::handleFinish);
     }
@@ -667,6 +668,7 @@ void AccountList::saveSecrets(const MinecraftAccount& account)
 
     auto* job = new QKeychain::WritePasswordJob{ BuildConfig.LAUNCHER_APPID };
     job->setAutoDelete(true);
+    job->setInsecureFallback(true);
     job->setKey(makeKeychainKey(account));
 
     const QJsonObject secretsObj = account.saveSecrets();
@@ -695,6 +697,7 @@ void AccountList::deleteSecrets(const MinecraftAccount& account)
 
     auto* job = new QKeychain::DeletePasswordJob{ BuildConfig.LAUNCHER_APPID };
     job->setAutoDelete(true);
+    job->setInsecureFallback(true);
     job->setKey(makeKeychainKey(account));
 
     connect(job, &QKeychain::Job::finished, this, [this, job, profileId = account.profileId(), profileName = account.profileName()] {

--- a/launcher/minecraft/auth/AccountList.h
+++ b/launcher/minecraft/auth/AccountList.h
@@ -97,8 +97,12 @@ class AccountList : public QAbstractListModel {
     void setListFilePath(QString path, bool autosave = false);
 
     bool loadList();
-    bool loadV3(QJsonObject& root);
+    bool loadListV3(QJsonObject& root);
+    std::unique_ptr<Task> loadSecrets();
+
     bool saveList();
+    void saveSecrets(const MinecraftAccount& account);
+    void deleteSecrets(const MinecraftAccount& account);
 
     MinecraftAccountPtr defaultAccount() const;
     void setDefaultAccount(MinecraftAccountPtr profileId);
@@ -117,6 +121,9 @@ class AccountList : public QAbstractListModel {
     void listActivityChanged();
     void defaultAccountChanged();
     void activityChanged(bool active);
+
+    void saveSecretsFailed(const QString& profileName, const QString& error);
+    void deleteSecretsFailed(const QString& profileName, const QString& error);
 
    public slots:
     /**
@@ -141,6 +148,8 @@ class AccountList : public QAbstractListModel {
     void authFailed(QString reason);
 
    protected:
+    std::unique_ptr<Task> m_saveSecretsTask;
+
     QList<QString> m_refreshQueue;
     QTimer* m_refreshTimer;
     QTimer* m_nextTimer;

--- a/launcher/minecraft/auth/MinecraftAccount.cpp
+++ b/launcher/minecraft/auth/MinecraftAccount.cpp
@@ -160,6 +160,7 @@ void MinecraftAccount::authSucceeded()
 {
     m_currentTask.reset();
     emit changed();
+    emit secretsChanged();
     emit activityChanged(false);
 }
 
@@ -185,10 +186,12 @@ void MinecraftAccount::authFailed(QString reason)
                 data.validity_ = Validity::None;
             }
             emit changed();
+            emit secretsChanged();
         } break;
         case AccountTaskState::STATE_FAILED_GONE: {
             data.validity_ = Validity::None;
             emit changed();
+            emit secretsChanged();
         } break;
         case AccountTaskState::STATE_WORKING: {
             data.accountState = AccountState::Unchecked;

--- a/launcher/minecraft/auth/MinecraftAccount.cpp
+++ b/launcher/minecraft/auth/MinecraftAccount.cpp
@@ -61,7 +61,8 @@ MinecraftAccount::MinecraftAccount(QObject* parent) : QObject(parent)
 MinecraftAccountPtr MinecraftAccount::loadFromJsonV3(const QJsonObject& json)
 {
     MinecraftAccountPtr account(new MinecraftAccount());
-    if (account->data.resumeStateFromV3(json)) {
+    if (account->data.loadStateV3(json)) {
+        account->data.loadSecrets(json);
         return account;
     }
     return nullptr;
@@ -89,9 +90,19 @@ MinecraftAccountPtr MinecraftAccount::createOffline(const QString& username)
     return account;
 }
 
-QJsonObject MinecraftAccount::saveToJson() const
+QJsonObject MinecraftAccount::saveState() const
 {
     return data.saveState();
+}
+
+QJsonObject MinecraftAccount::saveSecrets() const
+{
+    return data.saveSecrets();
+}
+
+void MinecraftAccount::loadSecrets(const QJsonObject& input)
+{
+    data.loadSecrets(input);
 }
 
 AccountState MinecraftAccount::accountState() const
@@ -193,7 +204,8 @@ void MinecraftAccount::authFailed(QString reason)
 
 QString MinecraftAccount::displayName() const
 {
-    if (const QList validStates{ AccountState::Unchecked, AccountState::Working, AccountState::Offline, AccountState::Online }; !validStates.contains(accountState())) {
+    if (const QList validStates{ AccountState::Unchecked, AccountState::Working, AccountState::Offline, AccountState::Online };
+        !validStates.contains(accountState())) {
         return QString("⚠ %1").arg(profileName());
     }
     return profileName();

--- a/launcher/minecraft/auth/MinecraftAccount.h
+++ b/launcher/minecraft/auth/MinecraftAccount.h
@@ -158,6 +158,8 @@ class MinecraftAccount : public QObject, public Usable {
      */
     void changed();
 
+    void secretsChanged();
+
     void activityChanged(bool active);
 
     // TODO: better signalling for the various possible state changes - especially errors

--- a/launcher/minecraft/auth/MinecraftAccount.h
+++ b/launcher/minecraft/auth/MinecraftAccount.h
@@ -92,7 +92,11 @@ class MinecraftAccount : public QObject, public Usable {
     static QUuid uuidFromUsername(QString username);
 
     //! Saves a MinecraftAccount to a JSON object and returns it.
-    QJsonObject saveToJson() const;
+    QJsonObject saveState() const;
+
+    QJsonObject saveSecrets() const;
+
+    void loadSecrets(const QJsonObject& input);
 
    public: /* manipulation */
     shared_qobject_ptr<AuthFlow> login(bool useDeviceCode = false);


### PR DESCRIPTION
Attempt 2, this time I'm correctly saving the credentials per-account rather than just stuffing the whole accounts.json in there

Honestly, so far with my testing on Windows (which most malware targets) I'm not convinced this makes a big difference in terms of security as there doesn't seem to be much stopping mods from reading credentials from the credential manager (and I haven't seen any launcher that seems able to successfully prevent this). At least on Linux you can set the wallet to automatically close after some time (at least with KDE), and I need to investigate macos.

fix #4073