### PR TITLE
ListViewDelegate: set data *before* emitting signals

### DIFF
--- a/launcher/ui/instanceview/InstanceDelegate.cpp
+++ b/launcher/ui/instanceview/InstanceDelegate.cpp
@@ -397,8 +397,9 @@ void ListViewDelegate::setModelData(QWidget* editor, QAbstractItemModel* model, 
     // Prevent instance names longer than 128 chars
     text.truncate(128);
     if (text.size() != 0) {
-        emit textChanged(model->data(index).toString(), text);
+        const auto before = model->data(index).toString();
         model->setData(index, text);
+        emit textChanged(before, text);
     }
 }
 


### PR DESCRIPTION
Closes #5813 

Conditions to replicate the original issue:
- You must accept the dialogs to rename the instance folder or have enabled `Always rename the folder`
- Instance sorting must be set to `By last launched`. I'm not sure why

`ListViewDelegate::textChanged` is connected to this lambda here:
https://github.com/PrismLauncher/PrismLauncher/blob/7174c26a90662fdedf736b7457b13a1a25f81f4e/launcher/ui/MainWindow.cpp#L304-L319

It's not an innocent lambda, as it renames the instance folder and reloads the instance list, causing all instances to be re-discovered. Since renaming the instance folder can change its position in the list, by the time we update the data, the index that we had can now be pointing at some other instance.