### PR TITLE
Avoid excessive config writes (less freezing especially on HDD!)

### DIFF
--- a/launcher/settings/INISettingsObject.cpp
+++ b/launcher/settings/INISettingsObject.cpp
@@ -56,11 +56,13 @@ bool INISettingsObject::reload()
 
 void INISettingsObject::suspendSave()
 {
+    Q_ASSERT(!m_suspendSave);
     m_suspendSave = true;
 }
 
 void INISettingsObject::resumeSave()
 {
+    Q_ASSERT(m_suspendSave);
     m_suspendSave = false;
     if (m_doSave) {
         m_ini.saveFile(m_filePath);

--- a/launcher/ui/pages/instance/InstanceSettingsPage.h
+++ b/launcher/ui/pages/instance/InstanceSettingsPage.h
@@ -46,7 +46,7 @@ class InstanceSettingsPage : public MinecraftSettingsWidget, public BasePage {
    public:
     explicit InstanceSettingsPage(MinecraftInstance* instance, QWidget* parent = nullptr) : MinecraftSettingsWidget(instance, parent)
     {
-        connect(APPLICATION, &Application::globalSettingsAboutToOpen, this, &InstanceSettingsPage::saveSettings);
+        connect(APPLICATION, &Application::globalSettingsAboutToOpen, this, &InstanceSettingsPage::apply);
         connect(APPLICATION, &Application::globalSettingsApplied, this, &InstanceSettingsPage::loadSettings);
     }
     ~InstanceSettingsPage() override {}
@@ -55,6 +55,7 @@ class InstanceSettingsPage : public MinecraftSettingsWidget, public BasePage {
     QString id() const override { return "settings"; }
     bool apply() override
     {
+        SettingsObject::Lock lock(m_instance->settings());
         saveSettings();
         return true;
     }

--- a/launcher/ui/widgets/JavaSettingsWidget.cpp
+++ b/launcher/ui/widgets/JavaSettingsWidget.cpp
@@ -167,8 +167,6 @@ void JavaSettingsWidget::saveSettings()
     else
         settings = APPLICATION->settings();
 
-    SettingsObject::Lock lock(settings);
-
     // Java Install Settings
     bool javaInstall = m_instance == nullptr || m_ui->javaInstallationGroupBox->isChecked();
 

--- a/launcher/ui/widgets/MinecraftSettingsWidget.cpp
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.cpp
@@ -317,179 +317,175 @@ void MinecraftSettingsWidget::saveSettings()
     else
         settings = APPLICATION->settings();
 
-    {
-        SettingsObject::Lock lock(settings);
+    // Console
+    bool console = m_instance == nullptr || m_ui->consoleSettingsBox->isChecked();
 
-        // Console
-        bool console = m_instance == nullptr || m_ui->consoleSettingsBox->isChecked();
+    if (m_instance != nullptr)
+        settings->set("OverrideConsole", console);
 
-        if (m_instance != nullptr)
-            settings->set("OverrideConsole", console);
+    if (console) {
+        settings->set("ShowConsole", m_ui->showConsoleCheck->isChecked());
+        settings->set("AutoCloseConsole", m_ui->autoCloseConsoleCheck->isChecked());
+        settings->set("ShowConsoleOnError", m_ui->showConsoleErrorCheck->isChecked());
+    } else {
+        settings->reset("ShowConsole");
+        settings->reset("AutoCloseConsole");
+        settings->reset("ShowConsoleOnError");
+    }
 
-        if (console) {
-            settings->set("ShowConsole", m_ui->showConsoleCheck->isChecked());
-            settings->set("AutoCloseConsole", m_ui->autoCloseConsoleCheck->isChecked());
-            settings->set("ShowConsoleOnError", m_ui->showConsoleErrorCheck->isChecked());
-        } else {
-            settings->reset("ShowConsole");
-            settings->reset("AutoCloseConsole");
-            settings->reset("ShowConsoleOnError");
-        }
+    // Game Window
+    bool window = m_instance == nullptr || m_ui->windowSizeGroupBox->isChecked();
 
-        // Game Window
-        bool window = m_instance == nullptr || m_ui->windowSizeGroupBox->isChecked();
+    if (m_instance != nullptr) {
+        settings->set("OverrideWindow", window);
+        settings->set("OverrideMiscellaneous", window);
+    }
 
-        if (m_instance != nullptr) {
-            settings->set("OverrideWindow", window);
-            settings->set("OverrideMiscellaneous", window);
-        }
+    if (window) {
+        settings->set("LaunchMaximized", m_ui->maximizedCheckBox->isChecked());
+        settings->set("MinecraftWinWidth", m_ui->windowWidthSpinBox->value());
+        settings->set("MinecraftWinHeight", m_ui->windowHeightSpinBox->value());
+        settings->set("CloseAfterLaunch", m_ui->closeAfterLaunchCheck->isChecked());
+        settings->set("QuitAfterGameStop", m_ui->quitAfterGameStopCheck->isChecked());
+    } else {
+        settings->reset("LaunchMaximized");
+        settings->reset("MinecraftWinWidth");
+        settings->reset("MinecraftWinHeight");
+        settings->reset("CloseAfterLaunch");
+        settings->reset("QuitAfterGameStop");
+    }
 
-        if (window) {
-            settings->set("LaunchMaximized", m_ui->maximizedCheckBox->isChecked());
-            settings->set("MinecraftWinWidth", m_ui->windowWidthSpinBox->value());
-            settings->set("MinecraftWinHeight", m_ui->windowHeightSpinBox->value());
-            settings->set("CloseAfterLaunch", m_ui->closeAfterLaunchCheck->isChecked());
-            settings->set("QuitAfterGameStop", m_ui->quitAfterGameStopCheck->isChecked());
-        } else {
-            settings->reset("LaunchMaximized");
-            settings->reset("MinecraftWinWidth");
-            settings->reset("MinecraftWinHeight");
-            settings->reset("CloseAfterLaunch");
-            settings->reset("QuitAfterGameStop");
-        }
+    // Custom Commands
+    bool custcmd = m_instance == nullptr || m_ui->customCommands->checked();
 
-        // Custom Commands
-        bool custcmd = m_instance == nullptr || m_ui->customCommands->checked();
+    if (m_instance != nullptr)
+        settings->set("OverrideCommands", custcmd);
 
-        if (m_instance != nullptr)
-            settings->set("OverrideCommands", custcmd);
+    if (custcmd) {
+        settings->set("PreLaunchCommand", m_ui->customCommands->prelaunchCommand());
+        settings->set("WrapperCommand", m_ui->customCommands->wrapperCommand());
+        settings->set("PostExitCommand", m_ui->customCommands->postexitCommand());
+    } else {
+        settings->reset("PreLaunchCommand");
+        settings->reset("WrapperCommand");
+        settings->reset("PostExitCommand");
+    }
 
-        if (custcmd) {
-            settings->set("PreLaunchCommand", m_ui->customCommands->prelaunchCommand());
-            settings->set("WrapperCommand", m_ui->customCommands->wrapperCommand());
-            settings->set("PostExitCommand", m_ui->customCommands->postexitCommand());
-        } else {
-            settings->reset("PreLaunchCommand");
-            settings->reset("WrapperCommand");
-            settings->reset("PostExitCommand");
-        }
+    // Environment Variables
+    auto env = m_instance == nullptr || m_ui->environmentVariables->override();
 
-        // Environment Variables
-        auto env = m_instance == nullptr || m_ui->environmentVariables->override();
+    if (m_instance != nullptr)
+        settings->set("OverrideEnv", env);
 
-        if (m_instance != nullptr)
-            settings->set("OverrideEnv", env);
+    if (env)
+        settings->set("Env", Json::fromMap(m_ui->environmentVariables->value()));
+    else
+        settings->reset("Env");
 
-        if (env)
-            settings->set("Env", Json::fromMap(m_ui->environmentVariables->value()));
-        else
-            settings->reset("Env");
+    // Workarounds
+    bool workarounds = m_instance == nullptr || m_ui->nativeWorkaroundsGroupBox->isChecked();
 
-        // Workarounds
-        bool workarounds = m_instance == nullptr || m_ui->nativeWorkaroundsGroupBox->isChecked();
+    if (m_instance != nullptr)
+        settings->set("OverrideNativeWorkarounds", workarounds);
 
-        if (m_instance != nullptr)
-            settings->set("OverrideNativeWorkarounds", workarounds);
+    if (workarounds) {
+        settings->set("UseNativeGLFW", m_ui->useNativeGLFWCheck->isChecked());
+        settings->set("CustomGLFWPath", m_ui->lineEditGLFWPath->text());
+        settings->set("UseNativeOpenAL", m_ui->useNativeOpenALCheck->isChecked());
+        settings->set("CustomOpenALPath", m_ui->lineEditOpenALPath->text());
+    } else {
+        settings->reset("UseNativeGLFW");
+        settings->reset("CustomGLFWPath");
+        settings->reset("UseNativeOpenAL");
+        settings->reset("CustomOpenALPath");
+    }
 
-        if (workarounds) {
-            settings->set("UseNativeGLFW", m_ui->useNativeGLFWCheck->isChecked());
-            settings->set("CustomGLFWPath", m_ui->lineEditGLFWPath->text());
-            settings->set("UseNativeOpenAL", m_ui->useNativeOpenALCheck->isChecked());
-            settings->set("CustomOpenALPath", m_ui->lineEditOpenALPath->text());
-        } else {
-            settings->reset("UseNativeGLFW");
-            settings->reset("CustomGLFWPath");
-            settings->reset("UseNativeOpenAL");
-            settings->reset("CustomOpenALPath");
-        }
+    // Performance
+    bool performance = m_instance == nullptr || m_ui->perfomanceGroupBox->isChecked();
 
-        // Performance
-        bool performance = m_instance == nullptr || m_ui->perfomanceGroupBox->isChecked();
+    if (m_instance != nullptr)
+        settings->set("OverridePerformance", performance);
 
-        if (m_instance != nullptr)
-            settings->set("OverridePerformance", performance);
+    if (performance) {
+        settings->set("EnableFeralGamemode", m_ui->enableFeralGamemodeCheck->isChecked());
+        settings->set("EnableMangoHud", m_ui->enableMangoHud->isChecked());
+        settings->set("UseDiscreteGpu", m_ui->useDiscreteGpuCheck->isChecked());
+        settings->set("UseZink", m_ui->useZink->isChecked());
+    } else {
+        settings->reset("EnableFeralGamemode");
+        settings->reset("EnableMangoHud");
+        settings->reset("UseDiscreteGpu");
+        settings->reset("UseZink");
+    }
 
-        if (performance) {
-            settings->set("EnableFeralGamemode", m_ui->enableFeralGamemodeCheck->isChecked());
-            settings->set("EnableMangoHud", m_ui->enableMangoHud->isChecked());
-            settings->set("UseDiscreteGpu", m_ui->useDiscreteGpuCheck->isChecked());
-            settings->set("UseZink", m_ui->useZink->isChecked());
-        } else {
-            settings->reset("EnableFeralGamemode");
-            settings->reset("EnableMangoHud");
-            settings->reset("UseDiscreteGpu");
-            settings->reset("UseZink");
-        }
+    // Game time
+    bool gameTime = m_instance == nullptr || m_ui->gameTimeGroupBox->isChecked();
 
-        // Game time
-        bool gameTime = m_instance == nullptr || m_ui->gameTimeGroupBox->isChecked();
-
-        if (m_instance != nullptr) {
-            settings->set("OverrideGameTime", gameTime);
-
-            if (gameTime) {
-                settings->set("CountGameTime", m_ui->countGameTime->isChecked());
-            } else {
-                settings->reset("CountGameTime");
-            }
-        }
+    if (m_instance != nullptr) {
+        settings->set("OverrideGameTime", gameTime);
 
         if (gameTime) {
-            settings->set("ShowGameTime", m_ui->showGameTime->isChecked());
-            settings->set("RecordGameTime", m_ui->recordGameTime->isChecked());
+            settings->set("CountGameTime", m_ui->countGameTime->isChecked());
         } else {
-            settings->reset("ShowGameTime");
-            settings->reset("RecordGameTime");
+            settings->reset("CountGameTime");
         }
+    }
 
-        if (m_instance == nullptr) {
-            settings->set("ShowGlobalGameTime", m_ui->showGlobalGameTime->isChecked());
-            settings->set("ShowGameTimeWithoutDays", m_ui->showGameTimeWithoutDays->isChecked());
-        }
+    if (gameTime) {
+        settings->set("ShowGameTime", m_ui->showGameTime->isChecked());
+        settings->set("RecordGameTime", m_ui->recordGameTime->isChecked());
+    } else {
+        settings->reset("ShowGameTime");
+        settings->reset("RecordGameTime");
+    }
 
-        if (m_instance != nullptr) {
-            // Join server on launch
-            bool joinServerOnLaunch = m_ui->serverJoinGroupBox->isChecked();
-            settings->set("JoinServerOnLaunch", joinServerOnLaunch);
-            if (joinServerOnLaunch) {
-                if (m_ui->serverJoinAddressButton->isChecked() || !m_quickPlaySingleplayer) {
-                    settings->set("JoinServerOnLaunchAddress", m_ui->serverJoinAddress->text());
-                    settings->reset("JoinWorldOnLaunch");
-                } else {
-                    settings->set("JoinWorldOnLaunch", m_ui->worldsCb->currentText());
-                    settings->reset("JoinServerOnLaunchAddress");
-                }
-            } else {
-                settings->reset("JoinServerOnLaunchAddress");
+    if (m_instance == nullptr) {
+        settings->set("ShowGlobalGameTime", m_ui->showGlobalGameTime->isChecked());
+        settings->set("ShowGameTimeWithoutDays", m_ui->showGameTimeWithoutDays->isChecked());
+    }
+
+    if (m_instance != nullptr) {
+        // Join server on launch
+        bool joinServerOnLaunch = m_ui->serverJoinGroupBox->isChecked();
+        settings->set("JoinServerOnLaunch", joinServerOnLaunch);
+        if (joinServerOnLaunch) {
+            if (m_ui->serverJoinAddressButton->isChecked() || !m_quickPlaySingleplayer) {
+                settings->set("JoinServerOnLaunchAddress", m_ui->serverJoinAddress->text());
                 settings->reset("JoinWorldOnLaunch");
-            }
-
-            // Use an account for this instance
-            bool useAccountForInstance = m_ui->instanceAccountGroupBox->isChecked();
-            settings->set("UseAccountForInstance", useAccountForInstance);
-            if (useAccountForInstance) {
-                int accountIndex = m_ui->instanceAccountSelector->currentIndex();
-
-                if (accountIndex != -1) {
-                    const MinecraftAccountPtr account = APPLICATION->accounts()->at(accountIndex);
-                    if (account != nullptr)
-                        settings->set("InstanceAccountId", account->profileId());
-                }
             } else {
-                settings->reset("InstanceAccountId");
+                settings->set("JoinWorldOnLaunch", m_ui->worldsCb->currentText());
+                settings->reset("JoinServerOnLaunchAddress");
             }
-        }
-
-        bool overrideLegacySettings = m_instance == nullptr || m_ui->legacySettingsGroupBox->isChecked();
-
-        if (m_instance != nullptr)
-            settings->set("OverrideLegacySettings", overrideLegacySettings);
-
-        if (overrideLegacySettings) {
-            settings->set("OnlineFixes", m_ui->onlineFixes->isChecked());
         } else {
-            settings->reset("OnlineFixes");
+            settings->reset("JoinServerOnLaunchAddress");
+            settings->reset("JoinWorldOnLaunch");
         }
+
+        // Use an account for this instance
+        bool useAccountForInstance = m_ui->instanceAccountGroupBox->isChecked();
+        settings->set("UseAccountForInstance", useAccountForInstance);
+        if (useAccountForInstance) {
+            int accountIndex = m_ui->instanceAccountSelector->currentIndex();
+
+            if (accountIndex != -1) {
+                const MinecraftAccountPtr account = APPLICATION->accounts()->at(accountIndex);
+                if (account != nullptr)
+                    settings->set("InstanceAccountId", account->profileId());
+            }
+        } else {
+            settings->reset("InstanceAccountId");
+        }
+    }
+
+    bool overrideLegacySettings = m_instance == nullptr || m_ui->legacySettingsGroupBox->isChecked();
+
+    if (m_instance != nullptr)
+        settings->set("OverrideLegacySettings", overrideLegacySettings);
+
+    if (overrideLegacySettings) {
+        settings->set("OnlineFixes", m_ui->onlineFixes->isChecked());
+    } else {
+        settings->reset("OnlineFixes");
     }
 
     if (m_javaSettings != nullptr)

--- a/launcher/ui/widgets/MinecraftSettingsWidget.h
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.h
@@ -61,7 +61,10 @@ class MinecraftSettingsWidget : public QWidget {
     void saveDataPacksPath();
     void selectDataPacksFolder();
 
+   protected:
     MinecraftInstance* m_instance;
+
+   public:
     Ui::MinecraftSettingsWidget* m_ui;
     JavaSettingsWidget* m_javaSettings = nullptr;
     bool m_quickPlaySingleplayer = false;


### PR DESCRIPTION
Since `Application::ShowGlobalSettings` locks, and so does `MinecraftSettingsWidget::saveSettings`, `suspendSave` is called multiple times, and `resumeSave` is called early
It ain't pretty

We still want the lock to apply to apply to instance settings (to avoid the file being saved a bajillion times), so I just added it to InstanceSettingsWidget...

Edit: from my testing on HDD it also causes noticeable extra freezing and disk activity upon closing settings
Edit: even on SSD, I don't know how I never noticed that I'd introduced a decent freeze when closing settings since 10.0.0