### PR TITLE
Cache resource hard link count

### DIFF
--- a/launcher/minecraft/mod/Resource.cpp
+++ b/launcher/minecraft/mod/Resource.cpp
@@ -50,6 +50,7 @@ void Resource::parseFile()
     m_internal_id = fileName;
 
     std::tie(m_size_str, m_size_info) = calculateFileSize(m_file_info);
+    m_hardLinkCount = FS::hardLinkCount(m_file_info.absoluteFilePath());
     if (m_file_info.isDir()) {
         m_type = ResourceType::FOLDER;
         m_name = fileName;
@@ -321,7 +322,7 @@ bool Resource::isSymLinkUnder(const QString& instPath) const
 
 bool Resource::isMoreThanOneHardLink() const
 {
-    return FS::hardLinkCount(m_file_info.absoluteFilePath()) > 1;
+    return m_hardLinkCount > 1;
 }
 
 auto Resource::getOriginalFileName() const -> QString

--- a/launcher/minecraft/mod/Resource.h
+++ b/launcher/minecraft/mod/Resource.h
@@ -35,6 +35,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include <QDateTime>
 #include <QFileInfo>
 #include <QObject>
@@ -210,4 +212,5 @@ class Resource : public QObject {
     int m_resolution_ticket = 0;
     QString m_size_str;
     qint64 m_size_info;
+    std::uintmax_t m_hardLinkCount = 0;
 };


### PR DESCRIPTION
~~Memoise~~ Cache once and remember forever the hard link count :trollface:
Whatever that is, it seems to be causing a lot of filesystem queries
Should fix #5747 (I noticed in [Process Monitor](https://learn.microsoft.com/en-us/sysinternals/downloads/procmon) a lot of `QueryStandardInformationFile` going on without this patch)