### PR TITLE
Add Developing Mod auto-sync for build output JARs

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -331,6 +331,8 @@ set(MINECRAFT_SOURCES
     minecraft/mod/ModDetails.h
     minecraft/mod/ModFolderModel.h
     minecraft/mod/ModFolderModel.cpp
+    minecraft/mod/DevelopingModWatcher.h
+    minecraft/mod/DevelopingModWatcher.cpp
     minecraft/mod/Resource.h
     minecraft/mod/Resource.cpp
     minecraft/mod/ResourceFolderModel.h
@@ -922,6 +924,8 @@ SET(LAUNCHER_SOURCES
     ui/pages/instance/ShaderPackPage.cpp
     ui/pages/instance/ModFolderPage.cpp
     ui/pages/instance/ModFolderPage.h
+    ui/pages/instance/DevelopingModPage.cpp
+    ui/pages/instance/DevelopingModPage.h
     ui/pages/instance/NotesPage.cpp
     ui/pages/instance/NotesPage.h
     ui/pages/instance/LogPage.cpp

--- a/launcher/InstancePageProvider.h
+++ b/launcher/InstancePageProvider.h
@@ -8,6 +8,7 @@
 #include "ui/pages/instance/LogPage.h"
 #include "ui/pages/instance/ManagedPackPage.h"
 #include "ui/pages/instance/ModFolderPage.h"
+#include "ui/pages/instance/DevelopingModPage.h"
 #include "ui/pages/instance/NotesPage.h"
 #include "ui/pages/instance/OtherLogsPage.h"
 #include "ui/pages/instance/ResourcePackPage.h"
@@ -36,6 +37,7 @@ class InstancePageProvider : protected QObject, public BasePageProvider {
         values.append(modsPage);
         values.append(new CoreModFolderPage(onesix, onesix->coreModList()));
         values.append(new NilModFolderPage(onesix, onesix->nilModList()));
+        values.append(new DevelopingModPage(onesix));
         values.append(new ResourcePackPage(onesix, onesix->resourcePackList()));
         values.append(new GlobalDataPackPage(onesix));
         values.append(new TexturePackPage(onesix, onesix->texturePackList()));

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -268,9 +268,10 @@ void MinecraftInstance::loadSpecificSettings()
     m_settings->registerSetting("OverrideModDownloadLoaders", false);
     m_settings->registerSetting("ModDownloadLoaders", "[]");
 
-    // Developing Mod — watch build output folders and sync JARs into mods/
+    // Developing Mod — watch build output folders/JARs and sync into mods/
     m_settings->registerSetting("DevelopingModEnabled", false);
     m_settings->registerSetting("DevelopingModFolders", "[]");
+    m_settings->registerSetting("DevelopingModJars", "[]");
     m_settings->registerSetting("DevelopingModIgnorePatterns",
                                 "*-sources.jar\n*-javadoc.jar\n*-dev.jar\n*-api.jar\n*-thin.jar");
     m_settings->registerSetting("DevelopingModManagedFiles", "[]");

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -79,6 +79,7 @@
 #include "icons/IconList.h"
 
 #include "mod/ModFolderModel.h"
+#include "mod/DevelopingModWatcher.h"
 #include "mod/ResourcePackFolderModel.h"
 #include "mod/ShaderPackFolderModel.h"
 #include "mod/TexturePackFolderModel.h"
@@ -267,11 +268,21 @@ void MinecraftInstance::loadSpecificSettings()
     m_settings->registerSetting("OverrideModDownloadLoaders", false);
     m_settings->registerSetting("ModDownloadLoaders", "[]");
 
+    // Developing Mod — watch build output folders and sync JARs into mods/
+    m_settings->registerSetting("DevelopingModEnabled", false);
+    m_settings->registerSetting("DevelopingModFolders", "[]");
+    m_settings->registerSetting("DevelopingModIgnorePatterns",
+                                "*-sources.jar\n*-javadoc.jar\n*-dev.jar\n*-api.jar\n*-thin.jar");
+    m_settings->registerSetting("DevelopingModManagedFiles", "[]");
+
     qDebug() << "Instance-type specific settings were loaded!";
 
     setSpecificSettingsLoaded(true);
 
     updateRuntimeContext();
+
+    // Start watching after settings are available (no-op when disabled).
+    developingModWatcher();
 }
 
 void MinecraftInstance::updateRuntimeContext()
@@ -1260,6 +1271,13 @@ ModFolderModel* MinecraftInstance::loaderModList()
         m_loader_mod_list.reset(new ModFolderModel(modsRoot(), this, is_indexed, true));
     }
     return m_loader_mod_list.get();
+}
+
+DevelopingModWatcher* MinecraftInstance::developingModWatcher()
+{
+    if (!m_developing_mod_watcher)
+        m_developing_mod_watcher = std::make_unique<DevelopingModWatcher>(this);
+    return m_developing_mod_watcher.get();
 }
 
 ModFolderModel* MinecraftInstance::coreModList()

--- a/launcher/minecraft/MinecraftInstance.h
+++ b/launcher/minecraft/MinecraftInstance.h
@@ -48,6 +48,7 @@ class ResourceFolderModel;
 class ResourcePackFolderModel;
 class ShaderPackFolderModel;
 class TexturePackFolderModel;
+class DevelopingModWatcher;
 class WorldList;
 class LaunchStep;
 class LaunchProfile;
@@ -122,6 +123,9 @@ class MinecraftInstance : public BaseInstance {
     QList<ResourceFolderModel*> resourceLists();
     WorldList* worldList();
 
+    /** Watches build output folders and syncs JARs into mods/. */
+    DevelopingModWatcher* developingModWatcher();
+
     //////  Launch stuff //////
     QList<Task::Ptr> createUpdateTask() override;
     LaunchTask* createLaunchTask(AuthSessionPtr account, MinecraftTarget::Ptr targetToJoin) override;
@@ -171,4 +175,5 @@ class MinecraftInstance : public BaseInstance {
     std::unique_ptr<TexturePackFolderModel> m_texture_pack_list;
     std::unique_ptr<DataPackFolderModel> m_data_pack_list;
     std::unique_ptr<WorldList> m_world_list;
+    std::unique_ptr<DevelopingModWatcher> m_developing_mod_watcher;
 };

--- a/launcher/minecraft/launch/ScanModFolders.cpp
+++ b/launcher/minecraft/launch/ScanModFolders.cpp
@@ -38,11 +38,16 @@
 #include "MMCZip.h"
 #include "launch/LaunchTask.h"
 #include "minecraft/MinecraftInstance.h"
+#include "minecraft/mod/DevelopingModWatcher.h"
 #include "minecraft/mod/ModFolderModel.h"
 
 void ScanModFolders::executeTask()
 {
     auto m_inst = m_parent->instance();
+
+    // Ensure developing mods are up to date before scanning/launching.
+    if (auto* watcher = m_inst->developingModWatcher())
+        watcher->syncNow();
 
     auto loaders = m_inst->loaderModList();
     connect(loaders, &ModFolderModel::updateFinished, this, &ScanModFolders::modsDone, Qt::SingleShotConnection);

--- a/launcher/minecraft/mod/DevelopingModWatcher.cpp
+++ b/launcher/minecraft/mod/DevelopingModWatcher.cpp
@@ -66,6 +66,7 @@ DevelopingModWatcher::DevelopingModWatcher(MinecraftInstance* instance) : QObjec
     };
     reconnect(settings->getSetting("DevelopingModEnabled"));
     reconnect(settings->getSetting("DevelopingModFolders"));
+    reconnect(settings->getSetting("DevelopingModJars"));
     reconnect(settings->getSetting("DevelopingModIgnorePatterns"));
 
     reloadFromSettings();
@@ -109,11 +110,17 @@ void DevelopingModWatcher::writeStringListSetting(const QString& key, const QStr
     m_instance->settings()->set(key, QString::fromUtf8(QJsonDocument(array).toJson(QJsonDocument::Compact)));
 }
 
+bool DevelopingModWatcher::hasWatchTargets() const
+{
+    return !m_folders.isEmpty() || !m_jars.isEmpty();
+}
+
 void DevelopingModWatcher::reloadFromSettings()
 {
     auto* settings = m_instance->settings();
     m_enabled = settings->get("DevelopingModEnabled").toBool();
     m_folders = readStringListSetting("DevelopingModFolders");
+    m_jars = readStringListSetting("DevelopingModJars");
     m_managedFiles = readStringListSetting("DevelopingModManagedFiles");
 
     const auto ignoreRaw = settings->get("DevelopingModIgnorePatterns").toString().trimmed();
@@ -128,10 +135,16 @@ void DevelopingModWatcher::reloadFromSettings()
 
     updateWatches();
 
-    if (m_enabled && !m_folders.isEmpty()) {
+    if (m_enabled && hasWatchTargets()) {
         m_lastSeenSources = collectSourceSignatures();
         m_poll.start();
-        setStatus(tr("Auto-watching %n folder(s).", "", m_folders.size()));
+        if (!m_folders.isEmpty() && !m_jars.isEmpty()) {
+            setStatus(tr("Auto-watching %1 folder(s) and %2 jar(s).").arg(m_folders.size()).arg(m_jars.size()));
+        } else if (!m_folders.isEmpty()) {
+            setStatus(tr("Auto-watching %n folder(s).", "", m_folders.size()));
+        } else {
+            setStatus(tr("Auto-watching %n jar(s).", "", m_jars.size()));
+        }
         scheduleSync();
     } else {
         m_poll.stop();
@@ -139,7 +152,7 @@ void DevelopingModWatcher::reloadFromSettings()
         if (!m_enabled)
             setStatus(tr("Disabled."));
         else
-            setStatus(tr("Enabled, but no folders are configured."));
+            setStatus(tr("Enabled, but no folders or jars are configured."));
     }
 }
 
@@ -152,6 +165,15 @@ void DevelopingModWatcher::updateWatches()
     if (!m_enabled)
         return;
 
+    auto tryWatch = [this](const QString& path, const char* what) {
+        if (path.isEmpty())
+            return;
+        if (m_watcher.files().contains(path) || m_watcher.directories().contains(path))
+            return;
+        if (!m_watcher.addPath(path))
+            qCWarning(developingModLog) << "Failed to watch developing mod" << what << ":" << path;
+    };
+
     for (const auto& folder : m_folders) {
         QFileInfo info(folder);
         if (!info.exists() || !info.isDir()) {
@@ -159,8 +181,7 @@ void DevelopingModWatcher::updateWatches()
             continue;
         }
         const auto absolute = QDir::cleanPath(info.absoluteFilePath());
-        if (!m_watcher.addPath(absolute))
-            qCWarning(developingModLog) << "Failed to watch developing mod folder:" << absolute;
+        tryWatch(absolute, "folder");
 
         // Also watch individual JARs: some Windows/Gradle rewrite paths only notify file watches.
         QDir dir(absolute);
@@ -168,10 +189,22 @@ void DevelopingModWatcher::updateWatches()
         for (const auto& jar : jars) {
             if (shouldIgnore(jar.fileName()))
                 continue;
-            const auto jarPath = jar.absoluteFilePath();
-            if (!m_watcher.files().contains(jarPath) && !m_watcher.addPath(jarPath))
-                qCDebug(developingModLog) << "Could not watch developing mod JAR:" << jarPath;
+            tryWatch(jar.absoluteFilePath(), "folder jar");
         }
+    }
+
+    for (const auto& jar : m_jars) {
+        QFileInfo info(jar);
+        const auto absolute = QDir::cleanPath(info.absoluteFilePath());
+        if (info.exists() && info.isFile()) {
+            tryWatch(absolute, "jar");
+        } else {
+            qCWarning(developingModLog) << "Developing mod jar does not exist yet:" << jar;
+        }
+        // Watch the parent directory so atomic delete/recreate still notifies us.
+        const auto parent = QDir::cleanPath(info.absolutePath());
+        if (!parent.isEmpty())
+            tryWatch(parent, "jar parent folder");
     }
 }
 
@@ -202,24 +235,39 @@ QStringList DevelopingModWatcher::collectSourceJars() const
     QStringList jars;
     QSet<QString> seenNames;
 
+    auto appendJar = [&](const QFileInfo& entry, bool applyIgnore) {
+        if (!entry.exists() || !entry.isFile())
+            return;
+        if (applyIgnore && shouldIgnore(entry.fileName()))
+            return;
+        if (!entry.fileName().endsWith(QLatin1String(".jar"), Qt::CaseInsensitive))
+            return;
+        if (entry.size() <= 0)
+            return;
+        if (seenNames.contains(entry.fileName())) {
+            qCWarning(developingModLog) << "Duplicate developing mod JAR name, later source wins:" << entry.absoluteFilePath();
+            for (int i = jars.size() - 1; i >= 0; --i) {
+                if (QFileInfo(jars.at(i)).fileName() == entry.fileName())
+                    jars.removeAt(i);
+            }
+        }
+        seenNames.insert(entry.fileName());
+        jars << entry.absoluteFilePath();
+    };
+
     for (const auto& folder : m_folders) {
         QDir dir(folder);
         if (!dir.exists())
             continue;
 
         const auto entries = dir.entryInfoList(QStringList{ QStringLiteral("*.jar") }, QDir::Files | QDir::Readable, QDir::Name);
-        for (const auto& entry : entries) {
-            if (shouldIgnore(entry.fileName()))
-                continue;
-            if (entry.size() <= 0)
-                continue;
-            if (seenNames.contains(entry.fileName())) {
-                qCWarning(developingModLog) << "Duplicate developing mod JAR name, later folder wins:" << entry.absoluteFilePath();
-            }
-            seenNames.insert(entry.fileName());
-            jars << entry.absoluteFilePath();
-        }
+        for (const auto& entry : entries)
+            appendJar(entry, true);
     }
+
+    // Explicitly watched JARs always sync; ignore patterns do not apply to them.
+    for (const auto& jar : m_jars)
+        appendJar(QFileInfo(jar), false);
 
     return jars;
 }
@@ -275,7 +323,7 @@ void DevelopingModWatcher::fileChanged(const QString& path)
 
 void DevelopingModWatcher::pollSources()
 {
-    if (!m_enabled || m_folders.isEmpty())
+    if (!m_enabled || !hasWatchTargets())
         return;
 
     const auto current = collectSourceSignatures();

--- a/launcher/minecraft/mod/DevelopingModWatcher.cpp
+++ b/launcher/minecraft/mod/DevelopingModWatcher.cpp
@@ -1,0 +1,444 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2026 Prism Launcher Contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "DevelopingModWatcher.h"
+
+#include <QDateTime>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QLocale>
+#include <QLoggingCategory>
+#include <QRegularExpression>
+#include <QSet>
+
+#include "FileSystem.h"
+#include "minecraft/MinecraftInstance.h"
+#include "minecraft/mod/ModFolderModel.h"
+#include "settings/Setting.h"
+
+Q_LOGGING_CATEGORY(developingModLog, "launcher.developingmod")
+
+namespace {
+constexpr int kDebounceMs = 900;
+constexpr int kPollMs = 1000;
+constexpr int kWriteSettleMs = 600;
+}  // namespace
+
+QStringList DevelopingModWatcher::defaultIgnorePatterns()
+{
+    return { QStringLiteral("*-sources.jar"), QStringLiteral("*-javadoc.jar"), QStringLiteral("*-dev.jar"),
+             QStringLiteral("*-api.jar"),     QStringLiteral("*-thin.jar") };
+}
+
+DevelopingModWatcher::DevelopingModWatcher(MinecraftInstance* instance) : QObject(instance), m_instance(instance)
+{
+    m_debounce.setSingleShot(true);
+    m_debounce.setInterval(kDebounceMs);
+    connect(&m_debounce, &QTimer::timeout, this, &DevelopingModWatcher::performSync);
+
+    m_poll.setInterval(kPollMs);
+    connect(&m_poll, &QTimer::timeout, this, &DevelopingModWatcher::pollSources);
+
+    connect(&m_watcher, &QFileSystemWatcher::directoryChanged, this, &DevelopingModWatcher::directoryChanged);
+    connect(&m_watcher, &QFileSystemWatcher::fileChanged, this, &DevelopingModWatcher::fileChanged);
+
+    auto* settings = m_instance->settings();
+    auto reconnect = [this](std::shared_ptr<Setting> setting) {
+        connect(setting.get(), &Setting::SettingChanged, this, [this] { reloadFromSettings(); });
+    };
+    reconnect(settings->getSetting("DevelopingModEnabled"));
+    reconnect(settings->getSetting("DevelopingModFolders"));
+    reconnect(settings->getSetting("DevelopingModIgnorePatterns"));
+
+    reloadFromSettings();
+}
+
+void DevelopingModWatcher::setStatus(const QString& status)
+{
+    if (m_statusText == status)
+        return;
+    m_statusText = status;
+    emit statusChanged(m_statusText);
+}
+
+QStringList DevelopingModWatcher::readStringListSetting(const QString& key) const
+{
+    const auto raw = m_instance->settings()->get(key).toString().trimmed();
+    if (raw.isEmpty())
+        return {};
+
+    QJsonParseError error{};
+    const auto doc = QJsonDocument::fromJson(raw.toUtf8(), &error);
+    if (error.error != QJsonParseError::NoError || !doc.isArray()) {
+        // Fall back to newline / semicolon separated values for resilience.
+        return raw.split(QRegularExpression(QStringLiteral("[\n;|]")), Qt::SkipEmptyParts);
+    }
+
+    QStringList result;
+    for (const auto& value : doc.array()) {
+        const auto text = value.toString().trimmed();
+        if (!text.isEmpty())
+            result << text;
+    }
+    return result;
+}
+
+void DevelopingModWatcher::writeStringListSetting(const QString& key, const QStringList& values)
+{
+    QJsonArray array;
+    for (const auto& value : values)
+        array.append(value);
+    m_instance->settings()->set(key, QString::fromUtf8(QJsonDocument(array).toJson(QJsonDocument::Compact)));
+}
+
+void DevelopingModWatcher::reloadFromSettings()
+{
+    auto* settings = m_instance->settings();
+    m_enabled = settings->get("DevelopingModEnabled").toBool();
+    m_folders = readStringListSetting("DevelopingModFolders");
+    m_managedFiles = readStringListSetting("DevelopingModManagedFiles");
+
+    const auto ignoreRaw = settings->get("DevelopingModIgnorePatterns").toString().trimmed();
+    if (ignoreRaw.isEmpty()) {
+        m_ignorePatterns = defaultIgnorePatterns();
+    } else {
+        m_ignorePatterns = ignoreRaw.split(QRegularExpression(QStringLiteral("[\n;]")), Qt::SkipEmptyParts);
+        for (auto& pattern : m_ignorePatterns)
+            pattern = pattern.trimmed();
+        m_ignorePatterns.removeAll(QString());
+    }
+
+    updateWatches();
+
+    if (m_enabled && !m_folders.isEmpty()) {
+        m_lastSeenSources = collectSourceSignatures();
+        m_poll.start();
+        setStatus(tr("Auto-watching %n folder(s).", "", m_folders.size()));
+        scheduleSync();
+    } else {
+        m_poll.stop();
+        m_lastSeenSources.clear();
+        if (!m_enabled)
+            setStatus(tr("Disabled."));
+        else
+            setStatus(tr("Enabled, but no folders are configured."));
+    }
+}
+
+void DevelopingModWatcher::updateWatches()
+{
+    const auto current = m_watcher.directories() + m_watcher.files();
+    if (!current.isEmpty())
+        m_watcher.removePaths(current);
+
+    if (!m_enabled)
+        return;
+
+    for (const auto& folder : m_folders) {
+        QFileInfo info(folder);
+        if (!info.exists() || !info.isDir()) {
+            qCWarning(developingModLog) << "Developing mod folder does not exist:" << folder;
+            continue;
+        }
+        const auto absolute = QDir::cleanPath(info.absoluteFilePath());
+        if (!m_watcher.addPath(absolute))
+            qCWarning(developingModLog) << "Failed to watch developing mod folder:" << absolute;
+
+        // Also watch individual JARs: some Windows/Gradle rewrite paths only notify file watches.
+        QDir dir(absolute);
+        const auto jars = dir.entryInfoList(QStringList{ QStringLiteral("*.jar") }, QDir::Files | QDir::Readable);
+        for (const auto& jar : jars) {
+            if (shouldIgnore(jar.fileName()))
+                continue;
+            const auto jarPath = jar.absoluteFilePath();
+            if (!m_watcher.files().contains(jarPath) && !m_watcher.addPath(jarPath))
+                qCDebug(developingModLog) << "Could not watch developing mod JAR:" << jarPath;
+        }
+    }
+}
+
+bool DevelopingModWatcher::shouldIgnore(const QString& fileName) const
+{
+    if (!fileName.endsWith(QLatin1String(".jar"), Qt::CaseInsensitive))
+        return true;
+    if (fileName.endsWith(QLatin1String(".jar.disabled"), Qt::CaseInsensitive))
+        return true;
+
+    for (const auto& pattern : m_ignorePatterns) {
+        if (QDir::match(pattern, fileName))
+            return true;
+    }
+    return false;
+}
+
+DevelopingModWatcher::SourceSignature DevelopingModWatcher::signatureFor(const QFileInfo& info) const
+{
+    SourceSignature signature;
+    signature.size = info.size();
+    signature.mtimeMs = info.lastModified().toMSecsSinceEpoch();
+    return signature;
+}
+
+QStringList DevelopingModWatcher::collectSourceJars() const
+{
+    QStringList jars;
+    QSet<QString> seenNames;
+
+    for (const auto& folder : m_folders) {
+        QDir dir(folder);
+        if (!dir.exists())
+            continue;
+
+        const auto entries = dir.entryInfoList(QStringList{ QStringLiteral("*.jar") }, QDir::Files | QDir::Readable, QDir::Name);
+        for (const auto& entry : entries) {
+            if (shouldIgnore(entry.fileName()))
+                continue;
+            if (entry.size() <= 0)
+                continue;
+            if (seenNames.contains(entry.fileName())) {
+                qCWarning(developingModLog) << "Duplicate developing mod JAR name, later folder wins:" << entry.absoluteFilePath();
+            }
+            seenNames.insert(entry.fileName());
+            jars << entry.absoluteFilePath();
+        }
+    }
+
+    return jars;
+}
+
+QHash<QString, DevelopingModWatcher::SourceSignature> DevelopingModWatcher::collectSourceSignatures() const
+{
+    QHash<QString, SourceSignature> signatures;
+    for (const auto& path : collectSourceJars()) {
+        QFileInfo info(path);
+        if (!info.exists())
+            continue;
+        signatures.insert(info.absoluteFilePath(), signatureFor(info));
+    }
+    return signatures;
+}
+
+bool DevelopingModWatcher::sourcesStillWriting(const QStringList& sourceJars) const
+{
+    const auto now = QDateTime::currentDateTime();
+    for (const auto& path : sourceJars) {
+        QFileInfo info(path);
+        if (!info.exists())
+            continue;
+        // Gradle often rewrites the JAR in place / via rename; wait until mtime settles.
+        if (info.lastModified().msecsTo(now) < kWriteSettleMs)
+            return true;
+
+        // Zero-length or locked-looking tiny files mid-write.
+        if (info.size() <= 0)
+            return true;
+    }
+    return false;
+}
+
+void DevelopingModWatcher::directoryChanged(const QString& path)
+{
+    Q_UNUSED(path);
+    if (!m_enabled)
+        return;
+    // Directory watches can drop after atomic replaces; refresh before syncing.
+    updateWatches();
+    scheduleSync();
+}
+
+void DevelopingModWatcher::fileChanged(const QString& path)
+{
+    Q_UNUSED(path);
+    if (!m_enabled)
+        return;
+    updateWatches();
+    scheduleSync();
+}
+
+void DevelopingModWatcher::pollSources()
+{
+    if (!m_enabled || m_folders.isEmpty())
+        return;
+
+    const auto current = collectSourceSignatures();
+    if (current != m_lastSeenSources) {
+        m_lastSeenSources = current;
+        // Watches often break when Gradle deletes/replaces the JAR.
+        updateWatches();
+        scheduleSync();
+    }
+}
+
+void DevelopingModWatcher::scheduleSync()
+{
+    m_debounce.start();
+}
+
+void DevelopingModWatcher::syncNow()
+{
+    m_debounce.stop();
+    performSync();
+}
+
+bool DevelopingModWatcher::copyJarToMods(const QString& sourcePath, const QString& destFileName, bool* didCopy)
+{
+    if (didCopy)
+        *didCopy = false;
+
+    const auto modsRoot = m_instance->modsRoot();
+    FS::ensureFolderPathExists(modsRoot);
+
+    const auto destPath = FS::PathCombine(modsRoot, destFileName);
+    const auto disabledPath = destPath + QStringLiteral(".disabled");
+
+    QFileInfo sourceInfo(sourcePath);
+    if (!sourceInfo.exists() || sourceInfo.size() <= 0)
+        return false;
+
+    const auto sourceSignature = signatureFor(sourceInfo);
+    QFileInfo destInfo(destPath);
+
+    // Compare against the last successfully synced SOURCE state, not destination mtime.
+    // Destination timestamps are bumped after copy and would hide same-version rebuilds.
+    const auto previous = m_lastSyncedSources.value(destFileName);
+    if (destInfo.exists() && destInfo.size() == sourceSignature.size && previous == sourceSignature) {
+        return true;
+    }
+
+    if (QFile::exists(destPath) && !FS::deletePath(destPath)) {
+        qCWarning(developingModLog) << "Could not remove previous developing mod copy:" << destPath;
+        return false;
+    }
+    if (QFile::exists(disabledPath) && !FS::deletePath(disabledPath)) {
+        qCWarning(developingModLog) << "Could not remove disabled developing mod copy:" << disabledPath;
+        return false;
+    }
+
+    // Re-stat source right before copy: Gradle may still be replacing the file.
+    sourceInfo.refresh();
+    if (!sourceInfo.exists() || sourceInfo.size() <= 0)
+        return false;
+
+    if (!QFile::copy(sourceInfo.absoluteFilePath(), destPath)) {
+        qCWarning(developingModLog) << "Failed to copy developing mod from" << sourcePath << "to" << destPath;
+        return false;
+    }
+
+    FS::updateTimestamp(destPath);
+    m_lastSyncedSources.insert(destFileName, signatureFor(sourceInfo));
+    if (didCopy)
+        *didCopy = true;
+    qCDebug(developingModLog) << "Synced developing mod:" << sourcePath << "->" << destPath;
+    return true;
+}
+
+bool DevelopingModWatcher::removeManagedMod(const QString& fileName)
+{
+    const auto modsRoot = m_instance->modsRoot();
+    const auto destPath = FS::PathCombine(modsRoot, fileName);
+    const auto disabledPath = destPath + QStringLiteral(".disabled");
+
+    bool ok = true;
+    if (QFile::exists(destPath) && !FS::deletePath(destPath)) {
+        qCWarning(developingModLog) << "Failed to remove stale developing mod:" << destPath;
+        ok = false;
+    }
+    if (QFile::exists(disabledPath) && !FS::deletePath(disabledPath)) {
+        qCWarning(developingModLog) << "Failed to remove stale disabled developing mod:" << disabledPath;
+        ok = false;
+    }
+    m_lastSyncedSources.remove(fileName);
+    return ok;
+}
+
+void DevelopingModWatcher::performSync()
+{
+    if (m_syncing)
+        return;
+
+    if (!m_enabled) {
+        setStatus(tr("Disabled."));
+        return;
+    }
+
+    const auto sourceJars = collectSourceJars();
+    if (sourcesStillWriting(sourceJars)) {
+        // Retry shortly — avoid copying a half-written Gradle output.
+        scheduleSync();
+        return;
+    }
+
+    m_syncing = true;
+    m_lastSeenSources = collectSourceSignatures();
+
+    QStringList activeManaged;
+    int updated = 0;
+    int unchanged = 0;
+    int removed = 0;
+    int failed = 0;
+
+    for (const auto& sourcePath : sourceJars) {
+        const QFileInfo info(sourcePath);
+        bool didCopy = false;
+        if (!copyJarToMods(sourcePath, info.fileName(), &didCopy)) {
+            failed++;
+            continue;
+        }
+        activeManaged << info.fileName();
+        if (didCopy)
+            updated++;
+        else
+            unchanged++;
+    }
+
+    for (const auto& previous : m_managedFiles) {
+        if (activeManaged.contains(previous))
+            continue;
+        if (removeManagedMod(previous))
+            removed++;
+        else
+            failed++;
+    }
+
+    m_managedFiles = activeManaged;
+    writeStringListSetting("DevelopingModManagedFiles", m_managedFiles);
+
+    if (auto* mods = m_instance->loaderModList())
+        mods->update();
+
+    // Keep file watches attached after renames/recreates.
+    updateWatches();
+
+    const auto stamp = QDateTime::currentDateTime().toString(QLocale().dateTimeFormat(QLocale::ShortFormat));
+    if (failed > 0) {
+        setStatus(tr("Auto-sync %1 — %2 updated, %3 removed, %4 failed.")
+                      .arg(stamp)
+                      .arg(updated)
+                      .arg(removed)
+                      .arg(failed));
+    } else if (updated > 0 || removed > 0) {
+        setStatus(tr("Auto-sync %1 — %2 updated, %3 removed.").arg(stamp).arg(updated).arg(removed));
+    } else {
+        setStatus(tr("Auto-watching — %1 mod(s) up to date (%2).").arg(unchanged).arg(stamp));
+    }
+
+    m_syncing = false;
+}

--- a/launcher/minecraft/mod/DevelopingModWatcher.h
+++ b/launcher/minecraft/mod/DevelopingModWatcher.h
@@ -28,8 +28,9 @@
 class MinecraftInstance;
 
 /**
- * Watches Gradle/Java build output folders and copies matching JAR files into
- * the instance mods folder, replacing previous developing-mod copies.
+ * Watches Gradle/Java build output folders and specific JAR files, copying
+ * matching artifacts into the instance mods folder and replacing previous
+ * developing-mod copies.
  *
  * Uses QFileSystemWatcher plus a polling timer so Windows/Gradle atomic
  * rewrites (same filename/version) are still picked up automatically.
@@ -69,6 +70,7 @@ class DevelopingModWatcher : public QObject {
     void setStatus(const QString& status);
     void scheduleSync();
     void updateWatches();
+    bool hasWatchTargets() const;
     bool shouldIgnore(const QString& fileName) const;
     QStringList collectSourceJars() const;
     QHash<QString, SourceSignature> collectSourceSignatures() const;
@@ -85,6 +87,7 @@ class DevelopingModWatcher : public QObject {
     QTimer m_poll;
     bool m_enabled = false;
     QStringList m_folders;
+    QStringList m_jars;
     QStringList m_ignorePatterns;
     QStringList m_managedFiles;
     QHash<QString, SourceSignature> m_lastSyncedSources;  // dest file name -> last copied source signature

--- a/launcher/minecraft/mod/DevelopingModWatcher.h
+++ b/launcher/minecraft/mod/DevelopingModWatcher.h
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2026 Prism Launcher Contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QFileInfo>
+#include <QFileSystemWatcher>
+#include <QHash>
+#include <QObject>
+#include <QStringList>
+#include <QTimer>
+
+class MinecraftInstance;
+
+/**
+ * Watches Gradle/Java build output folders and copies matching JAR files into
+ * the instance mods folder, replacing previous developing-mod copies.
+ *
+ * Uses QFileSystemWatcher plus a polling timer so Windows/Gradle atomic
+ * rewrites (same filename/version) are still picked up automatically.
+ */
+class DevelopingModWatcher : public QObject {
+    Q_OBJECT
+
+   public:
+    static QStringList defaultIgnorePatterns();
+
+    explicit DevelopingModWatcher(MinecraftInstance* instance);
+
+    void reloadFromSettings();
+    void syncNow();
+
+    bool isEnabled() const { return m_enabled; }
+    QString statusText() const { return m_statusText; }
+
+   signals:
+    void statusChanged(const QString& status);
+
+   private slots:
+    void directoryChanged(const QString& path);
+    void fileChanged(const QString& path);
+    void pollSources();
+    void performSync();
+
+   private:
+    struct SourceSignature {
+        qint64 size = -1;
+        qint64 mtimeMs = -1;
+
+        bool operator==(const SourceSignature& other) const { return size == other.size && mtimeMs == other.mtimeMs; }
+        bool operator!=(const SourceSignature& other) const { return !(*this == other); }
+    };
+
+    void setStatus(const QString& status);
+    void scheduleSync();
+    void updateWatches();
+    bool shouldIgnore(const QString& fileName) const;
+    QStringList collectSourceJars() const;
+    QHash<QString, SourceSignature> collectSourceSignatures() const;
+    SourceSignature signatureFor(const QFileInfo& info) const;
+    bool sourcesStillWriting(const QStringList& sourceJars) const;
+    QStringList readStringListSetting(const QString& key) const;
+    void writeStringListSetting(const QString& key, const QStringList& values);
+    bool copyJarToMods(const QString& sourcePath, const QString& destFileName, bool* didCopy = nullptr);
+    bool removeManagedMod(const QString& fileName);
+
+    MinecraftInstance* m_instance = nullptr;
+    QFileSystemWatcher m_watcher;
+    QTimer m_debounce;
+    QTimer m_poll;
+    bool m_enabled = false;
+    QStringList m_folders;
+    QStringList m_ignorePatterns;
+    QStringList m_managedFiles;
+    QHash<QString, SourceSignature> m_lastSyncedSources;  // dest file name -> last copied source signature
+    QHash<QString, SourceSignature> m_lastSeenSources;    // absolute source path -> last observed signature
+    QString m_statusText;
+    bool m_syncing = false;
+};

--- a/launcher/ui/pages/instance/DevelopingModPage.cpp
+++ b/launcher/ui/pages/instance/DevelopingModPage.cpp
@@ -24,9 +24,15 @@
 #include <QJsonArray>
 #include <QJsonDocument>
 #include <QListWidgetItem>
+#include <QVariant>
 
 #include "FileSystem.h"
 #include "minecraft/mod/DevelopingModWatcher.h"
+
+namespace {
+constexpr int kKindRole = Qt::UserRole;
+constexpr int kPathRole = Qt::UserRole + 1;
+}  // namespace
 
 DevelopingModPage::DevelopingModPage(MinecraftInstance* inst, QWidget* parent)
     : QWidget(parent), ui(new Ui::DevelopingModPage), m_inst(inst)
@@ -35,7 +41,8 @@ DevelopingModPage::DevelopingModPage(MinecraftInstance* inst, QWidget* parent)
 
     connect(ui->enableGroup, &QGroupBox::toggled, this, &DevelopingModPage::enableToggled);
     connect(ui->addFolderButton, &QPushButton::clicked, this, &DevelopingModPage::addFolder);
-    connect(ui->removeFolderButton, &QPushButton::clicked, this, &DevelopingModPage::removeSelectedFolder);
+    connect(ui->addJarButton, &QPushButton::clicked, this, &DevelopingModPage::addJar);
+    connect(ui->removeButton, &QPushButton::clicked, this, &DevelopingModPage::removeSelected);
     connect(ui->syncNowButton, &QPushButton::clicked, this, &DevelopingModPage::syncNowClicked);
 
     loadFromSettings();
@@ -58,6 +65,59 @@ void DevelopingModPage::openedImpl()
         updateStatusLabel(watcher->statusText());
 }
 
+QString DevelopingModPage::displayText(WatchKind kind, const QString& path)
+{
+    if (kind == WatchKind::Folder)
+        return QObject::tr("Folder — %1").arg(path);
+    return QObject::tr("Jar — %1").arg(path);
+}
+
+void DevelopingModPage::setControlsEnabled(bool enabled)
+{
+    ui->watchList->setEnabled(enabled);
+    ui->addFolderButton->setEnabled(enabled);
+    ui->addJarButton->setEnabled(enabled);
+    ui->removeButton->setEnabled(enabled);
+    ui->ignoreEdit->setEnabled(enabled);
+    ui->syncNowButton->setEnabled(enabled);
+}
+
+void DevelopingModPage::addWatchItem(WatchKind kind, const QString& path)
+{
+    const auto normalized = FS::NormalizePath(path);
+    if (normalized.isEmpty() || containsPath(normalized))
+        return;
+
+    auto* item = new QListWidgetItem(displayText(kind, normalized), ui->watchList);
+    item->setData(kKindRole, static_cast<int>(kind));
+    item->setData(kPathRole, normalized);
+}
+
+bool DevelopingModPage::containsPath(const QString& path) const
+{
+    const auto normalized = FS::NormalizePath(path);
+    for (int i = 0; i < ui->watchList->count(); ++i) {
+        if (FS::NormalizePath(ui->watchList->item(i)->data(kPathRole).toString()) == normalized)
+            return true;
+    }
+    return false;
+}
+
+QStringList DevelopingModPage::pathsOfKind(WatchKind kind) const
+{
+    QStringList paths;
+    for (int i = 0; i < ui->watchList->count(); ++i) {
+        auto* item = ui->watchList->item(i);
+        if (static_cast<WatchKind>(item->data(kKindRole).toInt()) != kind)
+            continue;
+        const auto path = FS::NormalizePath(item->data(kPathRole).toString());
+        if (!path.isEmpty())
+            paths << path;
+    }
+    paths.removeDuplicates();
+    return paths;
+}
+
 void DevelopingModPage::loadFromSettings()
 {
     auto* settings = m_inst->settings();
@@ -66,18 +126,22 @@ void DevelopingModPage::loadFromSettings()
     ui->ignoreEdit->blockSignals(true);
 
     ui->enableGroup->setChecked(settings->get("DevelopingModEnabled").toBool());
+    ui->watchList->clear();
 
-    ui->foldersList->clear();
-    const auto foldersRaw = settings->get("DevelopingModFolders").toString().trimmed();
-    QJsonParseError error{};
-    const auto doc = QJsonDocument::fromJson(foldersRaw.toUtf8(), &error);
-    if (error.error == QJsonParseError::NoError && doc.isArray()) {
+    auto loadJsonPaths = [this](const QString& raw, WatchKind kind) {
+        QJsonParseError error{};
+        const auto doc = QJsonDocument::fromJson(raw.toUtf8(), &error);
+        if (error.error != QJsonParseError::NoError || !doc.isArray())
+            return;
         for (const auto& value : doc.array()) {
             const auto path = value.toString().trimmed();
             if (!path.isEmpty())
-                ui->foldersList->addItem(path);
+                addWatchItem(kind, path);
         }
-    }
+    };
+
+    loadJsonPaths(settings->get("DevelopingModFolders").toString().trimmed(), WatchKind::Folder);
+    loadJsonPaths(settings->get("DevelopingModJars").toString().trimmed(), WatchKind::Jar);
 
     auto ignore = settings->get("DevelopingModIgnorePatterns").toString();
     if (ignore.trimmed().isEmpty())
@@ -87,32 +151,20 @@ void DevelopingModPage::loadFromSettings()
     ui->enableGroup->blockSignals(false);
     ui->ignoreEdit->blockSignals(false);
 
-    const bool enabled = ui->enableGroup->isChecked();
-    ui->foldersList->setEnabled(enabled);
-    ui->addFolderButton->setEnabled(enabled);
-    ui->removeFolderButton->setEnabled(enabled);
-    ui->ignoreEdit->setEnabled(enabled);
-    ui->syncNowButton->setEnabled(enabled);
+    setControlsEnabled(ui->enableGroup->isChecked());
 }
 
-QStringList DevelopingModPage::foldersFromUi() const
+void DevelopingModPage::saveWatchTargets()
 {
-    QStringList folders;
-    for (int i = 0; i < ui->foldersList->count(); ++i) {
-        const auto path = ui->foldersList->item(i)->text().trimmed();
-        if (!path.isEmpty())
-            folders << FS::NormalizePath(path);
-    }
-    folders.removeDuplicates();
-    return folders;
-}
+    QJsonArray folders;
+    for (const auto& folder : pathsOfKind(WatchKind::Folder))
+        folders.append(folder);
+    m_inst->settings()->set("DevelopingModFolders", QString::fromUtf8(QJsonDocument(folders).toJson(QJsonDocument::Compact)));
 
-void DevelopingModPage::saveFolders()
-{
-    QJsonArray array;
-    for (const auto& folder : foldersFromUi())
-        array.append(folder);
-    m_inst->settings()->set("DevelopingModFolders", QString::fromUtf8(QJsonDocument(array).toJson(QJsonDocument::Compact)));
+    QJsonArray jars;
+    for (const auto& jar : pathsOfKind(WatchKind::Jar))
+        jars.append(jar);
+    m_inst->settings()->set("DevelopingModJars", QString::fromUtf8(QJsonDocument(jars).toJson(QJsonDocument::Compact)));
 }
 
 void DevelopingModPage::saveIgnorePatterns()
@@ -123,11 +175,7 @@ void DevelopingModPage::saveIgnorePatterns()
 void DevelopingModPage::enableToggled(bool checked)
 {
     m_inst->settings()->set("DevelopingModEnabled", checked);
-    ui->foldersList->setEnabled(checked);
-    ui->addFolderButton->setEnabled(checked);
-    ui->removeFolderButton->setEnabled(checked);
-    ui->ignoreEdit->setEnabled(checked);
-    ui->syncNowButton->setEnabled(checked);
+    setControlsEnabled(checked);
 }
 
 void DevelopingModPage::addFolder()
@@ -136,25 +184,30 @@ void DevelopingModPage::addFolder()
     if (path.isEmpty())
         return;
 
-    const auto normalized = FS::NormalizePath(path);
-    for (int i = 0; i < ui->foldersList->count(); ++i) {
-        if (FS::NormalizePath(ui->foldersList->item(i)->text()) == normalized)
-            return;
-    }
-
-    ui->foldersList->addItem(normalized);
-    saveFolders();
+    addWatchItem(WatchKind::Folder, path);
+    saveWatchTargets();
 }
 
-void DevelopingModPage::removeSelectedFolder()
+void DevelopingModPage::addJar()
 {
-    const auto items = ui->foldersList->selectedItems();
+    const auto path = QFileDialog::getOpenFileName(this, tr("Select JAR to watch"), QDir::homePath(),
+                                                   tr("JAR files (*.jar);;All files (*)"));
+    if (path.isEmpty())
+        return;
+
+    addWatchItem(WatchKind::Jar, path);
+    saveWatchTargets();
+}
+
+void DevelopingModPage::removeSelected()
+{
+    const auto items = ui->watchList->selectedItems();
     if (items.isEmpty())
         return;
 
     for (auto* item : items)
         delete item;
-    saveFolders();
+    saveWatchTargets();
 }
 
 void DevelopingModPage::syncNowClicked()
@@ -172,7 +225,7 @@ void DevelopingModPage::updateStatusLabel(const QString& status)
 bool DevelopingModPage::apply()
 {
     m_inst->settings()->set("DevelopingModEnabled", ui->enableGroup->isChecked());
-    saveFolders();
+    saveWatchTargets();
     saveIgnorePatterns();
     return true;
 }
@@ -180,4 +233,11 @@ bool DevelopingModPage::apply()
 void DevelopingModPage::retranslate()
 {
     ui->retranslateUi(this);
+    // Refresh list labels for current language.
+    for (int i = 0; i < ui->watchList->count(); ++i) {
+        auto* item = ui->watchList->item(i);
+        const auto kind = static_cast<WatchKind>(item->data(kKindRole).toInt());
+        const auto path = item->data(kPathRole).toString();
+        item->setText(displayText(kind, path));
+    }
 }

--- a/launcher/ui/pages/instance/DevelopingModPage.cpp
+++ b/launcher/ui/pages/instance/DevelopingModPage.cpp
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2026 Prism Launcher Contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "DevelopingModPage.h"
+#include "ui_DevelopingModPage.h"
+
+#include <QDir>
+#include <QFileDialog>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QListWidgetItem>
+
+#include "FileSystem.h"
+#include "minecraft/mod/DevelopingModWatcher.h"
+
+DevelopingModPage::DevelopingModPage(MinecraftInstance* inst, QWidget* parent)
+    : QWidget(parent), ui(new Ui::DevelopingModPage), m_inst(inst)
+{
+    ui->setupUi(this);
+
+    connect(ui->enableGroup, &QGroupBox::toggled, this, &DevelopingModPage::enableToggled);
+    connect(ui->addFolderButton, &QPushButton::clicked, this, &DevelopingModPage::addFolder);
+    connect(ui->removeFolderButton, &QPushButton::clicked, this, &DevelopingModPage::removeSelectedFolder);
+    connect(ui->syncNowButton, &QPushButton::clicked, this, &DevelopingModPage::syncNowClicked);
+
+    loadFromSettings();
+
+    if (auto* watcher = m_inst->developingModWatcher()) {
+        connect(watcher, &DevelopingModWatcher::statusChanged, this, &DevelopingModPage::updateStatusLabel);
+        updateStatusLabel(watcher->statusText());
+    }
+}
+
+DevelopingModPage::~DevelopingModPage()
+{
+    delete ui;
+}
+
+void DevelopingModPage::openedImpl()
+{
+    loadFromSettings();
+    if (auto* watcher = m_inst->developingModWatcher())
+        updateStatusLabel(watcher->statusText());
+}
+
+void DevelopingModPage::loadFromSettings()
+{
+    auto* settings = m_inst->settings();
+
+    ui->enableGroup->blockSignals(true);
+    ui->ignoreEdit->blockSignals(true);
+
+    ui->enableGroup->setChecked(settings->get("DevelopingModEnabled").toBool());
+
+    ui->foldersList->clear();
+    const auto foldersRaw = settings->get("DevelopingModFolders").toString().trimmed();
+    QJsonParseError error{};
+    const auto doc = QJsonDocument::fromJson(foldersRaw.toUtf8(), &error);
+    if (error.error == QJsonParseError::NoError && doc.isArray()) {
+        for (const auto& value : doc.array()) {
+            const auto path = value.toString().trimmed();
+            if (!path.isEmpty())
+                ui->foldersList->addItem(path);
+        }
+    }
+
+    auto ignore = settings->get("DevelopingModIgnorePatterns").toString();
+    if (ignore.trimmed().isEmpty())
+        ignore = DevelopingModWatcher::defaultIgnorePatterns().join(QLatin1Char('\n'));
+    ui->ignoreEdit->setPlainText(ignore);
+
+    ui->enableGroup->blockSignals(false);
+    ui->ignoreEdit->blockSignals(false);
+
+    const bool enabled = ui->enableGroup->isChecked();
+    ui->foldersList->setEnabled(enabled);
+    ui->addFolderButton->setEnabled(enabled);
+    ui->removeFolderButton->setEnabled(enabled);
+    ui->ignoreEdit->setEnabled(enabled);
+    ui->syncNowButton->setEnabled(enabled);
+}
+
+QStringList DevelopingModPage::foldersFromUi() const
+{
+    QStringList folders;
+    for (int i = 0; i < ui->foldersList->count(); ++i) {
+        const auto path = ui->foldersList->item(i)->text().trimmed();
+        if (!path.isEmpty())
+            folders << FS::NormalizePath(path);
+    }
+    folders.removeDuplicates();
+    return folders;
+}
+
+void DevelopingModPage::saveFolders()
+{
+    QJsonArray array;
+    for (const auto& folder : foldersFromUi())
+        array.append(folder);
+    m_inst->settings()->set("DevelopingModFolders", QString::fromUtf8(QJsonDocument(array).toJson(QJsonDocument::Compact)));
+}
+
+void DevelopingModPage::saveIgnorePatterns()
+{
+    m_inst->settings()->set("DevelopingModIgnorePatterns", ui->ignoreEdit->toPlainText());
+}
+
+void DevelopingModPage::enableToggled(bool checked)
+{
+    m_inst->settings()->set("DevelopingModEnabled", checked);
+    ui->foldersList->setEnabled(checked);
+    ui->addFolderButton->setEnabled(checked);
+    ui->removeFolderButton->setEnabled(checked);
+    ui->ignoreEdit->setEnabled(checked);
+    ui->syncNowButton->setEnabled(checked);
+}
+
+void DevelopingModPage::addFolder()
+{
+    const auto path = QFileDialog::getExistingDirectory(this, tr("Select build output folder"), QDir::homePath());
+    if (path.isEmpty())
+        return;
+
+    const auto normalized = FS::NormalizePath(path);
+    for (int i = 0; i < ui->foldersList->count(); ++i) {
+        if (FS::NormalizePath(ui->foldersList->item(i)->text()) == normalized)
+            return;
+    }
+
+    ui->foldersList->addItem(normalized);
+    saveFolders();
+}
+
+void DevelopingModPage::removeSelectedFolder()
+{
+    const auto items = ui->foldersList->selectedItems();
+    if (items.isEmpty())
+        return;
+
+    for (auto* item : items)
+        delete item;
+    saveFolders();
+}
+
+void DevelopingModPage::syncNowClicked()
+{
+    apply();
+    if (auto* watcher = m_inst->developingModWatcher())
+        watcher->syncNow();
+}
+
+void DevelopingModPage::updateStatusLabel(const QString& status)
+{
+    ui->statusLabel->setText(tr("Status: %1").arg(status));
+}
+
+bool DevelopingModPage::apply()
+{
+    m_inst->settings()->set("DevelopingModEnabled", ui->enableGroup->isChecked());
+    saveFolders();
+    saveIgnorePatterns();
+    return true;
+}
+
+void DevelopingModPage::retranslate()
+{
+    ui->retranslateUi(this);
+}

--- a/launcher/ui/pages/instance/DevelopingModPage.h
+++ b/launcher/ui/pages/instance/DevelopingModPage.h
@@ -48,18 +48,26 @@ class DevelopingModPage : public QWidget, public BasePage {
     void retranslate() override;
     void openedImpl() override;
 
+   private:
+    enum class WatchKind { Folder = 0, Jar = 1 };
+
    private slots:
     void enableToggled(bool checked);
     void addFolder();
-    void removeSelectedFolder();
+    void addJar();
+    void removeSelected();
     void syncNowClicked();
     void updateStatusLabel(const QString& status);
 
    private:
     void loadFromSettings();
-    void saveFolders();
+    void setControlsEnabled(bool enabled);
+    void saveWatchTargets();
     void saveIgnorePatterns();
-    QStringList foldersFromUi() const;
+    void addWatchItem(WatchKind kind, const QString& path);
+    bool containsPath(const QString& path) const;
+    QStringList pathsOfKind(WatchKind kind) const;
+    static QString displayText(WatchKind kind, const QString& path);
 
     Ui::DevelopingModPage* ui;
     MinecraftInstance* m_inst;

--- a/launcher/ui/pages/instance/DevelopingModPage.h
+++ b/launcher/ui/pages/instance/DevelopingModPage.h
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2026 Prism Launcher Contributors
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QWidget>
+
+#include "minecraft/MinecraftInstance.h"
+#include "ui/pages/BasePage.h"
+
+namespace Ui {
+class DevelopingModPage;
+}
+
+class DevelopingModPage : public QWidget, public BasePage {
+    Q_OBJECT
+
+   public:
+    explicit DevelopingModPage(MinecraftInstance* inst, QWidget* parent = nullptr);
+    virtual ~DevelopingModPage();
+
+    QString displayName() const override { return tr("Developing Mod"); }
+    QIcon icon() const override
+    {
+        auto icon = QIcon::fromTheme("loadermods");
+        if (icon.isNull())
+            icon = QIcon::fromTheme("folder");
+        return icon;
+    }
+    QString id() const override { return "developing-mod"; }
+    bool apply() override;
+    QString helpPage() const override { return "Developing-Mod"; }
+    void retranslate() override;
+    void openedImpl() override;
+
+   private slots:
+    void enableToggled(bool checked);
+    void addFolder();
+    void removeSelectedFolder();
+    void syncNowClicked();
+    void updateStatusLabel(const QString& status);
+
+   private:
+    void loadFromSettings();
+    void saveFolders();
+    void saveIgnorePatterns();
+    QStringList foldersFromUi() const;
+
+    Ui::DevelopingModPage* ui;
+    MinecraftInstance* m_inst;
+};

--- a/launcher/ui/pages/instance/DevelopingModPage.ui
+++ b/launcher/ui/pages/instance/DevelopingModPage.ui
@@ -41,26 +41,32 @@
          <bool>true</bool>
         </property>
         <property name="text">
-         <string>Watch one or more build output folders (for example Gradle build/libs). Matching JAR files are copied into this instance's mods folder automatically whenever they change, so you do not need to remove and re-add the mod manually.</string>
+         <string>Add folders, jars, or both. Watched artifacts are copied into this instance's mods folder automatically whenever they change, so you do not need to remove and re-add the mod manually.</string>
         </property>
        </widget>
       </item>
       <item>
-       <widget class="QLabel" name="foldersLabel">
+       <widget class="QLabel" name="watchLabel">
         <property name="text">
-         <string>Watched folders:</string>
+         <string>Watched paths (folders and/or jars):</string>
         </property>
        </widget>
       </item>
       <item>
-       <widget class="QListWidget" name="foldersList">
+       <widget class="QListWidget" name="watchList">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>160</height>
+         </size>
+        </property>
         <property name="selectionMode">
-         <enum>QAbstractItemView::SingleSelection</enum>
+         <enum>QAbstractItemView::ExtendedSelection</enum>
         </property>
        </widget>
       </item>
       <item>
-       <layout class="QHBoxLayout" name="folderButtonsLayout">
+       <layout class="QHBoxLayout" name="watchButtonsLayout">
         <item>
          <widget class="QPushButton" name="addFolderButton">
           <property name="text">
@@ -69,14 +75,21 @@
          </widget>
         </item>
         <item>
-         <widget class="QPushButton" name="removeFolderButton">
+         <widget class="QPushButton" name="addJarButton">
+          <property name="text">
+           <string>Add Jar...</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="removeButton">
           <property name="text">
            <string>Remove</string>
           </property>
          </widget>
         </item>
         <item>
-         <spacer name="folderButtonsSpacer">
+         <spacer name="watchButtonsSpacer">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>
@@ -100,7 +113,7 @@
       <item>
        <widget class="QLabel" name="ignoreLabel">
         <property name="text">
-         <string>Ignore patterns (one wildcard per line, matched against file names):</string>
+         <string>Ignore patterns (one wildcard per line, applied to watched folders only; watched jars are always synced):</string>
         </property>
        </widget>
       </item>

--- a/launcher/ui/pages/instance/DevelopingModPage.ui
+++ b/launcher/ui/pages/instance/DevelopingModPage.ui
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>DevelopingModPage</class>
+ <widget class="QWidget" name="DevelopingModPage">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>720</width>
+    <height>560</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QGroupBox" name="enableGroup">
+     <property name="title">
+      <string>Enable Developing Mod</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <layout class="QVBoxLayout" name="enableLayout">
+      <item>
+       <widget class="QLabel" name="descriptionLabel">
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>Watch one or more build output folders (for example Gradle build/libs). Matching JAR files are copied into this instance's mods folder automatically whenever they change, so you do not need to remove and re-add the mod manually.</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="foldersLabel">
+        <property name="text">
+         <string>Watched folders:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QListWidget" name="foldersList">
+        <property name="selectionMode">
+         <enum>QAbstractItemView::SingleSelection</enum>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QHBoxLayout" name="folderButtonsLayout">
+        <item>
+         <widget class="QPushButton" name="addFolderButton">
+          <property name="text">
+           <string>Add Folder...</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="removeFolderButton">
+          <property name="text">
+           <string>Remove</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="folderButtonsSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QPushButton" name="syncNowButton">
+          <property name="text">
+           <string>Sync Now</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QLabel" name="ignoreLabel">
+        <property name="text">
+         <string>Ignore patterns (one wildcard per line, matched against file names):</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPlainTextEdit" name="ignoreEdit">
+        <property name="maximumHeight">
+         <number>110</number>
+        </property>
+        <property name="placeholderText">
+         <string>*-sources.jar
+*-javadoc.jar
+*-dev.jar
+*-api.jar
+*-thin.jar</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="statusLabel">
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>Status: —</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
## Summary

1. Adds a new **Developing Mod** page in Edit Instance that lets you watch one or more Java/Gradle build output folders (e.g. `build/libs`) and automatically sync compiled JARs into the instance `mods/` folder.
2. Replaces previously synced developing-mod copies when the same artifact is rebuilt (including same filename/version), so you no longer need to remove and re-add the mod from the Mods page after every compile.
3. Uses filesystem watching plus a short polling fallback (more reliable on Windows with Gradle atomic rewrites), waits for writes to settle, and also syncs before launch.

### Motivation / personal note

I came up with this idea while developing a Minecraft mod. Continuously removing and re-adding the JAR in a Prism Launcher instance gets tedious and, frankly, a bit of a pain. Sorry for the AI slop in how this idea was proposed — I still particularly wanted to put this forward because it would meaningfully improve the mod-development workflow in Prism.

### AI assistance

This pull request was written with AI assistance (see the `AI` label). I reviewed the changes and take responsibility for this contribution. Attribution is in the commit trailers per CONTRIBUTING.md.

## Test plan

1. Open Edit Instance → Developing Mod, enable the feature, add a build output folder containing a mod JAR
2. Confirm the JAR is copied into the instance `mods/` folder and appears in Mods without manual install
3. Rebuild the mod with the **same version/filename** and confirm the mods folder copy updates automatically (no Sync click required)
4. Confirm ignored patterns (e.g. `*-sources.jar`, `*-javadoc.jar`) are not synced
5. Remove/rename the source JAR and confirm the managed copy is cleaned up
6. Launch the instance and confirm a final sync happens before launch