### PR TITLE
Globally disable pop-ups for comboboxes

### DIFF
--- a/launcher/ui/pages/instance/ManagedPackPage.cpp
+++ b/launcher/ui/pages/instance/ManagedPackPage.cpp
@@ -11,9 +11,6 @@
 #include "ui_ManagedPackPage.h"
 
 #include <QFileDialog>
-#include <QListView>
-#include <QProxyStyle>
-#include <QStyleFactory>
 #include <memory>
 
 #include "Application.h"
@@ -26,58 +23,6 @@
 #include "ui/InstanceWindow.h"
 #include "ui/dialogs/CustomMessageBox.h"
 #include "ui/dialogs/ProgressDialog.h"
-
-/** This is just to override the combo box popup behavior so that the combo box doesn't take the whole screen.
- *  ... thanks Qt.
- */
-namespace {
-class NoBigComboBoxStyle : public QProxyStyle {
-    Q_OBJECT
-
-   public:
-    int styleHint(QStyle::StyleHint hint,
-                  const QStyleOption* option = nullptr,
-                  const QWidget* widget = nullptr,
-                  QStyleHintReturn* returnData = nullptr) const override
-    {
-        if (hint == QStyle::SH_ComboBox_Popup) {
-            return 0;
-        }
-
-        return QProxyStyle::styleHint(hint, option, widget, returnData);
-    }
-
-    /**
-     * Something about QProxyStyle and QStyle objects means they can't be free'd just
-     * because all the widgets using them are gone.
-     * They seems to be tied to the QApplicaiton lifecycle.
-     * So make singletons tied to the lifetime of the application to clean them up and ensure they aren't
-     * being remade over and over again, thus leaking memory.
-     */
-   public:
-    static NoBigComboBoxStyle* getInstance(QStyle* style)
-    {
-        static QHash<QStyle*, NoBigComboBoxStyle*> s_singleton_instances = {};
-        static std::mutex s_singleton_instances_mutex;
-
-        const std::scoped_lock lock(s_singleton_instances_mutex);
-        auto instIter = s_singleton_instances.constFind(style);
-        NoBigComboBoxStyle* inst = nullptr;
-        if (instIter == s_singleton_instances.constEnd() || *instIter == nullptr) {
-            inst = new NoBigComboBoxStyle(style);
-            inst->setParent(APPLICATION);
-            s_singleton_instances.insert(style, inst);
-            qDebug() << "QProxyStyle NoBigComboBox created for" << style->objectName() << style;
-        } else {
-            inst = *instIter;
-        }
-        return inst;
-    }
-
-   private:
-    explicit NoBigComboBoxStyle(QStyle* style) : QProxyStyle(style) {}
-};
-}  // namespace
 
 ManagedPackPage* ManagedPackPage::createPage(BaseInstance* inst, const QString& type, QWidget* parent)
 {
@@ -97,13 +42,6 @@ ManagedPackPage::ManagedPackPage(BaseInstance* inst, InstanceWindow* instanceWin
     Q_ASSERT(inst);
 
     ui->setupUi(this);
-
-    // NOTE: GTK2 themes crash with the proxy style.
-    // This seems like an upstream bug, so there's not much else that can be done.
-    if (!QStyleFactory::keys().contains("gtk2")) {
-        auto* comboStyle = NoBigComboBoxStyle::getInstance(ui->versionsComboBox->style());
-        ui->versionsComboBox->setStyle(comboStyle);
-    }
 
     ui->versionsComboBox->view()->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     ui->versionsComboBox->view()->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
@@ -543,5 +481,3 @@ void ManagedPackPage::updatePack(const QUrl& url, const QString& versionID, cons
     auto didSucceed = runUpdateTask(extracted);
     onUpdateTaskCompleted(didSucceed);
 }
-
-#include "ManagedPackPage.moc"

--- a/launcher/ui/pages/modplatform/ResourcePage.cpp
+++ b/launcher/ui/pages/modplatform/ResourcePage.cpp
@@ -75,7 +75,6 @@ ResourcePage::ResourcePage(ResourceDownloadDialog* parent,
 
     m_ui->versionSelectionBox->view()->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     m_ui->versionSelectionBox->view()->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
-    m_ui->versionSelectionBox->view()->parentWidget()->setMaximumHeight(300);
 
     m_searchTimer.setTimerType(Qt::TimerType::CoarseTimer);
     m_searchTimer.setSingleShot(true);

--- a/launcher/ui/pages/modplatform/atlauncher/AtlPage.cpp
+++ b/launcher/ui/pages/modplatform/atlauncher/AtlPage.cpp
@@ -62,7 +62,6 @@ AtlPage::AtlPage(NewInstanceDialog* dialog, QWidget* parent) : QWidget(parent), 
 
     ui->versionSelectionBox->view()->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     ui->versionSelectionBox->view()->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
-    ui->versionSelectionBox->view()->parentWidget()->setMaximumHeight(300);
 
     for (int i = 0; i < filterModel->getAvailableSortings().size(); i++) {
         ui->sortByBox->addItem(filterModel->getAvailableSortings().keys().at(i));

--- a/launcher/ui/pages/modplatform/flame/FlamePage.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.cpp
@@ -61,7 +61,6 @@ FlamePage::FlamePage(NewInstanceDialog* dialog, QWidget* parent)
 
     m_ui->versionSelectionBox->view()->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     m_ui->versionSelectionBox->view()->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
-    m_ui->versionSelectionBox->view()->parentWidget()->setMaximumHeight(300);
 
     m_search_timer.setTimerType(Qt::TimerType::CoarseTimer);
     m_search_timer.setSingleShot(true);

--- a/launcher/ui/pages/modplatform/ftb/FtbPage.cpp
+++ b/launcher/ui/pages/modplatform/ftb/FtbPage.cpp
@@ -61,7 +61,6 @@ FtbPage::FtbPage(NewInstanceDialog* dialog, QWidget* parent) : QWidget(parent), 
 
     m_ui->versionSelectionBox->view()->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     m_ui->versionSelectionBox->view()->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
-    m_ui->versionSelectionBox->view()->parentWidget()->setMaximumHeight(300);
 
     for (int i = 0; i < m_filterModel->getAvailableSortings().size(); i++) {
         m_ui->sortByBox->addItem(m_filterModel->getAvailableSortings().keys().at(i));

--- a/launcher/ui/pages/modplatform/legacy_ftb/Page.cpp
+++ b/launcher/ui/pages/modplatform/legacy_ftb/Page.cpp
@@ -108,7 +108,6 @@ Page::Page(NewInstanceDialog* dialog, QWidget* parent) : QWidget(parent), dialog
 
     ui->versionSelectionBox->view()->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     ui->versionSelectionBox->view()->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
-    ui->versionSelectionBox->view()->parentWidget()->setMaximumHeight(300);
 
     connect(ui->sortByBox, &QComboBox::currentTextChanged, this, &Page::onSortingSelectionChanged);
     connect(ui->versionSelectionBox, &QComboBox::currentTextChanged, this, &Page::onVersionSelectionItemChanged);

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
@@ -69,7 +69,6 @@ ModrinthPage::ModrinthPage(NewInstanceDialog* dialog, QWidget* parent)
 
     m_ui->versionSelectionBox->view()->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     m_ui->versionSelectionBox->view()->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
-    m_ui->versionSelectionBox->view()->parentWidget()->setMaximumHeight(300);
 
     m_search_timer.setTimerType(Qt::TimerType::CoarseTimer);
     m_search_timer.setSingleShot(true);

--- a/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
+++ b/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
@@ -63,7 +63,6 @@ TechnicPage::TechnicPage(NewInstanceDialog* dialog, QWidget* parent)
     ui->packView->setModel(model);
     ui->versionSelectionBox->view()->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     ui->versionSelectionBox->view()->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
-    ui->versionSelectionBox->view()->parentWidget()->setMaximumHeight(300);
 
     m_search_timer.setTimerType(Qt::TimerType::CoarseTimer);
     m_search_timer.setSingleShot(true);

--- a/launcher/ui/themes/HintOverrideProxyStyle.cpp
+++ b/launcher/ui/themes/HintOverrideProxyStyle.cpp
@@ -28,14 +28,19 @@ int HintOverrideProxyStyle::styleHint(QStyle::StyleHint hint,
                                       const QWidget* widget,
                                       QStyleHintReturn* returnData) const
 {
+    // Prevent instances from being activated on single click
     if (hint == QStyle::SH_ItemView_ActivateItemOnSingleClick)
         return 0;
 
+    // Make clicks on sliders directly set absolute position
     if (hint == QStyle::SH_Slider_AbsoluteSetButtons)
         return Qt::LeftButton | Qt::MiddleButton;
-
     if (hint == QStyle::SH_Slider_PageSetButtons)
         return Qt::RightButton;
+
+    // Disable popups, they ignore QComboBox#maxVisibleItems
+    if (hint == QStyle::SH_ComboBox_Popup)
+        return 0;
 
     return QProxyStyle::styleHint(hint, option, widget, returnData);
 }

--- a/launcher/ui/widgets/ModFilterWidget.cpp
+++ b/launcher/ui/widgets/ModFilterWidget.cpp
@@ -137,8 +137,6 @@ ModFilterWidget::ModFilterWidget(MinecraftInstance* instance, bool extended)
         ui->openSource->hide();
     }
 
-    ui->versions->setStyleSheet("combobox-popup: 0;");
-    ui->version->setStyleSheet("combobox-popup: 0;");
     connect(ui->showAllVersions, &QCheckBox::stateChanged, this, &ModFilterWidget::onShowAllVersionsChanged);
     connect(ui->versions, &QComboBox::currentIndexChanged, this, &ModFilterWidget::onVersionFilterChanged);
     connect(ui->versions, &CheckComboBox::checkedItemsChanged, this, [this] { onVersionFilterChanged(0); });


### PR DESCRIPTION
Closes #5708 

https://doc.qt.io/qt-6/qcombobox.html#maxVisibleItems-prop
> Note: This property is ignored for non-editable comboboxes in styles that returns true for [QStyle::SH_ComboBox_Popup](https://doc.qt.io/qt-6/qstyle.html#StyleHint-enum) such as the Mac style or the Gtk+ Style.

This is also true for the Fusion style. Items in pop-ups are very big, making them unpractical for comboboxes with large amounts of items, such as resource/modpack versions.
Pop-ups do not respect height restrictions when positioning themselves, causing #5708.
To enforce consistency, pop-ups are disabled for every combobox and every style through HintOverrideProxyStyle.

Pop-ups:
<img width="425" height="349" alt="image" src="https://github.com/user-attachments/assets/98844d85-779f-42c0-95c1-7afd1b655b83" />

Drop-downs:
<img width="407" height="215" alt="image" src="https://github.com/user-attachments/assets/9d47cc88-841b-4cfa-ae5c-b0f10e437dd9" />
