### PR TITLE
Remove ColumnLimit in .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,7 +2,7 @@
 BasedOnStyle: Chromium
 IndentWidth: 4
 AllowShortIfStatementsOnASingleLine: false
-ColumnLimit: 140
+ColumnLimit: 0
 ---
 Language: Cpp
 AccessModifierOffset: -1


### PR DESCRIPTION
Somewhat counter intuitively, the ColumnLimit forces things onto the same line - so it can make things a lot less readable

For example, you may write something like this... which could perhaps be slightly tweaked but is *decently readable*
```c++
    auto dialog = CustomMessageBox::selectable(
        parent,
        QObject::tr("Change instance name"),
        QObject::tr(
            "The instance's name seems to include the old version. Would you like to update it?\n\n"
            "Old name: %1\n"
            "New name: %2")
            .arg(old_name, new_name),
        QMessageBox::Question,
        QMessageBox::No | QMessageBox::Yes);
```
With our current ColumnLimit of 140, it becomes this dreadful mess (well, in my opinion :D)
```c++
    auto dialog =
        CustomMessageBox::selectable(parent, QObject::tr("Change instance name"),
                                     QObject::tr("The instance's name seems to include the old version. Would you like to update it?\n\n"
                                                 "Old name: %1\n"
                                                 "New name: %2")
                                         .arg(old_name, new_name),
                                     QMessageBox::Question, QMessageBox::No | QMessageBox::Yes);

```

Now, we could have a smaller ColumnLimit but that would cause a lot of changes and merge conflicts. Setting it to 0 allows for more control and for new code to be made more readable... without affecting existing code (at least in theory).