### PR TITLE
Fix crashes when using the launcher too enthusiastically

### DIFF
--- a/launcher/java/JavaInstallList.cpp
+++ b/launcher/java/JavaInstallList.cpp
@@ -41,10 +41,10 @@
 #include <algorithm>
 
 #include "Application.h"
-#include "settings/SettingsObject.h"
 #include "java/JavaChecker.h"
 #include "java/JavaInstallList.h"
 #include "java/JavaUtils.h"
+#include "settings/SettingsObject.h"
 #include "tasks/ConcurrentTask.h"
 
 JavaInstallList::JavaInstallList(QObject* parent, bool onlyManagedVersions)
@@ -163,14 +163,16 @@ void JavaListLoadTask::executeTask()
 
     ConcurrentTask::Ptr job(new ConcurrentTask("Java detection", APPLICATION->settings()->get("NumberOfConcurrentTasks").toInt()));
     m_job.reset(job);
-    connect(m_job.get(), &Task::finished, this, &JavaListLoadTask::javaCheckerFinished);
+    // HACK: as long as m_list is alive, we will be
+    // however, for some reason sometimes we outlive m_list (which javaCheckerFinished accesses)
+    connect(m_job.get(), &Task::finished, m_list, [this] { javaCheckerFinished(); });
     connect(m_job.get(), &Task::progress, this, &Task::setProgress);
 
     qDebug() << "Probing the following Java paths: ";
     int id = 0;
     for (QString candidate : candidate_paths) {
         auto checker = new JavaChecker(candidate, "", 0, 0, 0, id);
-        connect(checker, &JavaChecker::checkFinished, [this](const JavaChecker::Result& result) { m_results << result; });
+        connect(checker, &JavaChecker::checkFinished, this, [this](const JavaChecker::Result& result) { m_results << result; });
         job->addTask(Task::Ptr(checker));
         id++;
     }

--- a/launcher/ui/pages/modplatform/flame/FlamePage.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.cpp
@@ -335,7 +335,7 @@ void FlamePage::createFilterWidget()
     connect(m_filterWidget.get(), &ModFilterWidget::filterChanged, this, &FlamePage::triggerSearch);
     auto [task, response] = FlameAPI::getCategories(ModPlatform::ResourceType::Modpack);
     m_categoriesTask = task;
-    connect(m_categoriesTask.get(), &Task::succeeded, [this, response]() {
+    connect(m_categoriesTask.get(), &Task::succeeded, this, [this, response]() {
         auto categories = FlameAPI().loadModCategories(*response);
         m_filterWidget->setCategories(categories);
     });


### PR DESCRIPTION
Minor issues but spamming New Instance or Settings and escape can cause a crash (may be worse depending on hardware, internet speed etc. - I have found the settings issue worse on HDD unless I'm misremembering)

(actually there is another New Instance crash with an assert but I find it much less consistent and it wouldn't affect release)