### PR TITLE
Don't run tests for MinGW-arm64 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,6 +131,11 @@ jobs:
           cmake --build --preset "$CMAKE_PRESET" --config "$BUILD_TYPE"
 
       - name: Run tests
+        # NOTE(@getchoo): Tests are skipped for MinGW-arm64 builds due to
+        # repeated, random test failures exclusive to the platform
+        #
+        # As of Qt 6.11, official ARM support for Windows is also limited to MSVC...so
+        if: ${{ !(runner.os == 'Windows' && runner.arch == 'ARM64' && matrix.msystem != '') }}
         run: |
           ctest --preset "$CMAKE_PRESET" --build-config "$BUILD_TYPE"
 


### PR DESCRIPTION
This should remove the reds in our CI

I think it's a decently reasonable choice too considering not a single developer has a WoA machine in the first place (afaik) to really test this on, and it's not even [officially supported by Qt](https://doc.qt.io/qt-6.10/supported-platforms.html#windows)

~~Arguably this and the other issues MinGW-arm64 presents like us needing to keep our bundle mess for MSYS2 or just taking up concurrent jobs in CI is also a sign we should maybe get rid of this for now? I don't exactly like having an untested/unsupported by upstream build - but I digress~~