### PR TITLE
fix(launcher): decode game console output with the system code page on Windows

### DIFF
--- a/launcher/minecraft/launch/LauncherPartLaunch.cpp
+++ b/launcher/minecraft/launch/LauncherPartLaunch.cpp
@@ -48,9 +48,17 @@
 #include "gamemode_client.h"
 #endif
 
+#ifdef Q_OS_WIN
+#include <windows.h>
+#endif
+
 LauncherPartLaunch::LauncherPartLaunch(LaunchTask* parent)
     : LaunchStep(parent)
+#ifdef Q_OS_WIN
+    , m_process(GetACP() == 65001 ? QStringConverter::Utf8 : QStringConverter::System)
+#else
     , m_process(parent->instance()->getJavaVersion().defaultsToUtf8() ? QStringConverter::Utf8 : QStringConverter::System)
+#endif
 {
     if (parent->instance()->settings()->get("CloseAfterLaunch").toBool()) {
         static const QRegularExpression s_settingUser(".*Setting user.+", QRegularExpression::CaseInsensitiveOption);


### PR DESCRIPTION
## 问题（#5739）
在中文 Windows（系统 ANSI 代码页 936 / GBK，未开启“Beta: 使用 Unicode UTF-8”）上，启动器的游戏控制台输出里的中文（mod / 游戏日志）显示为乱码。

## 根因
启动器在 `LauncherPartLaunch` 里用 `LoggedProcess` 把游戏进程的标准输出字节解码成 `QString`，解码器编码由 `JavaVersion::defaultsToUtf8()` 决定：
- Java ≥ 18 时该函数恒为 `true`（JEP 400，Java 18 起默认 UTF-8），于是选 `QStringConverter::Utf8`。
- 但 Windows 上 Java 进程写控制台用的是**系统 ANSI 代码页**（`GetACP()`），并不是 JVM 默认编码；未开启 UTF-8 beta 时是 GBK。
- GBK 字节被当成 UTF-8 解码 → 乱码。

## 修复
在 Windows 上，直接按**真实控制台代码页**选择解码器：
- `GetACP() == 65001`（已开启 UTF-8 beta）→ `QStringConverter::Utf8`
- 否则 → `QStringConverter::System`（系统代码页，如 GBK）

非 Windows 平台保持原有「按 Java 版本选择」的逻辑不变。

## 备注
- 仅改动 `launcher/minecraft/launch/LauncherPartLaunch.cpp` 一处，范围小、风险低。
- 已通过 DCO 签名（`Signed-off-by`）。
- 该修复已从中文 README 分支拆分出来，单独成 PR，避免污染文档 PR。

> [!TIP]
> This PR is submitted on behalf of VZService~

Closes #5739
