### PR TITLE
Add option to disable the cat

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -791,6 +791,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         m_settings->registerSetting({ "PostExitCommand", "PostExitCmd" }, "");
 
         // The cat
+        m_settings->registerSetting("EnableCat", true);
         m_settings->registerSetting("TheCat", false);
         m_settings->registerSetting("CatOpacity", 100);
         m_settings->registerSetting("CatFit", "fit");

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -338,11 +338,9 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWi
     {
         // set the cat action priority here so you can still see the action in qt designer
         ui->actionCAT->setPriority(QAction::LowPriority);
-        bool cat_enable = APPLICATION->settings()->get("TheCat").toBool();
-        ui->actionCAT->setChecked(cat_enable);
+        updateCatState();
         connect(ui->actionCAT, &QAction::toggled, this, &MainWindow::onCatToggled);
-        connect(APPLICATION, &Application::currentCatChanged, this, &MainWindow::onCatChanged);
-        setCatBackground(cat_enable);
+        connect(APPLICATION, &Application::currentCatChanged, this, &MainWindow::updateCatState);
     }
 
     // Togglable status bar
@@ -852,6 +850,21 @@ void MainWindow::setCatBackground(bool enabled)
 {
     view->setPaintCat(enabled);
     view->viewport()->repaint();
+}
+
+void MainWindow::updateCatState()
+{
+    SettingsObject* settings = APPLICATION->settings();
+    const bool catEnabled = settings->get("EnableCat").toBool();
+    bool catVisible = settings->get("TheCat").toBool();
+    if (!catEnabled && catVisible) {
+        settings->set("TheCat", false);
+        catVisible = false;
+    }
+
+    ui->actionCAT->setVisible(catEnabled);
+    ui->actionCAT->setChecked(catVisible);
+    setCatBackground(catVisible);
 }
 
 void MainWindow::runModalTask(Task* task)
@@ -1374,6 +1387,7 @@ void MainWindow::globalSettingsClosed()
     updateLaunchButton();
     updateThemeMenu();
     updateStatusCenter();
+    updateCatState();
     // This needs to be done to prevent UI elements disappearing in the event the config is changed
     // but Prism Launcher exits abnormally, causing the window state to never be saved:
     APPLICATION->settings()->set("MainWindowState", QString::fromUtf8(saveState().toBase64()));
@@ -1470,11 +1484,6 @@ void MainWindow::newsButtonClicked()
     NewsDialog news_dialog(entries, this);
     news_dialog.toggleArticleList();
     news_dialog.exec();
-}
-
-void MainWindow::onCatChanged(int)
-{
-    setCatBackground(APPLICATION->settings()->get("TheCat").toBool());
 }
 
 void MainWindow::on_actionAbout_triggered()

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -340,7 +340,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWi
         ui->actionCAT->setPriority(QAction::LowPriority);
         updateCatState();
         connect(ui->actionCAT, &QAction::toggled, this, &MainWindow::onCatToggled);
-        connect(APPLICATION, &Application::currentCatChanged, this, &MainWindow::updateCatState);
+        connect(APPLICATION, &Application::currentCatChanged, this, &MainWindow::onCatChanged);
     }
 
     // Togglable status bar
@@ -1484,6 +1484,11 @@ void MainWindow::newsButtonClicked()
     NewsDialog news_dialog(entries, this);
     news_dialog.toggleArticleList();
     news_dialog.exec();
+}
+
+void MainWindow::onCatChanged(int)
+{
+    setCatBackground(APPLICATION->settings()->get("TheCat").toBool());
 }
 
 void MainWindow::on_actionAbout_triggered()

--- a/launcher/ui/MainWindow.h
+++ b/launcher/ui/MainWindow.h
@@ -90,6 +90,8 @@ class MainWindow : public QMainWindow {
    private slots:
     void onCatToggled(bool);
 
+    void onCatChanged(int);
+
     void on_actionAbout_triggered();
 
     void on_actionAddInstance_triggered();

--- a/launcher/ui/MainWindow.h
+++ b/launcher/ui/MainWindow.h
@@ -90,8 +90,6 @@ class MainWindow : public QMainWindow {
    private slots:
     void onCatToggled(bool);
 
-    void onCatChanged(int);
-
     void on_actionAbout_triggered();
 
     void on_actionAddInstance_triggered();
@@ -224,6 +222,7 @@ class MainWindow : public QMainWindow {
     void addInstance(const QString& url = QString(), const QMap<QString, QString>& extra_info = {});
     void activateInstance(BaseInstance* instance);
     void setCatBackground(bool enabled);
+    void updateCatState();
     void updateInstanceToolIcon(QString new_icon);
     void setSelectedInstanceById(const QString& id);
     void updateStatusCenter();

--- a/launcher/ui/widgets/AppearanceWidget.cpp
+++ b/launcher/ui/widgets/AppearanceWidget.cpp
@@ -51,10 +51,7 @@ AppearanceWidget::AppearanceWidget(bool themesOnly, QWidget* parent)
 {
     m_ui->setupUi(this);
 
-    connect(m_ui->enableCatCheckBox, &QCheckBox::toggled, m_ui->catOpacityLabel, &QWidget::setEnabled);
-    connect(m_ui->enableCatCheckBox, &QCheckBox::toggled, m_ui->catOpacityWidget, &QWidget::setEnabled);
-    connect(m_ui->enableCatCheckBox, &QCheckBox::toggled, m_ui->catFitLabel, &QWidget::setEnabled);
-    connect(m_ui->enableCatCheckBox, &QCheckBox::toggled, m_ui->catFitComboBox, &QWidget::setEnabled);
+    connect(m_ui->enableCatCheckBox, &QCheckBox::toggled, m_ui->catSettingsBox, &QWidget::setEnabled);
 
     m_ui->catPreview->setGraphicsEffect(new QGraphicsOpacityEffect(this));
 

--- a/launcher/ui/widgets/AppearanceWidget.cpp
+++ b/launcher/ui/widgets/AppearanceWidget.cpp
@@ -51,6 +51,11 @@ AppearanceWidget::AppearanceWidget(bool themesOnly, QWidget* parent)
 {
     m_ui->setupUi(this);
 
+    connect(m_ui->enableCatCheckBox, &QCheckBox::toggled, m_ui->catOpacityLabel, &QWidget::setEnabled);
+    connect(m_ui->enableCatCheckBox, &QCheckBox::toggled, m_ui->catOpacityWidget, &QWidget::setEnabled);
+    connect(m_ui->enableCatCheckBox, &QCheckBox::toggled, m_ui->catFitLabel, &QWidget::setEnabled);
+    connect(m_ui->enableCatCheckBox, &QCheckBox::toggled, m_ui->catFitComboBox, &QWidget::setEnabled);
+
     m_ui->catPreview->setGraphicsEffect(new QGraphicsOpacityEffect(this));
 
     m_defaultFormat = QTextCharFormat(m_ui->consolePreview->currentCharFormat());
@@ -99,6 +104,11 @@ void AppearanceWidget::applySettings()
     QString consoleFontFamily = m_ui->consoleFont->currentFont().family();
     settings->set("ConsoleFont", consoleFontFamily);
     settings->set("ConsoleFontSize", m_ui->fontSizeBox->value());
+    const bool catEnabled = m_ui->enableCatCheckBox->isChecked();
+    settings->set("EnableCat", catEnabled);
+    if (!catEnabled) {
+        settings->set("TheCat", false);
+    }
     settings->set("CatOpacity", m_ui->catOpacitySlider->value());
     auto catFit = m_ui->catFitComboBox->currentIndex();
     settings->set("CatFit", catFit == 0 ? "fit" : catFit == 1 ? "fill" : "strech");
@@ -118,6 +128,7 @@ void AppearanceWidget::loadSettings()
     }
     m_ui->fontSizeBox->setValue(fontSize);
 
+    m_ui->enableCatCheckBox->setChecked(settings->get("EnableCat").toBool());
     m_ui->catOpacitySlider->setValue(settings->get("CatOpacity").toInt());
 
     auto catFit = settings->get("CatFit").toString();

--- a/launcher/ui/widgets/AppearanceWidget.ui
+++ b/launcher/ui/widgets/AppearanceWidget.ui
@@ -214,170 +214,179 @@
        </widget>
       </item>
       <item>
-       <widget class="QLabel" name="catOpacityLabel">
-        <property name="text">
-         <string>Cat Opacity</string>
+       <widget class="QGroupBox" name="catSettingsBox">
+        <property name="title">
+         <string/>
         </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QWidget" name="widget_2" native="true">
-        <property name="maximumSize">
-         <size>
-          <width>300</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-        </layout>
-       </widget>
-      </item>
-      <item>
-       <widget class="QWidget" name="catOpacityWidget" native="true">
-        <property name="maximumSize">
-         <size>
-          <width>300</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_4">
-         <property name="leftMargin">
-          <number>0</number>
-         </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
-         <item row="3" column="3">
-          <widget class="QLabel" name="label_5">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
+        <layout class="QVBoxLayout" name="verticalLayout_6">
+         <item>
+          <widget class="QLabel" name="catOpacityLabel">
            <property name="text">
-            <string>Opaque</string>
+            <string>Cat Opacity</string>
            </property>
           </widget>
          </item>
-         <item row="3" column="2">
-          <spacer name="horizontalSpacer_4">
+         <item>
+          <widget class="QWidget" name="widget_2" native="true">
+           <property name="maximumSize">
+            <size>
+             <width>300</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QWidget" name="widget" native="true">
+           <property name="maximumSize">
+            <size>
+             <width>300</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_4">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <property name="topMargin">
+             <number>0</number>
+            </property>
+            <property name="rightMargin">
+             <number>0</number>
+            </property>
+            <property name="bottomMargin">
+             <number>0</number>
+            </property>
+            <item row="3" column="3">
+             <widget class="QLabel" name="label_5">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="text">
+               <string>Opaque</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="2">
+             <spacer name="horizontalSpacer_4">
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>0</width>
+                <height>0</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item row="3" column="1">
+             <widget class="QLabel" name="label_4">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="text">
+               <string>Transparent</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0" colspan="4">
+             <widget class="QSlider" name="catOpacitySlider">
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="maximum">
+               <number>100</number>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Orientation::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <spacer name="verticalSpacer">
            <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
+            <enum>Qt::Orientation::Vertical</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Policy::Fixed</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
              <width>0</width>
-             <height>0</height>
+             <height>6</height>
             </size>
            </property>
           </spacer>
          </item>
-         <item row="3" column="1">
-          <widget class="QLabel" name="label_4">
-           <property name="enabled">
-            <bool>false</bool>
+         <item>
+          <widget class="QLabel" name="catFitLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
            </property>
            <property name="text">
-            <string>Transparent</string>
+            <string>Cat Scaling</string>
            </property>
           </widget>
          </item>
-         <item row="2" column="0" colspan="4">
-          <widget class="QSlider" name="catOpacitySlider">
-           <property name="minimumSize">
+         <item>
+          <widget class="QComboBox" name="catFitComboBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="sizeHint" stdset="0">
             <size>
-             <width>0</width>
-             <height>0</height>
+             <width>81</width>
+             <height>32</height>
             </size>
            </property>
-           <property name="maximum">
-            <number>100</number>
+           <property name="currentIndex">
+            <number>0</number>
            </property>
-           <property name="orientation">
-            <enum>Qt::Orientation::Horizontal</enum>
-           </property>
+           <item>
+            <property name="text">
+             <string>Fit</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Fill</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Stretch</string>
+            </property>
+           </item>
           </widget>
          </item>
         </layout>
-       </widget>
-      </item>
-      <item>
-       <spacer name="verticalSpacer">
-        <property name="orientation">
-         <enum>Qt::Orientation::Vertical</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Policy::Fixed</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>0</width>
-          <height>6</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QLabel" name="catFitLabel">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>Cat Scaling</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QComboBox" name="catFitComboBox">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>81</width>
-          <height>32</height>
-         </size>
-        </property>
-        <property name="currentIndex">
-         <number>0</number>
-        </property>
-        <item>
-         <property name="text">
-          <string>Fit</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Fill</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Stretch</string>
-         </property>
-        </item>
        </widget>
       </item>
      </layout>

--- a/launcher/ui/widgets/AppearanceWidget.ui
+++ b/launcher/ui/widgets/AppearanceWidget.ui
@@ -204,6 +204,16 @@
        </spacer>
       </item>
       <item>
+       <widget class="QCheckBox" name="enableCatCheckBox">
+        <property name="text">
+         <string>Enable cat</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QLabel" name="catOpacityLabel">
         <property name="text">
          <string>Cat Opacity</string>
@@ -235,7 +245,7 @@
        </widget>
       </item>
       <item>
-       <widget class="QWidget" name="widget" native="true">
+       <widget class="QWidget" name="catOpacityWidget" native="true">
         <property name="maximumSize">
          <size>
           <width>300</width>
@@ -623,8 +633,9 @@
   <tabstop>reloadThemesButton</tabstop>
   <tabstop>consoleFont</tabstop>
   <tabstop>fontSizeBox</tabstop>
-  <tabstop>catFitComboBox</tabstop>
+  <tabstop>enableCatCheckBox</tabstop>
   <tabstop>catOpacitySlider</tabstop>
+  <tabstop>catFitComboBox</tabstop>
   <tabstop>consolePreview</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
This PR adds an option to disable the cat in Appearance. The cat stays enabled by default. Turning it off disables any active cat, hides its toolbar button and view menu entry, and grays out the related settings.

Related to #799 and #5102

### Preview

https://github.com/user-attachments/assets/c6d8d559-0636-4022-94de-ecce50fed75a