### PR TITLE
Make instance grid items themeable via InstanceView::item

### DIFF
--- a/launcher/ui/instanceview/InstanceDelegate.cpp
+++ b/launcher/ui/instanceview/InstanceDelegate.cpp
@@ -42,7 +42,9 @@
 #include <QtMath>
 
 #include <QIcon>
+#include <QStyle>
 #include <QTextEdit>
+#include <QWidget>
 #include "BaseInstance.h"
 #include "InstanceList.h"
 #include "InstanceView.h"
@@ -70,15 +72,113 @@ static void viewItemTextLayout(QTextLayout& textLayout, int lineWidth, qreal& he
 
 ListViewDelegate::ListViewDelegate(QObject* parent) : QStyledItemDelegate(parent) {}
 
+static bool highlightSelectedText(const QStyleOptionViewItem& option)
+{
+    if (option.widget) {
+        const QVariant value = option.widget->property("highlightSelectedText");
+        if (value.isValid())
+            return value.toBool();
+    }
+    return false;
+}
+
+static bool highlightSelectedIcon(const QStyleOptionViewItem& option)
+{
+    if (option.widget) {
+        const QVariant value = option.widget->property("highlightSelectedIcon");
+        if (value.isValid())
+            return value.toBool();
+    }
+    return false;
+}
+
+static QColor mixColor(const QColor& from, const QColor& to, qreal amount)
+{
+    return QColor::fromRgbF(from.redF() + (to.redF() - from.redF()) * amount, from.greenF() + (to.greenF() - from.greenF()) * amount,
+                            from.blueF() + (to.blueF() - from.blueF()) * amount);
+}
+
+// Built-in look for the instance grid, used when no theme stylesheet is loaded.
+//
+// Hover and selection are separated by kind rather than by strength. Hover is
+// transient, so it takes the brighter fill. Selection is permanent, so it stays
+// dim and is marked with a border instead - that keeps a constant block of
+// colour off the instance icons, and the two states remain distinct when they
+// overlap. Colours are mixed from the palette so this follows any theme,
+// including light ones, instead of hardcoding greys.
+static void drawDefaultItemPanel(QPainter* painter, const QStyleOptionViewItem& option)
+{
+    const bool selected = option.state & QStyle::State_Selected;
+    const bool hovered = option.state & QStyle::State_MouseOver;
+    if (!selected && !hovered)
+        return;
+
+    const QColor base = option.palette.color(QPalette::Window);
+    const QColor toward = option.palette.color(QPalette::Text);
+
+    // even tonal steps, roughly 1.1-1.2:1 apart from each other
+    qreal fillAmount = 0.05;
+    if (selected && hovered)
+        fillAmount = 0.15;
+    else if (hovered)
+        fillAmount = 0.11;
+
+    const qreal radius = 5.0;
+    const QRectF rounded = QRectF(option.rect).adjusted(0.5, 0.5, -0.5, -0.5);
+
+    painter->save();
+    painter->setRenderHint(QPainter::Antialiasing, true);
+    painter->setPen(Qt::NoPen);
+    painter->setBrush(mixColor(base, toward, fillAmount));
+    painter->drawRoundedRect(rounded, radius, radius);
+
+    if (selected) {
+        painter->setBrush(Qt::NoBrush);
+        painter->setPen(QPen(mixColor(base, toward, hovered ? 0.50 : 0.40), 1.0));
+        painter->drawRoundedRect(rounded, radius, radius);
+    }
+    painter->restore();
+}
+
+// With a theme stylesheet loaded, hand the item panel to QStyleSheetStyle so
+// InstanceView::item and its :hover / :selected rules take effect, the same way
+// QTreeView::item already works. Otherwise draw the built-in look above.
+static void drawItemPanel(QPainter* painter, const QStyleOptionViewItem& option)
+{
+    if (qApp && !qApp->styleSheet().isEmpty()) {
+        QStyle* style = option.widget ? option.widget->style() : QApplication::style();
+        QStyleOptionViewItem panel = option;
+        panel.showDecorationSelected = true;
+        style->drawPrimitive(QStyle::PE_PanelItemViewItem, &panel, painter, option.widget);
+        return;
+    }
+
+    drawDefaultItemPanel(painter, option);
+}
+
+// Optional translucent plate behind the instance name, for themes that leave
+// the item background transparent. Off unless a theme asks for it with
+// InstanceView { qproperty-labelBackgroundAlpha: 160; }
+static void drawLabelBackground(QPainter* painter, const QStyleOptionViewItem& option, const QRect& rect)
+{
+    int alpha = 0;
+    if (option.widget) {
+        const QVariant value = option.widget->property("labelBackgroundAlpha");
+        if (value.isValid())
+            alpha = qBound(0, value.toInt(), 255);
+    }
+    if (alpha == 0)
+        return;
+
+    QColor backgroundColor = option.palette.color(QPalette::Window);
+    backgroundColor.setAlpha(alpha);
+    painter->fillRect(rect, QBrush(backgroundColor));
+}
+
 void drawSelectionRect(QPainter* painter, const QStyleOptionViewItem& option, const QRect& rect)
 {
-    if ((option.state & QStyle::State_Selected))
-        painter->fillRect(rect, option.palette.brush(QPalette::Highlight));
-    else {
-        QColor backgroundColor = option.palette.color(QPalette::Window);
-        backgroundColor.setAlpha(160);
-        painter->fillRect(rect, QBrush(backgroundColor));
-    }
+    drawItemPanel(painter, option);
+    drawLabelBackground(painter, option, rect);
 }
 
 void drawFocusRect(QPainter* painter, const QStyleOptionViewItem& option, const QRect& rect)
@@ -266,7 +366,7 @@ void ListViewDelegate::paint(QPainter* painter, const QStyleOptionViewItem& opti
     QIcon::Mode mode = QIcon::Normal;
     if (!(opt.state & QStyle::State_Enabled))
         mode = QIcon::Disabled;
-    else if (opt.state & QStyle::State_Selected)
+    else if ((opt.state & QStyle::State_Selected) && highlightSelectedIcon(opt))
         mode = QIcon::Selected;
     QIcon::State state = opt.state & QStyle::State_Open ? QIcon::On : QIcon::Off;
 
@@ -279,7 +379,7 @@ void ListViewDelegate::paint(QPainter* painter, const QStyleOptionViewItem& opti
     QPalette::ColorGroup cg = opt.state & QStyle::State_Enabled ? QPalette::Normal : QPalette::Disabled;
     if (cg == QPalette::Normal && !(opt.state & QStyle::State_Active))
         cg = QPalette::Inactive;
-    if (opt.state & QStyle::State_Selected) {
+    if ((opt.state & QStyle::State_Selected) && highlightSelectedText(opt)) {
         painter->setPen(opt.palette.color(cg, QPalette::HighlightedText));
     } else {
         painter->setPen(opt.palette.color(cg, QPalette::Text));

--- a/launcher/ui/instanceview/InstanceView.cpp
+++ b/launcher/ui/instanceview/InstanceView.cpp
@@ -72,6 +72,9 @@ InstanceView::InstanceView(QWidget* parent) : QAbstractItemView(parent)
     setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     setAcceptDrops(true);
     setAutoScroll(true);
+    // needed so items can report State_MouseOver, for the hover state and for
+    // themes using InstanceView::item:hover
+    viewport()->setMouseTracking(true);
     setPaintCat(APPLICATION->settings()->get("TheCat").toBool());
     connect(verticalScrollBar(), &QScrollBar::valueChanged, viewport(), QOverload<>::of(&QWidget::update));
     connect(horizontalScrollBar(), &QScrollBar::valueChanged, viewport(), QOverload<>::of(&QWidget::update));
@@ -317,9 +320,24 @@ void InstanceView::mousePressEvent(QMouseEvent* event)
     }
 }
 
+bool InstanceView::viewportEvent(QEvent* event)
+{
+    if (event->type() == QEvent::Leave && m_hoveredIndex.isValid()) {
+        m_hoveredIndex = QModelIndex();
+        viewport()->update();
+    }
+    return QAbstractItemView::viewportEvent(event);
+}
+
 void InstanceView::mouseMoveEvent(QMouseEvent* event)
 {
     executeDelayedItemsLayout();
+
+    const QPersistentModelIndex hovered = indexAt(event->pos());
+    if (hovered != m_hoveredIndex) {
+        m_hoveredIndex = hovered;
+        viewport()->update();
+    }
 
     QPoint topLeft;
     QPoint visualPos = event->pos();
@@ -537,7 +555,18 @@ void InstanceView::paintEvent([[maybe_unused]] QPaintEvent* event)
         } else {
             option.state &= ~QStyle::State_Selected;
         }
-        option.state |= (index == currentIndex()) ? QStyle::State_HasFocus : QStyle::State_None;
+        // option is reused across iterations, so these have to be cleared as
+        // well as set - otherwise the flag leaks onto every later item. The
+        // view is also under the mouse as a whole, which sets State_MouseOver
+        // on the shared option before the loop even starts.
+        if (index == currentIndex())
+            option.state |= QStyle::State_HasFocus;
+        else
+            option.state &= ~QStyle::State_HasFocus;
+        if (index == m_hoveredIndex)
+            option.state |= QStyle::State_MouseOver;
+        else
+            option.state &= ~QStyle::State_MouseOver;
         if (!(flags & Qt::ItemIsEnabled)) {
             option.state &= ~QStyle::State_Enabled;
         }

--- a/launcher/ui/instanceview/InstanceView.h
+++ b/launcher/ui/instanceview/InstanceView.h
@@ -50,6 +50,24 @@ struct InstanceViewRoles {
 class InstanceView : public QAbstractItemView {
     Q_OBJECT
 
+    // Appearance knobs a theme can set from QSS, e.g.
+    //     InstanceView { qproperty-labelBackgroundAlpha: 160; }
+    //
+    // labelBackgroundAlpha draws a translucent plate behind the instance name.
+    // It is off by default because the item background covers readability;
+    // themes that leave the item transparent may want it back.
+    //
+    // highlightSelectedText paints selected labels with HighlightedText. It is
+    // off by default because the default selection has no filled background.
+    // Themes that fill InstanceView::item:selected should turn it on.
+    Q_PROPERTY(int labelBackgroundAlpha MEMBER m_labelBackgroundAlpha)
+    Q_PROPERTY(bool highlightSelectedText MEMBER m_highlightSelectedText)
+    //
+    // highlightSelectedIcon tints the icon with QIcon::Selected. Off by
+    // default: instance icons are user artwork and the tint only makes sense
+    // when the selection is a solid block of Highlight behind them.
+    Q_PROPERTY(bool highlightSelectedIcon MEMBER m_highlightSelectedIcon)
+
    public:
     InstanceView(QWidget* parent = 0);
     ~InstanceView();
@@ -99,6 +117,7 @@ class InstanceView : public QAbstractItemView {
     bool isIndexHidden(const QModelIndex& index) const override;
     void mousePressEvent(QMouseEvent* event) override;
     void mouseMoveEvent(QMouseEvent* event) override;
+    bool viewportEvent(QEvent* event) override;
     void mouseReleaseEvent(QMouseEvent* event) override;
     void mouseDoubleClickEvent(QMouseEvent* event) override;
     void paintEvent(QPaintEvent* event) override;
@@ -134,6 +153,12 @@ class InstanceView : public QAbstractItemView {
     // point where the currently active mouse action started in geometry coordinates
     QPoint m_pressedPosition;
     QPersistentModelIndex m_pressedIndex;
+    QPersistentModelIndex m_hoveredIndex;
+
+    // theme-settable appearance, see the Q_PROPERTY declarations above
+    int m_labelBackgroundAlpha = 0;
+    bool m_highlightSelectedText = false;
+    bool m_highlightSelectedIcon = false;
     bool m_pressedAlreadySelected;
     VisualGroup* m_pressedCategory;
     QItemSelectionModel::SelectionFlag m_ctrlDragSelectionFlag;


### PR DESCRIPTION
Instance grid items are hardcoded — the only lever a theme has is `Highlight` in `theme.json`, which paints a bar behind the instance name and leaves the icon area alone. Every other item view in Prism is themeable; this one isn't. There's already a `// TODO this can be made a lot prettier` on that function.

This routes the item background through `PE_PanelItemViewItem`, so themes can use `InstanceView::item` and its `:hover` / `:selected` states the same way they already use `QTreeView::item`:

```css
InstanceView::item:hover    { background-color: #302f3a; }
InstanceView::item:selected { background-color: transparent;
                              border: 1px solid #6a6878; }
```

It also adds hover tracking — `InstanceView` never set `State_MouseOver` at all, so items had no hover state.

The default look changes too. Colours are mixed from the palette rather than hardcoded, so it follows any theme including light ones: hover gets a brighter fill, selected gets a dimmer fill plus a border. Hover is transient so it can be the louder one; selection is permanent, so it stays quiet and is marked by the border instead, which keeps a constant block of colour off the icons.

Three `qproperty-` switches handle the bits CSS can't reach (the plate behind the label, and selected text/icon colours) — Prism draws those itself, so `::item` rules don't apply to them.

One rough edge: if a theme has a stylesheet but doesn't style `InstanceView::item`, my code steps aside and Qt falls back to its plain highlight instead of the new default. I couldn't find a way to ask Qt whether a rule exists for a selector — open to suggestions.

## Before (ugly)

Not selected:

<img width="112" height="114" alt="before, not selected" src="https://github.com/user-attachments/assets/78e53b63-8998-40a9-bca0-c4e391589b13" />

Selected — filled bar behind the name, icon tinted grey:

<img width="112" height="113" alt="before, selected" src="https://github.com/user-attachments/assets/288e815e-a632-41db-9b0d-1ec95dc5eeb1" />

## After (pretty)

Default look, 2nd item selected:

<img width="222" height="122" alt="after, selected" src="https://github.com/user-attachments/assets/af2e4328-e23d-432c-b6a7-fb8271a88a25" />

Hover on an unselected item, with another still selected:

<img width="219" height="128" alt="after, hover and selected" src="https://github.com/user-attachments/assets/376a2324-525f-467d-bdc1-b6b4244a2244" />

## For theme authors

Instance items are now styled like any other item view:

```css
InstanceView::item                { /* normal */ }
InstanceView::item:hover          { /* mouse over */ }
InstanceView::item:selected       { /* selected */ }
InstanceView::item:selected:hover { /* both */ }
```

Anything QSS supports works — `background-color`, `border`, `border-radius`, `border-image`, gradients.

Three properties cover what QSS can't reach, since the delegate lays out the label and paints the icon itself:

| property | default | what it does |
|---|---|---|
| `labelBackgroundAlpha` | `0` | alpha of the plate drawn behind the instance name (0–255) |
| `highlightSelectedText` | `false` | selected labels use `HighlightedText` instead of `Text` |
| `highlightSelectedIcon` | `false` | selected icons are tinted with `QIcon::Selected` |

Set those on `InstanceView` itself:

```css
InstanceView {
    qproperty-labelBackgroundAlpha: 160;
    qproperty-highlightSelectedText: true;
    qproperty-highlightSelectedIcon: true;
}
```

Themes that fill `::item:selected` with a solid colour will want the last two on, so the label and icon adapt to it. Themes using an outline or a subtle fill should leave them off.

Example theme:

```css
InstanceView {
    qproperty-highlightSelectedText: true;
}

InstanceView::item {
    background-color: transparent;
    border: 2px solid transparent;
    border-radius: 5px;
}

InstanceView::item:hover {
    background-color: #2a2833;
    border-color: #3d3a4a;
}

InstanceView::item:selected {
    background-color: #f7b8ff;
    border-color: #ffffff;
}
```