### PR TITLE
Add warning for untrusted mods in imported modpacks

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -1100,6 +1100,8 @@ SET(LAUNCHER_SOURCES
     ui/dialogs/InstallLoaderDialog.h
     ui/dialogs/ChooseOfflineNameDialog.cpp
     ui/dialogs/ChooseOfflineNameDialog.h
+    ui/dialogs/UntrustedModsDialog.cpp
+    ui/dialogs/UntrustedModsDialog.h
 
     ui/dialogs/skins/SkinManageDialog.cpp
     ui/dialogs/skins/SkinManageDialog.h

--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -300,11 +300,11 @@ void InstanceImportTask::processFlame()
             originalInstanceId = originalInstanceIdIt.value();
         }
 
-        instCreationTask =
-            makeShared<FlameCreationTask>(m_stagingPath, m_globalSettings, m_parent, packId, packVersionId, originalInstanceId);
+        instCreationTask = makeShared<FlameCreationTask>(m_stagingPath, m_trustedSource, m_globalSettings, m_parent, packId, packVersionId,
+                                                         originalInstanceId);
     } else {
         // FIXME: Find a way to get IDs in directly imported ZIPs
-        instCreationTask = makeShared<FlameCreationTask>(m_stagingPath, m_globalSettings, m_parent, QString(), QString());
+        instCreationTask = makeShared<FlameCreationTask>(m_stagingPath, m_trustedSource, m_globalSettings, m_parent, QString(), QString());
     }
 
     instCreationTask->setName(modifiedName());
@@ -397,8 +397,8 @@ void InstanceImportTask::processModrinth()
             originalInstanceId = originalInstanceIdIt.value();
         }
 
-        instCreationTask =
-            makeShared<ModrinthCreationTask>(m_stagingPath, m_globalSettings, m_parent, packId, packVersionId, originalInstanceId);
+        instCreationTask = makeShared<ModrinthCreationTask>(m_stagingPath, m_trustedSource, m_globalSettings, m_parent, packId,
+                                                            packVersionId, originalInstanceId);
     } else {
         QString packId;
         if (!m_sourceUrl.isEmpty()) {
@@ -407,7 +407,7 @@ void InstanceImportTask::processModrinth()
         }
 
         // FIXME: Find a way to get the ID in directly imported ZIPs
-        instCreationTask = makeShared<ModrinthCreationTask>(m_stagingPath, m_globalSettings, m_parent, packId);
+        instCreationTask = makeShared<ModrinthCreationTask>(m_stagingPath, m_trustedSource, m_globalSettings, m_parent, packId);
     }
 
     instCreationTask->setName(modifiedName());

--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -60,8 +60,8 @@
 #include <memory>
 #include <utility>
 
-InstanceImportTask::InstanceImportTask(QUrl sourceUrl, QWidget* parent, QMap<QString, QString> extraInfo)
-    : m_sourceUrl(std::move(sourceUrl)), m_extra_info(std::move(extraInfo)), m_parent(parent)
+InstanceImportTask::InstanceImportTask(QUrl sourceUrl, bool trustedSource, QWidget* parent, QMap<QString, QString> extraInfo)
+    : m_sourceUrl(std::move(sourceUrl)), m_trustedSource(trustedSource), m_extra_info(std::move(extraInfo)), m_parent(parent)
 {}
 
 bool InstanceImportTask::abort()

--- a/launcher/InstanceImportTask.h
+++ b/launcher/InstanceImportTask.h
@@ -43,7 +43,7 @@
 class InstanceImportTask : public InstanceTask {
     Q_OBJECT
    public:
-    explicit InstanceImportTask(QUrl sourceUrl, QWidget* parent = nullptr, QMap<QString, QString> extraInfo = {});
+    explicit InstanceImportTask(QUrl sourceUrl, bool trustedSource, QWidget* parent = nullptr, QMap<QString, QString> extraInfo = {});
     ~InstanceImportTask() override = default;
     bool abort() override;
 
@@ -64,6 +64,7 @@ class InstanceImportTask : public InstanceTask {
 
    private: /* data */
     QUrl m_sourceUrl;
+    bool m_trustedSource;
     QString m_archivePath;
     Task::Ptr m_task;
     enum class ModpackType : std::uint8_t {

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -67,6 +67,7 @@
 #include "minecraft/World.h"
 #include "minecraft/mod/tasks/LocalResourceParse.h"
 #include "net/ApiDownload.h"
+#include "ui/dialogs/UntrustedModsDialog.h"
 #include "ui/pages/modplatform/OptionalModDialog.h"
 
 bool FlameCreationTask::abort()
@@ -343,6 +344,31 @@ void FlameCreationTask::setManagedPack(BaseInstance* instance)
     }
 }
 
+bool FlameCreationTask::promptForUntrustedMods()
+{
+    if (m_trustedSource) {
+        return true;
+    }
+
+    QStringList untrustedMods;
+
+    const QDir mcDir{ FS::PathCombine(m_stagingPath, "minecraft") };
+    const QString modsPath{ FS::PathCombine(m_stagingPath, "minecraft/mods") };
+    if (QDir(modsPath).exists()) {
+        QDirIterator iter{ modsPath, QDir::Files, QDirIterator::Subdirectories | QDirIterator::FollowSymlinks };
+        while (iter.hasNext()) {
+            untrustedMods.append(mcDir.relativeFilePath(iter.next()));
+        }
+    }
+
+    if (untrustedMods.empty()) {
+        return true;
+    }
+
+    UntrustedModsDialog dialog{ untrustedMods, m_parent };
+    return dialog.exec() == QDialog::Accepted;
+}
+
 void FlameCreationTask::createInstance()
 {
     const QString parentFolder(FS::PathCombine(m_stagingPath, "flame"));
@@ -378,6 +404,11 @@ void FlameCreationTask::createInstance()
             logWarning(
                 tr("The specified overrides folder (%1) is missing. Maybe the modpack was already used before?").arg(m_pack.overrides));
         }
+    }
+
+    if (!promptForUntrustedMods()) {
+        emitAborted();
+        return;
     }
 
     QString loaderType;

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.h
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.h
@@ -52,12 +52,13 @@ class FlameCreationTask final : public InstanceTask {
 
    public:
     FlameCreationTask(const QString& stagingPath,
+                      bool trustedSource,
                       SettingsObject* globalSettings,
                       QWidget* parent,
                       QString id,
                       QString versionId,
                       const QString& originalInstanceId = {})
-        : m_parent(parent), m_managedId(std::move(id)), m_managedVersionId(std::move(versionId))
+        : m_parent(parent), m_trustedSource(trustedSource), m_managedId(std::move(id)), m_managedVersionId(std::move(versionId))
     {
         setStagingPath(stagingPath);
         setParentSettings(globalSettings);
@@ -81,8 +82,11 @@ class FlameCreationTask final : public InstanceTask {
    private:
     void setManagedPack(BaseInstance* instance);
 
+    [[nodiscard]] bool promptForUntrustedMods();
+
    private:
     QWidget* m_parent = nullptr;
+    bool m_trustedSource;
 
     shared_qobject_ptr<Flame::FileResolvingTask> m_modIdResolver;
     Flame::Manifest m_pack;

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
@@ -22,6 +22,7 @@
 #include "settings/INISettingsObject.h"
 
 #include "ui/dialogs/CustomMessageBox.h"
+#include "ui/dialogs/UntrustedModsDialog.h"
 #include "ui/pages/modplatform/OptionalModDialog.h"
 
 #include <QAbstractButton>
@@ -202,6 +203,11 @@ void ModrinthCreationTask::createInstance()
             emitFailed(tr("Could not rename the client overrides folder:\n") + "client overrides");
             return;
         }
+    }
+
+    if (!promptForUntrustedMods()) {
+        emitAborted();
+        return;
     }
 
     QString configPath = FS::PathCombine(m_stagingPath, "instance.cfg");
@@ -448,6 +454,40 @@ void ModrinthCreationTask::ensureMetaLoop()
 
     ensureMetadataTask->start();
     m_task = ensureMetadataTask;
+}
+
+bool ModrinthCreationTask::promptForUntrustedMods()
+{
+    if (m_trustedSource) {
+        return true;
+    }
+
+    QStringList untrustedMods;
+
+    for (const auto& file : m_files) {
+        for (const auto& url : file.downloads) {
+            if (url.scheme() != "https" || url.host() != BuildConfig.MODRINTH_DOWNLOAD_HOST) {
+                untrustedMods.append(file.path);
+                break;
+            }
+        }
+    }
+
+    const QDir mcDir{ FS::PathCombine(m_stagingPath, m_rootPath) };
+    const QString modsPath{ FS::PathCombine(m_stagingPath, m_rootPath, "mods") };
+    if (QDir(modsPath).exists()) {
+        QDirIterator iter{ modsPath, QDir::Files, QDirIterator::Subdirectories | QDirIterator::FollowSymlinks };
+        while (iter.hasNext()) {
+            untrustedMods.append(mcDir.relativeFilePath(iter.next()));
+        }
+    }
+
+    if (untrustedMods.empty()) {
+        return true;
+    }
+
+    UntrustedModsDialog dialog{ untrustedMods, m_parent };
+    return dialog.exec() == QDialog::Accepted;
 }
 
 ModrinthCreationTask::~ModrinthCreationTask()

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.h
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.h
@@ -27,12 +27,13 @@ class ModrinthCreationTask final : public InstanceTask {
 
    public:
     ModrinthCreationTask(const QString& stagingPath,
+                         bool trustedSource,
                          SettingsObject* globalSettings,
                          QWidget* parent,
                          QString id,
                          QString versionId = {},
                          QString originalInstanceId = {})
-        : m_parent(parent), m_managedId(std::move(id)), m_managedVersionId(std::move(versionId))
+        : m_parent(parent), m_trustedSource(trustedSource), m_managedId(std::move(id)), m_managedVersionId(std::move(versionId))
     {
         setStagingPath(stagingPath);
         setParentSettings(globalSettings);
@@ -55,8 +56,11 @@ class ModrinthCreationTask final : public InstanceTask {
     void ensureMetaLoop();
     void setManagedPack(BaseInstance* instance);
 
+    [[nodiscard]] bool promptForUntrustedMods();
+
    private:
     QWidget* m_parent = nullptr;
+    bool m_trustedSource;
 
     QString m_minecraftVersion, m_fabricVersion, m_quiltVersion, m_forgeVersion, m_neoForgeVersion;
     QString m_managedId, m_managedVersionId, m_managedName;

--- a/launcher/ui/dialogs/UntrustedModsDialog.cpp
+++ b/launcher/ui/dialogs/UntrustedModsDialog.cpp
@@ -1,0 +1,26 @@
+#include "UntrustedModsDialog.h"
+#include "ui_UntrustedModsDialog.h"
+
+#include <QAbstractButton>
+#include <QDialogButtonBox>
+#include <QPushButton>
+#include <QTimer>
+
+UntrustedModsDialog::UntrustedModsDialog(const QStringList& paths, QWidget* parent) : QDialog{ parent }, m_ui{ new Ui::UntrustedModsDialog }
+{
+    m_ui->setupUi(this);
+    m_ui->modList->addItems(paths);
+
+    auto* ok = m_ui->buttonBox->button(QDialogButtonBox::Ok);
+    ok->setEnabled(false);
+
+    connect(m_ui->confirmCheckbox, &QAbstractButton::clicked, ok, &QWidget::setEnabled);
+
+    m_ui->confirmCheckbox->setEnabled(false);
+    QTimer::singleShot(3000, this, [this] { m_ui->confirmCheckbox->setEnabled(true); });
+}
+
+UntrustedModsDialog::~UntrustedModsDialog()
+{
+    delete m_ui;
+}

--- a/launcher/ui/dialogs/UntrustedModsDialog.h
+++ b/launcher/ui/dialogs/UntrustedModsDialog.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <QDialog>
+#include <QObject>
+#include <QStringList>
+#include <QWidget>
+
+namespace Ui {
+class UntrustedModsDialog;
+}
+
+class UntrustedModsDialog : public QDialog {
+    Q_OBJECT
+   public:
+    explicit UntrustedModsDialog(const QStringList& paths, QWidget* parent = nullptr);
+    ~UntrustedModsDialog() override;
+
+   private:
+    Ui::UntrustedModsDialog* m_ui;
+};

--- a/launcher/ui/dialogs/UntrustedModsDialog.ui
+++ b/launcher/ui/dialogs/UntrustedModsDialog.ui
@@ -27,7 +27,7 @@
    <item>
     <widget class="QLabel" name="labelBelow">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Malicious mods are often distributed through links sent on platforms such as Discord. &lt;/span&gt;&lt;/p&gt;&lt;p&gt;We strongly recommend only importing modpacks from trusted sources.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;b&gt;Malicious mods are often distributed through links sent on platforms such as Discord.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;We strongly recommend only importing modpacks from trusted sources.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
     </widget>
    </item>

--- a/launcher/ui/dialogs/UntrustedModsDialog.ui
+++ b/launcher/ui/dialogs/UntrustedModsDialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>599</width>
+    <width>635</width>
     <height>269</height>
    </rect>
   </property>
@@ -27,7 +27,7 @@
    <item>
     <widget class="QLabel" name="labelBelow">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Malicious mods are often distributed through links sent on platforms such as Discord. &lt;/p&gt;&lt;p&gt;We strongly recommend only importing modpacks from trusted sources.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Malicious mods are often distributed through links sent on platforms such as Discord. &lt;/span&gt;&lt;/p&gt;&lt;p&gt;We strongly recommend only importing modpacks from trusted sources.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
     </widget>
    </item>

--- a/launcher/ui/dialogs/UntrustedModsDialog.ui
+++ b/launcher/ui/dialogs/UntrustedModsDialog.ui
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>UntrustedModsDialog</class>
+ <widget class="QDialog" name="UntrustedModsDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>599</width>
+    <height>269</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Easy There!</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="labelAbove">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The modpack you are installing includes mods which are not hosted on Modrinth or CurseForge:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QListWidget" name="modList"/>
+   </item>
+   <item>
+    <widget class="QLabel" name="labelBelow">
+     <property name="text">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Malicious mods are often distributed through links sent on platforms such as Discord. &lt;/p&gt;&lt;p&gt;We strongly recommend only importing modpacks from trusted sources.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QCheckBox" name="confirmCheckbox">
+     <property name="text">
+      <string>I trust this modpack and wish to proceed regardless</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>UntrustedModsDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>UntrustedModsDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/launcher/ui/pages/instance/ManagedPackPage.cpp
+++ b/launcher/ui/pages/instance/ManagedPackPage.cpp
@@ -304,7 +304,7 @@ void ModrinthManagedPackPage::update()
 {
     auto customURL = m_inst->settings()->get("ManagedPackURL").toString().trimmed();
     if (m_inst->getManagedPackID().isEmpty() && !customURL.isEmpty()) {
-        updatePack(customURL);
+        updatePack(customURL, false);
         return;
     }
     auto index = ui->versionsComboBox->currentIndex();
@@ -314,7 +314,7 @@ void ModrinthManagedPackPage::update()
     }
     auto version = m_pack.versions.at(index);
 
-    updatePack(version.downloadUrl, version.fileId.toString(), version.version);
+    updatePack(version.downloadUrl, true, version.fileId.toString(), version.version);
 }
 
 void ModrinthManagedPackPage::updateFromFile()
@@ -324,7 +324,7 @@ void ModrinthManagedPackPage::updateFromFile()
         return;
     }
 
-    updatePack(output);
+    updatePack(output, false);
 }
 
 // FLAME
@@ -434,7 +434,7 @@ void FlameManagedPackPage::update()
 {
     auto customURL = m_inst->settings()->get("ManagedPackURL").toString().trimmed();
     if (m_inst->getManagedPackID().isEmpty() && !customURL.isEmpty()) {
-        updatePack(customURL);
+        updatePack(customURL, false);
         return;
     }
     auto index = ui->versionsComboBox->currentIndex();
@@ -444,7 +444,7 @@ void FlameManagedPackPage::update()
     }
     auto version = m_pack.versions.at(index);
 
-    updatePack(version.downloadUrl, version.fileId.toString());
+    updatePack(version.downloadUrl, true, version.fileId.toString());
 }
 
 void FlameManagedPackPage::updateFromFile()
@@ -454,10 +454,10 @@ void FlameManagedPackPage::updateFromFile()
         return;
     }
 
-    updatePack(output);
+    updatePack(output, false);
 }
 
-void ManagedPackPage::updatePack(const QUrl& url, const QString& versionID, const QString& versionName)
+void ManagedPackPage::updatePack(const QUrl& url, bool trusted, const QString& versionID, const QString& versionName)
 {
     QMap<QString, QString> extraInfo;
     // NOTE: Don't use 'm_pack.id' here, since we didn't completely parse all the metadata for the pack, including this field.
@@ -465,7 +465,7 @@ void ManagedPackPage::updatePack(const QUrl& url, const QString& versionID, cons
     extraInfo.insert("pack_version_id", versionID);
     extraInfo.insert("original_instance_id", m_inst->id());
 
-    auto* extracted = new InstanceImportTask(url, this, std::move(extraInfo));
+    auto* extracted = new InstanceImportTask(url, trusted, this, std::move(extraInfo));
 
     if (versionName.isEmpty()) {
         extracted->setName(m_inst->name());

--- a/launcher/ui/pages/instance/ManagedPackPage.h
+++ b/launcher/ui/pages/instance/ManagedPackPage.h
@@ -84,7 +84,7 @@ class ManagedPackPage : public QWidget, public BasePage {
      */
     bool runUpdateTask(InstanceTask*);
 
-    void updatePack(const QUrl& url, const QString& versionID = {}, const QString& versionName = {});
+    void updatePack(const QUrl& url, bool trusted, const QString& versionID = {}, const QString& versionName = {});
 
     void onUpdateTaskCompleted(bool didSucceed) const;
 

--- a/launcher/ui/pages/modplatform/ImportPage.cpp
+++ b/launcher/ui/pages/modplatform/ImportPage.cpp
@@ -118,7 +118,7 @@ void ImportPage::updateState()
             if (fi.exists() && (isZip || isMRPack)) {
                 auto extra_info = QMap(m_extra_info);
                 qDebug() << "Pack Extra Info" << extra_info << m_extra_info;
-                dialog->setSuggestedPack(fi.completeBaseName(), new InstanceImportTask(url, this, std::move(extra_info)));
+                dialog->setSuggestedPack(fi.completeBaseName(), new InstanceImportTask(url, false, this, std::move(extra_info)));
                 dialog->setSuggestedIcon("default");
             }
         } else if (url.scheme() == "curseforge") {
@@ -163,7 +163,7 @@ void ImportPage::updateState()
                     extra_info.insert("pack_id", addonId);
                     extra_info.insert("pack_version_id", fileId);
 
-                    dialog->setSuggestedPack(pack_name, new InstanceImportTask(dl_url, this, std::move(extra_info)));
+                    dialog->setSuggestedPack(pack_name, new InstanceImportTask(dl_url, false, this, std::move(extra_info)));
                     dialog->setSuggestedIcon("default");
 
                 } else {
@@ -183,7 +183,7 @@ void ImportPage::updateState()
             // hook, line and sinker.
             QFileInfo fi(url.fileName());
             auto extra_info = QMap(m_extra_info);
-            dialog->setSuggestedPack(fi.completeBaseName(), new InstanceImportTask(url, this, std::move(extra_info)));
+            dialog->setSuggestedPack(fi.completeBaseName(), new InstanceImportTask(url, false, this, std::move(extra_info)));
             dialog->setSuggestedIcon("default");
         }
     } else {

--- a/launcher/ui/pages/modplatform/flame/FlamePage.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.cpp
@@ -240,7 +240,7 @@ void FlamePage::suggestCurrent()
     extra_info.insert("pack_id", m_current->addonId.toString());
     extra_info.insert("pack_version_id", version.fileId.toString());
 
-    m_dialog->setSuggestedPack(m_current->name, new InstanceImportTask(version.downloadUrl, this, std::move(extra_info)));
+    m_dialog->setSuggestedPack(m_current->name, new InstanceImportTask(version.downloadUrl, true, this, std::move(extra_info)));
     QString editedLogoName = "curseforge_" + m_current->logoName;
     m_listModel->getLogo(m_current->logoName, m_current->logoUrl,
                          [this, editedLogoName](const QString& logo) { m_dialog->setSuggestedIconFromFile(logo, editedLogoName); });

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
@@ -326,7 +326,8 @@ void ModrinthPage::suggestCurrent()
             extra_info.insert("pack_id", m_current->addonId.toString());
             extra_info.insert("pack_version_id", ver.fileId.toString());
 
-            m_dialog->setSuggestedPack(m_current->name, ver.version, new InstanceImportTask(ver.downloadUrl, this, std::move(extra_info)));
+            m_dialog->setSuggestedPack(m_current->name, ver.version,
+                                       new InstanceImportTask(ver.downloadUrl, true, this, std::move(extra_info)));
             QString editedLogoName = "modrinth_" + m_current->logoName;
             m_model->getLogo(m_current->logoName, m_current->logoUrl,
                              [this, editedLogoName](const QString& logo) { m_dialog->setSuggestedIconFromFile(logo, editedLogoName); });


### PR DESCRIPTION
Untrusted source = manually entered URL or manually browsed-to file
Untrusted mod = Any mod under the mods directory after extracting overrides, or in the case of Modrinth, a file in the index where the URL is not on the Modrinth CDN (even though GitHub and GitLab links are also allowed on modpacks uploaded to Modrinth) 

If a modpack from an untrusted source includes 1 or more untrusted mods, a dialog is shown similar to what the Modrinth app has:

<img width="602" height="296" alt="image" src="https://github.com/user-attachments/assets/477d9db2-4bda-44fe-909f-5917f7fad508" />

Not totally sure how I feel about it, but this is just something I threw together