### PR TITLE
Improve performance of BaseInstance::uuid

### DIFF
--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -86,8 +86,12 @@ BaseInstance::BaseInstance(SettingsObject* globalSettings, std::unique_ptr<Setti
     m_settings->registerSetting("linkedInstances", "[]");
     m_settings->registerSetting("shortcuts", QString());
     m_settings->registerSetting("uuid", QString());
-    if (m_settings->get("uuid").toString().isEmpty()) {
+
+    const auto savedUUID = m_settings->get("uuid").toString();
+    if (savedUUID.isEmpty()) {
         regenerateUuid();
+    } else {
+        m_uuid = savedUUID;
     }
 
     // Game time override
@@ -253,14 +257,11 @@ QString BaseInstance::id() const
     return QFileInfo(instanceRoot()).fileName();
 }
 
-QString BaseInstance::uuid() const
-{
-    return m_settings->get("uuid").toString();
-}
-
 void BaseInstance::regenerateUuid()
 {
-    m_settings->set("uuid", QUuid::createUuid().toString(QUuid::Id128));
+    const auto newUUID = QUuid::createUuid().toString(QUuid::Id128);
+    m_settings->set("uuid", newUUID);
+    m_uuid = newUUID;
 }
 
 bool BaseInstance::isRunning() const

--- a/launcher/BaseInstance.h
+++ b/launcher/BaseInstance.h
@@ -110,8 +110,8 @@ class BaseInstance : public QObject {
 
     /// The instance's ID. The ID SHALL be determined by LAUNCHER internally. The ID IS guaranteed to
     /// be unique.
-    virtual QString id() const;
-    virtual QString uuid() const;
+    QString id() const;
+    QString uuid() const { return m_uuid; }
     void regenerateUuid();
 
     void setMinecraftRunning(bool running);
@@ -313,6 +313,7 @@ class BaseInstance : public QObject {
     RuntimeContext m_runtimeContext;
 
    private: /* data */
+    QString m_uuid;
     Status m_status = Status::Present;
     bool m_crashed = false;
     bool m_hasUpdate = false;


### PR DESCRIPTION
Parent PR: #5816

It looks like a useless microoptimisation, but we're constantly linear searching instances against the ID and UUID while painting the instance view - and somehow with asan active and the Breeze style it becomes almost unusable (and I have tested this fix and it does make things noticeably better)

I don't have any evidence this affects release builds, and I have experienced weird performance problems that I can only produce with asan - so it shouldn't be too important

Also removing the virtual keywords in the name of performance - it won't likely do much but virtual functions for no reason seems like bad practice