### PR TITLE
fix: fall back to the system code page when UTF-8 log decoding fails

### DIFF
--- a/launcher/LoggedProcess.cpp
+++ b/launcher/LoggedProcess.cpp
@@ -40,7 +40,7 @@
 #include "MessageLevel.h"
 
 LoggedProcess::LoggedProcess(const QStringConverter::Encoding output_codec, QObject* parent)
-    : QProcess(parent), m_err_decoder(output_codec), m_out_decoder(output_codec)
+    : QProcess(parent), m_err_decoder(output_codec), m_out_decoder(output_codec), m_fallback_decoder(QStringConverter::System)
 {
     // QProcess has a strange interface... let's map a lot of those into a few.
     connect(this, &QProcess::readyReadStandardOutput, this, &LoggedProcess::on_stdOut);
@@ -60,6 +60,15 @@ LoggedProcess::~LoggedProcess()
 QStringList LoggedProcess::reprocess(const QByteArray& data, QStringDecoder& decoder)
 {
     QString str = decoder(data);
+
+    // Some programs (e.g. modloaders on non-UTF-8 Windows) emit output in the
+    // system code page rather than UTF-8. When the primary decoder (usually
+    // UTF-8) fails to decode a chunk, fall back to the system codec so the text
+    // is not replaced with U+FFFD. This keeps #2419 (UTF-8 logs) working while
+    // fixing #5739 (garbled logs on Chinese Windows).
+    if (str.contains(QChar(0xFFFD))) {
+        str = m_fallback_decoder(data);
+    }
 
     if (!m_leftover_line.isEmpty()) {
         str.prepend(m_leftover_line);

--- a/launcher/LoggedProcess.h
+++ b/launcher/LoggedProcess.h
@@ -82,6 +82,7 @@ class LoggedProcess : public QProcess {
    private:
     QStringDecoder m_err_decoder;
     QStringDecoder m_out_decoder;
+    QStringDecoder m_fallback_decoder;
     QString m_leftover_line;
     bool m_killed = false;
     State m_state = NotRunning;


### PR DESCRIPTION
## Summary

On non-UTF-8 Windows (e.g. code page 936/GBK), Minecraft modloaders such as Forge/NeoForge and some mods print their console output using the **system code page** rather than UTF-8. Prism decodes the whole game log stream as UTF-8 (since #2419 / JEP 400), so those GBK bytes become mojibake — see #5739.

This PR keeps UTF-8 as the primary decoder (so #2419 stays fixed) and adds a per-chunk fallback: when a chunk fails to decode as UTF-8 (produces U+FFFD), it is re-decoded with the system codec. This fixes the garbled Chinese logs on Windows without regressing the UTF-8 case.

## How it works

- `LoggedProcess` now keeps a `QStringDecoder` for the system code page.
- In `reprocess()`, if the primary decode produces a replacement character, the same chunk is decoded again with the system decoder. The fallback decoder is stateful, so a multibyte character split across reads is still handled correctly.

## Test plan

- [ ] Launch a Forge/NeoForge instance on a Chinese Windows (ACP 936) and confirm Chinese log lines are readable.
- [ ] Launch on a system with "Beta: Use Unicode UTF-8" enabled (ACP 65001) and confirm UTF-8 logs are still correct.
- [ ] Confirm the build compiles (CI).

Closes #5739

> [!TIP]
> This PR is submitted on behalf of VZService.
