### PR TITLE
code quality: remove contextless connects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ include(GenerateExportHeader)
 add_compile_definitions($<$<NOT:$<CONFIG:Debug>>:QT_NO_DEBUG>)
 add_compile_definitions(QT_WARN_DEPRECATED_UP_TO=0x060400)
 add_compile_definitions(QT_DISABLE_DEPRECATED_UP_TO=0x060400)
+add_compile_definitions(QT_NO_CONTEXTLESS_CONNECT)
 
 if(CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL "MSVC")
     add_compile_options(

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -942,7 +942,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         QStringList instFolders = { ":/icons/multimc/32x32/instances/", ":/icons/multimc/50x50/instances/",
                                     ":/icons/multimc/128x128/instances/", ":/icons/multimc/scalable/instances/" };
         m_icons.reset(new IconList(instFolders, setting->get().toString()));
-        connect(setting.get(), &Setting::SettingChanged,
+        connect(setting.get(), &Setting::SettingChanged, this,
                 [this](const Setting&, QVariant value) { m_icons->directoryChanged(value.toString()); });
         qInfo() << "<> Instance icons initialized.";
     }
@@ -1046,10 +1046,10 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
     }
 
 #ifdef Q_OS_MACOS
-    connect(this, &Application::clickedOnDock, [this]() { this->showMainWindow(); });
+    connect(this, &Application::clickedOnDock, this, [this]() { this->showMainWindow(); });
 #endif
 
-    connect(this, &Application::aboutToQuit, [this]() {
+    connect(this, &Application::aboutToQuit, this, [this]() {
         if (m_instances) {
             // save any remaining instance state
             m_instances->saveNow();

--- a/launcher/DataMigrationTask.cpp
+++ b/launcher/DataMigrationTask.cpp
@@ -45,7 +45,7 @@ void DataMigrationTask::dryRunFinished()
     // 2. Copy
     // Actually copy all files now.
     m_toCopy = m_copy.totalCopied();
-    connect(&m_copy, &FS::copy::fileCopied, [&, this](const QString& relativeName) {
+    connect(&m_copy, &FS::copy::fileCopied, this, [this](const QString& relativeName) {
         QString shortenedName = relativeName;
         // shorten the filename to hopefully fit into one line
         if (shortenedName.length() > 50)

--- a/launcher/InstanceCopyTask.cpp
+++ b/launcher/InstanceCopyTask.cpp
@@ -46,7 +46,7 @@ void InstanceCopyTask::executeTask()
 
             folderClone(true);
             setProgress(0, folderClone.totalCloned());
-            connect(&folderClone, &FS::clone::fileCloned,
+            connect(&folderClone, &FS::clone::fileCloned, this,
                     [this](QString src, QString dst) { setProgress(m_progress + 1, m_progressTotal); });
             return folderClone();
         }
@@ -66,7 +66,8 @@ void InstanceCopyTask::executeTask()
                                                        FS::PathCombine(staging_mc_dir, "saves"));
                 (*savesCopy)(true);
                 setProgress(0, savesCopy->totalCopied());
-                connect(savesCopy.get(), &FS::copy::fileCopied, [this](QString src) { setProgress(m_progress + 1, m_progressTotal); });
+                connect(savesCopy.get(), &FS::copy::fileCopied, this,
+                        [this](QString src) { setProgress(m_progress + 1, m_progressTotal); });
             }
             FS::create_link folderLink(m_origInstance->instanceRoot(), m_stagingPath);
             int depth = m_linkRecursively ? -1 : 0;  // we need to at least link the top level instead of the instance folder
@@ -74,7 +75,7 @@ void InstanceCopyTask::executeTask()
 
             folderLink(true);
             setProgress(0, m_progressTotal + folderLink.totalToLink());
-            connect(&folderLink, &FS::create_link::fileLinked,
+            connect(&folderLink, &FS::create_link::fileLinked, this,
                     [this](QString src, QString dst) { setProgress(m_progress + 1, m_progressTotal); });
             bool there_were_errors = false;
 
@@ -129,7 +130,7 @@ void InstanceCopyTask::executeTask()
 
         folderCopy(true);
         setProgress(0, folderCopy.totalCopied());
-        connect(&folderCopy, &FS::copy::fileCopied, [this]() { setProgress(m_progress + 1, m_progressTotal); });
+        connect(&folderCopy, &FS::copy::fileCopied, this, [this]() { setProgress(m_progress + 1, m_progressTotal); });
         return folderCopy();
     });
     connect(&m_copyFutureWatcher, &QFutureWatcher<bool>::finished, this, &InstanceCopyTask::copyFinished);

--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -432,7 +432,7 @@ void LaunchController::readyForLaunch()
     }
     BaseProfiler* profilerInstance = m_profiler->createProfiler(m_launcher->instance(), this);
 
-    connect(profilerInstance, &BaseProfiler::readyToLaunch, [this](const QString& message) {
+    connect(profilerInstance, &BaseProfiler::readyToLaunch, this, [this](const QString& message) {
         QMessageBox msg(m_parentWidget);
         msg.setText(tr("The game launch is delayed until you press the "
                        "button. This is the right time to setup the profiler, as the "
@@ -444,7 +444,7 @@ void LaunchController::readyForLaunch()
         msg.exec();
         m_launcher->proceed();
     });
-    connect(profilerInstance, &BaseProfiler::abortLaunch, [this](const QString& message) {
+    connect(profilerInstance, &BaseProfiler::abortLaunch, this, [this](const QString& message) {
         QMessageBox msg;
         msg.setText(tr("Couldn't start the profiler: %1").arg(message));
         msg.setWindowTitle(tr("Error"));

--- a/launcher/java/download/ArchiveDownloadTask.cpp
+++ b/launcher/java/download/ArchiveDownloadTask.cpp
@@ -55,7 +55,7 @@ void ArchiveDownloadTask::executeTask()
     connect(download.get(), &Task::status, this, &ArchiveDownloadTask::setStatus);
     connect(download.get(), &Task::details, this, &ArchiveDownloadTask::setDetails);
     connect(download.get(), &Task::aborted, this, &ArchiveDownloadTask::emitAborted);
-    connect(download.get(), &Task::succeeded, [this, fullPath] {
+    connect(download.get(), &Task::succeeded, this, [this, fullPath] {
         // This should do all of the extracting and creating folders
         extractJava(fullPath);
     });

--- a/launcher/java/download/ManifestDownloadTask.cpp
+++ b/launcher/java/download/ManifestDownloadTask.cpp
@@ -56,7 +56,7 @@ void ManifestDownloadTask::executeTask()
     connect(download.get(), &Task::status, this, &ManifestDownloadTask::setStatus);
     connect(download.get(), &Task::details, this, &ManifestDownloadTask::setDetails);
 
-    connect(download.get(), &Task::succeeded, [files, this] {
+    connect(download.get(), &Task::succeeded, this, [files, this] {
         QJsonParseError parse_error{};
         QJsonDocument doc = QJsonDocument::fromJson(*files, &parse_error);
         if (parse_error.error != QJsonParseError::NoError) {
@@ -108,7 +108,7 @@ void ManifestDownloadTask::downloadJava(const QJsonDocument& doc)
             dl->addValidator(new Net::ChecksumValidator(QCryptographicHash::Sha1, file.hash));
         }
         if (file.isExec) {
-            connect(dl.get(), &Net::Download::succeeded,
+            connect(dl.get(), &Net::Download::succeeded, dl.get(),
                     [file] { QFile(file.path).setPermissions(QFile(file.path).permissions() | QFileDevice::Permissions(0x1111)); });
         }
         elementDownload->addNetAction(dl);

--- a/launcher/java/download/SymlinkTask.cpp
+++ b/launcher/java/download/SymlinkTask.cpp
@@ -70,7 +70,7 @@ void SymlinkTask::executeTask()
 
     setStatus(tr("Symlinking Java binary path"));
     FS::create_link folderLink(files);
-    connect(&folderLink, &FS::create_link::fileLinked, [this](QString src, QString dst) { setProgress(m_progress + 1, m_progressTotal); });
+    connect(&folderLink, &FS::create_link::fileLinked, this, [this](QString src, QString dst) { setProgress(m_progress + 1, m_progressTotal); });
     if (!folderLink()) {
         emitFailed(folderLink.getOSError().message().c_str());
     } else {

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -315,16 +315,16 @@ void MinecraftInstance::populateLaunchMenu(QMenu* menu)
 
     normalLaunchDemo->setEnabled(supportsDemo());
 
-    connect(normalLaunch, &QAction::triggered, [this] { APPLICATION->launch(this); });
-    connect(normalLaunchOffline, &QAction::triggered, [this] { APPLICATION->launch(this, LaunchMode::Offline); });
-    connect(normalLaunchDemo, &QAction::triggered, [this] { APPLICATION->launch(this, LaunchMode::Demo); });
+    connect(normalLaunch, &QAction::triggered, this, [this] { APPLICATION->launch(this); });
+    connect(normalLaunchOffline, &QAction::triggered, this, [this] { APPLICATION->launch(this, LaunchMode::Offline); });
+    connect(normalLaunchDemo, &QAction::triggered, this, [this] { APPLICATION->launch(this, LaunchMode::Demo); });
 
     QString profilersTitle = tr("Profilers");
     menu->addSeparator()->setText(profilersTitle);
 
     auto profilers = new QActionGroup(menu);
     profilers->setExclusive(true);
-    connect(profilers, &QActionGroup::triggered, [this](QAction* action) {
+    connect(profilers, &QActionGroup::triggered, this, [this](QAction* action) {
         settings()->set("Profiler", action->data());
         emit profilerChanged();
     });

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -188,7 +188,7 @@ void ResourceFolderModel::installResourceWithFlameMetadata(const QString& path, 
         auto [job, response] = FlameAPI().getProject(vers.addonId.toString());
         connect(job.get(), &Task::failed, this, install);
         connect(job.get(), &Task::aborted, this, install);
-        connect(job.get(), &Task::succeeded, [response, this, &vers, install, &pack] {
+        connect(job.get(), &Task::succeeded, this, [response, this, &vers, install, &pack] {
             QJsonParseError parseError{};
             QJsonDocument doc = QJsonDocument::fromJson(*response, &parseError);
             if (parseError.error != QJsonParseError::NoError) {
@@ -361,7 +361,7 @@ bool ResourceFolderModel::update()
         task->addTask(preUpdate);
         task->addTask(m_currentUpdateTask);
 
-        connect(task, &Task::finished, [task] { task->deleteLater(); });
+        connect(task, &Task::finished, task, &Task::deleteLater);
 
         QThreadPool::globalInstance()->start(task);
     } else {

--- a/launcher/minecraft/mod/tasks/GetModDependenciesTask.cpp
+++ b/launcher/minecraft/mod/tasks/GetModDependenciesTask.cpp
@@ -140,7 +140,7 @@ Task::Ptr GetModDependenciesTask::getProjectInfoTask(std::shared_ptr<PackDepende
 {
     auto provider = pDep->pack->provider;
     auto [info, responseInfo] = getAPI(provider)->getProject(pDep->pack->addonId.toString());
-    connect(info.get(), &NetJob::succeeded, [this, responseInfo, provider, pDep] {
+    connect(info.get(), &NetJob::succeeded, this, [this, responseInfo, provider, pDep] {
         QJsonParseError parse_error{};
         QJsonDocument doc = QJsonDocument::fromJson(*responseInfo, &parse_error);
         if (parse_error.error != QJsonParseError::NoError) {

--- a/launcher/modplatform/EnsureMetadataTask.cpp
+++ b/launcher/modplatform/EnsureMetadataTask.cpp
@@ -25,8 +25,8 @@ EnsureMetadataTask::EnsureMetadataTask(Resource* resource, QDir dir, ModPlatform
     auto hashTask = createNewHash(resource);
     if (!hashTask)
         return;
-    connect(hashTask.get(), &Hashing::Hasher::resultsReady, [this, resource](QString hash) { m_resources.insert(hash, resource); });
-    connect(hashTask.get(), &Task::failed, [this, resource] { emitFail(resource, "", RemoveFromList::No); });
+    connect(hashTask.get(), &Hashing::Hasher::resultsReady, this, [this, resource](QString hash) { m_resources.insert(hash, resource); });
+    connect(hashTask.get(), &Task::failed, this, [this, resource] { emitFail(resource, "", RemoveFromList::No); });
     m_hashingTask = hashTask;
 }
 
@@ -39,8 +39,8 @@ EnsureMetadataTask::EnsureMetadataTask(QList<Resource*>& resources, QDir dir, Mo
         auto hash_task = createNewHash(resource);
         if (!hash_task)
             continue;
-        connect(hash_task.get(), &Hashing::Hasher::resultsReady, [this, resource](QString hash) { m_resources.insert(hash, resource); });
-        connect(hash_task.get(), &Task::failed, [this, resource] { emitFail(resource, "", RemoveFromList::No); });
+        connect(hash_task.get(), &Hashing::Hasher::resultsReady, this, [this, resource](QString hash) { m_resources.insert(hash, resource); });
+        connect(hash_task.get(), &Task::failed, this, [this, resource] { emitFail(resource, "", RemoveFromList::No); });
         hashTask->addTask(hash_task);
     }
 }

--- a/launcher/modplatform/ResourceAPI.cpp
+++ b/launcher/modplatform/ResourceAPI.cpp
@@ -23,7 +23,7 @@ Task::Ptr ResourceAPI::searchProjects(SearchArgs&& args, Callback<QList<ModPlatf
     auto [action, response] = Net::ApiDownload::makeByteArray(QUrl(search_url));
     netJob->addNetAction(action);
 
-    QObject::connect(netJob.get(), &NetJob::succeeded, [this, response, callbacks] {
+    QObject::connect(netJob.get(), &NetJob::succeeded, netJob.get(), [this, response, callbacks] {
         QJsonParseError parse_error{};
         QJsonDocument doc = QJsonDocument::fromJson(*response, &parse_error);
         if (parse_error.error != QJsonParseError::NoError) {
@@ -59,7 +59,7 @@ Task::Ptr ResourceAPI::searchProjects(SearchArgs&& args, Callback<QList<ModPlatf
     // This prevents the lambda from extending the lifetime of the shared resource,
     // as it only temporarily locks the resource when needed.
     auto weak = netJob.toWeakRef();
-    QObject::connect(netJob.get(), &NetJob::failed, [weak, callbacks](const QString& reason) {
+    QObject::connect(netJob.get(), &NetJob::failed, netJob.get(), [weak, callbacks](const QString& reason) {
         int network_error_code = -1;
         if (auto netJob = weak.lock()) {
             if (auto* failed_action = netJob->getFailedActions().at(0); failed_action)
@@ -67,7 +67,7 @@ Task::Ptr ResourceAPI::searchProjects(SearchArgs&& args, Callback<QList<ModPlatf
         }
         callbacks.on_fail(reason, network_error_code);
     });
-    QObject::connect(netJob.get(), &NetJob::aborted, [callbacks] {
+    QObject::connect(netJob.get(), &NetJob::aborted, netJob.get(), [callbacks] {
         if (callbacks.on_abort != nullptr)
             callbacks.on_abort();
     });
@@ -88,7 +88,7 @@ Task::Ptr ResourceAPI::getProjectVersions(VersionSearchArgs&& args, Callback<QVe
     auto [action, response] = Net::ApiDownload::makeByteArray(versions_url);
     netJob->addNetAction(action);
 
-    QObject::connect(netJob.get(), &NetJob::succeeded, [this, response, callbacks, args] {
+    QObject::connect(netJob.get(), &NetJob::succeeded, netJob.get(), [this, response, callbacks, args] {
         QJsonParseError parse_error{};
         QJsonDocument doc = QJsonDocument::fromJson(*response, &parse_error);
         if (parse_error.error != QJsonParseError::NoError) {
@@ -132,7 +132,7 @@ Task::Ptr ResourceAPI::getProjectVersions(VersionSearchArgs&& args, Callback<QVe
     // This prevents the lambda from extending the lifetime of the shared resource,
     // as it only temporarily locks the resource when needed.
     auto weak = netJob.toWeakRef();
-    QObject::connect(netJob.get(), &NetJob::failed, [weak, callbacks](const QString& reason) {
+    QObject::connect(netJob.get(), &NetJob::failed, netJob.get(), [weak, callbacks](const QString& reason) {
         int network_error_code = -1;
         if (auto netJob = weak.lock()) {
             if (auto* failed_action = netJob->getFailedActions().at(0); failed_action)
@@ -140,7 +140,7 @@ Task::Ptr ResourceAPI::getProjectVersions(VersionSearchArgs&& args, Callback<QVe
         }
         callbacks.on_fail(reason, network_error_code);
     });
-    QObject::connect(netJob.get(), &NetJob::aborted, [callbacks] {
+    QObject::connect(netJob.get(), &NetJob::aborted, netJob.get(), [callbacks] {
         if (callbacks.on_abort != nullptr)
             callbacks.on_abort();
     });
@@ -152,7 +152,7 @@ Task::Ptr ResourceAPI::getProjectInfo(ProjectInfoArgs&& args, Callback<ModPlatfo
 {
     auto [job, response] = getProject(args.pack->addonId.toString(), askRetry);
 
-    QObject::connect(job.get(), &NetJob::succeeded, [this, response, callbacks, args] {
+    QObject::connect(job.get(), &NetJob::succeeded, job.get(), [this, response, callbacks, args] {
         auto pack = args.pack;
         QJsonParseError parse_error{};
         QJsonDocument doc = QJsonDocument::fromJson(*response, &parse_error);
@@ -178,7 +178,7 @@ Task::Ptr ResourceAPI::getProjectInfo(ProjectInfoArgs&& args, Callback<ModPlatfo
     // This prevents the lambda from extending the lifetime of the shared resource,
     // as it only temporarily locks the resource when needed.
     auto weak = job.toWeakRef();
-    QObject::connect(job.get(), &NetJob::failed, [weak, callbacks](const QString& reason) {
+    QObject::connect(job.get(), &NetJob::failed, job.get(), [weak, callbacks](const QString& reason) {
         int network_error_code = -1;
         if (auto job = weak.lock()) {
             if (auto netJob = qSharedPointerDynamicCast<NetJob>(job)) {
@@ -189,7 +189,7 @@ Task::Ptr ResourceAPI::getProjectInfo(ProjectInfoArgs&& args, Callback<ModPlatfo
         }
         callbacks.on_fail(reason, network_error_code);
     });
-    QObject::connect(job.get(), &NetJob::aborted, [callbacks] {
+    QObject::connect(job.get(), &NetJob::aborted, job.get(), [callbacks] {
         if (callbacks.on_abort != nullptr)
             callbacks.on_abort();
     });
@@ -208,7 +208,7 @@ Task::Ptr ResourceAPI::getDependencyVersion(DependencySearchArgs&& args, Callbac
     auto [action, response] = Net::ApiDownload::makeByteArray(versions_url);
     netJob->addNetAction(action);
 
-    QObject::connect(netJob.get(), &NetJob::succeeded, [this, response, callbacks, args] {
+    QObject::connect(netJob.get(), &NetJob::succeeded, netJob.get(), [this, response, callbacks, args] {
         QJsonParseError parse_error{};
         QJsonDocument doc = QJsonDocument::fromJson(*response, &parse_error);
         if (parse_error.error != QJsonParseError::NoError) {
@@ -251,7 +251,7 @@ Task::Ptr ResourceAPI::getDependencyVersion(DependencySearchArgs&& args, Callbac
     // This prevents the lambda from extending the lifetime of the shared resource,
     // as it only temporarily locks the resource when needed.
     auto weak = netJob.toWeakRef();
-    QObject::connect(netJob.get(), &NetJob::failed, [weak, callbacks](const QString& reason) {
+    QObject::connect(netJob.get(), &NetJob::failed, netJob.get(), [weak, callbacks](const QString& reason) {
         int network_error_code = -1;
         if (auto netJob = weak.lock()) {
             if (auto* failed_action = netJob->getFailedActions().at(0); failed_action)

--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
@@ -673,17 +673,17 @@ void PackInstallTask::installConfigs()
         jobPtr.reset();
         extractConfigs();
     });
-    connect(jobPtr.get(), &NetJob::failed, [this](QString reason) {
+    connect(jobPtr.get(), &NetJob::failed, this, [this](QString reason) {
         abortable = false;
         jobPtr.reset();
         emitFailed(std::move(reason));
     });
-    connect(jobPtr.get(), &NetJob::progress, [this](qint64 current, qint64 total) {
+    connect(jobPtr.get(), &NetJob::progress, this, [this](qint64 current, qint64 total) {
         abortable = true;
         setProgress(current, total);
     });
     connect(jobPtr.get(), &NetJob::stepProgress, this, &PackInstallTask::propagateStepProgress);
-    connect(jobPtr.get(), &NetJob::aborted, [this] {
+    connect(jobPtr.get(), &NetJob::aborted, this, [this] {
         abortable = false;
         jobPtr.reset();
         emitAborted();
@@ -897,14 +897,14 @@ void PackInstallTask::downloadMods()
     }
 
     connect(jobPtr.get(), &NetJob::succeeded, this, &PackInstallTask::onModsDownloaded);
-    connect(jobPtr.get(), &NetJob::progress, [this](qint64 current, qint64 total) {
+    connect(jobPtr.get(), &NetJob::progress, this, [this](qint64 current, qint64 total) {
         setDetails(tr("%1 out of %2 complete").arg(current).arg(total));
         abortable = true;
         setProgress(current, total);
     });
     connect(jobPtr.get(), &NetJob::stepProgress, this, &PackInstallTask::propagateStepProgress);
-    connect(jobPtr.get(), &NetJob::aborted, &PackInstallTask::emitAborted);
-    connect(jobPtr.get(), &NetJob::failed, &PackInstallTask::emitFailed);
+    connect(jobPtr.get(), &NetJob::aborted, this, &PackInstallTask::emitAborted);
+    connect(jobPtr.get(), &NetJob::failed, this, &PackInstallTask::emitFailed);
 
     jobPtr->start();
 }

--- a/launcher/modplatform/flame/FlameAPI.cpp
+++ b/launcher/modplatform/flame/FlameAPI.cpp
@@ -46,7 +46,7 @@ QString FlameAPI::getModFileChangelog(int modId, int fileId)
             .arg(QString::fromStdString(std::to_string(modId)), QString::fromStdString(std::to_string(fileId))));
     netJob->addNetAction(action);
 
-    QObject::connect(netJob.get(), &NetJob::succeeded, [&netJob, response, &changelog] {
+    QObject::connect(netJob.get(), &NetJob::succeeded, netJob.get(), [&netJob, response, &changelog] {
         QJsonParseError parse_error{};
         QJsonDocument doc = QJsonDocument::fromJson(*response, &parse_error);
         if (parse_error.error != QJsonParseError::NoError) {
@@ -61,7 +61,7 @@ QString FlameAPI::getModFileChangelog(int modId, int fileId)
         changelog = doc.object()["data"].toString();
     });
 
-    QObject::connect(netJob.get(), &NetJob::finished, [&lock] { lock.quit(); });
+    QObject::connect(netJob.get(), &NetJob::finished, &lock, &QEventLoop::quit);
 
     netJob->start();
     lock.exec();
@@ -79,7 +79,7 @@ QString FlameAPI::getModDescription(int modId)
         Net::ApiDownload::makeByteArray(QString(BuildConfig.FLAME_BASE_URL + "/mods/%1/description").arg(QString::number(modId)));
     netJob->addNetAction(action);
 
-    QObject::connect(netJob.get(), &NetJob::succeeded, [&netJob, response, &description] {
+    QObject::connect(netJob.get(), &NetJob::succeeded, netJob.get(), [&netJob, response, &description] {
         QJsonParseError parse_error{};
         QJsonDocument doc = QJsonDocument::fromJson(*response, &parse_error);
         if (parse_error.error != QJsonParseError::NoError) {
@@ -94,7 +94,7 @@ QString FlameAPI::getModDescription(int modId)
         description = doc.object()["data"].toString();
     });
 
-    QObject::connect(netJob.get(), &NetJob::finished, [&lock] { lock.quit(); });
+    QObject::connect(netJob.get(), &NetJob::finished, &lock, &QEventLoop::quit);
 
     netJob->start();
     lock.exec();
@@ -119,7 +119,7 @@ std::pair<Task::Ptr, QByteArray*> FlameAPI::getProjects(QStringList addonIds) co
     auto [action, response] = Net::ApiUpload::makeByteArray(QString(BuildConfig.FLAME_BASE_URL + "/mods"), body_raw);
     netJob->addNetAction(action);
 
-    QObject::connect(netJob.get(), &NetJob::failed, [body_raw] { qDebug() << body_raw; });
+    QObject::connect(netJob.get(), &NetJob::failed, netJob.get(), [body_raw] { qDebug() << body_raw; });
 
     return { netJob, response };
 }
@@ -142,7 +142,7 @@ std::pair<Task::Ptr, QByteArray*> FlameAPI::getFiles(const QStringList& fileIds)
     auto [action, response] = Net::ApiUpload::makeByteArray(QString(BuildConfig.FLAME_BASE_URL + "/mods/files"), body_raw);
     netJob->addNetAction(action);
 
-    QObject::connect(netJob.get(), &NetJob::failed, [body_raw] { qDebug() << body_raw; });
+    QObject::connect(netJob.get(), &NetJob::failed, netJob.get(), [body_raw] { qDebug() << body_raw; });
 
     return { netJob, response };
 }
@@ -154,7 +154,7 @@ std::pair<Task::Ptr, QByteArray*> FlameAPI::getFile(const QString& addonId, cons
         Net::ApiDownload::makeByteArray(QUrl(QString(BuildConfig.FLAME_BASE_URL + "/mods/%1/files/%2").arg(addonId, fileId)));
     netJob->addNetAction(action);
 
-    QObject::connect(netJob.get(), &NetJob::failed, [addonId, fileId] { qDebug() << "Flame API file failure" << addonId << fileId; });
+    QObject::connect(netJob.get(), &NetJob::failed, netJob.get(), [addonId, fileId] { qDebug() << "Flame API file failure" << addonId << fileId; });
 
     return { netJob, response };
 }
@@ -178,7 +178,7 @@ std::pair<Task::Ptr, QByteArray*> FlameAPI::getCategories(ModPlatform::ResourceT
     auto [action, response] = Net::ApiDownload::makeByteArray(
         QUrl(QString(BuildConfig.FLAME_BASE_URL + "/categories?gameId=432&classId=%1").arg(getClassId(type))));
     netJob->addNetAction(action);
-    QObject::connect(netJob.get(), &Task::failed, [](QString msg) { qDebug() << "Flame failed to get categories:" << msg; });
+    QObject::connect(netJob.get(), &Task::failed, netJob.get(), [](QString msg) { qDebug() << "Flame failed to get categories:" << msg; });
     return { netJob, response };
 }
 

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -488,7 +488,7 @@ void FlameCreationTask::createInstance()
 
     m_modIdResolver.reset(new Flame::FileResolvingTask(m_pack));
     connect(m_modIdResolver.get(), &Flame::FileResolvingTask::succeeded, this, &FlameCreationTask::idResolverSucceeded);
-    connect(m_modIdResolver.get(), &Flame::FileResolvingTask::failed, [this](const QString& reason) {
+    connect(m_modIdResolver.get(), &Flame::FileResolvingTask::failed, this, [this](const QString& reason) {
         m_modIdResolver.reset();
         emitFailed(tr("Unable to resolve mod IDs:\n") + reason);
     });
@@ -600,7 +600,7 @@ void FlameCreationTask::setupDownloadJob()
         m_filesJob.reset();
         validateOtherResources();
     });
-    connect(m_filesJob.get(), &NetJob::failed, [this](QString reason) {
+    connect(m_filesJob.get(), &NetJob::failed, this, [this](QString reason) {
         m_filesJob.reset();
         emitFailed(std::move(reason));
     });

--- a/launcher/modplatform/flame/FlamePackExportTask.cpp
+++ b/launcher/modplatform/flame/FlamePackExportTask.cpp
@@ -99,7 +99,7 @@ void FlamePackExportTask::collectHashes()
         if (relative.startsWith("resourcepacks/") &&
             (relative.endsWith(".zip") || relative.endsWith(".zip.disabled"))) {  // is resourcepack
             auto hashTask = Hashing::createHasher(file.absoluteFilePath(), ModPlatform::ResourceProvider::FLAME);
-            connect(hashTask.get(), &Hashing::Hasher::resultsReady, [this, relative, file](QString hash) {
+            connect(hashTask.get(), &Hashing::Hasher::resultsReady, this, [this, relative, file](QString hash) {
                 if (m_state == Task::State::Running) {
                     pendingHashes.insert(hash, { relative, file.absoluteFilePath(), relative.endsWith(".zip") });
                 }
@@ -123,7 +123,7 @@ void FlamePackExportTask::collectHashes()
             }
 
             auto hashTask = Hashing::createHasher(mod->fileinfo().absoluteFilePath(), ModPlatform::ResourceProvider::FLAME);
-            connect(hashTask.get(), &Hashing::Hasher::resultsReady, [this, mod](QString hash) {
+            connect(hashTask.get(), &Hashing::Hasher::resultsReady, this, [this, mod](QString hash) {
                 if (m_state == Task::State::Running) {
                     pendingHashes.insert(hash, { mod->name(), mod->fileinfo().absoluteFilePath(), mod->enabled(), true });
                 }

--- a/launcher/modplatform/modrinth/ModrinthAPI.cpp
+++ b/launcher/modplatform/modrinth/ModrinthAPI.cpp
@@ -128,7 +128,7 @@ std::pair<Task::Ptr, QByteArray*> ModrinthAPI::getModCategories()
     auto netJob = makeShared<NetJob>(QString("Modrinth::GetCategories"), APPLICATION->network());
     auto [action, response] = Net::ApiDownload::makeByteArray(QUrl(BuildConfig.MODRINTH_PROD_URL + "/tag/category"));
     netJob->addNetAction(action);
-    QObject::connect(netJob.get(), &Task::failed, [](const QString& msg) { qDebug() << "Modrinth failed to get categories:" << msg; });
+    QObject::connect(netJob.get(), &Task::failed, netJob.get(), [](const QString& msg) { qDebug() << "Modrinth failed to get categories:" << msg; });
 
     return { netJob, response };
 }

--- a/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
+++ b/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
@@ -64,9 +64,9 @@ void ModrinthCheckUpdate::executeTask()
         // (though it will rarely happen, if at all)
         if (resource->metadata()->hash_format != m_hashType) {
             auto hashTask = Hashing::createHasher(resource->fileinfo().absoluteFilePath(), ModPlatform::ResourceProvider::MODRINTH);
-            connect(hashTask.get(), &Hashing::Hasher::resultsReady,
+            connect(hashTask.get(), &Hashing::Hasher::resultsReady, this,
                     [this, resource](const QString& hash) { m_mappings.insert(hash, resource); });
-            connect(hashTask.get(), &Task::failed, [this] { failed("Failed to generate hash"); });
+            connect(hashTask.get(), &Task::failed, this, [this] { emitFailed("Failed to generate hash"); });
             hashingTask->addTask(hashTask);
             startHasing = true;
         } else {

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
@@ -283,7 +283,7 @@ void ModrinthCreationTask::createInstance()
             // FIXME: This really needs to be put into a ConcurrentTask of
             // MultipleOptionsTask's , once those exist :)
             auto param = dl.toWeakRef();
-            connect(dl.get(), &Task::failed, [&file, filePath, param, downloadMods, meta] {
+            connect(dl.get(), &Task::failed, dl.get(), [&file, filePath, param, downloadMods, meta] {
                 QUrl fallbackUrl = file.downloads.dequeue();
                 auto ndl = Net::ApiDownload::makeFile(fallbackUrl, filePath, Net::Download::Option::NoOptions, meta);
                 ndl->addValidator(new Net::ChecksumValidator(file.hashAlgorithm, file.hash));
@@ -298,7 +298,7 @@ void ModrinthCreationTask::createInstance()
     connect(downloadMods.get(), &NetJob::succeeded, this, &ModrinthCreationTask::ensureMetaLoop);
     connect(downloadMods.get(), &NetJob::failed, this, &ModrinthCreationTask::emitFailed);
     connect(downloadMods.get(), &NetJob::aborted, this, &ModrinthCreationTask::emitAborted);
-    connect(downloadMods.get(), &NetJob::progress, [this](qint64 current, qint64 total) {
+    connect(downloadMods.get(), &NetJob::progress, this, [this](qint64 current, qint64 total) {
         setDetails(tr("%1 out of %2 complete").arg(current).arg(total));
         setProgress(current, total);
     });
@@ -440,7 +440,7 @@ void ModrinthCreationTask::ensureMetaLoop()
     connect(ensureMetadataTask.get(), &Task::succeeded, this, &ModrinthCreationTask::finishInstall);
     connect(ensureMetadataTask.get(), &Task::failed, this, &ModrinthCreationTask::emitFailed);
     connect(ensureMetadataTask.get(), &Task::aborted, this, &ModrinthCreationTask::emitAborted);
-    connect(ensureMetadataTask.get(), &Task::progress, [this](qint64 current, qint64 total) {
+    connect(ensureMetadataTask.get(), &Task::progress, this, [this](qint64 current, qint64 total) {
         setDetails(tr("%1 out of %2 complete").arg(current).arg(total));
         setProgress(current, total);
     });

--- a/launcher/modplatform/modrinth/ModrinthPackExportTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackExportTask.cpp
@@ -161,7 +161,7 @@ void ModrinthPackExportTask::makeApiRequest()
         setStatus(tr("Finding versions for hashes..."));
         auto [versionsTask, response] = api.currentVersions(pendingHashes.values(), "sha512");
         task = versionsTask;
-        connect(task.get(), &Task::succeeded, [this, response]() { parseApiResponse(response); });
+        connect(task.get(), &Task::succeeded, this, [this, response]() { parseApiResponse(response); });
         connect(task.get(), &Task::failed, this, &ModrinthPackExportTask::emitFailed);
         connect(task.get(), &Task::aborted, this, &ModrinthPackExportTask::emitAborted);
         task->start();

--- a/launcher/ui/GuiUtil.cpp
+++ b/launcher/ui/GuiUtil.cpp
@@ -137,10 +137,10 @@ std::optional<QString> GuiUtil::uploadPaste(const QString& name, const QString& 
 
     auto pasteJob = new PasteUpload(textToUpload, baseURL, pasteType);
     job->addNetAction(Net::NetRequest::Ptr(pasteJob));
-    QObject::connect(job.get(), &Task::failed, [parentWidget](QString reason) {
+    QObject::connect(job.get(), &Task::failed, parentWidget, [parentWidget](QString reason) {
         CustomMessageBox::selectable(parentWidget, QObject::tr("Failed to upload logs!"), reason, QMessageBox::Critical)->show();
     });
-    QObject::connect(job.get(), &Task::aborted, [parentWidget] {
+    QObject::connect(job.get(), &Task::aborted, parentWidget, [parentWidget] {
         CustomMessageBox::selectable(parentWidget, QObject::tr("Logs upload aborted"),
                                      QObject::tr("The task has been aborted by the user."), QMessageBox::Information)
             ->show();

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -160,7 +160,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWi
     {
         // Qt doesn't like vertical moving toolbars, so we have to force them...
         // See https://github.com/PolyMC/PolyMC/issues/493
-        connect(ui->instanceToolBar, &QToolBar::orientationChanged,
+        connect(ui->instanceToolBar, &QToolBar::orientationChanged, this,
                 [this](Qt::Orientation) { ui->instanceToolBar->setOrientation(Qt::Vertical); });
 
         // if you try to add a widget to a toolbar in a .ui file
@@ -396,9 +396,9 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWi
     // Update the menu when the active account changes.
     // Shouldn't have to use lambdas here like this, but if I don't, the compiler throws a fit.
     // Template hell sucks...
-    connect(APPLICATION->accounts(), &AccountList::defaultAccountChanged, [this] { defaultAccountChanged(); });
-    connect(APPLICATION->accounts(), &AccountList::listActivityChanged, [this] { defaultAccountChanged(); });
-    connect(APPLICATION->accounts(), &AccountList::listChanged, [this] { defaultAccountChanged(); });
+    connect(APPLICATION->accounts(), &AccountList::defaultAccountChanged, this, [this] { defaultAccountChanged(); });
+    connect(APPLICATION->accounts(), &AccountList::listActivityChanged, this, [this] { defaultAccountChanged(); });
+    connect(APPLICATION->accounts(), &AccountList::listChanged, this, [this] { defaultAccountChanged(); });
 
     // Show initial account
     defaultAccountChanged();
@@ -631,7 +631,7 @@ void MainWindow::updateThemeMenu()
         }
         themeAction->setActionGroup(themesGroup);
 
-        connect(themeAction, &QAction::triggered, [theme]() {
+        connect(themeAction, &QAction::triggered, APPLICATION, [theme]() {
             APPLICATION->themeManager()->setApplicationTheme(theme->id());
             APPLICATION->settings()->set("ApplicationTheme", theme->id());
         });
@@ -856,15 +856,15 @@ void MainWindow::setCatBackground(bool enabled)
 
 void MainWindow::runModalTask(Task* task)
 {
-    connect(task, &Task::failed,
+    connect(task, &Task::failed, this,
             [this](QString reason) { CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show(); });
-    connect(task, &Task::succeeded, [this, task]() {
+    connect(task, &Task::succeeded, this, [this, task]() {
         QStringList warnings = task->warnings();
         if (warnings.count()) {
             CustomMessageBox::selectable(this, tr("Warnings"), warnings.join('\n'), QMessageBox::Warning)->show();
         }
     });
-    connect(task, &Task::aborted, [this] {
+    connect(task, &Task::aborted, this, [this] {
         CustomMessageBox::selectable(this, tr("Task aborted"), tr("The task has been aborted by the user."), QMessageBox::Information)
             ->show();
     });

--- a/launcher/ui/dialogs/AboutDialog.cpp
+++ b/launcher/ui/dialogs/AboutDialog.cpp
@@ -121,7 +121,7 @@ AboutDialog::AboutDialog(QWidget* parent) : QDialog(parent), ui(new Ui::AboutDia
 
     connect(ui->closeButton, &QPushButton::clicked, this, &AboutDialog::close);
 
-    connect(ui->aboutQt, &QPushButton::clicked, &QApplication::aboutQt);
+    connect(ui->aboutQt, &QPushButton::clicked, APPLICATION, &QApplication::aboutQt);
 }
 
 AboutDialog::~AboutDialog()

--- a/launcher/ui/dialogs/ExportPackDialog.cpp
+++ b/launcher/ui/dialogs/ExportPackDialog.cpp
@@ -196,13 +196,13 @@ void ExportPackDialog::done(int result)
             task = new FlamePackExportTask(std::move(options));
         }
 
-        connect(task, &Task::failed,
+        connect(task, &Task::failed, this,
                 [this](const QString reason) { CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show(); });
-        connect(task, &Task::aborted, [this] {
+        connect(task, &Task::aborted, this, [this] {
             CustomMessageBox::selectable(this, tr("Task aborted"), tr("The task has been aborted by the user."), QMessageBox::Information)
                 ->show();
         });
-        connect(task, &Task::finished, [task] { task->deleteLater(); });
+        connect(task, &Task::finished, task, &Task::deleteLater);
 
         ProgressDialog progress(this);
         progress.setSkipButton(true, tr("Abort"));

--- a/launcher/ui/dialogs/ResourceUpdateDialog.cpp
+++ b/launcher/ui/dialogs/ResourceUpdateDialog.cpp
@@ -354,11 +354,11 @@ auto ResourceUpdateDialog::ensureMetadata() -> bool
     // prepare task for the modrinth mods
     if (!modrinthTmp.empty()) {
         auto modrinthTask = makeShared<EnsureMetadataTask>(modrinthTmp, indexDir2, ModPlatform::ResourceProvider::MODRINTH);
-        connect(modrinthTask.get(), &EnsureMetadataTask::metadataReady, [this](Resource* candidate) { onMetadataEnsured(candidate); });
-        connect(modrinthTask.get(), &EnsureMetadataTask::metadataFailed, [this, &shouldTryOthers](Resource* candidate) {
+        connect(modrinthTask.get(), &EnsureMetadataTask::metadataReady, this, [this](Resource* candidate) { onMetadataEnsured(candidate); });
+        connect(modrinthTask.get(), &EnsureMetadataTask::metadataFailed, this, [this, &shouldTryOthers](Resource* candidate) {
             onMetadataFailed(candidate, shouldTryOthers.find(candidate->internalId()).value(), ModPlatform::ResourceProvider::MODRINTH);
         });
-        connect(modrinthTask.get(), &EnsureMetadataTask::failed,
+        connect(modrinthTask.get(), &EnsureMetadataTask::failed, this,
                 [this](const QString& reason) { CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->exec(); });
 
         if (modrinthTask->getHashingTask()) {
@@ -371,11 +371,11 @@ auto ResourceUpdateDialog::ensureMetadata() -> bool
     // prepare task for the flame mods
     if (!flameTmp.empty()) {
         auto flameTask = makeShared<EnsureMetadataTask>(flameTmp, indexDir2, ModPlatform::ResourceProvider::FLAME);
-        connect(flameTask.get(), &EnsureMetadataTask::metadataReady, [this](Resource* candidate) { onMetadataEnsured(candidate); });
-        connect(flameTask.get(), &EnsureMetadataTask::metadataFailed, [this, &shouldTryOthers](Resource* candidate) {
+        connect(flameTask.get(), &EnsureMetadataTask::metadataReady, this, [this](Resource* candidate) { onMetadataEnsured(candidate); });
+        connect(flameTask.get(), &EnsureMetadataTask::metadataFailed, this, [this, &shouldTryOthers](Resource* candidate) {
             onMetadataFailed(candidate, shouldTryOthers.find(candidate->internalId()).value(), ModPlatform::ResourceProvider::FLAME);
         });
-        connect(flameTask.get(), &EnsureMetadataTask::failed,
+        connect(flameTask.get(), &EnsureMetadataTask::failed, this,
                 [this](const QString& reason) { CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->exec(); });
 
         if (flameTask->getHashingTask()) {
@@ -431,9 +431,9 @@ void ResourceUpdateDialog::onMetadataFailed(Resource* resource, bool tryOthers, 
         auto indexDir2 = indexDir();
 
         auto task = makeShared<EnsureMetadataTask>(resource, indexDir2, next(firstChoice));
-        connect(task.get(), &EnsureMetadataTask::metadataReady, [this](Resource* candidate) { onMetadataEnsured(candidate); });
-        connect(task.get(), &EnsureMetadataTask::metadataFailed, [this](Resource* candidate) { onMetadataFailed(candidate, false); });
-        connect(task.get(), &EnsureMetadataTask::failed,
+        connect(task.get(), &EnsureMetadataTask::metadataReady, this, [this](Resource* candidate) { onMetadataEnsured(candidate); });
+        connect(task.get(), &EnsureMetadataTask::metadataFailed, this, [this](Resource* candidate) { onMetadataFailed(candidate, false); });
+        connect(task.get(), &EnsureMetadataTask::failed, this,
                 [this](const QString& reason) { CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->exec(); });
         if (task->getHashingTask()) {
             auto seq = makeShared<SequentialTask>();

--- a/launcher/ui/dialogs/ReviewMessageBox.cpp
+++ b/launcher/ui/dialogs/ReviewMessageBox.cpp
@@ -26,7 +26,7 @@ ReviewMessageBox::ReviewMessageBox(QWidget* parent, [[maybe_unused]] QString con
 
     // Overwrite Ctrl+C functionality to exclude the label when copying text from tree
     auto shortcut = new QShortcut(QKeySequence::Copy, ui->modTreeWidget);
-    connect(shortcut, &QShortcut::activated, [this]() {
+    connect(shortcut, &QShortcut::activated, this, [this]() {
         auto currentItem = this->ui->modTreeWidget->currentItem();
         if (!currentItem)
             return;

--- a/launcher/ui/pages/global/AccountListPage.cpp
+++ b/launcher/ui/pages/global/AccountListPage.cpp
@@ -71,7 +71,7 @@ AccountListPage::AccountListPage(QWidget* parent) : QMainWindow(parent), ui(new 
 
     QItemSelectionModel* selectionModel = ui->listView->selectionModel();
 
-    connect(selectionModel, &QItemSelectionModel::selectionChanged,
+    connect(selectionModel, &QItemSelectionModel::selectionChanged, this,
             [this]([[maybe_unused]] const QItemSelection& sel, [[maybe_unused]] const QItemSelection& dsel) { updateButtonStates(); });
     connect(ui->listView, &VersionListView::customContextMenuRequested, this, &AccountListPage::ShowContextMenu);
     connect(ui->listView, &VersionListView::activated, this,

--- a/launcher/ui/pages/instance/DataPackPage.cpp
+++ b/launcher/ui/pages/instance/DataPackPage.cpp
@@ -79,15 +79,15 @@ void DataPackPage::downloadDialogFinished(int result)
 {
     if (result != 0) {
         auto* tasks = new ConcurrentTask(tr("Download Data Packs"), APPLICATION->settings()->get("NumberOfConcurrentDownloads").toInt());
-        connect(tasks, &Task::failed, [this, tasks](const QString& reason) {
+        connect(tasks, &Task::failed, this, [this, tasks](const QString& reason) {
             CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show();
             tasks->deleteLater();
         });
-        connect(tasks, &Task::aborted, [this, tasks]() {
+        connect(tasks, &Task::aborted, this, [this, tasks]() {
             CustomMessageBox::selectable(this, tr("Aborted"), tr("Download stopped by user."), QMessageBox::Information)->show();
             tasks->deleteLater();
         });
-        connect(tasks, &Task::succeeded, [this, tasks]() {
+        connect(tasks, &Task::succeeded, this, [this, tasks]() {
             QStringList warnings = tasks->warnings();
             if (warnings.count()) {
                 CustomMessageBox::selectable(this, tr("Warnings"), warnings.join('\n'), QMessageBox::Warning)->show();
@@ -168,15 +168,15 @@ void DataPackPage::updateDataPacks()
 
     if (updateDialog.exec() != 0) {
         auto* tasks = new ConcurrentTask("Download Data Packs", APPLICATION->settings()->get("NumberOfConcurrentDownloads").toInt());
-        connect(tasks, &Task::failed, [this, tasks](const QString& reason) {
+        connect(tasks, &Task::failed, this, [this, tasks](const QString& reason) {
             CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show();
             tasks->deleteLater();
         });
-        connect(tasks, &Task::aborted, [this, tasks]() {
+        connect(tasks, &Task::aborted, this, [this, tasks]() {
             CustomMessageBox::selectable(this, tr("Aborted"), tr("Download stopped by user."), QMessageBox::Information)->show();
             tasks->deleteLater();
         });
-        connect(tasks, &Task::succeeded, [this, tasks]() {
+        connect(tasks, &Task::succeeded, this, [this, tasks]() {
             QStringList warnings = tasks->warnings();
             if (warnings.count()) {
                 CustomMessageBox::selectable(this, tr("Warnings"), warnings.join('\n'), QMessageBox::Warning)->show();
@@ -246,15 +246,15 @@ void DataPackPage::changeDataPackVersion()
     m_downloadDialog->setResourceMetadata(resource.metadata());
     if (m_downloadDialog->exec() != 0) {
         auto* tasks = new ConcurrentTask("Download Data Packs", APPLICATION->settings()->get("NumberOfConcurrentDownloads").toInt());
-        connect(tasks, &Task::failed, [this, tasks](const QString& reason) {
+        connect(tasks, &Task::failed, this, [this, tasks](const QString& reason) {
             CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show();
             tasks->deleteLater();
         });
-        connect(tasks, &Task::aborted, [this, tasks]() {
+        connect(tasks, &Task::aborted, this, [this, tasks]() {
             CustomMessageBox::selectable(this, tr("Aborted"), tr("Download stopped by user."), QMessageBox::Information)->show();
             tasks->deleteLater();
         });
-        connect(tasks, &Task::succeeded, [this, tasks]() {
+        connect(tasks, &Task::succeeded, this, [this, tasks]() {
             QStringList warnings = tasks->warnings();
             if (warnings.count()) {
                 CustomMessageBox::selectable(this, tr("Warnings"), warnings.join('\n'), QMessageBox::Warning)->show();

--- a/launcher/ui/pages/instance/ManagedPackPage.cpp
+++ b/launcher/ui/pages/instance/ManagedPackPage.cpp
@@ -146,15 +146,15 @@ bool ManagedPackPage::runUpdateTask(InstanceTask* task)
 
     const unique_qobject_ptr<Task> wrappedTask(APPLICATION->instances()->wrapInstanceTask(task));
 
-    connect(wrappedTask.get(), &Task::failed,
+    connect(wrappedTask.get(), &Task::failed, this,
             [this](const QString& reason) { CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show(); });
-    connect(wrappedTask.get(), &Task::succeeded, [this, task]() {
+    connect(wrappedTask.get(), &Task::succeeded, this, [this, task]() {
         QStringList warnings = task->warnings();
         if (warnings.count()) {
             CustomMessageBox::selectable(this, tr("Warnings"), warnings.join('\n'), QMessageBox::Warning)->show();
         }
     });
-    connect(wrappedTask.get(), &Task::aborted, [this] {
+    connect(wrappedTask.get(), &Task::aborted, this, [this] {
         CustomMessageBox::selectable(this, tr("Task aborted"), tr("The task has been aborted by the user."), QMessageBox::Information)
             ->show();
     });

--- a/launcher/ui/pages/instance/ModFolderPage.cpp
+++ b/launcher/ui/pages/instance/ModFolderPage.cpp
@@ -188,15 +188,15 @@ void ModFolderPage::downloadDialogFinished(int result)
 {
     if (result != 0) {
         auto* tasks = new ConcurrentTask(tr("Download Mods"), APPLICATION->settings()->get("NumberOfConcurrentDownloads").toInt());
-        connect(tasks, &Task::failed, [this, tasks](const QString& reason) {
+        connect(tasks, &Task::failed, this, [this, tasks](const QString& reason) {
             CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show();
             tasks->deleteLater();
         });
-        connect(tasks, &Task::aborted, [this, tasks]() {
+        connect(tasks, &Task::aborted, this, [this, tasks]() {
             CustomMessageBox::selectable(this, tr("Aborted"), tr("Download stopped by user."), QMessageBox::Information)->show();
             tasks->deleteLater();
         });
-        connect(tasks, &Task::succeeded, [this, tasks]() {
+        connect(tasks, &Task::succeeded, this, [this, tasks]() {
             QStringList warnings = tasks->warnings();
             if (warnings.count()) {
                 CustomMessageBox::selectable(this, tr("Warnings"), warnings.join('\n'), QMessageBox::Warning)->show();
@@ -281,15 +281,15 @@ void ModFolderPage::updateMods(bool includeDeps)
 
     if (updateDialog.exec() != 0) {
         auto* tasks = new ConcurrentTask("Download Mods", APPLICATION->settings()->get("NumberOfConcurrentDownloads").toInt());
-        connect(tasks, &Task::failed, [this, tasks](const QString& reason) {
+        connect(tasks, &Task::failed, this, [this, tasks](const QString& reason) {
             CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show();
             tasks->deleteLater();
         });
-        connect(tasks, &Task::aborted, [this, tasks]() {
+        connect(tasks, &Task::aborted, this, [this, tasks]() {
             CustomMessageBox::selectable(this, tr("Aborted"), tr("Download stopped by user."), QMessageBox::Information)->show();
             tasks->deleteLater();
         });
-        connect(tasks, &Task::succeeded, [this, tasks]() {
+        connect(tasks, &Task::succeeded, this, [this, tasks]() {
             QStringList warnings = tasks->warnings();
             if (warnings.count()) {
                 CustomMessageBox::selectable(this, tr("Warnings"), warnings.join('\n'), QMessageBox::Warning)->show();

--- a/launcher/ui/pages/instance/ResourcePackPage.cpp
+++ b/launcher/ui/pages/instance/ResourcePackPage.cpp
@@ -96,15 +96,15 @@ void ResourcePackPage::downloadDialogFinished(int result)
 {
     if (result != 0) {
         auto* tasks = new ConcurrentTask("Download Resource Pack", APPLICATION->settings()->get("NumberOfConcurrentDownloads").toInt());
-        connect(tasks, &Task::failed, [this, tasks](const QString& reason) {
+        connect(tasks, &Task::failed, this, [this, tasks](const QString& reason) {
             CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show();
             tasks->deleteLater();
         });
-        connect(tasks, &Task::aborted, [this, tasks]() {
+        connect(tasks, &Task::aborted, this, [this, tasks]() {
             CustomMessageBox::selectable(this, tr("Aborted"), tr("Download stopped by user."), QMessageBox::Information)->show();
             tasks->deleteLater();
         });
-        connect(tasks, &Task::succeeded, [this, tasks]() {
+        connect(tasks, &Task::succeeded, this, [this, tasks]() {
             QStringList warnings = tasks->warnings();
             if (warnings.count()) {
                 CustomMessageBox::selectable(this, tr("Warnings"), warnings.join('\n'), QMessageBox::Warning)->show();
@@ -185,15 +185,15 @@ void ResourcePackPage::updateResourcePacks()
 
     if (updateDialog.exec() != 0) {
         auto* tasks = new ConcurrentTask("Download Resource Packs", APPLICATION->settings()->get("NumberOfConcurrentDownloads").toInt());
-        connect(tasks, &Task::failed, [this, tasks](const QString& reason) {
+        connect(tasks, &Task::failed, this, [this, tasks](const QString& reason) {
             CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show();
             tasks->deleteLater();
         });
-        connect(tasks, &Task::aborted, [this, tasks]() {
+        connect(tasks, &Task::aborted, this, [this, tasks]() {
             CustomMessageBox::selectable(this, tr("Aborted"), tr("Download stopped by user."), QMessageBox::Information)->show();
             tasks->deleteLater();
         });
-        connect(tasks, &Task::succeeded, [this, tasks]() {
+        connect(tasks, &Task::succeeded, this, [this, tasks]() {
             QStringList warnings = tasks->warnings();
             if (warnings.count()) {
                 CustomMessageBox::selectable(this, tr("Warnings"), warnings.join('\n'), QMessageBox::Warning)->show();

--- a/launcher/ui/pages/instance/ScreenshotsPage.cpp
+++ b/launcher/ui/pages/instance/ScreenshotsPage.cpp
@@ -434,10 +434,10 @@ void ScreenshotsPage::on_actionUpload_triggered()
         auto screenshot = std::make_shared<ScreenShot>(info);
         job->addNetAction(ImgurUpload::make(screenshot));
 
-        connect(job.get(), &Task::failed, [this](const QString& reason) {
+        connect(job.get(), &Task::failed, this, [this](const QString& reason) {
             CustomMessageBox::selectable(this, tr("Failed to upload screenshots!"), reason, QMessageBox::Critical)->show();
         });
-        connect(job.get(), &Task::aborted, [this] {
+        connect(job.get(), &Task::aborted, this, [this] {
             CustomMessageBox::selectable(this, tr("Screenshots upload aborted"), tr("The task has been aborted by the user."),
                                          QMessageBox::Information)
                 ->show();
@@ -475,10 +475,10 @@ void ScreenshotsPage::on_actionUpload_triggered()
     task.addTask(job);
     task.addTask(albumTask);
 
-    connect(&task, &Task::failed, [this](const QString& reason) {
+    connect(&task, &Task::failed, this, [this](const QString& reason) {
         CustomMessageBox::selectable(this, tr("Failed to upload screenshots!"), reason, QMessageBox::Critical)->show();
     });
-    connect(&task, &Task::aborted, [this] {
+    connect(&task, &Task::aborted, this, [this] {
         CustomMessageBox::selectable(this, tr("Screenshots upload aborted"), tr("The task has been aborted by the user."),
                                      QMessageBox::Information)
             ->show();

--- a/launcher/ui/pages/instance/ServerPingTask.cpp
+++ b/launcher/ui/pages/instance/ServerPingTask.cpp
@@ -42,6 +42,6 @@ void ServerPingTask::executeTask()
     connect(resolver, &McResolver::failed, this, [this](QString error) { emitFailed(error); });
 
     // Delete McResolver object when done
-    connect(resolver, &McResolver::finished, [resolver]() { resolver->deleteLater(); });
+    connect(resolver, &McResolver::finished, resolver, &McResolver::deleteLater);
     resolver->ping();
 }

--- a/launcher/ui/pages/instance/ShaderPackPage.cpp
+++ b/launcher/ui/pages/instance/ShaderPackPage.cpp
@@ -91,15 +91,15 @@ void ShaderPackPage::downloadDialogFinished(int result)
 {
     if (result != 0) {
         auto* tasks = new ConcurrentTask("Download Shader Packs", APPLICATION->settings()->get("NumberOfConcurrentDownloads").toInt());
-        connect(tasks, &Task::failed, [this, tasks](const QString& reason) {
+        connect(tasks, &Task::failed, this, [this, tasks](const QString& reason) {
             CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show();
             tasks->deleteLater();
         });
-        connect(tasks, &Task::aborted, [this, tasks]() {
+        connect(tasks, &Task::aborted, this, [this, tasks]() {
             CustomMessageBox::selectable(this, tr("Aborted"), tr("Download stopped by user."), QMessageBox::Information)->show();
             tasks->deleteLater();
         });
-        connect(tasks, &Task::succeeded, [this, tasks]() {
+        connect(tasks, &Task::succeeded, this, [this, tasks]() {
             QStringList warnings = tasks->warnings();
             if (warnings.count()) {
                 CustomMessageBox::selectable(this, tr("Warnings"), warnings.join('\n'), QMessageBox::Warning)->show();
@@ -180,15 +180,15 @@ void ShaderPackPage::updateShaderPacks()
 
     if (updateDialog.exec() != 0) {
         auto* tasks = new ConcurrentTask("Download Shader Packs", APPLICATION->settings()->get("NumberOfConcurrentDownloads").toInt());
-        connect(tasks, &Task::failed, [this, tasks](const QString& reason) {
+        connect(tasks, &Task::failed, this, [this, tasks](const QString& reason) {
             CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show();
             tasks->deleteLater();
         });
-        connect(tasks, &Task::aborted, [this, tasks]() {
+        connect(tasks, &Task::aborted, this, [this, tasks]() {
             CustomMessageBox::selectable(this, tr("Aborted"), tr("Download stopped by user."), QMessageBox::Information)->show();
             tasks->deleteLater();
         });
-        connect(tasks, &Task::succeeded, [this, tasks]() {
+        connect(tasks, &Task::succeeded, this, [this, tasks]() {
             QStringList warnings = tasks->warnings();
             if (warnings.count()) {
                 CustomMessageBox::selectable(this, tr("Warnings"), warnings.join('\n'), QMessageBox::Warning)->show();

--- a/launcher/ui/pages/instance/TexturePackPage.cpp
+++ b/launcher/ui/pages/instance/TexturePackPage.cpp
@@ -97,15 +97,15 @@ void TexturePackPage::downloadDialogFinished(int result)
 {
     if (result != 0) {
         auto* tasks = new ConcurrentTask("Download Texture Packs", APPLICATION->settings()->get("NumberOfConcurrentDownloads").toInt());
-        connect(tasks, &Task::failed, [this, tasks](const QString& reason) {
+        connect(tasks, &Task::failed, this, [this, tasks](const QString& reason) {
             CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show();
             tasks->deleteLater();
         });
-        connect(tasks, &Task::aborted, [this, tasks]() {
+        connect(tasks, &Task::aborted, this, [this, tasks]() {
             CustomMessageBox::selectable(this, tr("Aborted"), tr("Download stopped by user."), QMessageBox::Information)->show();
             tasks->deleteLater();
         });
-        connect(tasks, &Task::succeeded, [this, tasks]() {
+        connect(tasks, &Task::succeeded, this, [this, tasks]() {
             QStringList warnings = tasks->warnings();
             if (warnings.count()) {
                 CustomMessageBox::selectable(this, tr("Warnings"), warnings.join('\n'), QMessageBox::Warning)->show();
@@ -186,15 +186,15 @@ void TexturePackPage::updateTexturePacks()
 
     if (updateDialog.exec() != 0) {
         auto* tasks = new ConcurrentTask("Download Texture Packs", APPLICATION->settings()->get("NumberOfConcurrentDownloads").toInt());
-        connect(tasks, &Task::failed, [this, tasks](const QString& reason) {
+        connect(tasks, &Task::failed, this, [this, tasks](const QString& reason) {
             CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show();
             tasks->deleteLater();
         });
-        connect(tasks, &Task::aborted, [this, tasks]() {
+        connect(tasks, &Task::aborted, this, [this, tasks]() {
             CustomMessageBox::selectable(this, tr("Aborted"), tr("Download stopped by user."), QMessageBox::Information)->show();
             tasks->deleteLater();
         });
-        connect(tasks, &Task::succeeded, [this, tasks]() {
+        connect(tasks, &Task::succeeded, this, [this, tasks]() {
             QStringList warnings = tasks->warnings();
             if (warnings.count()) {
                 CustomMessageBox::selectable(this, tr("Warnings"), warnings.join('\n'), QMessageBox::Warning)->show();

--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -145,7 +145,7 @@ void ModPage::prepareProviderCategories()
 {
     auto [task, response] = m_api->getModCategories();
     m_categoriesTask = task;
-    connect(m_categoriesTask.get(), &Task::succeeded, [this, response]() {
+    connect(m_categoriesTask.get(), &Task::succeeded, this, [this, response]() {
         auto categories = m_api->loadModCategories(*response);
         m_filterWidget->setCategories(categories);
     });

--- a/launcher/ui/pages/modplatform/OptionalModDialog.cpp
+++ b/launcher/ui/pages/modplatform/OptionalModDialog.cpp
@@ -37,7 +37,7 @@ OptionalModDialog::OptionalModDialog(QWidget* parent, const QStringList& mods) :
         for (int i = 0; i < ui->list->count(); i++)
             ui->list->item(i)->setCheckState(Qt::Unchecked);
     });
-    connect(ui->list, &QListWidget::itemActivated, [](QListWidgetItem* item) {
+    connect(ui->list, &QListWidget::itemActivated, ui->list, [](QListWidgetItem* item) {
         if (item->checkState() == Qt::Checked)
             item->setCheckState(Qt::Unchecked);
         else

--- a/launcher/ui/pages/modplatform/ResourcePage.cpp
+++ b/launcher/ui/pages/modplatform/ResourcePage.cpp
@@ -561,7 +561,7 @@ void ResourcePage::openUrl(QUrl url)
             newPage->triggerSearch();
 
             if (model->hasActiveSearchJob()) {
-                connect(model->activeSearchJob().get(), &Task::finished, jump);
+                connect(model->activeSearchJob().get(), &Task::finished, newPage, jump);
             } else {
                 jump();
             }
@@ -620,7 +620,7 @@ void ResourcePage::openProject(const QVariant& projectID)
     triggerSearch();
 
     if (m_model->hasActiveSearchJob()) {
-        connect(m_model->activeSearchJob().get(), &Task::finished, jump);
+        connect(m_model->activeSearchJob().get(), &Task::finished, this, jump);
     } else {
         jump();
     }

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
@@ -382,7 +382,7 @@ void ModrinthPage::createFilterWidget()
     connect(m_filterWidget.get(), &ModFilterWidget::filterChanged, this, &ModrinthPage::triggerSearch);
     auto [categoriesTask, response] = ModrinthAPI().getModCategories();
     m_categoriesTask = categoriesTask;
-    connect(m_categoriesTask.get(), &Task::succeeded, [this, response]() {
+    connect(m_categoriesTask.get(), &Task::succeeded, this, [this, response]() {
         auto categories = ModrinthAPI::loadCategories(*response, "modpack");
         m_filterWidget->setCategories(categories);
     });

--- a/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
+++ b/launcher/ui/pages/modplatform/technic/TechnicPage.cpp
@@ -216,7 +216,7 @@ void TechnicPage::suggestCurrent()
 
         metadataLoaded();
     });
-    connect(jobPtr.get(), &NetJob::failed,
+    connect(jobPtr.get(), &NetJob::failed, this,
             [this](QString reason) { CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->exec(); });
 
     jobPtr = netJob;
@@ -269,7 +269,7 @@ void TechnicPage::metadataLoaded()
         netJob->addNetAction(action);
 
         connect(netJob.get(), &NetJob::succeeded, this, [this, response] { onSolderLoaded(response); });
-        connect(jobPtr.get(), &NetJob::failed,
+        connect(jobPtr.get(), &NetJob::failed, this,
                 [this](QString reason) { CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->exec(); });
 
         jobPtr = netJob;

--- a/launcher/ui/setupwizard/SetupWizard.cpp
+++ b/launcher/ui/setupwizard/SetupWizard.cpp
@@ -57,7 +57,7 @@ void SetupWizard::pageChanged(int id)
     if (basePagePtr->wantsRefreshButton()) {
         setButtonLayout({ QWizard::CustomButton1, QWizard::Stretch, QWizard::BackButton, QWizard::NextButton, QWizard::FinishButton });
         auto customButton = button(QWizard::CustomButton1);
-        connect(customButton, &QAbstractButton::clicked, [this]() {
+        connect(customButton, &QAbstractButton::clicked, this, [this]() {
             auto basePagePtr = getCurrentBasePage();
             if (basePagePtr) {
                 basePagePtr->refresh();

--- a/launcher/ui/widgets/InfoFrame.cpp
+++ b/launcher/ui/widgets/InfoFrame.cpp
@@ -48,7 +48,7 @@
 
 void setupLinkToolTip(QLabel* label)
 {
-    QObject::connect(label, &QLabel::linkHovered, [label](const QString& link) {
+    QObject::connect(label, &QLabel::linkHovered, label, [label](const QString& link) {
         if (auto url = QUrl(link); !url.isValid() || (url.scheme() != "http" && url.scheme() != "https"))
             return;
         label->setToolTip(link);

--- a/launcher/ui/widgets/JavaSettingsWidget.cpp
+++ b/launcher/ui/widgets/JavaSettingsWidget.cpp
@@ -91,7 +91,7 @@ JavaSettingsWidget::JavaSettingsWidget(BaseInstance* instance, QWidget* parent)
             auto javaDialog = new Java::InstallDialog({}, m_instance, this);
             javaDialog->exec();
         });
-        connect(m_ui->javaPathTextBox, &QLineEdit::textChanged, [this](QString newValue) {
+        connect(m_ui->javaPathTextBox, &QLineEdit::textChanged, this, [this](QString newValue) {
             if (m_instance->settings()->get("JavaPath").toString() != newValue) {
                 m_instance->settings()->set("AutomaticJava", false);
             }

--- a/launcher/ui/widgets/LanguageSelectionWidget.cpp
+++ b/launcher/ui/widgets/LanguageSelectionWidget.cpp
@@ -35,7 +35,7 @@ LanguageSelectionWidget::LanguageSelectionWidget(QWidget* parent) : QWidget(pare
     formatCheckbox = new QCheckBox(this);
     formatCheckbox->setObjectName(QStringLiteral("formatCheckbox"));
     formatCheckbox->setCheckState(APPLICATION->settings()->get("UseSystemLocale").toBool() ? Qt::Checked : Qt::Unchecked);
-    connect(formatCheckbox, &QCheckBox::stateChanged,
+    connect(formatCheckbox, &QCheckBox::stateChanged, this,
             [this]() { APPLICATION->translations()->setUseSystemLocale(formatCheckbox->isChecked()); });
     verticalLayout->addWidget(formatCheckbox);
 

--- a/launcher/ui/widgets/ModFilterWidget.cpp
+++ b/launcher/ui/widgets/ModFilterWidget.cpp
@@ -203,7 +203,7 @@ void ModFilterWidget::loadVersionList()
 
         auto task = m_version_list->getLoadTask();
 
-        connect(task.get(), &Task::failed, [this] {
+        connect(task.get(), &Task::failed, this, [this] {
             ui->versions->setEnabled(false);
             ui->showAllVersions->setEnabled(false);
         });

--- a/launcher/ui/widgets/VersionSelectWidget.cpp
+++ b/launcher/ui/widgets/VersionSelectWidget.cpp
@@ -36,7 +36,7 @@ VersionSelectWidget::VersionSelectWidget(QWidget* parent) : QWidget(parent)
     search->setPlaceholderText(tr("Search"));
     search->setClearButtonEnabled(true);
     verticalLayout->addWidget(search);
-    connect(search, &QLineEdit::textEdited, [this](const QString& value) {
+    connect(search, &QLineEdit::textEdited, this, [this](const QString& value) {
         m_proxyModel->setSearch(value);
         if (!value.isEmpty() || !listView->selectionModel()->hasSelection()) {
             const QModelIndex first = listView->model()->index(0, 0);

--- a/tests/FileSystem_test.cpp
+++ b/tests/FileSystem_test.cpp
@@ -320,7 +320,7 @@ class FileSystemTest : public QObject {
 
             LinkTask lnk_tsk(folder, target_dir.path());
             lnk_tsk.linkRecursively(false);
-            connect(&lnk_tsk, &Task::finished,
+            connect(&lnk_tsk, &Task::finished, &lnk_tsk,
                     [&lnk_tsk] { QVERIFY2(lnk_tsk.wasSuccessful(), "Task finished but was not successful when it should have been."); });
             lnk_tsk.start();
 
@@ -416,7 +416,7 @@ class FileSystemTest : public QObject {
             auto re = Filters::regexp(QRegularExpression("[.]?mcmeta"));
             lnk_tsk.matcher(re);
             lnk_tsk.linkRecursively(true);
-            connect(&lnk_tsk, &Task::finished,
+            connect(&lnk_tsk, &Task::finished, &lnk_tsk,
                     [&lnk_tsk] { QVERIFY2(lnk_tsk.wasSuccessful(), "Task finished but was not successful when it should have been."); });
             lnk_tsk.start();
 
@@ -463,7 +463,7 @@ class FileSystemTest : public QObject {
             lnk_tsk.matcher(re);
             lnk_tsk.linkRecursively(true);
             lnk_tsk.whitelist(true);
-            connect(&lnk_tsk, &Task::finished,
+            connect(&lnk_tsk, &Task::finished, &lnk_tsk,
                     [&lnk_tsk] { QVERIFY2(lnk_tsk.wasSuccessful(), "Task finished but was not successful when it should have been."); });
             lnk_tsk.start();
 
@@ -507,7 +507,7 @@ class FileSystemTest : public QObject {
 
             LinkTask lnk_tsk(folder, target_dir.path());
             lnk_tsk.linkRecursively(true);
-            connect(&lnk_tsk, &Task::finished,
+            connect(&lnk_tsk, &Task::finished, &lnk_tsk,
                     [&lnk_tsk] { QVERIFY2(lnk_tsk.wasSuccessful(), "Task finished but was not successful when it should have been."); });
             lnk_tsk.start();
 
@@ -555,7 +555,7 @@ class FileSystemTest : public QObject {
             qDebug() << target_dir.path();
 
             LinkTask lnk_tsk(file, target_dir.filePath("pack.mcmeta"));
-            connect(&lnk_tsk, &Task::finished,
+            connect(&lnk_tsk, &Task::finished, &lnk_tsk,
                     [&lnk_tsk] { QVERIFY2(lnk_tsk.wasSuccessful(), "Task finished but was not successful when it should have been."); });
             lnk_tsk.start();
 
@@ -590,7 +590,7 @@ class FileSystemTest : public QObject {
             LinkTask lnk_tsk(folder, target_dir.path());
             lnk_tsk.linkRecursively(true);
             lnk_tsk.setMaxDepth(0);
-            connect(&lnk_tsk, &Task::finished,
+            connect(&lnk_tsk, &Task::finished, &lnk_tsk,
                     [&lnk_tsk] { QVERIFY2(lnk_tsk.wasSuccessful(), "Task finished but was not successful when it should have been."); });
             lnk_tsk.start();
 
@@ -640,7 +640,7 @@ class FileSystemTest : public QObject {
             LinkTask lnk_tsk(folder, target_dir.path());
             lnk_tsk.linkRecursively(true);
             lnk_tsk.setMaxDepth(-1);
-            connect(&lnk_tsk, &Task::finished,
+            connect(&lnk_tsk, &Task::finished, &lnk_tsk,
                     [&lnk_tsk] { QVERIFY2(lnk_tsk.wasSuccessful(), "Task finished but was not successful when it should have been."); });
             lnk_tsk.start();
 

--- a/tests/Task_test.cpp
+++ b/tests/Task_test.cpp
@@ -127,7 +127,7 @@ class TaskTest : public QObject {
     void test_basicRun()
     {
         BasicTask t;
-        connect(&t, &Task::finished,
+        connect(&t, &Task::finished, &t,
                 [&t] { QVERIFY2(t.wasSuccessful(), "Task finished but was not successful when it should have been."); });
         t.start();
 
@@ -146,7 +146,7 @@ class TaskTest : public QObject {
         t.addTask(t2);
         t.addTask(t3);
 
-        connect(&t, &Task::finished, [&t, &t1, &t2, &t3] {
+        connect(&t, &Task::finished, &t, [&t, &t1, &t2, &t3] {
             QVERIFY2(t.wasSuccessful(), "Task finished but was not successful when it should have been.");
             QVERIFY(t1->wasSuccessful());
             QVERIFY(t2->wasSuccessful());
@@ -182,7 +182,7 @@ class TaskTest : public QObject {
         t.addTask(t8);
         t.addTask(t9);
 
-        connect(&t, &Task::finished, [&t, &t1, &t2, &t3, &t4, &t5, &t6, &t7, &t8, &t9] {
+        connect(&t, &Task::finished, &t, [&t, &t1, &t2, &t3, &t4, &t5, &t6, &t7, &t8, &t9] {
             QVERIFY2(t.wasSuccessful(), "Task finished but was not successful when it should have been.");
             QVERIFY(t1->wasSuccessful());
             QVERIFY(t2->wasSuccessful());
@@ -211,7 +211,7 @@ class TaskTest : public QObject {
         t.addTask(t2);
         t.addTask(t3);
 
-        connect(&t, &Task::finished, [&t, &t1, &t2, &t3] {
+        connect(&t, &Task::finished, &t, [&t, &t1, &t2, &t3] {
             QVERIFY2(t.wasSuccessful(), "Task finished but was not successful when it should have been.");
             QVERIFY(t1->wasSuccessful());
             QVERIFY(t2->wasSuccessful());
@@ -234,7 +234,7 @@ class TaskTest : public QObject {
         t.addTask(t2);
         t.addTask(t3);
 
-        connect(&t, &Task::finished, [&t, &t1, &t2, &t3] {
+        connect(&t, &Task::finished, &t, [&t, &t1, &t2, &t3] {
             QVERIFY2(t.wasSuccessful(), "Task finished but was not successful when it should have been.");
             QVERIFY(t1->wasSuccessful());
             QVERIFY(!t2->wasSuccessful());


### PR DESCRIPTION
https://doc.qt.io/qt-6/qobject.html#QT_NO_CONTEXTLESS_CONNECT
> Using the context-less overload is error prone, because it is easy to connect to functors that depend on some local state of the receiving end. If such local state gets destroyed, the connection does not get automatically disconnected.
> Moreover, such connections are always direct connections, which may cause issues in multithreaded scenarios (for instance, if the signal is emitted from another thread).

Furthermore, it is slightly easier to leak lambda captures with contextless connects, as there is no automatic disconnect when the receiver is deleted (because there is no receiver)