### PR TITLE
Migrate legacy instgroups.json to new location

### DIFF
--- a/launcher/InstanceList.cpp
+++ b/launcher/InstanceList.cpp
@@ -799,9 +799,17 @@ void InstanceList::loadGroupList()
     m_groupNameCache.clear();
     m_collapsedGroups.clear();
 
-    // if there's no group file, fail
+    bool migratingLegacyGroups = false;
+
+    // If there's no group file, try the legacy location.
     if (!QFileInfo::exists(groupFileName)) {
-        return;
+        QString legacyGroupFileName = FS::PathCombine(primaryDir(), "instgroups.json");
+        if (!QFileInfo::exists(legacyGroupFileName)) {
+            return;
+        }
+        qInfo() << "Migrating instance groups from legacy location" << legacyGroupFileName;
+        groupFileName = legacyGroupFileName;
+        migratingLegacyGroups = true;
     }
 
     QByteArray jsonData;
@@ -884,6 +892,10 @@ void InstanceList::loadGroupList()
     }
     m_groupsLoaded = true;
     qDebug() << "Group list loaded.";
+
+    if (migratingLegacyGroups) {
+        saveGroupList();
+    }
 }
 
 void InstanceList::instanceDirContentsChanged(const QString& path)


### PR DESCRIPTION
Parent PR: #5827
Fixes #5891 

#5827 did not handle migration of existing files, so people would lose their groups as instgroups used to be in primary instance dir. Added a fallback such that if new location doesn't exist, we load from the old spot and save once migration is done