### PR TITLE
Change InstanceList to only hold MinecraftInstance

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -1461,7 +1461,7 @@ void Application::messageReceived(const QByteArray& message)
         bool offline = received.args["offline_enabled"] == "true";
         QString offlineName = received.args["offline_name"];
 
-        BaseInstance* instance;
+        MinecraftInstance* instance;
         if (!id.isEmpty()) {
             instance = instances()->getInstanceById(id);
             if (!instance) {
@@ -1524,7 +1524,7 @@ bool Application::openJsonEditor(const QString& filename)
     }
 }
 
-bool Application::launch(BaseInstance* instance,
+bool Application::launch(MinecraftInstance* instance,
                          LaunchMode mode,
                          MinecraftTarget::Ptr targetToJoin,
                          MinecraftAccountPtr accountToUse,
@@ -1706,7 +1706,7 @@ ViewLogWindow* Application::showLogWindow()
     return m_viewLogWindow;
 }
 
-InstanceWindow* Application::showInstanceWindow(BaseInstance* instance, QString page)
+InstanceWindow* Application::showInstanceWindow(MinecraftInstance* instance, QString page)
 {
     if (!instance)
         return nullptr;

--- a/launcher/Application.h
+++ b/launcher/Application.h
@@ -75,6 +75,7 @@ class MCEditTool;
 class ThemeManager;
 class IconTheme;
 class BaseInstance;
+class MinecraftInstance;
 
 class LogModel;
 
@@ -187,7 +188,7 @@ class Application : public QApplication {
      */
     bool openJsonEditor(const QString& filename);
 
-    InstanceWindow* showInstanceWindow(BaseInstance* instance, QString page = QString());
+    InstanceWindow* showInstanceWindow(MinecraftInstance* instance, QString page = QString());
     MainWindow* showMainWindow(bool minimized = false);
     ViewLogWindow* showLogWindow();
 
@@ -214,7 +215,7 @@ class Application : public QApplication {
 #endif
 
    public slots:
-    bool launch(BaseInstance* instance,
+    bool launch(MinecraftInstance* instance,
                 LaunchMode mode = LaunchMode::Normal,
                 std::shared_ptr<MinecraftTarget> targetToJoin = nullptr,
                 shared_qobject_ptr<MinecraftAccount> accountToUse = nullptr,

--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -224,7 +224,7 @@ bool BaseInstance::isLinkedToInstanceId(const QString& id) const
 void BaseInstance::iconUpdated(const QString& key)
 {
     if (iconKey() == key) {
-        emit propertiesChanged(this);
+        emit propertiesChanged();
     }
 }
 
@@ -295,7 +295,7 @@ void BaseInstance::setMinecraftRunning(bool running)
         settings()->set("totalTimePlayed", current + m_timeStarted.secsTo(timeEnded));
         settings()->set("lastTimePlayed", m_timeStarted.secsTo(timeEnded));
 
-        emit propertiesChanged(this);
+        emit propertiesChanged();
     }
 }
 
@@ -365,7 +365,7 @@ void BaseInstance::setLastLaunch(qint64 val)
 {
     // FIXME: if no change, do not set. setting involves saving a file.
     m_settings->set("lastLaunchTime", val);
-    emit propertiesChanged(this);
+    emit propertiesChanged();
 }
 
 void BaseInstance::setNotes(const QString& val)
@@ -383,7 +383,7 @@ void BaseInstance::setIconKey(const QString& val)
 {
     // FIXME: if no change, do not set. setting involves saving a file.
     m_settings->set("iconKey", val);
-    emit propertiesChanged(this);
+    emit propertiesChanged();
 }
 
 QString BaseInstance::iconKey() const
@@ -395,7 +395,7 @@ void BaseInstance::setName(const QString& val)
 {
     // FIXME: if no change, do not set. setting involves saving a file.
     m_settings->set("name", val);
-    emit propertiesChanged(this);
+    emit propertiesChanged();
 }
 
 bool BaseInstance::syncInstanceDirName(const QString& newRoot) const

--- a/launcher/BaseInstance.h
+++ b/launcher/BaseInstance.h
@@ -233,7 +233,7 @@ class BaseInstance : public QObject {
     {
         if (m_hasBrokenVersion != value) {
             m_hasBrokenVersion = value;
-            emit propertiesChanged(this);
+            emit propertiesChanged();
         }
     }
 
@@ -242,7 +242,7 @@ class BaseInstance : public QObject {
     {
         if (m_hasUpdate != value) {
             m_hasUpdate = value;
-            emit propertiesChanged(this);
+            emit propertiesChanged();
         }
     }
 
@@ -251,7 +251,7 @@ class BaseInstance : public QObject {
     {
         if (m_crashed != value) {
             m_crashed = value;
-            emit propertiesChanged(this);
+            emit propertiesChanged();
         }
     }
 
@@ -290,7 +290,7 @@ class BaseInstance : public QObject {
     /*!
      * \brief Signal emitted when properties relevant to the instance view change
      */
-    void propertiesChanged(BaseInstance* inst);
+    void propertiesChanged();
 
     void launchTaskChanged(LaunchTask*);
 

--- a/launcher/BaseInstance.h
+++ b/launcher/BaseInstance.h
@@ -223,8 +223,6 @@ class BaseInstance : public QObject {
     /// get variables this instance exports
     virtual QMap<QString, QString> getVariables() = 0;
 
-    virtual QString typeName() const = 0;
-
     virtual void updateRuntimeContext();
     RuntimeContext runtimeContext() const { return m_runtimeContext; }
 

--- a/launcher/InstanceList.cpp
+++ b/launcher/InstanceList.cpp
@@ -163,7 +163,7 @@ QVariant InstanceList::data(const QModelIndex& index, int role) const
     if (!index.isValid()) {
         return QVariant();
     }
-    auto* pdata = static_cast<BaseInstance*>(index.internalPointer());
+    auto* pdata = static_cast<MinecraftInstance*>(index.internalPointer());
     switch (role) {
         case InstancePointerRole: {
             QVariant v = QVariant::fromValue((void*)pdata);
@@ -203,7 +203,7 @@ bool InstanceList::setData(const QModelIndex& index, const QVariant& value, int 
     if (role != Qt::EditRole) {
         return false;
     }
-    auto* pdata = static_cast<BaseInstance*>(index.internalPointer());
+    auto* pdata = static_cast<MinecraftInstance*>(index.internalPointer());
     auto newName = value.toString();
     if (pdata->name() == newName) {
         return true;
@@ -458,7 +458,7 @@ void InstanceList::deleteInstance(const InstanceId& id)
 }
 
 namespace {
-QMap<InstanceId, InstanceLocator> getIdMapping(const std::vector<std::unique_ptr<BaseInstance>>& list)
+QMap<InstanceId, InstanceLocator> getIdMapping(const std::vector<std::unique_ptr<MinecraftInstance>>& list)
 {
     QMap<InstanceId, InstanceLocator> out;
     int i = 0;
@@ -523,14 +523,14 @@ InstanceList::InstListError InstanceList::loadList()
 {
     auto existingIds = getIdMapping(m_instances);
 
-    std::vector<std::unique_ptr<BaseInstance>> newList;
+    std::vector<std::unique_ptr<MinecraftInstance>> newList;
 
     for (auto& id : discoverInstances()) {
         if (existingIds.contains(id)) {
             existingIds.remove(id);
             qInfo() << "Should keep and soft-reload" << id;
         } else {
-            std::unique_ptr<BaseInstance> instPtr = loadInstance(id);
+            std::unique_ptr<MinecraftInstance> instPtr = loadInstance(id);
             if (instPtr) {
                 newList.push_back(std::move(instPtr));
             }
@@ -598,12 +598,13 @@ void InstanceList::saveNow()
     }
 }
 
-void InstanceList::add(std::vector<std::unique_ptr<BaseInstance>>& t)
+void InstanceList::add(std::vector<std::unique_ptr<MinecraftInstance>>& t)
 {
     beginInsertRows(QModelIndex(), count(), static_cast<int>(count() + t.size() - 1));
     for (auto& ptr : t) {
+        MinecraftInstance* inst = ptr.get();
         m_instances.push_back(std::move(ptr));
-        connect(m_instances.back().get(), &BaseInstance::propertiesChanged, this, &InstanceList::propertiesChanged);
+        connect(inst, &MinecraftInstance::propertiesChanged, this, [this, inst]() { propertiesChanged(inst); });
     }
     endInsertRows();
 }
@@ -633,7 +634,7 @@ void InstanceList::providerUpdated()
     }
 }
 
-BaseInstance* InstanceList::getInstanceById(const QString& instId) const
+MinecraftInstance* InstanceList::getInstanceById(const QString& instId) const
 {
     if (instId.isEmpty()) {
         return nullptr;
@@ -646,7 +647,7 @@ BaseInstance* InstanceList::getInstanceById(const QString& instId) const
     return nullptr;
 }
 
-BaseInstance* InstanceList::getInstanceByManagedName(const QString& managedName) const
+MinecraftInstance* InstanceList::getInstanceByManagedName(const QString& managedName) const
 {
     if (managedName.isEmpty()) {
         return {};
@@ -666,7 +667,7 @@ QModelIndex InstanceList::getInstanceIndexById(const QString& id) const
     return index(getInstIndex(getInstanceById(id)));
 }
 
-int InstanceList::getInstIndex(BaseInstance* inst) const
+int InstanceList::getInstIndex(MinecraftInstance* inst) const
 {
     int count = this->count();
     for (int i = 0; i < count; i++) {
@@ -677,7 +678,7 @@ int InstanceList::getInstIndex(BaseInstance* inst) const
     return -1;
 }
 
-void InstanceList::propertiesChanged(BaseInstance* inst)
+void InstanceList::propertiesChanged(MinecraftInstance* inst)
 {
     int i = getInstIndex(inst);
     if (i != -1) {
@@ -686,7 +687,7 @@ void InstanceList::propertiesChanged(BaseInstance* inst)
     }
 }
 
-std::unique_ptr<BaseInstance> InstanceList::loadInstance(const InstanceId& id)
+std::unique_ptr<MinecraftInstance> InstanceList::loadInstance(const InstanceId& id)
 {
     if (!m_groupsLoaded) {
         loadGroupList();
@@ -694,19 +695,16 @@ std::unique_ptr<BaseInstance> InstanceList::loadInstance(const InstanceId& id)
 
     auto instanceRoot = FS::PathCombine(rootDirOf(id), id);
     auto instanceSettings = std::make_unique<INISettingsObject>(FS::PathCombine(instanceRoot, "instance.cfg"));
-    std::unique_ptr<BaseInstance> inst;
 
     instanceSettings->registerSetting("InstanceType", "");
 
     const QString instType = instanceSettings->get("InstanceType").toString();
-
-    // NOTE: Some launcher versions didn't save the InstanceType properly. We will just bank on the probability that this is probably a
-    // OneSix instance
-    if (instType == "OneSix" || instType.isEmpty()) {
-        inst.reset(new MinecraftInstance(m_globalSettings, std::move(instanceSettings), instanceRoot));
-    } else {
-        inst.reset(new NullInstance(m_globalSettings, std::move(instanceSettings), instanceRoot));
+    if (!instType.isEmpty() && instType != "OneSix") {
+        qDebug() << "Instance " << id << "has invalid type" << instType;
+        return nullptr;
     }
+
+    auto inst = std::make_unique<MinecraftInstance>(m_globalSettings, std::move(instanceSettings), instanceRoot);
     qDebug() << "Loaded instance" << inst->name() << "from" << inst->instanceRoot();
 
     auto shortcut = inst->shortcuts();

--- a/launcher/InstanceList.h
+++ b/launcher/InstanceList.h
@@ -44,14 +44,14 @@
 #include <QStack>
 #include <cstdint>
 
-#include "BaseInstance.h"
+#include "minecraft/MinecraftInstance.h"
 
 class QFileSystemWatcher;
 class InstanceTask;
 
 using InstanceId = QString;
 using GroupId = QString;
-using InstanceLocator = std::pair<BaseInstance*, int>;
+using InstanceLocator = std::pair<MinecraftInstance*, int>;
 
 enum class InstCreateError : std::uint8_t { NoCreateError = 0, NoSuchVersion, UnknownCreateError, InstExists, CantCreateDir };
 
@@ -97,7 +97,7 @@ class InstanceList : public QAbstractListModel {
      */
     enum InstListError : std::uint8_t { NoError = 0, UnknownError };
 
-    BaseInstance* at(int i) const { return m_instances.at(i).get(); }
+    MinecraftInstance* at(int i) const { return m_instances.at(i).get(); }
 
     int count() const { return static_cast<int>(m_instances.size()); }
 
@@ -105,9 +105,9 @@ class InstanceList : public QAbstractListModel {
     void saveNow();
 
     /* O(n) */
-    BaseInstance* getInstanceById(const QString& id) const;
+    MinecraftInstance* getInstanceById(const QString& id) const;
     /* O(n) */
-    BaseInstance* getInstanceByManagedName(const QString& managedName) const;
+    MinecraftInstance* getInstanceByManagedName(const QString& managedName) const;
     QModelIndex getInstanceIndexById(const QString& id) const;
     QStringList getGroups();
     bool isGroupCollapsed(const QString& groupName);
@@ -167,20 +167,20 @@ class InstanceList : public QAbstractListModel {
     void on_GroupStateChanged(const QString& group, bool collapsed);
 
    private slots:
-    void propertiesChanged(BaseInstance* inst);
+    void propertiesChanged(MinecraftInstance* inst);
     void providerUpdated();
     void instanceDirContentsChanged(const QString& path);
 
    private:
-    int getInstIndex(BaseInstance* inst) const;
+    int getInstIndex(MinecraftInstance* inst) const;
     void updateTotalPlayTime();
     void suspendWatch();
     void resumeWatch();
-    void add(std::vector<std::unique_ptr<BaseInstance>>& list);
+    void add(std::vector<std::unique_ptr<MinecraftInstance>>& list);
     void loadGroupList();
     void saveGroupList();
     QList<InstanceId> discoverInstances();
-    std::unique_ptr<BaseInstance> loadInstance(const InstanceId& id);
+    std::unique_ptr<MinecraftInstance> loadInstance(const InstanceId& id);
 
     void increaseGroupCount(const QString& group);
     void decreaseGroupCount(const QString& group);
@@ -189,7 +189,7 @@ class InstanceList : public QAbstractListModel {
     int m_watchLevel = 0;
     int64_t m_totalPlayTime = 0;
     bool m_dirty = false;
-    std::vector<std::unique_ptr<BaseInstance>> m_instances;
+    std::vector<std::unique_ptr<MinecraftInstance>> m_instances;
     // id -> refs
     QMap<QString, int> m_groupNameCache;
 

--- a/launcher/InstancePageProvider.h
+++ b/launcher/InstancePageProvider.h
@@ -21,30 +21,29 @@
 class InstancePageProvider : protected QObject, public BasePageProvider {
     Q_OBJECT
    public:
-    explicit InstancePageProvider(BaseInstance* parent) { inst = parent; }
+    explicit InstancePageProvider(MinecraftInstance* parent) { inst = parent; }
 
     virtual ~InstancePageProvider() = default;
     virtual QList<BasePage*> getPages() override
     {
         QList<BasePage*> values;
         values.append(new LogPage(inst));
-        MinecraftInstance* onesix = dynamic_cast<MinecraftInstance*>(inst);
-        values.append(new VersionPage(onesix));
-        values.append(ManagedPackPage::createPage(onesix));
-        auto modsPage = new ModFolderPage(onesix, onesix->loaderModList());
+        values.append(new VersionPage(inst));
+        values.append(ManagedPackPage::createPage(inst));
+        auto modsPage = new ModFolderPage(inst, inst->loaderModList());
         modsPage->setFilter("%1 (*.zip *.jar *.litemod *.nilmod)");
         values.append(modsPage);
-        values.append(new CoreModFolderPage(onesix, onesix->coreModList()));
-        values.append(new NilModFolderPage(onesix, onesix->nilModList()));
-        values.append(new ResourcePackPage(onesix, onesix->resourcePackList()));
-        values.append(new GlobalDataPackPage(onesix));
-        values.append(new TexturePackPage(onesix, onesix->texturePackList()));
-        values.append(new ShaderPackPage(onesix, onesix->shaderPackList()));
-        values.append(new NotesPage(onesix));
-        values.append(new WorldListPage(onesix, onesix->worldList()));
-        values.append(new ServersPage(onesix));
-        values.append(new ScreenshotsPage(FS::PathCombine(onesix->gameRoot(), "screenshots")));
-        values.append(new InstanceSettingsPage(onesix));
+        values.append(new CoreModFolderPage(inst, inst->coreModList()));
+        values.append(new NilModFolderPage(inst, inst->nilModList()));
+        values.append(new ResourcePackPage(inst, inst->resourcePackList()));
+        values.append(new GlobalDataPackPage(inst));
+        values.append(new TexturePackPage(inst, inst->texturePackList()));
+        values.append(new ShaderPackPage(inst, inst->shaderPackList()));
+        values.append(new NotesPage(inst));
+        values.append(new WorldListPage(inst, inst->worldList()));
+        values.append(new ServersPage(inst));
+        values.append(new ScreenshotsPage(FS::PathCombine(inst->gameRoot(), "screenshots")));
+        values.append(new InstanceSettingsPage(inst));
         values.append(new OtherLogsPage("logs", tr("Other Logs"), "Other-Logs", inst));
         return values;
     }
@@ -52,5 +51,5 @@ class InstancePageProvider : protected QObject, public BasePageProvider {
     virtual QString dialogTitle() override { return tr("Edit Instance (%1)").arg(inst->name()); }
 
    protected:
-    BaseInstance* inst;
+    MinecraftInstance* inst;
 };

--- a/launcher/LaunchController.h
+++ b/launcher/LaunchController.h
@@ -34,9 +34,9 @@
  */
 
 #pragma once
-#include <BaseInstance.h>
 #include <tools/BaseProfiler.h>
 
+#include "minecraft/MinecraftInstance.h"
 #include "minecraft/auth/MinecraftAccount.h"
 #include "minecraft/launch/MinecraftTarget.h"
 
@@ -52,9 +52,9 @@ class LaunchController : public Task {
     LaunchController();
     ~LaunchController() override = default;
 
-    void setInstance(BaseInstance* instance) { m_instance = instance; }
+    void setInstance(MinecraftInstance* instance) { m_instance = instance; }
 
-    BaseInstance* instance() const { return m_instance; }
+    MinecraftInstance* instance() const { return m_instance; }
 
     void setLaunchMode(const LaunchMode mode) { m_wantedLaunchMode = mode; }
 
@@ -93,7 +93,7 @@ class LaunchController : public Task {
     LaunchMode m_actualLaunchMode = LaunchMode::Normal;
     BaseProfilerFactory* m_profiler = nullptr;
     QString m_offlineName;
-    BaseInstance* m_instance = nullptr;
+    MinecraftInstance* m_instance = nullptr;
     QWidget* m_parentWidget = nullptr;
     InstanceWindow* m_console = nullptr;
     MinecraftAccountPtr m_accountToUse = nullptr;

--- a/launcher/NullInstance.h
+++ b/launcher/NullInstance.h
@@ -58,7 +58,6 @@ class NullInstance : public BaseInstance {
     QProcessEnvironment createLaunchEnvironment() override { return QProcessEnvironment(); }
     QMap<QString, QString> getVariables() override { return QMap<QString, QString>(); }
     QStringList getLogFileSearchPaths() override { return {}; }
-    QString typeName() const override { return "Null"; }
     bool canExport() const override { return false; }
     bool canEdit() const override { return false; }
     bool canLaunch() const override { return false; }

--- a/launcher/ResourceDownloadTask.cpp
+++ b/launcher/ResourceDownloadTask.cpp
@@ -35,14 +35,9 @@
 #include "net/ChecksumValidator.h"
 
 namespace {
-Net::ModrinthDownloadMeta createModrinthMeta(BaseInstance* instance, QString reason, QString dependentOn)
+Net::ModrinthDownloadMeta createModrinthMeta(MinecraftInstance* instance, QString reason, QString dependentOn)
 {
-    auto* mcInstance = dynamic_cast<MinecraftInstance*>(instance);
-    if (!mcInstance) {
-        return {};
-    }
-
-    auto* profile = mcInstance->getPackProfile();
+    auto* profile = instance->getPackProfile();
     if (!profile) {
         return {};
     }

--- a/launcher/java/JavaUtils.cpp
+++ b/launcher/java/JavaUtils.cpp
@@ -47,6 +47,13 @@
 #include "java/JavaInstallList.h"
 #include "java/JavaUtils.h"
 
+#ifdef Q_OS_WIN
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+#endif
+
 #define IBUS "@im=ibus"
 
 JavaUtils::JavaUtils() {}
@@ -175,7 +182,7 @@ QStringList addJavasFromEnv(QList<QString> javas)
 }
 
 #if defined(Q_OS_WIN32)
-QList<JavaInstallPtr> JavaUtils::FindJavaFromRegistryKey(DWORD keyType, QString keyName, QString keyJavaDir, QString subkeySuffix)
+QList<JavaInstallPtr> JavaUtils::FindJavaFromRegistryKey(std::uint32_t keyType, QString keyName, QString keyJavaDir, QString subkeySuffix)
 {
     QList<JavaInstallPtr> javas;
 

--- a/launcher/java/JavaUtils.h
+++ b/launcher/java/JavaUtils.h
@@ -20,7 +20,7 @@
 #include "java/JavaInstall.h"
 
 #ifdef Q_OS_WIN
-#include <windows.h>
+#include <cstdint>
 #endif
 
 QString stripVariableEntries(QString name, QString target, QString remove);
@@ -38,7 +38,7 @@ class JavaUtils : public QObject {
     JavaInstallPtr GetDefaultJava();
 
 #ifdef Q_OS_WIN
-    QList<JavaInstallPtr> FindJavaFromRegistryKey(DWORD keyType, QString keyName, QString keyJavaDir, QString subkeySuffix = "");
+    QList<JavaInstallPtr> FindJavaFromRegistryKey(std::uint32_t keyType, QString keyName, QString keyJavaDir, QString subkeySuffix = "");
 #endif
 
     static QString getJavaCheckPath();

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -280,11 +280,6 @@ void MinecraftInstance::updateRuntimeContext()
     m_components->invalidateLaunchProfile();
 }
 
-QString MinecraftInstance::typeName() const
-{
-    return "Minecraft";
-}
-
 PackProfile* MinecraftInstance::getPackProfile() const
 {
     return m_components.get();

--- a/launcher/minecraft/MinecraftInstance.h
+++ b/launcher/minecraft/MinecraftInstance.h
@@ -63,8 +63,6 @@ class MinecraftInstance : public BaseInstance {
     void loadSpecificSettings() override;
 
     // FIXME: remove
-    QString typeName() const override;
-    // FIXME: remove
     QSet<QString> traits() const override;
 
     bool canEdit() const override { return true; }

--- a/launcher/minecraft/mod/DataPackFolderModel.cpp
+++ b/launcher/minecraft/mod/DataPackFolderModel.cpp
@@ -42,7 +42,7 @@
 
 #include "minecraft/mod/tasks/LocalDataPackParseTask.h"
 
-DataPackFolderModel::DataPackFolderModel(const QString& dir, BaseInstance* instance, bool isIndexed, bool createDir, QObject* parent)
+DataPackFolderModel::DataPackFolderModel(const QString& dir, MinecraftInstance* instance, bool isIndexed, bool createDir, QObject* parent)
     : ResourceFolderModel(QDir(dir), instance, isIndexed, createDir, parent)
 {
     m_columnNames = QStringList({ "Enable", "Image", "Name", "Pack Format", "Last Modified", "Size", "File Name" });

--- a/launcher/minecraft/mod/DataPackFolderModel.h
+++ b/launcher/minecraft/mod/DataPackFolderModel.h
@@ -54,7 +54,7 @@ class DataPackFolderModel : public ResourceFolderModel {
         NumColumns
     };
 
-    explicit DataPackFolderModel(const QString& dir, BaseInstance* instance, bool isIndexed, bool createDir, QObject* parent = nullptr);
+    explicit DataPackFolderModel(const QString& dir, MinecraftInstance* instance, bool isIndexed, bool createDir, QObject* parent = nullptr);
 
     QString id() const override { return "datapacks"; }
 

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -59,7 +59,7 @@
 #include "modplatform/ModIndex.h"
 #include "ui/dialogs/CustomMessageBox.h"
 
-ModFolderModel::ModFolderModel(const QDir& dir, BaseInstance* instance, bool isIndexed, bool createDir, QObject* parent)
+ModFolderModel::ModFolderModel(const QDir& dir, MinecraftInstance* instance, bool isIndexed, bool createDir, QObject* parent)
     : ResourceFolderModel(QDir(dir), instance, isIndexed, createDir, parent)
 {
     m_columnNames = QStringList({ "Enable", "Image", "Name", "Version", "Last Modified", "Provider", "Size", "Side", "Loaders",

--- a/launcher/minecraft/mod/ModFolderModel.h
+++ b/launcher/minecraft/mod/ModFolderModel.h
@@ -75,7 +75,7 @@ class ModFolderModel : public ResourceFolderModel {
         FileNameColumn,
         NumColumns
     };
-    ModFolderModel(const QDir& dir, BaseInstance* instance, bool isIndexed, bool createDir, QObject* parent = nullptr);
+    ModFolderModel(const QDir& dir, MinecraftInstance* instance, bool isIndexed, bool createDir, QObject* parent = nullptr);
 
     QString id() const override { return "mods"; }
 

--- a/launcher/minecraft/mod/Resource.cpp
+++ b/launcher/minecraft/mod/Resource.cpp
@@ -135,7 +135,7 @@ QStringList Resource::issues() const
     return result;
 }
 
-void Resource::updateIssues(const BaseInstance* inst)
+void Resource::updateIssues(const MinecraftInstance* inst)
 {
     m_issues.clear();
 
@@ -143,12 +143,7 @@ void Resource::updateIssues(const BaseInstance* inst)
         return;
     }
 
-    const auto* mcInst = dynamic_cast<const MinecraftInstance*>(inst);
-    if (mcInst == nullptr) {
-        return;
-    }
-
-    auto* profile = mcInst->getPackProfile();
+    auto* profile = inst->getPackProfile();
     QString mcVersion = profile->getComponentVersion("net.minecraft");
 
     if (!m_metadata->mcVersions.empty() && !m_metadata->mcVersions.contains(mcVersion)) {

--- a/launcher/minecraft/mod/Resource.h
+++ b/launcher/minecraft/mod/Resource.h
@@ -45,7 +45,7 @@
 
 #include "MetadataHandler.h"
 
-class BaseInstance;
+class MinecraftInstance;
 
 enum class ResourceType : std::uint8_t {
     UNKNOWN,     //!< Indicates an unspecified resource type.
@@ -133,7 +133,7 @@ class Resource {
      * This is initially empty, and may be updated when calling updateIssues.
      */
     QStringList issues() const;
-    void updateIssues(const BaseInstance* inst);
+    void updateIssues(const MinecraftInstance* inst);
     bool hasIssues() const { return !m_issues.empty(); }
 
     /** Compares two Resources, for sorting purposes, considering a ascending order, returning:

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -20,6 +20,7 @@
 #include "minecraft/mod/tasks/ResourceFolderLoadTask.h"
 
 #include "Json.h"
+#include "minecraft/MinecraftInstance.h"
 #include "minecraft/mod/tasks/LocalResourceUpdateTask.h"
 #include "modplatform/flame/FlameAPI.h"
 #include "modplatform/flame/FlameModIndex.h"
@@ -28,7 +29,7 @@
 #include "tasks/Task.h"
 #include "ui/dialogs/CustomMessageBox.h"
 
-ResourceFolderModel::ResourceFolderModel(const QDir& dir, BaseInstance* instance, bool isIndexed, bool createDir, QObject* parent)
+ResourceFolderModel::ResourceFolderModel(const QDir& dir, MinecraftInstance* instance, bool isIndexed, bool createDir, QObject* parent)
     : QAbstractListModel(parent), m_dir(dir), m_instance(instance), m_watcher(this), m_isIndexed(isIndexed)
 {
     if (createDir) {

--- a/launcher/minecraft/mod/ResourceFolderModel.h
+++ b/launcher/minecraft/mod/ResourceFolderModel.h
@@ -17,6 +17,7 @@
 #include "tasks/ConcurrentTask.h"
 #include "tasks/Task.h"
 
+class MinecraftInstance;
 class QSortFilterProxyModel;
 
 /* A macro to define useful functions to handle Resource* -> T* more easily on derived classes */
@@ -61,7 +62,7 @@ class QSortFilterProxyModel;
 class ResourceFolderModel : public QAbstractListModel {
     Q_OBJECT
    public:
-    ResourceFolderModel(const QDir& dir, BaseInstance* instance, bool isIndexed, bool createDir, QObject* parent = nullptr);
+    ResourceFolderModel(const QDir& dir, MinecraftInstance* instance, bool isIndexed, bool createDir, QObject* parent = nullptr);
     ~ResourceFolderModel() override;
 
     virtual QString id() const { return "resource"; }
@@ -183,7 +184,7 @@ class ResourceFolderModel : public QAbstractListModel {
     };
 
     QString instDirPath() const;
-    BaseInstance* instance() const { return m_instance; }
+    MinecraftInstance* instance() const { return m_instance; }
 
    signals:
     void updateFinished();
@@ -249,7 +250,7 @@ class ResourceFolderModel : public QAbstractListModel {
     QList<bool> m_columnsHideable = { false, false, true, true, true, true };
 
     QDir m_dir;
-    BaseInstance* m_instance;
+    MinecraftInstance* m_instance;
     QFileSystemWatcher m_watcher;
     bool m_isWatching = false;
 

--- a/launcher/minecraft/mod/ResourcePackFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourcePackFolderModel.cpp
@@ -41,7 +41,7 @@
 
 #include "minecraft/mod/tasks/LocalDataPackParseTask.h"
 
-ResourcePackFolderModel::ResourcePackFolderModel(const QDir& dir, BaseInstance* instance, bool isIndexed, bool createDir, QObject* parent)
+ResourcePackFolderModel::ResourcePackFolderModel(const QDir& dir, MinecraftInstance* instance, bool isIndexed, bool createDir, QObject* parent)
     : ResourceFolderModel(dir, instance, isIndexed, createDir, parent)
 {
     m_columnNames = QStringList({ "Enable", "Image", "Name", "Pack Format", "Last Modified", "Provider", "Size", "File Name" });

--- a/launcher/minecraft/mod/ResourcePackFolderModel.h
+++ b/launcher/minecraft/mod/ResourcePackFolderModel.h
@@ -19,7 +19,7 @@ class ResourcePackFolderModel : public ResourceFolderModel {
         NumColumns
     };
 
-    explicit ResourcePackFolderModel(const QDir& dir, BaseInstance* instance, bool isIndexed, bool createDir, QObject* parent = nullptr);
+    explicit ResourcePackFolderModel(const QDir& dir, MinecraftInstance* instance, bool isIndexed, bool createDir, QObject* parent = nullptr);
 
     QString id() const override { return "resourcepacks"; }
 

--- a/launcher/minecraft/mod/ShaderPackFolderModel.h
+++ b/launcher/minecraft/mod/ShaderPackFolderModel.h
@@ -8,7 +8,7 @@ class ShaderPackFolderModel : public ResourceFolderModel {
     Q_OBJECT
 
    public:
-    explicit ShaderPackFolderModel(const QDir& dir, BaseInstance* instance, bool is_indexed, bool create_dir, QObject* parent = nullptr)
+    explicit ShaderPackFolderModel(const QDir& dir, MinecraftInstance* instance, bool is_indexed, bool create_dir, QObject* parent = nullptr)
         : ResourceFolderModel(dir, instance, is_indexed, create_dir, parent)
     {}
 

--- a/launcher/minecraft/mod/TexturePackFolderModel.cpp
+++ b/launcher/minecraft/mod/TexturePackFolderModel.cpp
@@ -37,7 +37,7 @@
 
 #include "minecraft/mod/tasks/LocalTexturePackParseTask.h"
 
-TexturePackFolderModel::TexturePackFolderModel(const QDir& dir, BaseInstance* instance, bool isIndexed, bool createDir, QObject* parent)
+TexturePackFolderModel::TexturePackFolderModel(const QDir& dir, MinecraftInstance* instance, bool isIndexed, bool createDir, QObject* parent)
     : ResourceFolderModel(QDir(dir), instance, isIndexed, createDir, parent)
 {
     m_columnNames = QStringList({ "Enable", "Image", "Name", "Last Modified", "Provider", "Size", "File Name" });

--- a/launcher/minecraft/mod/TexturePackFolderModel.h
+++ b/launcher/minecraft/mod/TexturePackFolderModel.h
@@ -55,7 +55,7 @@ class TexturePackFolderModel : public ResourceFolderModel {
         NumColumns
     };
 
-    explicit TexturePackFolderModel(const QDir& dir, BaseInstance* instance, bool isIndexed, bool createDir, QObject* parent = nullptr);
+    explicit TexturePackFolderModel(const QDir& dir, MinecraftInstance* instance, bool isIndexed, bool createDir, QObject* parent = nullptr);
 
     QString id() const override { return "texturepacks"; }
 

--- a/launcher/minecraft/mod/tasks/GetModDependenciesTask.cpp
+++ b/launcher/minecraft/mod/tasks/GetModDependenciesTask.cpp
@@ -30,14 +30,14 @@
 #include "tasks/SequentialTask.h"
 #include "ui/pages/modplatform/ModModel.h"
 
-static Version mcVersion(BaseInstance* inst)
+static Version mcVersion(MinecraftInstance* inst)
 {
-    return static_cast<MinecraftInstance*>(inst)->getPackProfile()->getComponent("net.minecraft")->getVersion();
+    return inst->getPackProfile()->getComponent("net.minecraft")->getVersion();
 }
 
-static ModPlatform::ModLoaderTypes mcLoaders(BaseInstance* inst)
+static ModPlatform::ModLoaderTypes mcLoaders(MinecraftInstance* inst)
 {
-    return static_cast<MinecraftInstance*>(inst)->getPackProfile()->getSupportedModLoaders().value_or(ModPlatform::ModLoaderTypes(0));
+    return inst->getPackProfile()->getSupportedModLoaders().value_or(ModPlatform::ModLoaderTypes(0));
 }
 
 static bool checkDependencies(std::shared_ptr<GetModDependenciesTask::PackDependency> sel,
@@ -48,7 +48,7 @@ static bool checkDependencies(std::shared_ptr<GetModDependenciesTask::PackDepend
            (!loaders || !sel->version.loaders || sel->version.loaders & loaders);
 }
 
-GetModDependenciesTask::GetModDependenciesTask(BaseInstance* instance,
+GetModDependenciesTask::GetModDependenciesTask(MinecraftInstance* instance,
                                                ModFolderModel* folder,
                                                QList<std::shared_ptr<PackDependency>> selected)
     : SequentialTask(tr("Get dependencies")), m_selected(selected), m_version(mcVersion(instance)), m_loaderType(mcLoaders(instance))

--- a/launcher/minecraft/mod/tasks/GetModDependenciesTask.h
+++ b/launcher/minecraft/mod/tasks/GetModDependenciesTask.h
@@ -54,7 +54,7 @@ class GetModDependenciesTask : public SequentialTask {
         QStringList required_by_ids;
     };
 
-    explicit GetModDependenciesTask(BaseInstance* instance, ModFolderModel* folder, QList<std::shared_ptr<PackDependency>> selected);
+    explicit GetModDependenciesTask(MinecraftInstance* instance, ModFolderModel* folder, QList<std::shared_ptr<PackDependency>> selected);
 
     auto getDependecies() const -> QList<std::shared_ptr<PackDependency>> { return m_pack_dependencies; }
     QHash<QString, PackDependencyExtraInfo> getExtraInfo();

--- a/launcher/modplatform/modrinth/ModrinthPackExportTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackExportTask.cpp
@@ -41,7 +41,7 @@ ModrinthPackExportTask::ModrinthPackExportTask(const QString& name,
                                                const QString& version,
                                                const QString& summary,
                                                bool optionalFiles,
-                                               BaseInstance* instance,
+                                               MinecraftInstance* instance,
                                                const QString& output,
                                                MMCZip::FilterFileFunction filter)
     : name(name)
@@ -49,7 +49,6 @@ ModrinthPackExportTask::ModrinthPackExportTask(const QString& name,
     , summary(summary)
     , optionalFiles(optionalFiles)
     , instance(instance)
-    , mcInstance(dynamic_cast<MinecraftInstance*>(instance))
     , gameRoot(instance->gameRoot())
     , output(output)
     , filter(std::move(filter))
@@ -85,12 +84,8 @@ void ModrinthPackExportTask::collectFiles()
     pendingHashes.clear();
     resolvedFiles.clear();
 
-    if (mcInstance) {
-        mcInstance->loaderModList()->update();
-        connect(mcInstance->loaderModList(), &ModFolderModel::updateFinished, this, &ModrinthPackExportTask::collectHashes);
-    } else {
-        collectHashes();
-    }
+    instance->loaderModList()->update();
+    connect(instance->loaderModList(), &ModFolderModel::updateFinished, this, &ModrinthPackExportTask::collectHashes);
 }
 
 void ModrinthPackExportTask::collectHashes()
@@ -123,7 +118,7 @@ void ModrinthPackExportTask::collectHashes()
         }
         auto sha512 = Hashing::hash(data, Hashing::Algorithm::Sha512);
 
-        auto allMods = mcInstance->loaderModList()->allMods();
+        auto allMods = instance->loaderModList()->allMods();
         if (auto modIter = std::find_if(allMods.begin(), allMods.end(), [&file](Mod* mod) { return mod->fileinfo() == file; });
             modIter != allMods.end()) {
             const Mod* mod = *modIter;
@@ -250,8 +245,8 @@ QByteArray ModrinthPackExportTask::generateIndex()
         out["summary"] = summary;
     }
 
-    if (mcInstance) {
-        auto* profile = mcInstance->getPackProfile();
+    if (instance) {
+        auto* profile = instance->getPackProfile();
         // collect all supported components
         const ComponentPtr minecraft = profile->getComponent("net.minecraft");
         const ComponentPtr quilt = profile->getComponent("org.quiltmc.quilt-loader");

--- a/launcher/modplatform/modrinth/ModrinthPackExportTask.h
+++ b/launcher/modplatform/modrinth/ModrinthPackExportTask.h
@@ -34,7 +34,7 @@ class ModrinthPackExportTask : public Task {
                            const QString& version,
                            const QString& summary,
                            bool optionalFiles,
-                           BaseInstance* instance,
+                           MinecraftInstance* instance,
                            const QString& output,
                            MMCZip::FilterFileFunction filter);
 
@@ -55,8 +55,7 @@ class ModrinthPackExportTask : public Task {
     // inputs
     const QString name, version, summary;
     const bool optionalFiles;
-    const BaseInstance* instance;
-    MinecraftInstance* mcInstance;
+    MinecraftInstance* instance;
     const QDir gameRoot;
     const QString output;
     const MMCZip::FilterFileFunction filter;

--- a/launcher/ui/InstanceWindow.cpp
+++ b/launcher/ui/InstanceWindow.cpp
@@ -50,7 +50,7 @@
 
 #include "icons/IconList.h"
 
-InstanceWindow::InstanceWindow(BaseInstance* instance, QWidget* parent) : QMainWindow(parent), m_instance(instance)
+InstanceWindow::InstanceWindow(MinecraftInstance* instance, QWidget* parent) : QMainWindow(parent), m_instance(instance)
 {
     setAttribute(Qt::WA_DeleteOnClose);
 

--- a/launcher/ui/InstanceWindow.h
+++ b/launcher/ui/InstanceWindow.h
@@ -53,7 +53,7 @@ class InstanceWindow : public QMainWindow, public BasePageContainer {
     Q_OBJECT
 
    public:
-    explicit InstanceWindow(BaseInstance* proc, QWidget* parent = 0);
+    explicit InstanceWindow(MinecraftInstance* proc, QWidget* parent = 0);
     virtual ~InstanceWindow() = default;
 
     bool selectPage(QString pageId) override;
@@ -85,7 +85,7 @@ class InstanceWindow : public QMainWindow, public BasePageContainer {
 
    private:
     LaunchTask* m_proc;
-    BaseInstance* m_instance;
+    MinecraftInstance* m_instance;
     bool m_doNotSave = false;
     bool m_restartQueued = false;
     PageContainer* m_container = nullptr;

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -655,7 +655,7 @@ void MainWindow::repopulateAccountsMenu()
 
     auto accounts = APPLICATION->accounts();
     MinecraftAccountPtr defaultAccount = accounts->defaultAccount();
-    
+
     bool canChangeSkin = defaultAccount && (defaultAccount->accountType() == AccountType::MSA) && !defaultAccount->isActive();
     ui->actionManageSkins->setEnabled(canChangeSkin);
 
@@ -1147,7 +1147,7 @@ void MainWindow::processURLs(QList<QUrl> urls)
         qDebug() << "Adding resource" << localFileName << "to" << dlg.selectedInstanceKey;
 
         auto inst = APPLICATION->instances()->getInstanceById(dlg.selectedInstanceKey);
-        auto minecraftInst = dynamic_cast<MinecraftInstance*>(inst);
+        auto minecraftInst = inst;
 
         switch (type) {
             case ModPlatform::ResourceType::ResourcePack:
@@ -1537,29 +1537,23 @@ void MainWindow::on_actionExportInstanceZip_triggered()
 void MainWindow::on_actionExportInstanceMrPack_triggered()
 {
     if (m_selectedInstance) {
-        auto instance = dynamic_cast<MinecraftInstance*>(m_selectedInstance);
-        if (instance != nullptr) {
-            ExportPackDialog dlg(instance, this);
-            dlg.exec();
-        }
+        ExportPackDialog dlg(m_selectedInstance, this);
+        dlg.exec();
     }
 }
 
 void MainWindow::on_actionExportInstanceFlamePack_triggered()
 {
     if (m_selectedInstance) {
-        auto instance = dynamic_cast<MinecraftInstance*>(m_selectedInstance);
-        if (instance) {
-            if (auto cmp = instance->getPackProfile()->getComponent("net.minecraft");
-                cmp && cmp->getVersionFile() && cmp->getVersionFile()->type == "snapshot") {
-                QMessageBox msgBox(this);
-                msgBox.setText("Snapshots are currently not supported by CurseForge modpacks.");
-                msgBox.exec();
-                return;
-            }
-            ExportPackDialog dlg(instance, this, ModPlatform::ResourceProvider::FLAME);
-            dlg.exec();
+        if (auto cmp = m_selectedInstance->getPackProfile()->getComponent("net.minecraft");
+            cmp && cmp->getVersionFile() && cmp->getVersionFile()->type == "snapshot") {
+            QMessageBox msgBox(this);
+            msgBox.setText("Snapshots are currently not supported by CurseForge modpacks.");
+            msgBox.exec();
+            return;
         }
+        ExportPackDialog dlg(m_selectedInstance, this, ModPlatform::ResourceProvider::FLAME);
+        dlg.exec();
     }
 }
 
@@ -1601,11 +1595,11 @@ void MainWindow::instanceActivated(QModelIndex index)
     if (!index.isValid())
         return;
     QString id = index.data(InstanceList::InstanceIDRole).toString();
-    BaseInstance* inst = APPLICATION->instances()->getInstanceById(id);
+    MinecraftInstance* inst = APPLICATION->instances()->getInstanceById(id);
     if (!inst)
         return;
 
-    activateInstance(inst);
+    APPLICATION->launch(inst);
 }
 
 void MainWindow::on_actionLaunchInstance_triggered()
@@ -1613,11 +1607,6 @@ void MainWindow::on_actionLaunchInstance_triggered()
     if (m_selectedInstance && !m_selectedInstance->isRunning()) {
         APPLICATION->launch(m_selectedInstance);
     }
-}
-
-void MainWindow::activateInstance(BaseInstance* instance)
-{
-    APPLICATION->launch(instance);
 }
 
 void MainWindow::on_actionKillInstance_triggered()

--- a/launcher/ui/MainWindow.h
+++ b/launcher/ui/MainWindow.h
@@ -46,7 +46,6 @@
 #include <QProcess>
 #include <QTimer>
 
-#include "BaseInstance.h"
 #include "minecraft/auth/MinecraftAccount.h"
 
 class LaunchController;
@@ -55,12 +54,14 @@ class QToolButton;
 class InstanceProxyModel;
 class LabeledToolButton;
 class QLabel;
+class MinecraftInstance;
 class MinecraftLauncher;
 class BaseProfilerFactory;
 class InstanceView;
 class KonamiCode;
 class InstanceTask;
 class LabeledToolButton;
+class Setting;
 
 namespace Ui {
 class MainWindow;
@@ -222,7 +223,6 @@ class MainWindow : public QMainWindow {
     void retranslateUi();
 
     void addInstance(const QString& url = QString(), const QMap<QString, QString>& extra_info = {});
-    void activateInstance(BaseInstance* instance);
     void setCatBackground(bool enabled);
     void updateInstanceToolIcon(QString new_icon);
     void setSelectedInstanceById(const QString& id);
@@ -249,7 +249,7 @@ class MainWindow : public QMainWindow {
 
     unique_qobject_ptr<NewsChecker> m_newsChecker;
 
-    BaseInstance* m_selectedInstance = nullptr;
+    MinecraftInstance* m_selectedInstance = nullptr;
     QString m_currentInstIcon;
 
     // managed by the application object

--- a/launcher/ui/dialogs/CreateShortcutDialog.cpp
+++ b/launcher/ui/dialogs/CreateShortcutDialog.cpp
@@ -55,7 +55,7 @@
 #include "minecraft/WorldList.h"
 #include "minecraft/auth/AccountList.h"
 
-CreateShortcutDialog::CreateShortcutDialog(BaseInstance* instance, QWidget* parent)
+CreateShortcutDialog::CreateShortcutDialog(MinecraftInstance* instance, QWidget* parent)
     : QDialog(parent), ui(new Ui::CreateShortcutDialog), m_instance(instance)
 {
     ui->setupUi(this);
@@ -64,9 +64,8 @@ CreateShortcutDialog::CreateShortcutDialog(BaseInstance* instance, QWidget* pare
     ui->iconButton->setIcon(APPLICATION->icons()->getIcon(InstIconKey));
     ui->instNameTextBox->setPlaceholderText(instance->name());
 
-    auto mInst = dynamic_cast<MinecraftInstance*>(instance);
-    m_QuickJoinSupported = mInst && mInst->traits().contains("feature:is_quick_play_singleplayer");
-    auto worldList = mInst->worldList();
+    m_QuickJoinSupported = instance && instance->traits().contains("feature:is_quick_play_singleplayer");
+    auto worldList = instance->worldList();
     worldList->update();
     if (!m_QuickJoinSupported || worldList->empty()) {
         ui->worldTarget->hide();

--- a/launcher/ui/dialogs/CreateShortcutDialog.h
+++ b/launcher/ui/dialogs/CreateShortcutDialog.h
@@ -16,9 +16,8 @@
 #pragma once
 
 #include <QDialog>
-#include "BaseInstance.h"
 
-class BaseInstance;
+class MinecraftInstance;
 
 namespace Ui {
 class CreateShortcutDialog;
@@ -28,7 +27,7 @@ class CreateShortcutDialog : public QDialog {
     Q_OBJECT
 
    public:
-    explicit CreateShortcutDialog(BaseInstance* instance, QWidget* parent = nullptr);
+    explicit CreateShortcutDialog(MinecraftInstance* instance, QWidget* parent = nullptr);
     ~CreateShortcutDialog();
 
     void createShortcut();
@@ -51,7 +50,7 @@ class CreateShortcutDialog : public QDialog {
     // Data
     Ui::CreateShortcutDialog* ui;
     QString InstIconKey;
-    BaseInstance* m_instance;
+    MinecraftInstance* m_instance;
     bool m_QuickJoinSupported = false;
 
     // Functions

--- a/launcher/ui/dialogs/ResourceDownloadDialog.cpp
+++ b/launcher/ui/dialogs/ResourceDownloadDialog.cpp
@@ -49,7 +49,7 @@ namespace ResourceDownload {
 
 ResourceDownloadDialog::ResourceDownloadDialog(QWidget* parent,
                                                ResourceFolderModel* baseModel,
-                                               BaseInstance* instance,
+                                               MinecraftInstance* instance,
                                                QString resourcesString,
                                                QString geometrySaveKey,
                                                bool suppressInitialSearch)
@@ -242,7 +242,10 @@ ResourcePage* ResourceDownloadDialog::selectedPage()
     return result;
 }
 
-void ResourceDownloadDialog::addResource(ModPlatform::IndexedPack::Ptr pack, ModPlatform::IndexedVersion& ver, QString downloadReason, QString dependentOn)
+void ResourceDownloadDialog::addResource(ModPlatform::IndexedPack::Ptr pack,
+                                         ModPlatform::IndexedVersion& ver,
+                                         QString downloadReason,
+                                         QString dependentOn)
 {
     removeResource(pack->name);
     selectedPage()->addResourceToPage(pack, ver, getBaseModel(), std::move(downloadReason), std::move(dependentOn));
@@ -296,7 +299,6 @@ void ResourceDownloadDialog::selectedPageChanged(BasePage* previous, BasePage* s
     result->setSearchTerm(prevPage->getSearchTerm());
 }
 
-
 void ResourceDownloadDialog::setResourceMetadata(const std::shared_ptr<Metadata::ModStruct>& meta)
 {
     switch (meta->provider) {
@@ -332,13 +334,13 @@ GetModDependenciesTask::Ptr ResourceDownloadDialog::getModDependenciesTask()
 
 ResourceDownloadDialog* ResourceDownloadDialog::createMod(QWidget* parent,
                                                           ResourceFolderModel* mods,
-                                                          BaseInstance* instance,
+                                                          MinecraftInstance* instance,
                                                           bool suppressInitialSearch)
 {
     auto* dialog = new ResourceDownloadDialog(parent, mods, instance, tr("mods"), "ModDownloadGeometry", suppressInitialSearch);
     QList<BasePage*> pages;
 
-    auto loaders = static_cast<MinecraftInstance*>(instance)->getPackProfile()->getSupportedModLoaders().value_or(ModPlatform::ModLoaderTypes(0));
+    auto loaders = instance->getPackProfile()->getSupportedModLoaders().value_or(ModPlatform::ModLoaderTypes(0));
 
     if (ModrinthAPI::validateModLoaders(loaders)) {
         auto* page = Modrinth::createModPage(dialog, *instance);
@@ -356,7 +358,7 @@ ResourceDownloadDialog* ResourceDownloadDialog::createMod(QWidget* parent,
 
 ResourceDownloadDialog* ResourceDownloadDialog::createResourcePack(QWidget* parent,
                                                                    ResourceFolderModel* mods,
-                                                                   BaseInstance* instance,
+                                                                   MinecraftInstance* instance,
                                                                    bool suppressInitialSearch)
 {
     auto* dialog = new ResourceDownloadDialog(parent, mods, instance, tr("resource packs"), "RPDownloadGeometry", suppressInitialSearch);
@@ -377,7 +379,7 @@ ResourceDownloadDialog* ResourceDownloadDialog::createResourcePack(QWidget* pare
 
 ResourceDownloadDialog* ResourceDownloadDialog::createTexturePack(QWidget* parent,
                                                                   ResourceFolderModel* mods,
-                                                                  BaseInstance* instance,
+                                                                  MinecraftInstance* instance,
                                                                   bool suppressInitialSearch)
 {
     auto* dialog = new ResourceDownloadDialog(parent, mods, instance, tr("texture packs"), "TPDownloadGeometry", suppressInitialSearch);
@@ -398,7 +400,7 @@ ResourceDownloadDialog* ResourceDownloadDialog::createTexturePack(QWidget* paren
 
 ResourceDownloadDialog* ResourceDownloadDialog::createShaderPack(QWidget* parent,
                                                                  ResourceFolderModel* mods,
-                                                                 BaseInstance* instance,
+                                                                 MinecraftInstance* instance,
                                                                  bool suppressInitialSearch)
 {
     auto* dialog = new ResourceDownloadDialog(parent, mods, instance, tr("shader packs"), "ShaderDownloadGeometry", suppressInitialSearch);
@@ -419,7 +421,7 @@ ResourceDownloadDialog* ResourceDownloadDialog::createShaderPack(QWidget* parent
 
 ResourceDownloadDialog* ResourceDownloadDialog::createDataPack(QWidget* parent,
                                                                ResourceFolderModel* mods,
-                                                               BaseInstance* instance,
+                                                               MinecraftInstance* instance,
                                                                bool suppressInitialSearch)
 {
     auto* dialog = new ResourceDownloadDialog(parent, mods, instance, tr("data packs"), "DataPackDownloadGeometry", suppressInitialSearch);

--- a/launcher/ui/dialogs/ResourceDownloadDialog.h
+++ b/launcher/ui/dialogs/ResourceDownloadDialog.h
@@ -52,23 +52,23 @@ class ResourceDownloadDialog : public QDialog, public BasePageProvider {
 
     static ResourceDownloadDialog* createMod(QWidget* parent,
                                              ResourceFolderModel* mods,
-                                             BaseInstance* instance,
+                                             MinecraftInstance* instance,
                                              bool suppressInitialSearch = false);
     static ResourceDownloadDialog* createResourcePack(QWidget* parent,
                                                       ResourceFolderModel* mods,
-                                                      BaseInstance* instance,
+                                                      MinecraftInstance* instance,
                                                       bool suppressInitialSearch = false);
     static ResourceDownloadDialog* createTexturePack(QWidget* parent,
                                                      ResourceFolderModel* mods,
-                                                     BaseInstance* instance,
+                                                     MinecraftInstance* instance,
                                                      bool suppressInitialSearch = false);
     static ResourceDownloadDialog* createShaderPack(QWidget* parent,
                                                     ResourceFolderModel* mods,
-                                                    BaseInstance* instance,
+                                                    MinecraftInstance* instance,
                                                     bool suppressInitialSearch = false);
     static ResourceDownloadDialog* createDataPack(QWidget* parent,
                                                   ResourceFolderModel* mods,
-                                                  BaseInstance* instance,
+                                                  MinecraftInstance* instance,
                                                   bool suppressInitialSearch = false);
 
     void initializeContainer();
@@ -104,7 +104,7 @@ class ResourceDownloadDialog : public QDialog, public BasePageProvider {
    protected:
     ResourceDownloadDialog(QWidget* parent,
                            ResourceFolderModel* baseModel,
-                           BaseInstance* instance,
+                           MinecraftInstance* instance,
                            QString resourcesString = tr("resources"),
                            QString geometrySaveKey = "",
                            bool suppressInitialSearch = false);
@@ -126,7 +126,7 @@ class ResourceDownloadDialog : public QDialog, public BasePageProvider {
 
    protected:
     bool m_suppressInitialSearch = false;
-    BaseInstance* m_instance;
+    MinecraftInstance* m_instance;
 
     QString m_resourcesString;
     QString m_geometrySaveKey;

--- a/launcher/ui/dialogs/ResourceUpdateDialog.cpp
+++ b/launcher/ui/dialogs/ResourceUpdateDialog.cpp
@@ -30,14 +30,14 @@
 #include <optional>
 
 namespace {
-std::vector<Version> mcVersions(BaseInstance* inst)
+std::vector<Version> mcVersions(MinecraftInstance* inst)
 {
-    return { static_cast<MinecraftInstance*>(inst)->getPackProfile()->getComponent("net.minecraft")->getVersion() };
+    return { inst->getPackProfile()->getComponent("net.minecraft")->getVersion() };
 }
 }  // namespace
 
 ResourceUpdateDialog::ResourceUpdateDialog(QWidget* parent,
-                                           BaseInstance* instance,
+                                           MinecraftInstance* instance,
                                            ResourceFolderModel* resourceModel,
                                            QList<Resource*>& searchFor,
                                            bool includeDeps,

--- a/launcher/ui/dialogs/ResourceUpdateDialog.h
+++ b/launcher/ui/dialogs/ResourceUpdateDialog.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "BaseInstance.h"
 #include "ResourceDownloadTask.h"
 #include "ReviewMessageBox.h"
 
@@ -8,6 +7,7 @@
 
 #include "modplatform/CheckUpdateTask.h"
 
+class Minecraft;
 class Mod;
 class ModrinthCheckUpdate;
 class FlameCheckUpdate;
@@ -17,7 +17,7 @@ class ResourceUpdateDialog final : public ReviewMessageBox {
     Q_OBJECT
    public:
     explicit ResourceUpdateDialog(QWidget* parent,
-                                  BaseInstance* instance,
+                                  MinecraftInstance* instance,
                                   ResourceFolderModel* resourceModel,
                                   QList<Resource*>& searchFor,
                                   bool includeDeps,
@@ -59,7 +59,7 @@ class ResourceUpdateDialog final : public ReviewMessageBox {
     QList<std::tuple<Resource*, QString, QUrl>> m_failedCheckUpdate;
 
     QHash<QString, ResourceDownloadTask::Ptr> m_tasks;
-    BaseInstance* m_instance;
+    MinecraftInstance* m_instance;
 
     bool m_noUpdates = false;
     bool m_aborted = false;

--- a/launcher/ui/java/InstallJavaDialog.cpp
+++ b/launcher/ui/java/InstallJavaDialog.cpp
@@ -182,7 +182,7 @@ QStringList getRecommendedJavaVersionsFromVersionList(Meta::VersionList::Ptr lis
     return recommendedJavas;
 }
 
-InstallDialog::InstallDialog(const QString& uid, BaseInstance* instance, QWidget* parent)
+InstallDialog::InstallDialog(const QString& uid, MinecraftInstance* instance, QWidget* parent)
     : QDialog(parent), container(new PageContainer(this, QString(), this)), buttons(new QDialogButtonBox(this))
 {
     auto layout = new QVBoxLayout(this);
@@ -231,8 +231,8 @@ InstallDialog::InstallDialog(const QString& uid, BaseInstance* instance, QWidget
     resize(840, 480);
 
     QStringList recommendedJavas;
-    if (auto mcInst = dynamic_cast<MinecraftInstance*>(instance); mcInst) {
-        auto mc = mcInst->getPackProfile()->getComponent("net.minecraft");
+    if (instance != nullptr) {
+        auto mc = instance->getPackProfile()->getComponent("net.minecraft");
         if (mc) {
             auto file = mc->getVersionFile();  // no need for load as it should already be loaded
             if (file) {

--- a/launcher/ui/java/InstallJavaDialog.h
+++ b/launcher/ui/java/InstallJavaDialog.h
@@ -32,7 +32,7 @@ class InstallDialog final : public QDialog, private BasePageProvider {
     Q_OBJECT
 
    public:
-    explicit InstallDialog(const QString& uid = QString(), BaseInstance* instance = nullptr, QWidget* parent = nullptr);
+    explicit InstallDialog(const QString& uid = QString(), MinecraftInstance* instance = nullptr, QWidget* parent = nullptr);
 
     QList<BasePage*> getPages() override;
     QString dialogTitle() override;

--- a/launcher/ui/pages/instance/DataPackPage.cpp
+++ b/launcher/ui/pages/instance/DataPackPage.cpp
@@ -25,7 +25,7 @@
 #include "ui/dialogs/ResourceDownloadDialog.h"
 #include "ui/dialogs/ResourceUpdateDialog.h"
 
-DataPackPage::DataPackPage(BaseInstance* instance, DataPackFolderModel* model, QWidget* parent)
+DataPackPage::DataPackPage(MinecraftInstance* instance, DataPackFolderModel* model, QWidget* parent)
     : ExternalResourcesPage(instance, model, parent), m_model(model)
 {
     ui->actionDownloadItem->setText(tr("Download Packs"));
@@ -64,10 +64,6 @@ void DataPackPage::updateFrame(const QModelIndex& current, [[maybe_unused]] cons
 
 void DataPackPage::downloadDataPacks()
 {
-    if (m_instance->typeName() != "Minecraft") {
-        return;  // this is a null instance or a legacy instance
-    }
-
     m_downloadDialog = ResourceDownload::ResourceDownloadDialog::createDataPack(this, m_model, m_instance);
     connect(this, &QObject::destroyed, m_downloadDialog, &QDialog::close);
     connect(m_downloadDialog, &QDialog::finished, this, &DataPackPage::downloadDialogFinished);
@@ -117,10 +113,6 @@ void DataPackPage::downloadDialogFinished(int result)
 
 void DataPackPage::updateDataPacks()
 {
-    if (m_instance->typeName() != "Minecraft") {
-        return;  // this is a null instance or a legacy instance
-    }
-
     if (APPLICATION->settings()->get("ModMetadataDisabled").toBool()) {
         QMessageBox::critical(this, tr("Error"), tr("Data pack updates are unavailable when metadata is disabled!"));
         return;
@@ -221,10 +213,6 @@ void DataPackPage::deleteDataPackMetadata()
 
 void DataPackPage::changeDataPackVersion()
 {
-    if (m_instance->typeName() != "Minecraft") {
-        return;  // this is a null instance or a legacy instance
-    }
-
     if (APPLICATION->settings()->get("ModMetadataDisabled").toBool()) {
         QMessageBox::critical(this, tr("Error"), tr("Data pack updates are unavailable when metadata is disabled!"));
         return;

--- a/launcher/ui/pages/instance/DataPackPage.h
+++ b/launcher/ui/pages/instance/DataPackPage.h
@@ -26,7 +26,7 @@
 class DataPackPage : public ExternalResourcesPage {
     Q_OBJECT
    public:
-    explicit DataPackPage(BaseInstance* instance, DataPackFolderModel* model, QWidget* parent = nullptr);
+    explicit DataPackPage(MinecraftInstance* instance, DataPackFolderModel* model, QWidget* parent = nullptr);
 
     QString displayName() const override { return QObject::tr("Data Packs"); }
     QIcon icon() const override { return QIcon::fromTheme("datapacks"); }

--- a/launcher/ui/pages/instance/ExternalResourcesPage.cpp
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.cpp
@@ -47,7 +47,7 @@
 #include <QMenu>
 #include <algorithm>
 
-ExternalResourcesPage::ExternalResourcesPage(BaseInstance* instance, ResourceFolderModel* model, QWidget* parent)
+ExternalResourcesPage::ExternalResourcesPage(MinecraftInstance* instance, ResourceFolderModel* model, QWidget* parent)
     : QMainWindow(parent), m_instance(instance), ui(new Ui::ExternalResourcesPage), m_model(model)
 {
     ui->setupUi(this);

--- a/launcher/ui/pages/instance/ExternalResourcesPage.h
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.h
@@ -20,7 +20,7 @@ class ExternalResourcesPage : public QMainWindow, public BasePage {
     Q_OBJECT
 
    public:
-    explicit ExternalResourcesPage(BaseInstance* instance, ResourceFolderModel* model, QWidget* parent = nullptr);
+    explicit ExternalResourcesPage(MinecraftInstance* instance, ResourceFolderModel* model, QWidget* parent = nullptr);
     virtual ~ExternalResourcesPage();
 
     virtual QString displayName() const override = 0;
@@ -65,7 +65,7 @@ class ExternalResourcesPage : public QMainWindow, public BasePage {
     void ShowHeaderContextMenu(const QPoint& pos);
 
    protected:
-    BaseInstance* m_instance = nullptr;
+    MinecraftInstance* m_instance = nullptr;
 
     Ui::ExternalResourcesPage* ui = nullptr;
     ResourceFolderModel* m_model;

--- a/launcher/ui/pages/instance/ModFolderPage.cpp
+++ b/launcher/ui/pages/instance/ModFolderPage.cpp
@@ -67,7 +67,7 @@
 #include "tasks/Task.h"
 #include "ui/dialogs/ProgressDialog.h"
 
-ModFolderPage::ModFolderPage(BaseInstance* inst, ModFolderModel* model, QWidget* parent)
+ModFolderPage::ModFolderPage(MinecraftInstance* inst, ModFolderModel* model, QWidget* parent)
     : ExternalResourcesPage(inst, model, parent), m_model(model)
 {
     ui->actionDownloadItem->setText(tr("Download Mods"));
@@ -168,11 +168,7 @@ void ModFolderPage::removeItems(const QItemSelection& selection)
 
 void ModFolderPage::downloadMods()
 {
-    if (m_instance->typeName() != "Minecraft") {
-        return;  // this is a null instance or a legacy instance
-    }
-
-    auto* profile = static_cast<MinecraftInstance*>(m_instance)->getPackProfile();
+    auto* profile = m_instance->getPackProfile();
     if (!profile->getModLoaders().has_value() && handleNoModLoader()) {
         return;
     }
@@ -226,11 +222,7 @@ void ModFolderPage::downloadDialogFinished(int result)
 
 void ModFolderPage::updateMods(bool includeDeps)
 {
-    if (m_instance->typeName() != "Minecraft") {
-        return;  // this is a null instance or a legacy instance
-    }
-
-    auto* profile = static_cast<MinecraftInstance*>(m_instance)->getPackProfile();
+    auto* profile = m_instance->getPackProfile();
     if (!profile->getModLoaders().has_value() && handleNoModLoader()) {
         return;
     }
@@ -334,11 +326,7 @@ void ModFolderPage::deleteModMetadata()
 
 void ModFolderPage::changeModVersion()
 {
-    if (m_instance->typeName() != "Minecraft") {
-        return;  // this is a null instance or a legacy instance
-    }
-
-    auto* profile = static_cast<MinecraftInstance*>(m_instance)->getPackProfile();
+    auto* profile = m_instance->getPackProfile();
     if (!profile->getModLoaders().has_value() && handleNoModLoader()) {
         return;
     }
@@ -373,25 +361,22 @@ void ModFolderPage::exportModMetadata()
     dlg.exec();
 }
 
-CoreModFolderPage::CoreModFolderPage(BaseInstance* inst, ModFolderModel* mods, QWidget* parent) : ModFolderPage(inst, mods, parent)
+CoreModFolderPage::CoreModFolderPage(MinecraftInstance* inst, ModFolderModel* mods, QWidget* parent) : ModFolderPage(inst, mods, parent)
 {
-    auto* mcInst = dynamic_cast<MinecraftInstance*>(m_instance);
-    if (mcInst) {
-        auto* version = mcInst->getPackProfile();
-        if ((version != nullptr) && version->getComponent("net.minecraftforge") && version->getComponent("net.minecraft")) {
-            auto minecraftCmp = version->getComponent("net.minecraft");
-            if (!minecraftCmp->m_loaded) {
-                version->reload(Net::Mode::Offline);
-                auto update = version->getCurrentTask();
-                if (update) {
-                    connect(update.get(), &Task::finished, this, [this] {
-                        if (m_container) {
-                            m_container->refreshContainer();
-                        }
-                    });
-                    if (!update->isRunning()) {
-                        update->start();
+    auto* version = inst->getPackProfile();
+    if ((version != nullptr) && version->getComponent("net.minecraftforge") && version->getComponent("net.minecraft")) {
+        auto minecraftCmp = version->getComponent("net.minecraft");
+        if (!minecraftCmp->m_loaded) {
+            version->reload(Net::Mode::Offline);
+            auto update = version->getCurrentTask();
+            if (update) {
+                connect(update.get(), &Task::finished, this, [this] {
+                    if (m_container) {
+                        m_container->refreshContainer();
                     }
+                });
+                if (!update->isRunning()) {
+                    update->start();
                 }
             }
         }
@@ -401,12 +386,7 @@ CoreModFolderPage::CoreModFolderPage(BaseInstance* inst, ModFolderModel* mods, Q
 bool CoreModFolderPage::shouldDisplay() const
 {
     if (ModFolderPage::shouldDisplay()) {
-        auto* inst = dynamic_cast<MinecraftInstance*>(m_instance);
-        if (!inst) {
-            return true;
-        }
-
-        auto* version = inst->getPackProfile();
+        auto* version = m_instance->getPackProfile();
         if ((version == nullptr) || !version->getComponent("net.minecraftforge") || !version->getComponent("net.minecraft")) {
             return false;
         }
@@ -416,7 +396,7 @@ bool CoreModFolderPage::shouldDisplay() const
     return false;
 }
 
-NilModFolderPage::NilModFolderPage(BaseInstance* inst, ModFolderModel* mods, QWidget* parent) : ModFolderPage(inst, mods, parent) {}
+NilModFolderPage::NilModFolderPage(MinecraftInstance* inst, ModFolderModel* mods, QWidget* parent) : ModFolderPage(inst, mods, parent) {}
 
 bool NilModFolderPage::shouldDisplay() const
 {
@@ -432,7 +412,7 @@ inline bool ModFolderPage::handleNoModLoader()
         QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
     if (resp == QMessageBox::Yes) {
         // Should be safe
-        auto* profile = static_cast<MinecraftInstance*>(this->m_instance)->getPackProfile();
+        auto* profile = this->m_instance->getPackProfile();
         InstallLoaderDialog dialog(profile, QString(), this);
         // true if the user went through the install loader dialog
         // false if the dialog got canceled/closed

--- a/launcher/ui/pages/instance/ModFolderPage.h
+++ b/launcher/ui/pages/instance/ModFolderPage.h
@@ -48,7 +48,7 @@ class ModFolderPage : public ExternalResourcesPage {
     inline bool handleNoModLoader();
 
    public:
-    explicit ModFolderPage(BaseInstance* inst, ModFolderModel* model, QWidget* parent = nullptr);
+    explicit ModFolderPage(MinecraftInstance* inst, ModFolderModel* model, QWidget* parent = nullptr);
     virtual ~ModFolderPage() = default;
 
     void setFilter(const QString& filter) { m_fileSelectionFilter = filter; }
@@ -81,7 +81,7 @@ class ModFolderPage : public ExternalResourcesPage {
 class CoreModFolderPage : public ModFolderPage {
     Q_OBJECT
    public:
-    explicit CoreModFolderPage(BaseInstance* inst, ModFolderModel* mods, QWidget* parent = 0);
+    explicit CoreModFolderPage(MinecraftInstance* inst, ModFolderModel* mods, QWidget* parent = 0);
     virtual ~CoreModFolderPage() = default;
 
     virtual QString displayName() const override { return tr("Core Mods"); }
@@ -95,7 +95,7 @@ class CoreModFolderPage : public ModFolderPage {
 class NilModFolderPage : public ModFolderPage {
     Q_OBJECT
    public:
-    explicit NilModFolderPage(BaseInstance* inst, ModFolderModel* mods, QWidget* parent = 0);
+    explicit NilModFolderPage(MinecraftInstance* inst, ModFolderModel* mods, QWidget* parent = 0);
     virtual ~NilModFolderPage() = default;
 
     virtual QString displayName() const override { return tr("Nilmods"); }

--- a/launcher/ui/pages/instance/ResourcePackPage.cpp
+++ b/launcher/ui/pages/instance/ResourcePackPage.cpp
@@ -81,10 +81,6 @@ void ResourcePackPage::updateFrame(const QModelIndex& current, [[maybe_unused]] 
 
 void ResourcePackPage::downloadResourcePacks()
 {
-    if (m_instance->typeName() != "Minecraft") {
-        return;  // this is a null instance or a legacy instance
-    }
-
     m_downloadDialog = ResourceDownload::ResourceDownloadDialog::createResourcePack(this, m_model, m_instance);
     connect(this, &QObject::destroyed, m_downloadDialog, &QDialog::close);
     connect(m_downloadDialog, &QDialog::finished, this, &ResourcePackPage::downloadDialogFinished);
@@ -134,10 +130,6 @@ void ResourcePackPage::downloadDialogFinished(int result)
 
 void ResourcePackPage::updateResourcePacks()
 {
-    if (m_instance->typeName() != "Minecraft") {
-        return;  // this is a null instance or a legacy instance
-    }
-
     if (APPLICATION->settings()->get("ModMetadataDisabled").toBool()) {
         QMessageBox::critical(this, tr("Error"), tr("Resource pack updates are unavailable when metadata is disabled!"));
         return;
@@ -238,10 +230,6 @@ void ResourcePackPage::deleteResourcePackMetadata()
 
 void ResourcePackPage::changeResourcePackVersion()
 {
-    if (m_instance->typeName() != "Minecraft") {
-        return;  // this is a null instance or a legacy instance
-    }
-
     if (APPLICATION->settings()->get("ModMetadataDisabled").toBool()) {
         QMessageBox::critical(this, tr("Error"), tr("Resource pack updates are unavailable when metadata is disabled!"));
         return;

--- a/launcher/ui/pages/instance/ServersPage.cpp
+++ b/launcher/ui/pages/instance/ServersPage.cpp
@@ -548,7 +548,7 @@ class ServersModel : public QAbstractListModel {
     ConcurrentTask::Ptr m_currentQueryTask = nullptr;
 };
 
-ServersPage::ServersPage(BaseInstance* inst, QWidget* parent) : QMainWindow(parent), ui(new Ui::ServersPage)
+ServersPage::ServersPage(MinecraftInstance* inst, QWidget* parent) : QMainWindow(parent), ui(new Ui::ServersPage)
 {
     ui->setupUi(this);
     m_inst = inst;

--- a/launcher/ui/pages/instance/ServersPage.h
+++ b/launcher/ui/pages/instance/ServersPage.h
@@ -56,7 +56,7 @@ class ServersPage : public QMainWindow, public BasePage {
     Q_OBJECT
 
    public:
-    explicit ServersPage(BaseInstance* inst, QWidget* parent = 0);
+    explicit ServersPage(MinecraftInstance* inst, QWidget* parent = 0);
     virtual ~ServersPage();
 
     void openedImpl() override;
@@ -100,7 +100,7 @@ class ServersPage : public QMainWindow, public BasePage {
     bool m_locked = true;
     Ui::ServersPage* ui = nullptr;
     ServersModel* m_model = nullptr;
-    BaseInstance* m_inst = nullptr;
+    MinecraftInstance* m_inst = nullptr;
 
     std::shared_ptr<Setting> m_wide_bar_setting = nullptr;
 };

--- a/launcher/ui/pages/instance/ShaderPackPage.cpp
+++ b/launcher/ui/pages/instance/ShaderPackPage.cpp
@@ -76,10 +76,6 @@ ShaderPackPage::ShaderPackPage(MinecraftInstance* instance, ShaderPackFolderMode
 
 void ShaderPackPage::downloadShaderPack()
 {
-    if (m_instance->typeName() != "Minecraft") {
-        return;  // this is a null instance or a legacy instance
-    }
-
     m_downloadDialog = ResourceDownload::ResourceDownloadDialog::createShaderPack(this, m_model, m_instance);
     connect(this, &QObject::destroyed, m_downloadDialog, &QDialog::close);
     connect(m_downloadDialog, &QDialog::finished, this, &ShaderPackPage::downloadDialogFinished);
@@ -129,10 +125,6 @@ void ShaderPackPage::downloadDialogFinished(int result)
 
 void ShaderPackPage::updateShaderPacks()
 {
-    if (m_instance->typeName() != "Minecraft") {
-        return;  // this is a null instance or a legacy instance
-    }
-
     if (APPLICATION->settings()->get("ModMetadataDisabled").toBool()) {
         QMessageBox::critical(this, tr("Error"), tr("Shader pack updates are unavailable when metadata is disabled!"));
         return;
@@ -233,10 +225,6 @@ void ShaderPackPage::deleteShaderPackMetadata()
 
 void ShaderPackPage::changeShaderPackVersion()
 {
-    if (m_instance->typeName() != "Minecraft") {
-        return;  // this is a null instance or a legacy instance
-    }
-
     if (APPLICATION->settings()->get("ModMetadataDisabled").toBool()) {
         QMessageBox::critical(this, tr("Error"), tr("Shader pack updates are unavailable when metadata is disabled!"));
         return;

--- a/launcher/ui/pages/instance/TexturePackPage.cpp
+++ b/launcher/ui/pages/instance/TexturePackPage.cpp
@@ -83,10 +83,6 @@ void TexturePackPage::updateFrame(const QModelIndex& current, [[maybe_unused]] c
 
 void TexturePackPage::downloadTexturePacks()
 {
-    if (m_instance->typeName() != "Minecraft") {
-        return;  // this is a null instance or a legacy instance
-    }
-
     m_downloadDialog = ResourceDownload::ResourceDownloadDialog::createTexturePack(this, m_model, m_instance);
     connect(this, &QObject::destroyed, m_downloadDialog, &QDialog::close);
     connect(m_downloadDialog, &QDialog::finished, this, &TexturePackPage::downloadDialogFinished);
@@ -135,10 +131,6 @@ void TexturePackPage::downloadDialogFinished(int result)
 
 void TexturePackPage::updateTexturePacks()
 {
-    if (m_instance->typeName() != "Minecraft") {
-        return;  // this is a null instance or a legacy instance
-    }
-
     if (APPLICATION->settings()->get("ModMetadataDisabled").toBool()) {
         QMessageBox::critical(this, tr("Error"), tr("Texture pack updates are unavailable when metadata is disabled!"));
         return;
@@ -239,10 +231,6 @@ void TexturePackPage::deleteTexturePackMetadata()
 
 void TexturePackPage::changeTexturePackVersion()
 {
-    if (m_instance->typeName() != "Minecraft") {
-        return;  // this is a null instance or a legacy instance
-    }
-
     if (APPLICATION->settings()->get("ModMetadataDisabled").toBool()) {
         QMessageBox::critical(this, tr("Error"), tr("Texture pack updates are unavailable when metadata is disabled!"));
         return;

--- a/launcher/ui/widgets/JavaSettingsWidget.cpp
+++ b/launcher/ui/widgets/JavaSettingsWidget.cpp
@@ -47,6 +47,7 @@
 #include "SysInfo.h"
 #include "java/JavaInstallList.h"
 #include "java/JavaUtils.h"
+#include "minecraft/MinecraftInstance.h"
 #include "settings/Setting.h"
 #include "ui/dialogs/CustomMessageBox.h"
 #include "ui/dialogs/VersionSelectDialog.h"
@@ -54,7 +55,7 @@
 
 #include "ui_JavaSettingsWidget.h"
 
-JavaSettingsWidget::JavaSettingsWidget(BaseInstance* instance, QWidget* parent)
+JavaSettingsWidget::JavaSettingsWidget(MinecraftInstance* instance, QWidget* parent)
     : QWidget(parent), m_instance(instance), m_ui(new Ui::JavaSettingsWidget)
 {
     m_ui->setupUi(this);

--- a/launcher/ui/widgets/JavaSettingsWidget.h
+++ b/launcher/ui/widgets/JavaSettingsWidget.h
@@ -37,8 +37,9 @@
 #pragma once
 
 #include <QWidget>
-#include "BaseInstance.h"
 #include "JavaCommon.h"
+
+class MinecraftInstance;
 
 namespace Ui {
 class JavaSettingsWidget;
@@ -49,7 +50,7 @@ class JavaSettingsWidget : public QWidget {
 
    public:
     explicit JavaSettingsWidget(QWidget* parent = nullptr) : JavaSettingsWidget(nullptr, parent) {}
-    explicit JavaSettingsWidget(BaseInstance* instance, QWidget* parent = nullptr);
+    explicit JavaSettingsWidget(MinecraftInstance* instance, QWidget* parent = nullptr);
     ~JavaSettingsWidget() override;
 
     void loadSettings();
@@ -62,7 +63,7 @@ class JavaSettingsWidget : public QWidget {
     void updateThresholds();
 
    private:
-    BaseInstance* m_instance;
+    MinecraftInstance* m_instance;
     Ui::JavaSettingsWidget* m_ui;
     unique_qobject_ptr<JavaCommon::TestCheck> m_checker;
 };


### PR DESCRIPTION
This allows a lot of casts to be removed, as well as typeName.
The only "advantage" of InstanceList being able to hold BaseInstance is that it can also hold NullInstance. NullInstance is just used for broken instances anyway and is buggy to interact with... (technically it is also used in the instance creation process in some places IIRC so not removing it yet)