### PR TITLE
fix(accessibility): improve keyboard focus and screen reader support across main UI, settings, and mod platforms

### DIFF
--- a/launcher/minecraft/PackProfile.cpp
+++ b/launcher/minecraft/PackProfile.cpp
@@ -560,6 +560,17 @@ QVariant PackProfile::data(const QModelIndex& index, int role) const
             }
             return QVariant();
         }
+        case Qt::AccessibleTextRole:
+        case Qt::AccessibleDescriptionRole: {
+            switch (column) {
+                case NameColumn:
+                    return patch->getName();
+                case VersionColumn:
+                    return patch->getVersion();
+                default:
+                    return QVariant();
+            }
+        }
     }
     return QVariant();
 }

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -598,6 +598,23 @@ QVariant ResourceFolderModel::data(const QModelIndex& index, int role) const
                 return m_resources[row]->enabled() ? Qt::Checked : Qt::Unchecked;
             }
             return {};
+        case Qt::AccessibleTextRole:
+        case Qt::AccessibleDescriptionRole:
+            switch (column) {
+                case ActiveColumn:
+                case NameColumn:
+                    return m_resources[row]->name();
+                case DateColumn:
+                    return m_resources[row]->dateTimeChanged();
+                case ProviderColumn:
+                    return m_resources[row]->provider();
+                case SizeColumn:
+                    return m_resources[row]->sizeStr();
+                case FileNameColumn:
+                    return m_resources[row]->fileinfo().fileName();
+                default:
+                    return {};
+            }
         default:
             return {};
     }

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -45,6 +45,8 @@
 #include "MainWindow.h"
 #include "ui_MainWindow.h"
 
+#include <algorithm>
+
 #include <QDir>
 #include <QFileInfo>
 #include <QUrl>
@@ -282,7 +284,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), ui(new Ui::MainWi
         newsLabel->setIcon(QIcon::fromTheme("news"));
         newsLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
         newsLabel->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
-        newsLabel->setFocusPolicy(Qt::NoFocus);
+        newsLabel->setFocusPolicy(Qt::TabFocus);
         ui->newsToolBar->insertWidget(ui->actionMoreNews, newsLabel);
 
         connect(newsLabel, &QAbstractButton::clicked, this, &MainWindow::newsButtonClicked);
@@ -477,9 +479,84 @@ void MainWindow::retranslateUi()
         if (action->toolTip().contains("%1"))
             action->setToolTip(action->toolTip().arg(BuildConfig.LAUNCHER_DISPLAYNAME));
     }
+
+    setupFocusAndTabOrder();
 }
 
 MainWindow::~MainWindow() {}
+
+void MainWindow::setupFocusAndTabOrder()
+{
+    for (auto* action : ui->mainToolBar->actions()) {
+        if (auto* w = ui->mainToolBar->widgetForAction(action)) {
+            w->setFocusPolicy(Qt::TabFocus);
+        }
+    }
+
+    for (auto* action : ui->instanceToolBar->actions()) {
+        if (auto* w = ui->instanceToolBar->widgetForAction(action)) {
+            w->setFocusPolicy(Qt::TabFocus);
+        }
+    }
+
+    if (changeIconButton) {
+        changeIconButton->setFocusPolicy(Qt::TabFocus);
+        changeIconButton->setAccessibleName(tr("Change Icon"));
+        changeIconButton->setAccessibleDescription(ui->actionChangeInstIcon->toolTip());
+    }
+    if (renameButton) {
+        renameButton->setFocusPolicy(Qt::TabFocus);
+        renameButton->setAccessibleName(tr("Rename Instance"));
+        renameButton->setAccessibleDescription(ui->actionRenameInstance->toolTip());
+    }
+
+    if (newsLabel) {
+        newsLabel->setFocusPolicy(Qt::TabFocus);
+        newsLabel->setAccessibleName(tr("News"));
+    }
+    for (auto* action : ui->newsToolBar->actions()) {
+        if (auto* w = ui->newsToolBar->widgetForAction(action)) {
+            w->setFocusPolicy(Qt::TabFocus);
+        }
+    }
+
+    if (view) {
+        view->setFocusPolicy(Qt::StrongFocus);
+        view->setAccessibleName(tr("Instances"));
+        view->setAccessibleDescription(tr("List of Minecraft instances"));
+    }
+
+    auto getSortedWidgets = [](QWidget* parent, bool isHorizontal) -> QList<QWidget*> {
+        QList<QWidget*> list;
+        for (auto* obj : parent->children()) {
+            if (auto* child = qobject_cast<QWidget*>(obj)) {
+                if (child->isVisible() && child->focusPolicy() != Qt::NoFocus && child->width() > 0 && child->height() > 0) {
+                    list.append(child);
+                }
+            }
+        }
+        std::sort(list.begin(), list.end(), [isHorizontal](QWidget* a, QWidget* b) {
+            return isHorizontal ? a->x() < b->x() : a->y() < b->y();
+        });
+        return list;
+    };
+
+    QList<QWidget*> mainToolbarWidgets = getSortedWidgets(ui->mainToolBar, true);
+    QList<QWidget*> instanceToolbarWidgets = getSortedWidgets(ui->instanceToolBar, false);
+    QList<QWidget*> newsToolbarWidgets = getSortedWidgets(ui->newsToolBar, true);
+
+    QList<QWidget*> allFocusChain;
+    allFocusChain.append(mainToolbarWidgets);
+    if (view) {
+        allFocusChain.append(view);
+    }
+    allFocusChain.append(instanceToolbarWidgets);
+    allFocusChain.append(newsToolbarWidgets);
+
+    for (int i = 0; i < allFocusChain.size() - 1; ++i) {
+        QWidget::setTabOrder(allFocusChain[i], allFocusChain[i + 1]);
+    }
+}
 
 QMenu* MainWindow::createPopupMenu()
 {

--- a/launcher/ui/MainWindow.h
+++ b/launcher/ui/MainWindow.h
@@ -220,6 +220,7 @@ class MainWindow : public QMainWindow {
 
    private:
     void retranslateUi();
+    void setupFocusAndTabOrder();
 
     void addInstance(const QString& url = QString(), const QMap<QString, QString>& extra_info = {});
     void activateInstance(BaseInstance* instance);

--- a/launcher/ui/dialogs/ExportPackDialog.ui
+++ b/launcher/ui/dialogs/ExportPackDialog.ui
@@ -82,6 +82,9 @@
       </item>
       <item>
        <widget class="QPlainTextEdit" name="summary">
+        <property name="tabChangesFocus">
+         <bool>true</bool>
+        </property>
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
           <horstretch>0</horstretch>

--- a/launcher/ui/dialogs/ExportToModListDialog.ui
+++ b/launcher/ui/dialogs/ExportToModListDialog.ui
@@ -73,6 +73,9 @@
           <layout class="QVBoxLayout" name="verticalLayout_4">
            <item>
             <widget class="QTextEdit" name="templateText">
+             <property name="tabChangesFocus">
+              <bool>true</bool>
+             </property>
              <property name="sizePolicy">
               <sizepolicy hsizetype="Expanding" vsizetype="Maximum">
                <horstretch>0</horstretch>
@@ -185,6 +188,9 @@
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QPlainTextEdit" name="finalText">
+          <property name="tabChangesFocus">
+           <bool>true</bool>
+          </property>
           <property name="minimumSize">
            <size>
             <width>0</width>

--- a/launcher/ui/dialogs/IconPickerDialog.cpp
+++ b/launcher/ui/dialogs/IconPickerDialog.cpp
@@ -149,6 +149,8 @@ IconPickerDialog::IconPickerDialog(QWidget* parent) : QDialog(parent), ui(new Ui
     contentsWidget->installEventFilter(this);
 
     contentsWidget->setModel(proxyModel);
+    contentsWidget->setAccessibleName(tr("Icons List"));
+    ui->searchLine->setAccessibleName(tr("Search Icons"));
 
     // NOTE: ResetRole forces the button to be on the left, while the OK/Cancel ones are on the right. We win.
     auto buttonAdd = ui->buttonBox->addButton(tr("Add Icon"), QDialogButtonBox::ResetRole);

--- a/launcher/ui/dialogs/NewInstanceDialog.cpp
+++ b/launcher/ui/dialogs/NewInstanceDialog.cpp
@@ -80,6 +80,8 @@ NewInstanceDialog::NewInstanceDialog(const QString& initialGroup,
     setWindowIcon(QIcon::fromTheme("new"));
 
     ui->iconButton->setIcon(APPLICATION->icons()->getIcon(m_instIconKey));
+    ui->iconButton->setAccessibleName(tr("Choose Instance Icon"));
+    ui->iconButton->setToolTip(tr("Change icon for the new instance"));
 
     QStringList groups = APPLICATION->instances()->getGroups();
     groups.prepend("");

--- a/launcher/ui/pages/global/LauncherPage.cpp
+++ b/launcher/ui/pages/global/LauncherPage.cpp
@@ -75,6 +75,26 @@ LauncherPage::LauncherPage(QWidget* parent) : QWidget(parent), ui(new Ui::Launch
     ui->sortingModeGroup->setId(ui->sortLastLaunchedBtn, Sort_LastLaunch);
     ui->sortingModeGroup->setId(ui->sortByPlaytimeBtn, Sort_Playtime);
 
+    ui->instanceSortingLabel->setBuddy(ui->sortByNameBtn);
+    ui->sortByNameBtn->setAccessibleName(tr("Instance Sorting: By name"));
+    ui->sortByNameBtn->setAccessibleDescription(tr("Instance Sorting"));
+    ui->sortLastLaunchedBtn->setAccessibleName(tr("Instance Sorting: By last launched"));
+    ui->sortLastLaunchedBtn->setAccessibleDescription(tr("Instance Sorting"));
+    ui->sortByPlaytimeBtn->setAccessibleName(tr("Instance Sorting: By total time played"));
+    ui->sortByPlaytimeBtn->setAccessibleDescription(tr("Instance Sorting"));
+
+    ui->renamingBehaviorLabel->setBuddy(ui->askToRenameDirBtn);
+    ui->askToRenameDirBtn->setAccessibleName(tr("Instance Renaming: Ask what to do"));
+    ui->askToRenameDirBtn->setAccessibleDescription(tr("Instance Renaming"));
+    ui->alwaysRenameDirBtn->setAccessibleName(tr("Instance Renaming: Always rename the folder"));
+    ui->alwaysRenameDirBtn->setAccessibleDescription(tr("Instance Renaming"));
+    ui->neverRenameDirBtn->setAccessibleName(tr("Instance Renaming: Never rename the folder"));
+    ui->neverRenameDirBtn->setAccessibleDescription(tr("Instance Renaming"));
+
+    ui->updateIntervalLabel->setBuddy(ui->updateIntervalSpinBox);
+    ui->updateIntervalSpinBox->setAccessibleName(tr("Update Check Interval"));
+    ui->updateIntervalSpinBox->setAccessibleDescription(tr("Update Check Interval in hours"));
+
     loadSettings();
 
     ui->updateSettingsBox->setHidden(!APPLICATION->updater());

--- a/launcher/ui/pages/instance/ExternalResourcesPage.cpp
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.cpp
@@ -63,6 +63,24 @@ ExternalResourcesPage::ExternalResourcesPage(BaseInstance* instance, ResourceFol
     ui->treeView->setModel(m_filterModel);
     // must come after setModel
     ui->treeView->setResizeModes(m_model->columnResizeModes());
+    ui->treeView->setAccessibleName(tr("Resource List"));
+    ui->filterEdit->setAccessibleName(tr("Search"));
+
+    for (auto* action : ui->actionsToolbar->actions()) {
+        if (auto* w = ui->actionsToolbar->widgetForAction(action)) {
+            w->setFocusPolicy(Qt::TabFocus);
+        }
+    }
+
+    QWidget::setTabOrder(ui->filterEdit, ui->treeView);
+    QWidget* prevWidget = ui->treeView;
+    for (auto* action : ui->actionsToolbar->actions()) {
+        if (action->isSeparator()) continue;
+        if (auto* w = ui->actionsToolbar->widgetForAction(action)) {
+            QWidget::setTabOrder(prevWidget, w);
+            prevWidget = w;
+        }
+    }
 
     ui->treeView->installEventFilter(this);
     ui->treeView->sortByColumn(1, Qt::AscendingOrder);

--- a/launcher/ui/pages/instance/ScreenshotsPage.cpp
+++ b/launcher/ui/pages/instance/ScreenshotsPage.cpp
@@ -293,6 +293,23 @@ ScreenshotsPage::ScreenshotsPage(QString path, QWidget* parent)
     ui->listView->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(ui->listView, &QListView::customContextMenuRequested, this, &ScreenshotsPage::showContextMenu);
     connect(ui->listView, &QAbstractItemView::activated, this, &ScreenshotsPage::onItemActivated);
+
+    ui->listView->setAccessibleName(tr("Screenshots List"));
+
+    for (auto* action : ui->toolBar->actions()) {
+        if (auto* w = ui->toolBar->widgetForAction(action)) {
+            w->setFocusPolicy(Qt::TabFocus);
+        }
+    }
+
+    QWidget* prevWidget = ui->listView;
+    for (auto* action : ui->toolBar->actions()) {
+        if (action->isSeparator()) continue;
+        if (auto* w = ui->toolBar->widgetForAction(action)) {
+            QWidget::setTabOrder(prevWidget, w);
+            prevWidget = w;
+        }
+    }
 }
 
 bool ScreenshotsPage::eventFilter(QObject* obj, QEvent* evt)

--- a/launcher/ui/pages/instance/ServersPage.cpp
+++ b/launcher/ui/pages/instance/ServersPage.cpp
@@ -580,6 +580,23 @@ ServersPage::ServersPage(BaseInstance* inst, QWidget* parent) : QMainWindow(pare
     }
 
     updateState();
+
+    ui->serversView->setAccessibleName(tr("Servers List"));
+
+    for (auto* action : ui->toolBar->actions()) {
+        if (auto* w = ui->toolBar->widgetForAction(action)) {
+            w->setFocusPolicy(Qt::TabFocus);
+        }
+    }
+
+    QWidget* prevWidget = ui->serversView;
+    for (auto* action : ui->toolBar->actions()) {
+        if (action->isSeparator()) continue;
+        if (auto* w = ui->toolBar->widgetForAction(action)) {
+            QWidget::setTabOrder(prevWidget, w);
+            prevWidget = w;
+        }
+    }
 }
 
 ServersPage::~ServersPage()

--- a/launcher/ui/pages/instance/VersionPage.cpp
+++ b/launcher/ui/pages/instance/VersionPage.cpp
@@ -176,6 +176,25 @@ VersionPage::VersionPage(MinecraftInstance* inst, QWidget* parent) : QMainWindow
         auto component = m_profile->getComponent(index.row());
         component->setEnabled(!component->isEnabled());
     });
+    ui->packageView->setAccessibleName(tr("Version Components"));
+    ui->filterEdit->setAccessibleName(tr("Search"));
+
+    for (auto* action : ui->toolBar->actions()) {
+        if (auto* w = ui->toolBar->widgetForAction(action)) {
+            w->setFocusPolicy(Qt::TabFocus);
+        }
+    }
+
+    QWidget::setTabOrder(ui->filterEdit, ui->packageView);
+    QWidget* prevWidget = ui->packageView;
+    for (auto* action : ui->toolBar->actions()) {
+        if (action->isSeparator()) continue;
+        if (auto* w = ui->toolBar->widgetForAction(action)) {
+            QWidget::setTabOrder(prevWidget, w);
+            prevWidget = w;
+        }
+    }
+
     connect(ui->filterEdit, &QLineEdit::textChanged, this, &VersionPage::onFilterTextChanged);
 }
 

--- a/launcher/ui/pages/instance/WorldListPage.cpp
+++ b/launcher/ui/pages/instance/WorldListPage.cpp
@@ -112,6 +112,23 @@ WorldListPage::WorldListPage(MinecraftInstance* inst, WorldList* worlds, QWidget
 
     connect(ui->worldTreeView->selectionModel(), &QItemSelectionModel::currentChanged, this, &WorldListPage::worldChanged);
     worldChanged(QModelIndex(), QModelIndex());
+
+    ui->worldTreeView->setAccessibleName(tr("Worlds List"));
+
+    for (auto* action : ui->toolBar->actions()) {
+        if (auto* w = ui->toolBar->widgetForAction(action)) {
+            w->setFocusPolicy(Qt::TabFocus);
+        }
+    }
+
+    QWidget* prevWidget = ui->worldTreeView;
+    for (auto* action : ui->toolBar->actions()) {
+        if (action->isSeparator()) continue;
+        if (auto* w = ui->toolBar->widgetForAction(action)) {
+            QWidget::setTabOrder(prevWidget, w);
+            prevWidget = w;
+        }
+    }
 }
 
 void WorldListPage::openedImpl()

--- a/launcher/ui/pages/modplatform/OptionalModDialog.cpp
+++ b/launcher/ui/pages/modplatform/OptionalModDialog.cpp
@@ -27,6 +27,7 @@ OptionalModDialog::OptionalModDialog(QWidget* parent, const QStringList& mods) :
         item->setFlags(item->flags() | Qt::ItemIsUserCheckable);
         item->setCheckState(Qt::Unchecked);
         item->setData(Qt::UserRole, mod);
+        item->setData(Qt::AccessibleTextRole, mod);
     }
 
     connect(ui->selectAllButton, &QPushButton::clicked, ui->list, [this] {

--- a/launcher/ui/pages/modplatform/ResourceModel.cpp
+++ b/launcher/ui/pages/modplatform/ResourceModel.cpp
@@ -79,9 +79,12 @@ auto ResourceModel::data(const QModelIndex& index, int role) const -> QVariant
             v.setValue(pack);
             return v;
         }
-            // Custom data
+            // Custom & Accessible data
+        case Qt::DisplayRole:
+        case Qt::AccessibleTextRole:
         case UserDataTypes::TITLE:
             return pack->name;
+        case Qt::AccessibleDescriptionRole:
         case UserDataTypes::DESCRIPTION:
             return pack->description;
         case Qt::CheckStateRole:

--- a/launcher/ui/pages/modplatform/ResourcePage.cpp
+++ b/launcher/ui/pages/modplatform/ResourcePage.cpp
@@ -98,6 +98,23 @@ ResourcePage::ResourcePage(ResourceDownloadDialog* parent,
 
     connect(m_ui->packView, &QAbstractItemView::doubleClicked, this, &ResourcePage::onResourceToggle);
     connect(delegate, &ProjectItemDelegate::checkboxClicked, this, &ResourcePage::onResourceToggle);
+
+    m_ui->searchEdit->setAccessibleName(tr("Search mods"));
+    m_ui->searchEdit->setAccessibleDescription(tr("Search mods"));
+    m_ui->resourceFilterButton->setAccessibleName(tr("Filter options"));
+    m_ui->packView->setAccessibleName(tr("Mods list"));
+    m_ui->packDescription->setAccessibleName(tr("Mod description"));
+    m_ui->sortByBox->setAccessibleName(tr("Sort by"));
+    m_ui->label->setBuddy(m_ui->versionSelectionBox);
+    m_ui->versionSelectionBox->setAccessibleName(tr("Version selected"));
+    m_ui->resourceSelectionButton->setAccessibleName(tr("Download selected mod"));
+
+    setTabOrder(m_ui->resourceFilterButton, m_ui->searchEdit);
+    setTabOrder(m_ui->searchEdit, m_ui->packView);
+    setTabOrder(m_ui->packView, m_ui->packDescription);
+    setTabOrder(m_ui->packDescription, m_ui->sortByBox);
+    setTabOrder(m_ui->sortByBox, m_ui->versionSelectionBox);
+    setTabOrder(m_ui->versionSelectionBox, m_ui->resourceSelectionButton);
 }
 
 ResourcePage::~ResourcePage()

--- a/launcher/ui/pages/modplatform/atlauncher/AtlListModel.cpp
+++ b/launcher/ui/pages/modplatform/atlauncher/AtlListModel.cpp
@@ -74,14 +74,14 @@ QVariant ListModel::data(const QModelIndex& index, int role) const
             return v;
         }
         case Qt::DisplayRole:
-            return pack.name;
-        case Qt::SizeHintRole:
-            return QSize(0, 58);
-        // Custom data
+        case Qt::AccessibleTextRole:
         case UserDataTypes::TITLE:
             return pack.name;
+        case Qt::AccessibleDescriptionRole:
         case UserDataTypes::DESCRIPTION:
             return pack.description;
+        case Qt::SizeHintRole:
+            return QSize(0, 58);
         case UserDataTypes::INSTALLED:
             return false;
         default:

--- a/launcher/ui/pages/modplatform/atlauncher/AtlOptionalModDialog.cpp
+++ b/launcher/ui/pages/modplatform/atlauncher/AtlOptionalModDialog.cpp
@@ -93,13 +93,15 @@ QVariant AtlOptionalModListModel::data(const QModelIndex& index, int role) const
     auto row = index.row();
     auto mod = m_mods.at(row);
 
-    if (role == Qt::DisplayRole) {
-        if (index.column() == NameColumn) {
+    if (role == Qt::DisplayRole || role == Qt::AccessibleTextRole) {
+        if (index.column() == NameColumn || index.column() == EnabledColumn) {
             return mod.name;
         }
         if (index.column() == DescriptionColumn) {
             return mod.description;
         }
+    } else if (role == Qt::AccessibleDescriptionRole) {
+        return mod.description;
     } else if (role == Qt::ToolTipRole) {
         if (index.column() == DescriptionColumn) {
             return mod.description;

--- a/launcher/ui/pages/modplatform/flame/FlameModel.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameModel.cpp
@@ -62,8 +62,11 @@ QVariant ListModel::data(const QModelIndex& index, int role) const
         }
         case Qt::SizeHintRole:
             return QSize(0, 58);
+        case Qt::DisplayRole:
+        case Qt::AccessibleTextRole:
         case UserDataTypes::TITLE:
             return pack->name;
+        case Qt::AccessibleDescriptionRole:
         case UserDataTypes::DESCRIPTION:
             return pack->description;
         case UserDataTypes::INSTALLED:

--- a/launcher/ui/pages/modplatform/ftb/FtbListModel.cpp
+++ b/launcher/ui/pages/modplatform/ftb/FtbListModel.cpp
@@ -46,8 +46,10 @@ QVariant ListModel::data(const QModelIndex& index, int role) const
     }
 
     FTB::Modpack pack = m_modpacks.at(pos);
-    if (role == Qt::DisplayRole) {
+    if (role == Qt::DisplayRole || role == Qt::AccessibleTextRole) {
         return pack.name;
+    } else if (role == Qt::AccessibleDescriptionRole) {
+        return pack.synopsis;
     } else if (role == Qt::ToolTipRole) {
         return pack.synopsis;
     } else if (role == Qt::DecorationRole) {

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
@@ -104,9 +104,12 @@ auto ModpackListModel::data(const QModelIndex& index, int role) const -> QVarian
         }
         case Qt::SizeHintRole:
             return QSize(0, 58);
-        // Custom data
+        // Custom & Accessible data
+        case Qt::DisplayRole:
+        case Qt::AccessibleTextRole:
         case UserDataTypes::TITLE:
             return pack->name;
+        case Qt::AccessibleDescriptionRole:
         case UserDataTypes::DESCRIPTION:
             return pack->description;
         case UserDataTypes::INSTALLED:

--- a/launcher/ui/pages/modplatform/technic/TechnicModel.cpp
+++ b/launcher/ui/pages/modplatform/technic/TechnicModel.cpp
@@ -59,6 +59,11 @@ QVariant Technic::ListModel::data(const QModelIndex& index, int role) const
 
     Modpack pack = modpacks.at(pos);
     switch (role) {
+        case Qt::DisplayRole:
+        case Qt::AccessibleTextRole:
+            return pack.title;
+        case Qt::AccessibleDescriptionRole:
+            return pack.description;
         case Qt::ToolTipRole: {
             if (pack.description.length() > 100) {
                 // some magic to prevent to long tooltips and replace html linebreaks

--- a/launcher/ui/widgets/JavaSettingsWidget.cpp
+++ b/launcher/ui/widgets/JavaSettingsWidget.cpp
@@ -59,6 +59,22 @@ JavaSettingsWidget::JavaSettingsWidget(BaseInstance* instance, QWidget* parent)
 {
     m_ui->setupUi(this);
 
+    m_ui->jvmArgsTextBox->setTabChangesFocus(true);
+    m_ui->jvmArgsTextBox->setAccessibleName(tr("Java Arguments"));
+    m_ui->jvmArgsTextBox->setAccessibleDescription(tr("Java Arguments"));
+
+    m_ui->javaPathTextBox->setAccessibleName(tr("Java Executable Path"));
+    m_ui->javaPathTextBox->setAccessibleDescription(tr("Java Executable Path"));
+
+    m_ui->minMemSpinBox->setAccessibleName(tr("Minimum Memory Usage"));
+    m_ui->minMemSpinBox->setAccessibleDescription(tr("Minimum Memory Usage"));
+
+    m_ui->maxMemSpinBox->setAccessibleName(tr("Maximum Memory Usage"));
+    m_ui->maxMemSpinBox->setAccessibleDescription(tr("Maximum Memory Usage"));
+
+    m_ui->permGenSpinBox->setAccessibleName(tr("PermGen Memory Usage"));
+    m_ui->permGenSpinBox->setAccessibleDescription(tr("PermGen Memory Usage"));
+
     if (m_instance == nullptr) {
         m_ui->javaDownloadBtn->hide();
         if (BuildConfig.JAVA_DOWNLOADER_ENABLED) {

--- a/launcher/ui/widgets/JavaSettingsWidget.ui
+++ b/launcher/ui/widgets/JavaSettingsWidget.ui
@@ -375,7 +375,11 @@
      </property>
      <layout class="QGridLayout" name="gridLayout_6">
       <item row="1" column="1">
-       <widget class="QPlainTextEdit" name="jvmArgsTextBox"/>
+       <widget class="QPlainTextEdit" name="jvmArgsTextBox">
+        <property name="tabChangesFocus">
+         <bool>true</bool>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/launcher/ui/widgets/MinecraftSettingsWidget.cpp
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.cpp
@@ -53,6 +53,9 @@ MinecraftSettingsWidget::MinecraftSettingsWidget(MinecraftInstance* instance, QW
 {
     m_ui->setupUi(this);
 
+    m_ui->windowWidthSpinBox->setAccessibleName(tr("Window Width"));
+    m_ui->windowHeightSpinBox->setAccessibleName(tr("Window Height"));
+
     if (m_instance == nullptr) {
         m_ui->settingsTabs->removeTab(1);
 

--- a/launcher/ui/widgets/WideBar.cpp
+++ b/launcher/ui/widgets/WideBar.cpp
@@ -40,7 +40,7 @@ class ActionButton : public QToolButton {
             setToolTip(m_action->toolTip());
             setHidden(!m_action->isVisible());
         }
-        setFocusPolicy(Qt::NoFocus);
+        setFocusPolicy(Qt::TabFocus);
     }
 
    private:


### PR DESCRIPTION
## Description

This pull request comprehensively addresses and resolves screen reader accessibility and keyboard focus navigation issues across Prism Launcher:

1. **Main Window & Toolbars**:
   - Enabled `Qt::TabFocus` on toolbar actions, wide sidebar buttons, and news toolbar.
   - Implemented a logical tab order chain (`mainToolBar` -> `InstanceView` -> `instanceToolBar` -> `newsToolBar`).

2. **Edit Instance Dialog Pages**:
   - Implemented `Qt::AccessibleTextRole` and `Qt::AccessibleDescriptionRole` in `ResourceFolderModel` (Mods, Resource Packs, Texture Packs, Shader Packs, Data Packs) and `PackProfile` (Version components) so screen readers announce item names alongside checkbox state.
   - Enabled keyboard focus and tab ordering for side action buttons on Version, External Resources, World List, Servers, and Screenshots pages.

3. **App Settings Panel**:
   - Linked section header labels (`instanceSortingLabel`, `renamingBehaviorLabel`, `updateIntervalLabel`, etc.) to option controls via buddies, `accessibleName`, and `accessibleDescription`.
   - Fixed `jvmArgsTextBox` by enabling `tabChangesFocus` on the `QPlainTextEdit` widget to prevent keyboard navigation traps.

4. **Online Mod & Modpack Platforms**:
   - Added `Qt::DisplayRole`, `Qt::AccessibleTextRole`, and `Qt::AccessibleDescriptionRole` across all online mod platform item models (`ResourceModel`, `FlameModel`, `ModrinthModel`, `AtlListModel`, `FtbListModel`, `TechnicModel`, `AtlOptionalModListModel`, and `OptionalModDialog`).
   - Added accessible names and logical tab ordering for search, filter options, sorting, and version selection controls in `ResourcePage`.

5. **Text Editors & Icon Picker**:
   - Enabled `tabChangesFocus` across dialog text edit widgets (`ExportPackDialog`, `ExportToModListDialog`) to ensure users can tab in and out cleanly.
   - Added accessible names for icon picker list items, search inputs, and new instance icon buttons.

---

## Verification & DCO Compliance
- All commits are signed off (`Signed-off-by: makhlwf <altrhwnyashrf1@gmail.com>`) in accordance with the Developer Certificate of Origin (DCO) guidelines.
- All changes have passed local build verification and GitHub Actions CI build checks.

Assisted-by: Antigravity:2.0
