### PR TITLE
Remove MinGW-arm64 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,12 +59,6 @@ jobs:
             msystem: CLANG64
             vcvars-arch: amd64_x86
 
-          - os: windows-11-arm
-            artifact-name: Windows-MinGW-arm64
-            cmake-preset: windows_mingw
-            msystem: CLANGARM64
-            vcvars-arch: arm64
-
           - os: windows-2022
             artifact-name: Windows-MSVC
             cmake-preset: windows_msvc
@@ -131,11 +125,6 @@ jobs:
           cmake --build --preset "$CMAKE_PRESET" --config "$BUILD_TYPE"
 
       - name: Run tests
-        # NOTE(@getchoo): Tests are skipped for MinGW-arm64 builds due to
-        # repeated, random test failures exclusive to the platform
-        #
-        # As of Qt 6.11, official ARM support for Windows is also limited to MSVC...so
-        if: ${{ !(runner.os == 'Windows' && runner.arch == 'ARM64' && matrix.msystem != '') }}
         run: |
           ctest --preset "$CMAKE_PRESET" --build-config "$BUILD_TYPE"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,17 +81,6 @@ jobs:
             cd ..
           done
 
-          for d in PrismLauncher-Windows-MinGW-arm64*; do
-            cd "${d}" || continue
-            INST="$(echo -n ${d} | grep -o Setup || true)"
-            PORT="$(echo -n ${d} | grep -o Portable || true)"
-            NAME="PrismLauncher-Windows-MinGW-arm64"
-            test -z "${PORT}" || NAME="${NAME}-Portable"
-            test -z "${INST}" || mv PrismLauncher-*.exe ../${NAME}-Setup-${{ env.VERSION }}.exe
-            test -n "${INST}" || zip -r -9 "../${NAME}-${{ env.VERSION }}.zip" *
-            cd ..
-          done
-
       - name: Create release
         id: create_release
         uses: softprops/action-gh-release@v3
@@ -112,9 +101,6 @@ jobs:
             PrismLauncher-Windows-MinGW-w64-${{ env.VERSION }}.zip
             PrismLauncher-Windows-MinGW-w64-Portable-${{ env.VERSION }}.zip
             PrismLauncher-Windows-MinGW-w64-Setup-${{ env.VERSION }}.exe
-            PrismLauncher-Windows-MinGW-arm64-${{ env.VERSION }}.zip
-            PrismLauncher-Windows-MinGW-arm64-Portable-${{ env.VERSION }}.zip
-            PrismLauncher-Windows-MinGW-arm64-Setup-${{ env.VERSION }}.exe
             PrismLauncher-Windows-MSVC-arm64-${{ env.VERSION }}.zip
             PrismLauncher-Windows-MSVC-arm64-Portable-${{ env.VERSION }}.zip
             PrismLauncher-Windows-MSVC-arm64-Setup-${{ env.VERSION }}.exe


### PR DESCRIPTION
These are untested in CI or by any maintainer, and unsupported by Qt upstream - so people probably shouldn't be using them....


See https://github.com/PrismLauncher/PrismLauncher/pull/5878 for context