### PR TITLE
Change ModrinthAPI and FlameAPI to singletons to avoid lifetime issues

### DIFF
--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -186,7 +186,7 @@ void ResourceFolderModel::installResourceWithFlameMetadata(const QString& path, 
             .provider = ModPlatform::ResourceProvider::FLAME,
         };
 
-        auto [job, response] = FlameAPI().getProject(vers.addonId.toString());
+        auto [job, response] = FlameAPI::get().getProject(vers.addonId.toString());
         connect(job.get(), &Task::failed, this, install);
         connect(job.get(), &Task::aborted, this, install);
         connect(job.get(), &Task::succeeded, this, [response, this, &vers, install, &pack] {

--- a/launcher/minecraft/mod/tasks/GetModDependenciesTask.h
+++ b/launcher/minecraft/mod/tasks/GetModDependenciesTask.h
@@ -60,12 +60,12 @@ class GetModDependenciesTask : public SequentialTask {
     QHash<QString, PackDependencyExtraInfo> getExtraInfo();
 
    private:
-    ResourceAPI* getAPI(ModPlatform::ResourceProvider provider)
+    const ResourceAPI* getAPI(ModPlatform::ResourceProvider provider)
     {
         if (provider == ModPlatform::ResourceProvider::FLAME) {
-            return &m_flameAPI;
+            return &FlameAPI::get();
         }
-        return &m_modrinthAPI;
+        return &ModrinthAPI::get();
     }
 
    protected slots:
@@ -88,7 +88,4 @@ class GetModDependenciesTask : public SequentialTask {
 
     Version m_version;
     ModPlatform::ModLoaderTypes m_loaderType;
-
-    ModrinthAPI m_modrinthAPI;
-    FlameAPI m_flameAPI;
 };

--- a/launcher/modplatform/EnsureMetadataTask.cpp
+++ b/launcher/modplatform/EnsureMetadataTask.cpp
@@ -16,9 +16,6 @@
 #include "modplatform/modrinth/ModrinthAPI.h"
 #include "modplatform/modrinth/ModrinthPackIndex.h"
 
-static ModrinthAPI modrinth_api;
-static FlameAPI flame_api;
-
 EnsureMetadataTask::EnsureMetadataTask(Resource* resource, QDir dir, ModPlatform::ResourceProvider prov)
     : Task(), m_indexDir(dir), m_provider(prov), m_hashingTask(nullptr), m_currentTask(nullptr)
 {
@@ -215,7 +212,7 @@ Task::Ptr EnsureMetadataTask::modrinthVersionsTask()
 {
     auto hash_type = ModPlatform::ProviderCapabilities::hashType(ModPlatform::ResourceProvider::MODRINTH).first();
 
-    auto [ver_task, response] = modrinth_api.currentVersions(m_resources.keys(), hash_type);
+    auto [ver_task, response] = ModrinthAPI::get().currentVersions(m_resources.keys(), hash_type);
 
     // Prevents unfortunate timings when aborting the task
     if (!ver_task)
@@ -272,9 +269,9 @@ Task::Ptr EnsureMetadataTask::modrinthProjectsTask()
     if (addonIds.isEmpty()) {
         qWarning() << "No addonId found!";
     } else if (addonIds.size() == 1) {
-        std::tie(proj_task, response) = modrinth_api.getProject(*addonIds.keyBegin());
+        std::tie(proj_task, response) = ModrinthAPI::get().getProject(*addonIds.keyBegin());
     } else {
-        std::tie(proj_task, response) = modrinth_api.getProjects(addonIds.keys());
+        std::tie(proj_task, response) = ModrinthAPI::get().getProjects(addonIds.keys());
     }
 
     // Prevents unfortunate timings when aborting the task
@@ -345,7 +342,7 @@ Task::Ptr EnsureMetadataTask::flameVersionsTask()
         fingerprints.push_back(murmur.toUInt());
     }
 
-    auto [ver_task, response] = flame_api.matchFingerprints(fingerprints);
+    auto [ver_task, response] = FlameAPI::get().matchFingerprints(fingerprints);
 
     connect(ver_task.get(), &Task::succeeded, this, [this, response] {
         QJsonParseError parse_error{};
@@ -420,9 +417,9 @@ Task::Ptr EnsureMetadataTask::flameProjectsTask()
     if (addonIds.isEmpty()) {
         qWarning() << "No addonId found!";
     } else if (addonIds.size() == 1) {
-        std::tie(proj_task, response) = flame_api.getProject(*addonIds.keyBegin());
+        std::tie(proj_task, response) = FlameAPI::get().getProject(*addonIds.keyBegin());
     } else {
-        std::tie(proj_task, response) = flame_api.getProjects(addonIds.keys());
+        std::tie(proj_task, response) = FlameAPI::get().getProjects(addonIds.keys());
     }
 
     // Prevents unfortunate timings when aborting the task

--- a/launcher/modplatform/ResourceAPI.h
+++ b/launcher/modplatform/ResourceAPI.h
@@ -55,8 +55,6 @@
 /* Simple class with a common interface for interacting with APIs */
 class ResourceAPI {
    public:
-    virtual ~ResourceAPI() = default;
-
     struct SortingMethod {
         // The index of the sorting method. Used to allow for arbitrary ordering in the list of methods.
         // Used by Flame in the API request.
@@ -123,6 +121,8 @@ class ResourceAPI {
     virtual Task::Ptr getDependencyVersion(DependencySearchArgs&&, Callback<ModPlatform::IndexedVersion>&&) const;
 
    protected:
+    ~ResourceAPI() = default;
+
     inline QString debugName() const { return "External resource API"; }
 
     QString mapMCVersionToModrinth(Version v) const;

--- a/launcher/modplatform/ResourceAPI.h
+++ b/launcher/modplatform/ResourceAPI.h
@@ -157,7 +157,7 @@ class ResourceAPI {
 
     virtual void loadExtraPackInfo(ModPlatform::IndexedPack&, QJsonObject&) const = 0;
 
-    virtual std::pair<Task::Ptr, QByteArray*> getModCategories() = 0;
+    virtual std::pair<Task::Ptr, QByteArray*> getModCategories() const = 0;
 
-    virtual QList<ModPlatform::Category> loadModCategories(const QByteArray& response) = 0;
+    virtual QList<ModPlatform::Category> loadModCategories(const QByteArray& response) const = 0;
 };

--- a/launcher/modplatform/flame/FileResolvingTask.cpp
+++ b/launcher/modplatform/flame/FileResolvingTask.cpp
@@ -31,9 +31,6 @@
 
 #include "Application.h"
 
-static const FlameAPI flameAPI;
-static ModrinthAPI modrinthAPI;
-
 Flame::FileResolvingTask::FileResolvingTask(Flame::Manifest& toProcess) : m_manifest(toProcess) {}
 
 bool Flame::FileResolvingTask::abort()
@@ -58,7 +55,7 @@ void Flame::FileResolvingTask::executeTask()
     for (auto file : m_manifest.files) {
         fileIds.push_back(QString::number(file.fileId));
     }
-    auto [task, response] = flameAPI.getFiles(fileIds);
+    auto [task, response] = FlameAPI::get().getFiles(fileIds);
     m_task = task;
 
     auto step_progress = std::make_shared<TaskStepProgress>();
@@ -155,7 +152,7 @@ void Flame::FileResolvingTask::netJobFinished(QByteArray* response)
         getFlameProjects();
         return;
     }
-    auto [modrinthTask, modrinthResponse] = modrinthAPI.currentVersions(hashes, "sha1");
+    auto [modrinthTask, modrinthResponse] = ModrinthAPI::get().currentVersions(hashes, "sha1");
     m_task = modrinthTask;
     (dynamic_cast<NetJob*>(m_task.get()))->setAskRetry(false);
     auto step_progress = std::make_shared<TaskStepProgress>();
@@ -172,7 +169,7 @@ void Flame::FileResolvingTask::netJobFinished(QByteArray* response)
             getFlameProjects();
             return;
             }
-        if (APPLICATION->settings()->get("FallbackMRBlockedMods").toBool()){ 
+        if (APPLICATION->settings()->get("FallbackMRBlockedMods").toBool()){
             try {
                 auto entries = Json::requireObject(doc);
                 for (auto& out : m_manifest.files) {
@@ -224,7 +221,7 @@ void Flame::FileResolvingTask::getFlameProjects()
         addonIds.push_back(QString::number(file.projectId));
     }
 
-    auto [task, response] = flameAPI.getProjects(addonIds);
+    auto [task, response] = FlameAPI::get().getProjects(addonIds);
     m_task = task;
 
     auto step_progress = std::make_shared<TaskStepProgress>();

--- a/launcher/modplatform/flame/FlameAPI.cpp
+++ b/launcher/modplatform/flame/FlameAPI.cpp
@@ -15,7 +15,7 @@
 #include "net/ApiUpload.h"
 #include "net/NetJob.h"
 
-std::pair<Task::Ptr, QByteArray*> FlameAPI::matchFingerprints(const QList<uint>& fingerprints)
+std::pair<Task::Ptr, QByteArray*> FlameAPI::matchFingerprints(const QList<uint>& fingerprints) const
 {
     auto netJob = makeShared<NetJob>(QString("Flame::MatchFingerprints"), APPLICATION->network());
 
@@ -35,7 +35,7 @@ std::pair<Task::Ptr, QByteArray*> FlameAPI::matchFingerprints(const QList<uint>&
     return { netJob, response };
 }
 
-QString FlameAPI::getModFileChangelog(int modId, int fileId)
+QString FlameAPI::getModFileChangelog(int modId, int fileId) const
 {
     QEventLoop lock;
     QString changelog;
@@ -69,7 +69,7 @@ QString FlameAPI::getModFileChangelog(int modId, int fileId)
     return changelog;
 }
 
-QString FlameAPI::getModDescription(int modId)
+QString FlameAPI::getModDescription(int modId) const
 {
     QEventLoop lock;
     QString description;
@@ -154,7 +154,8 @@ std::pair<Task::Ptr, QByteArray*> FlameAPI::getFile(const QString& addonId, cons
         Net::ApiDownload::makeByteArray(QUrl(QString(BuildConfig.FLAME_BASE_URL + "/mods/%1/files/%2").arg(addonId, fileId)));
     netJob->addNetAction(action);
 
-    QObject::connect(netJob.get(), &NetJob::failed, netJob.get(), [addonId, fileId] { qDebug() << "Flame API file failure" << addonId << fileId; });
+    QObject::connect(netJob.get(), &NetJob::failed, netJob.get(),
+                     [addonId, fileId] { qDebug() << "Flame API file failure" << addonId << fileId; });
 
     return { netJob, response };
 }
@@ -182,12 +183,12 @@ std::pair<Task::Ptr, QByteArray*> FlameAPI::getCategories(ModPlatform::ResourceT
     return { netJob, response };
 }
 
-std::pair<Task::Ptr, QByteArray*> FlameAPI::getModCategories()
+std::pair<Task::Ptr, QByteArray*> FlameAPI::getModCategories() const
 {
     return getCategories(ModPlatform::ResourceType::Mod);
 }
 
-QList<ModPlatform::Category> FlameAPI::loadModCategories(const QByteArray& response)
+QList<ModPlatform::Category> FlameAPI::loadModCategories(const QByteArray& response) const
 {
     QList<ModPlatform::Category> categories;
     QJsonParseError parse_error{};
@@ -221,7 +222,7 @@ QList<ModPlatform::Category> FlameAPI::loadModCategories(const QByteArray& respo
 std::optional<ModPlatform::IndexedVersion> FlameAPI::getLatestVersion(QList<ModPlatform::IndexedVersion> versions,
                                                                       QList<ModPlatform::ModLoaderType> instanceLoaders,
                                                                       ModPlatform::ModLoaderTypes modLoaders,
-                                                                      bool checkLoaders)
+                                                                      bool checkLoaders) const
 {
     static const auto noLoader = ModPlatform::ModLoaderType(0);
     if (!checkLoaders) {

--- a/launcher/modplatform/flame/FlameAPI.h
+++ b/launcher/modplatform/flame/FlameAPI.h
@@ -15,8 +15,14 @@
 #include "modplatform/ResourceAPI.h"
 #include "modplatform/flame/FlameModIndex.h"
 
-class FlameAPI : public ResourceAPI {
+class FlameAPI final : public ResourceAPI {
    public:
+    static const FlameAPI& get()
+    {
+        static const FlameAPI s_instance;
+        return s_instance;
+    }
+
     QString getModFileChangelog(int modId, int fileId) const;
     QString getModDescription(int modId) const;
 
@@ -42,6 +48,11 @@ class FlameAPI : public ResourceAPI {
     }
 
    private:
+    // NOTE: prevent creation and deletion of type - get should be used instead
+    FlameAPI() = default;
+
+    ~FlameAPI() = default;
+
     static int getClassId(ModPlatform::ResourceType type)
     {
         switch (type) {

--- a/launcher/modplatform/flame/FlameAPI.h
+++ b/launcher/modplatform/flame/FlameAPI.h
@@ -17,22 +17,22 @@
 
 class FlameAPI : public ResourceAPI {
    public:
-    QString getModFileChangelog(int modId, int fileId);
-    QString getModDescription(int modId);
+    QString getModFileChangelog(int modId, int fileId) const;
+    QString getModDescription(int modId) const;
 
     std::optional<ModPlatform::IndexedVersion> getLatestVersion(QList<ModPlatform::IndexedVersion> versions,
                                                                 QList<ModPlatform::ModLoaderType> instanceLoaders,
                                                                 ModPlatform::ModLoaderTypes fallback,
-                                                                bool checkLoaders);
+                                                                bool checkLoaders) const;
 
     std::pair<Task::Ptr, QByteArray*> getProjects(QStringList addonIds) const override;
-    std::pair<Task::Ptr, QByteArray*> matchFingerprints(const QList<uint>& fingerprints);
+    std::pair<Task::Ptr, QByteArray*> matchFingerprints(const QList<uint>& fingerprints) const;
     std::pair<Task::Ptr, QByteArray*> getFiles(const QStringList& fileIds) const;
     std::pair<Task::Ptr, QByteArray*> getFile(const QString& addonId, const QString& fileId) const;
 
     static std::pair<Task::Ptr, QByteArray*> getCategories(ModPlatform::ResourceType type);
-    std::pair<Task::Ptr, QByteArray*> getModCategories() override;
-    QList<ModPlatform::Category> loadModCategories(const QByteArray& response) override;
+    std::pair<Task::Ptr, QByteArray*> getModCategories() const override;
+    QList<ModPlatform::Category> loadModCategories(const QByteArray& response) const override;
 
     QList<ResourceAPI::SortingMethod> getSortingMethods() const override;
 

--- a/launcher/modplatform/flame/FlameCheckUpdate.cpp
+++ b/launcher/modplatform/flame/FlameCheckUpdate.cpp
@@ -46,7 +46,7 @@ void FlameCheckUpdate::executeTask()
     for (auto* resource : m_resources) {
         auto project = std::make_shared<ModPlatform::IndexedPack>();
         project->addonId = resource->metadata()->project_id.toString();
-        auto versionsUrlOptional = FlameAPI().getVersionsURL({ .pack = project, .mcVersions = m_gameVersions });
+        auto versionsUrlOptional = FlameAPI::get().getVersionsURL({ .pack = project, .mcVersions = m_gameVersions });
         if (!versionsUrlOptional.has_value()) {
             continue;
         }
@@ -87,7 +87,8 @@ void FlameCheckUpdate::getLatestVersionCallback(Resource* resource, QByteArray* 
         qCritical() << e.what();
         qDebug() << doc;
     }
-    auto latestVer = FlameAPI().getLatestVersion(pack->versions, m_loadersList, resource->metadata()->loaders, !m_loadersList.isEmpty());
+    auto latestVer =
+        FlameAPI::get().getLatestVersion(pack->versions, m_loadersList, resource->metadata()->loaders, !m_loadersList.isEmpty());
 
     setStatus(tr("Parsing the API response from CurseForge for '%1'...").arg(resource->name()));
 
@@ -123,7 +124,7 @@ void FlameCheckUpdate::getLatestVersionCallback(Resource* resource, QByteArray* 
 
         auto downloadTask = makeShared<ResourceDownloadTask>(pack, latestVer.value(), m_resourceModel, true, "update");
         m_updates.emplace_back(pack->name, resource->metadata()->hash, oldVersion, latestVer->version, latestVer->version_type,
-                               FlameAPI().getModFileChangelog(latestVer->addonId.toInt(), latestVer->fileId.toInt()),
+                               FlameAPI::get().getModFileChangelog(latestVer->addonId.toInt(), latestVer->fileId.toInt()),
                                ModPlatform::ResourceProvider::FLAME, downloadTask, resource->enabled());
     }
     m_deps.append(std::make_shared<GetModDependenciesTask::PackDependency>(pack, latestVer.value()));
@@ -147,9 +148,9 @@ void FlameCheckUpdate::collectBlockedMods()
         return;
     }
     if (addonIds.size() == 1) {
-        std::tie(projTask, response) = FlameAPI().getProject(*addonIds.begin());
+        std::tie(projTask, response) = FlameAPI::get().getProject(*addonIds.begin());
     } else {
-        std::tie(projTask, response) = FlameAPI().getProjects(addonIds);
+        std::tie(projTask, response) = FlameAPI::get().getProjects(addonIds);
     }
 
     connect(projTask.get(), &Task::succeeded, this, [this, response, addonIds, quickSearch] {

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -212,7 +212,7 @@ void FlameCreationTask::executeTask()
             fileIds.append(QString::number(file.fileId));
         }
 
-        auto [job, rawResponse] = FlameAPI().getFiles(fileIds);
+        auto [job, rawResponse] = FlameAPI::get().getFiles(fileIds);
 
         connect(job.get(), &Task::succeeded, this,
                 [this, rawResponse, fileIds, oldInstDir, oldFiles, oldMinecraftDir, createInst]() mutable {

--- a/launcher/modplatform/flame/FlameModIndex.cpp
+++ b/launcher/modplatform/flame/FlameModIndex.cpp
@@ -63,7 +63,7 @@ void FlameMod::loadURLs(ModPlatform::IndexedPack& pack, QJsonObject& obj)
 
 void FlameMod::loadBody(ModPlatform::IndexedPack& pack)
 {
-    pack.extraData.body = FlameAPI().getModDescription(pack.addonId.toInt());
+    pack.extraData.body = FlameAPI::get().getModDescription(pack.addonId.toInt());
 
     if (!pack.extraData.issuesUrl.isEmpty() || !pack.extraData.sourceUrl.isEmpty() || !pack.extraData.wikiUrl.isEmpty()) {
         pack.extraDataLoaded = true;
@@ -211,7 +211,7 @@ auto FlameMod::loadIndexedPackVersion(QJsonObject& obj, bool load_changelog) -> 
     }
 
     if (load_changelog) {
-        file.changelog = FlameAPI().getModFileChangelog(file.addonId.toInt(), file.fileId.toInt());
+        file.changelog = FlameAPI::get().getModFileChangelog(file.addonId.toInt(), file.fileId.toInt());
     }
 
     return file;

--- a/launcher/modplatform/flame/FlamePackExportTask.cpp
+++ b/launcher/modplatform/flame/FlamePackExportTask.cpp
@@ -173,7 +173,7 @@ void FlamePackExportTask::makeApiRequest()
         fingerprints.push_back(murmur.toUInt());
     }
 
-    auto [matchTask, response] = api.matchFingerprints(fingerprints);
+    auto [matchTask, response] = FlameAPI::get().matchFingerprints(fingerprints);
     task = matchTask;
 
     connect(task.get(), &Task::succeeded, this, [this, response] {
@@ -252,9 +252,9 @@ void FlamePackExportTask::getProjectsInfo()
         buildZip();
         return;
     } else if (addonIds.size() == 1) {
-        std::tie(projTask, response) = api.getProject(*addonIds.begin());
+        std::tie(projTask, response) = FlameAPI::get().getProject(*addonIds.begin());
     } else {
-        std::tie(projTask, response) = api.getProjects(addonIds);
+        std::tie(projTask, response) = FlameAPI::get().getProjects(addonIds);
     }
 
     connect(projTask.get(), &Task::succeeded, this, [this, response, addonIds] {

--- a/launcher/modplatform/flame/FlamePackExportTask.h
+++ b/launcher/modplatform/flame/FlamePackExportTask.h
@@ -70,8 +70,6 @@ class FlamePackExportTask : public Task {
     FlamePackExportOptions m_options;
     QDir m_gameRoot;
 
-    FlameAPI api;
-
     QFileInfoList m_files;
     QMap<QString, HashInfo> pendingHashes{};
     QMap<QString, ResolvedFile> resolvedFiles{};

--- a/launcher/modplatform/modrinth/ModrinthAPI.cpp
+++ b/launcher/modplatform/modrinth/ModrinthAPI.cpp
@@ -123,12 +123,13 @@ QList<ResourceAPI::SortingMethod> ModrinthAPI::getSortingMethods() const
              { .index = 5, .name = "updated", .readable_name = QObject::tr("Sort by Last Updated") } };
 }
 
-std::pair<Task::Ptr, QByteArray*> ModrinthAPI::getModCategories()
+std::pair<Task::Ptr, QByteArray*> ModrinthAPI::getModCategories() const
 {
     auto netJob = makeShared<NetJob>(QString("Modrinth::GetCategories"), APPLICATION->network());
     auto [action, response] = Net::ApiDownload::makeByteArray(QUrl(BuildConfig.MODRINTH_PROD_URL + "/tag/category"));
     netJob->addNetAction(action);
-    QObject::connect(netJob.get(), &Task::failed, netJob.get(), [](const QString& msg) { qDebug() << "Modrinth failed to get categories:" << msg; });
+    QObject::connect(netJob.get(), &Task::failed, netJob.get(),
+                     [](const QString& msg) { qDebug() << "Modrinth failed to get categories:" << msg; });
 
     return { netJob, response };
 }
@@ -164,7 +165,7 @@ QList<ModPlatform::Category> ModrinthAPI::loadCategories(const QByteArray& respo
     return categories;
 }
 
-QList<ModPlatform::Category> ModrinthAPI::loadModCategories(const QByteArray& response)
+QList<ModPlatform::Category> ModrinthAPI::loadModCategories(const QByteArray& response) const
 {
     return loadCategories(response, "mod");
-};
+}

--- a/launcher/modplatform/modrinth/ModrinthAPI.h
+++ b/launcher/modplatform/modrinth/ModrinthAPI.h
@@ -12,8 +12,14 @@
 #include <QDebug>
 #include <utility>
 
-class ModrinthAPI : public ResourceAPI {
+class ModrinthAPI final : public ResourceAPI {
    public:
+    static const ModrinthAPI& get()
+    {
+        static const ModrinthAPI s_instance;
+        return s_instance;
+    }
+
     std::pair<Task::Ptr, QByteArray*> currentVersion(const QString& hash, const QString& hash_format) const;
 
     std::pair<Task::Ptr, QByteArray*> currentVersions(const QStringList& hashes, QString hash_format) const;
@@ -102,6 +108,10 @@ class ModrinthAPI : public ResourceAPI {
     }
 
    private:
+    // NOTE: prevent creation and deletion of type - get should be used instead
+    ModrinthAPI() = default;
+    ~ModrinthAPI() = default;
+
     static QString resourceTypeParameter(ModPlatform::ResourceType type)
     {
         switch (type) {

--- a/launcher/modplatform/modrinth/ModrinthAPI.h
+++ b/launcher/modplatform/modrinth/ModrinthAPI.h
@@ -30,9 +30,9 @@ class ModrinthAPI : public ResourceAPI {
 
     std::pair<Task::Ptr, QByteArray*> getProjects(QStringList addonIds) const override;
 
-    std::pair<Task::Ptr, QByteArray*> getModCategories() override;
+    std::pair<Task::Ptr, QByteArray*> getModCategories() const override;
     static QList<ModPlatform::Category> loadCategories(const QByteArray& response, const QString& projectType);
-    QList<ModPlatform::Category> loadModCategories(const QByteArray& response) override;
+    QList<ModPlatform::Category> loadModCategories(const QByteArray& response) const override;
 
    public:
     auto getSortingMethods() const -> QList<ResourceAPI::SortingMethod> override;

--- a/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
+++ b/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
@@ -13,8 +13,6 @@
 
 #include "tasks/ConcurrentTask.h"
 
-static const ModrinthAPI g_api;
-
 ModrinthCheckUpdate::ModrinthCheckUpdate(QList<Resource*>& resources,
                                          std::vector<Version>& mcVersions,
                                          QList<ModPlatform::ModLoaderType> loadersList,
@@ -106,7 +104,7 @@ void ModrinthCheckUpdate::getUpdateModsForLoader(std::optional<ModPlatform::ModL
         return;
     }
 
-    auto [job, response] = g_api.latestVersions(hashes, m_hashType, m_gameVersions, loader);
+    auto [job, response] = ModrinthAPI::get().latestVersions(hashes, m_hashType, m_gameVersions, loader);
 
     connect(job.get(), &Task::succeeded, this, [this, response, loader] { checkVersionsResponse(response, loader); });
 

--- a/launcher/modplatform/modrinth/ModrinthPackExportTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackExportTask.cpp
@@ -154,7 +154,7 @@ void ModrinthPackExportTask::makeApiRequest()
         buildZip();
     } else {
         setStatus(tr("Finding versions for hashes..."));
-        auto [versionsTask, response] = api.currentVersions(pendingHashes.values(), "sha512");
+        auto [versionsTask, response] = ModrinthAPI::get().currentVersions(pendingHashes.values(), "sha512");
         task = versionsTask;
         connect(task.get(), &Task::succeeded, this, [this, response]() { parseApiResponse(response); });
         connect(task.get(), &Task::failed, this, &ModrinthPackExportTask::emitFailed);

--- a/launcher/modplatform/modrinth/ModrinthPackExportTask.h
+++ b/launcher/modplatform/modrinth/ModrinthPackExportTask.h
@@ -60,7 +60,6 @@ class ModrinthPackExportTask : public Task {
     const QString output;
     const MMCZip::FilterFileFunction filter;
 
-    ModrinthAPI api;
     QFileInfoList files;
     QMap<QString, QString> pendingHashes;
     QMap<QString, ResolvedFile> resolvedFiles;

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -977,8 +977,7 @@ void MainWindow::processURLs(QList<QUrl> urls)
                 extra_info.insert("pack_id", addonId);
                 extra_info.insert("pack_version_id", fileId);
 
-                auto api = FlameAPI();
-                auto [job, array] = api.getFile(addonId, fileId);
+                auto [job, array] = FlameAPI::get().getFile(addonId, fileId);
 
                 connect(job.get(), &Task::failed, this,
                         [this](QString reason) { CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show(); });

--- a/launcher/ui/dialogs/ResourceUpdateDialog.cpp
+++ b/launcher/ui/dialogs/ResourceUpdateDialog.cpp
@@ -231,14 +231,13 @@ void ResourceUpdateDialog::checkCandidates()
                 QMetaObject::invokeMethod(this, "reject", Qt::QueuedConnection);
                 return;
             }
-            static FlameAPI s_api;
 
             auto dependencyExtraInfo = depTask->getExtraInfo();
 
             for (const auto& dep : depTask->getDependecies()) {
                 auto changelog = dep->version.changelog;
                 if (dep->pack->provider == ModPlatform::ResourceProvider::FLAME) {
-                    changelog = s_api.getModFileChangelog(dep->version.addonId.toInt(), dep->version.fileId.toInt());
+                    changelog = FlameAPI::get().getModFileChangelog(dep->version.addonId.toInt(), dep->version.fileId.toInt());
                 }
 
                 auto [maybe_installed, required_by_names, required_by_ids] = dependencyExtraInfo.value(dep->version.addonId.toString());

--- a/launcher/ui/pages/instance/ManagedPackPage.cpp
+++ b/launcher/ui/pages/instance/ManagedPackPage.cpp
@@ -240,12 +240,12 @@ void ModrinthManagedPackPage::parseManagedPack()
     };
     callbacks.on_fail = [this](const QString& /*reason*/, int) { setFailState(); };
     callbacks.on_abort = [this]() { setFailState(); };
-    m_fetchJob = m_api.getProjectVersions({ .pack = std::make_shared<ModPlatform::IndexedPack>(m_pack),
-                                            .mcVersions = {},
-                                            .loaders = {},
-                                            .resourceType = ModPlatform::ResourceType::Modpack,
-                                            .includeChangelog = true },
-                                          std::move(callbacks));
+    m_fetchJob = ModrinthAPI::get().getProjectVersions({ .pack = std::make_shared<ModPlatform::IndexedPack>(m_pack),
+                                                         .mcVersions = {},
+                                                         .loaders = {},
+                                                         .resourceType = ModPlatform::ResourceType::Modpack,
+                                                         .includeChangelog = true },
+                                                       std::move(callbacks));
 
     ui->changelogTextBrowser->setText(tr("Fetching changelogs..."));
 
@@ -395,12 +395,12 @@ void FlameManagedPackPage::parseManagedPack()
     };
     callbacks.on_fail = [this](const QString& /*reason*/, int) { setFailState(); };
     callbacks.on_abort = [this]() { setFailState(); };
-    m_fetchJob = m_api.getProjectVersions({ .pack = std::make_shared<ModPlatform::IndexedPack>(m_pack),
-                                            .mcVersions = {},
-                                            .loaders = {},
-                                            .resourceType = ModPlatform::ResourceType::Modpack,
-                                            .includeChangelog = true },
-                                          std::move(callbacks));
+    m_fetchJob = FlameAPI::get().getProjectVersions({ .pack = std::make_shared<ModPlatform::IndexedPack>(m_pack),
+                                                      .mcVersions = {},
+                                                      .loaders = {},
+                                                      .resourceType = ModPlatform::ResourceType::Modpack,
+                                                      .includeChangelog = true },
+                                                    std::move(callbacks));
 
     m_fetchJob->start();
 }
@@ -421,7 +421,7 @@ void FlameManagedPackPage::suggestVersion()
     auto version = m_pack.versions.at(index);
 
     ui->changelogTextBrowser->setHtml(
-        StringUtils::htmlListPatch(m_api.getModFileChangelog(m_inst->getManagedPackID().toInt(), version.fileId.toInt())));
+        StringUtils::htmlListPatch(FlameAPI::get().getModFileChangelog(m_inst->getManagedPackID().toInt(), version.fileId.toInt())));
 
     ManagedPackPage::suggestVersion();
 }

--- a/launcher/ui/pages/instance/ManagedPackPage.h
+++ b/launcher/ui/pages/instance/ManagedPackPage.h
@@ -132,7 +132,6 @@ class ModrinthManagedPackPage final : public ManagedPackPage {
     Task::Ptr m_fetchJob = nullptr;
 
     ModPlatform::IndexedPack m_pack;
-    ModrinthAPI m_api;
 };
 
 class FlameManagedPackPage final : public ManagedPackPage {
@@ -156,5 +155,4 @@ class FlameManagedPackPage final : public ManagedPackPage {
     Task::Ptr m_fetchJob = nullptr;
 
     ModPlatform::IndexedPack m_pack;
-    FlameAPI m_api;
 };

--- a/launcher/ui/pages/modplatform/DataPackModel.cpp
+++ b/launcher/ui/pages/modplatform/DataPackModel.cpp
@@ -9,7 +9,7 @@
 
 namespace ResourceDownload {
 
-DataPackResourceModel::DataPackResourceModel(BaseInstance const& base_inst, ResourceAPI* api, QString debugName, QString metaEntryBase)
+DataPackResourceModel::DataPackResourceModel(BaseInstance const& base_inst, const ResourceAPI* api, QString debugName, QString metaEntryBase)
     : ResourceModel(api), m_base_instance(base_inst), m_debugName(debugName + " (Model)"), m_metaEntryBase(metaEntryBase)
 {}
 

--- a/launcher/ui/pages/modplatform/DataPackModel.h
+++ b/launcher/ui/pages/modplatform/DataPackModel.h
@@ -21,7 +21,7 @@ class DataPackResourceModel : public ResourceModel {
     Q_OBJECT
 
    public:
-    DataPackResourceModel(BaseInstance const&, ResourceAPI*, QString, QString);
+    DataPackResourceModel(BaseInstance const&, const ResourceAPI*, QString, QString);
 
     /* Ask the API for more information */
     void searchWithTerm(const QString& term, unsigned int sort);

--- a/launcher/ui/pages/modplatform/DataPackPage.cpp
+++ b/launcher/ui/pages/modplatform/DataPackPage.cpp
@@ -40,7 +40,7 @@ namespace ResourceDownload {
 DataPackResourcePage::DataPackResourcePage(ResourceDownloadDialog* dialog,
                                            BaseInstance& instance,
                                            ResourceProviderData provider,
-                                           ResourceAPI* api)
+                                           const ResourceAPI* api)
     : ResourcePage(dialog, instance, prepareDataPackDescriptor(), std::move(provider))
 {
     m_model = new DataPackResourceModel(instance, api, debugName(), metaEntryBase());

--- a/launcher/ui/pages/modplatform/DataPackPage.h
+++ b/launcher/ui/pages/modplatform/DataPackPage.h
@@ -14,7 +14,7 @@ class DataPackResourcePage : public ResourcePage {
     Q_OBJECT
 
    public:
-    DataPackResourcePage(ResourceDownloadDialog* dialog, BaseInstance& instance, ResourceProviderData provider, ResourceAPI* api);
+    DataPackResourcePage(ResourceDownloadDialog* dialog, BaseInstance& instance, ResourceProviderData provider, const ResourceAPI* api);
 
    protected slots:
     void triggerSearch() override;

--- a/launcher/ui/pages/modplatform/ImportPage.cpp
+++ b/launcher/ui/pages/modplatform/ImportPage.cpp
@@ -132,8 +132,7 @@ void ImportPage::updateState()
             auto addonId = query.allQueryItemValues("addonId")[0];
             auto fileId = query.allQueryItemValues("fileId")[0];
 
-            auto api = FlameAPI();
-            auto [job, array] = api.getFile(addonId, fileId);
+            auto [job, array] = FlameAPI::get().getFile(addonId, fileId);
 
             connect(job.get(), &NetJob::failed, this,
                     [this](QString reason) { CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show(); });

--- a/launcher/ui/pages/modplatform/ModModel.cpp
+++ b/launcher/ui/pages/modplatform/ModModel.cpp
@@ -21,7 +21,7 @@
 
 namespace ResourceDownload {
 
-ModModel::ModModel(BaseInstance& base_inst, ResourceAPI* api, const QString& debugName, QString metaEntryBase)
+ModModel::ModModel(BaseInstance& base_inst, const ResourceAPI* api, const QString& debugName, QString metaEntryBase)
     : ResourceModel(api), m_base_instance(base_inst), m_debugName(debugName + " (Model)"), m_metaEntryBase(std::move(metaEntryBase))
 {}
 

--- a/launcher/ui/pages/modplatform/ModModel.h
+++ b/launcher/ui/pages/modplatform/ModModel.h
@@ -28,7 +28,7 @@ class ModModel : public ResourceModel {
     Q_OBJECT
 
    public:
-    ModModel(BaseInstance&, ResourceAPI* api, const QString& debugName, QString metaEntryBase);
+    ModModel(BaseInstance&, const ResourceAPI* api, const QString& debugName, QString metaEntryBase);
 
     /* Ask the API for more information */
     void searchWithTerm(const QString& term, unsigned int sort, bool filter_changed);

--- a/launcher/ui/pages/modplatform/ModPage.cpp
+++ b/launcher/ui/pages/modplatform/ModPage.cpp
@@ -72,7 +72,7 @@ namespace ResourceDownload {
 ModPage::ModPage(ResourceDownloadDialog* dialog,
                  BaseInstance& instance,
                  ResourceProviderData p,
-                 ResourceAPI* api,
+                 const ResourceAPI* api,
                  ModFilterWidget* filterWidget)
     : ResourcePage(dialog, instance, prepareModDescriptor(), std::move(p)), m_api(api)
 {

--- a/launcher/ui/pages/modplatform/ModPage.h
+++ b/launcher/ui/pages/modplatform/ModPage.h
@@ -24,7 +24,7 @@ class ModPage : public ResourcePage {
     ModPage(ResourceDownloadDialog* dialog,
             BaseInstance& instance,
             ResourceProviderData provider,
-            ResourceAPI* api,
+            const ResourceAPI* api,
             ModFilterWidget* filterWidget);
 
    protected:
@@ -39,7 +39,7 @@ class ModPage : public ResourcePage {
     std::unique_ptr<ModFilterWidget> m_filterWidget;
     std::shared_ptr<ModFilterWidget::Filter> m_filter;
     Task::Ptr m_categoriesTask;
-    ResourceAPI* m_api = nullptr;
+    const ResourceAPI* m_api = nullptr;
 };
 
 }  // namespace ResourceDownload

--- a/launcher/ui/pages/modplatform/ResourceModel.cpp
+++ b/launcher/ui/pages/modplatform/ResourceModel.cpp
@@ -30,7 +30,7 @@ namespace ResourceDownload {
 
 QHash<ResourceModel*, bool> ResourceModel::s_running_models;
 
-ResourceModel::ResourceModel(ResourceAPI* api) : m_api(api)
+ResourceModel::ResourceModel(const ResourceAPI* api) : m_api(api)
 {
     s_running_models.insert(this, true);
     if (APPLICATION_DYN) {

--- a/launcher/ui/pages/modplatform/ResourceModel.h
+++ b/launcher/ui/pages/modplatform/ResourceModel.h
@@ -33,7 +33,7 @@ class ResourceModel : public QAbstractListModel {
    public:
     using DownloadTaskPtr = shared_qobject_ptr<ResourceDownloadTask>;
 
-    ResourceModel(ResourceAPI* api);
+    ResourceModel(const ResourceAPI* api);
     ~ResourceModel() override;
 
     auto data(const QModelIndex& /*index*/, int role) const -> QVariant override;
@@ -118,7 +118,7 @@ class ResourceModel : public QAbstractListModel {
     QString m_search_term;
     unsigned int m_current_sort_index = 0;
 
-    std::unique_ptr<ResourceAPI> m_api;
+    const ResourceAPI* m_api;
 
     // Job for searching for new entries
     shared_qobject_ptr<Task> m_current_search_job;

--- a/launcher/ui/pages/modplatform/ResourcePackModel.cpp
+++ b/launcher/ui/pages/modplatform/ResourcePackModel.cpp
@@ -10,7 +10,7 @@
 namespace ResourceDownload {
 
 ResourcePackResourceModel::ResourcePackResourceModel(const BaseInstance& base_inst,
-                                                     ResourceAPI* api,
+                                                     const ResourceAPI* api,
                                                      const QString& debugName,
                                                      QString metaEntryBase)
     : ResourceModel(api), m_base_instance(base_inst), m_debugName(debugName + " (Model)"), m_metaEntryBase(std::move(metaEntryBase))

--- a/launcher/ui/pages/modplatform/ResourcePackModel.h
+++ b/launcher/ui/pages/modplatform/ResourcePackModel.h
@@ -18,7 +18,7 @@ class ResourcePackResourceModel : public ResourceModel {
     Q_OBJECT
 
    public:
-    ResourcePackResourceModel(const BaseInstance&, ResourceAPI*, const QString& debugName, QString metaEntryBase);
+    ResourcePackResourceModel(const BaseInstance&, const ResourceAPI*, const QString& debugName, QString metaEntryBase);
 
     /* Ask the API for more information */
     void searchWithTerm(const QString& term, unsigned int sort);

--- a/launcher/ui/pages/modplatform/ResourcePackPage.cpp
+++ b/launcher/ui/pages/modplatform/ResourcePackPage.cpp
@@ -39,7 +39,7 @@ namespace ResourceDownload {
 ResourcePackResourcePage::ResourcePackResourcePage(ResourceDownloadDialog* dialog,
                                                    BaseInstance& instance,
                                                    ResourceProviderData provider,
-                                                   ResourceAPI* api)
+                                                   const ResourceAPI* api)
     : ResourcePage(dialog, instance, prepareResourcePackDescriptor(), std::move(provider))
 {
     m_model = new ResourcePackResourceModel(instance, api, debugName(), metaEntryBase());

--- a/launcher/ui/pages/modplatform/ResourcePackPage.h
+++ b/launcher/ui/pages/modplatform/ResourcePackPage.h
@@ -14,7 +14,7 @@ class ResourcePackResourcePage : public ResourcePage {
     Q_OBJECT
 
    public:
-    ResourcePackResourcePage(ResourceDownloadDialog* dialog, BaseInstance& instance, ResourceProviderData provider, ResourceAPI* api);
+    ResourcePackResourcePage(ResourceDownloadDialog* dialog, BaseInstance& instance, ResourceProviderData provider, const ResourceAPI* api);
 
    protected slots:
     void triggerSearch() override;

--- a/launcher/ui/pages/modplatform/ShaderPackModel.cpp
+++ b/launcher/ui/pages/modplatform/ShaderPackModel.cpp
@@ -10,7 +10,7 @@
 namespace ResourceDownload {
 
 ShaderPackResourceModel::ShaderPackResourceModel(const BaseInstance& baseInst,
-                                                 ResourceAPI* api,
+                                                 const ResourceAPI* api,
                                                  const QString& debugName,
                                                  QString metaEntryBase)
     : ResourceModel(api), m_baseInstance(baseInst), m_debugName(debugName + " (Model)"), m_metaEntryBase(std::move(metaEntryBase))

--- a/launcher/ui/pages/modplatform/ShaderPackModel.h
+++ b/launcher/ui/pages/modplatform/ShaderPackModel.h
@@ -18,7 +18,7 @@ class ShaderPackResourceModel : public ResourceModel {
     Q_OBJECT
 
    public:
-    ShaderPackResourceModel(const BaseInstance&, ResourceAPI*, const QString& debugName, QString metaEntryBase);
+    ShaderPackResourceModel(const BaseInstance&, const ResourceAPI*, const QString& debugName, QString metaEntryBase);
 
     /* Ask the API for more information */
     void searchWithTerm(const QString& term, unsigned int sort);

--- a/launcher/ui/pages/modplatform/ShaderPackPage.cpp
+++ b/launcher/ui/pages/modplatform/ShaderPackPage.cpp
@@ -37,7 +37,7 @@ namespace ResourceDownload {
 ShaderPackResourcePage::ShaderPackResourcePage(ResourceDownloadDialog* dialog,
                                                BaseInstance& instance,
                                                ResourceProviderData provider,
-                                               ResourceAPI* api)
+                                               const ResourceAPI* api)
     : ResourcePage(dialog, instance, prepareShaderPackDescriptor(), std::move(provider))
 {
     m_model = new ShaderPackResourceModel(instance, api, debugName(), metaEntryBase());

--- a/launcher/ui/pages/modplatform/ShaderPackPage.h
+++ b/launcher/ui/pages/modplatform/ShaderPackPage.h
@@ -14,7 +14,7 @@ class ShaderPackResourcePage : public ResourcePage {
     Q_OBJECT
 
    public:
-    ShaderPackResourcePage(ResourceDownloadDialog* dialog, BaseInstance& instance, ResourceProviderData provider, ResourceAPI* api);
+    ShaderPackResourcePage(ResourceDownloadDialog* dialog, BaseInstance& instance, ResourceProviderData provider, const ResourceAPI* api);
 
    protected slots:
     void triggerSearch() override;

--- a/launcher/ui/pages/modplatform/TexturePackModel.cpp
+++ b/launcher/ui/pages/modplatform/TexturePackModel.cpp
@@ -15,7 +15,7 @@ static std::vector<Version> s_availableVersions = {};
 
 namespace ResourceDownload {
 TexturePackResourceModel::TexturePackResourceModel(const BaseInstance& inst,
-                                                   ResourceAPI* api,
+                                                   const ResourceAPI* api,
                                                    const QString& debugName,
                                                    QString metaEntryBase)
     : ResourcePackResourceModel(inst, api, debugName, std::move(metaEntryBase))

--- a/launcher/ui/pages/modplatform/TexturePackModel.h
+++ b/launcher/ui/pages/modplatform/TexturePackModel.h
@@ -13,7 +13,7 @@ class TexturePackResourceModel : public ResourcePackResourceModel {
     Q_OBJECT
 
    public:
-    TexturePackResourceModel(const BaseInstance& inst, ResourceAPI* api, const QString& debugName, QString metaEntryBase);
+    TexturePackResourceModel(const BaseInstance& inst, const ResourceAPI* api, const QString& debugName, QString metaEntryBase);
 
     inline ::Version maximumTexturePackVersion() const { return { "1.6" }; }
 

--- a/launcher/ui/pages/modplatform/TexturePackPage.cpp
+++ b/launcher/ui/pages/modplatform/TexturePackPage.cpp
@@ -38,7 +38,7 @@ namespace ResourceDownload {
 TexturePackResourcePage::TexturePackResourcePage(ResourceDownloadDialog* dialog,
                                                  BaseInstance& instance,
                                                  ResourceProviderData provider,
-                                                 ResourceAPI* api,
+                                                 const ResourceAPI* api,
                                                  TexturePackResourceModel* model)
     : ResourcePage(dialog, instance, prepareResourcePackDescriptor(), std::move(provider))
 {

--- a/launcher/ui/pages/modplatform/TexturePackPage.h
+++ b/launcher/ui/pages/modplatform/TexturePackPage.h
@@ -18,7 +18,7 @@ class TexturePackResourcePage : public ResourcePage {
     TexturePackResourcePage(ResourceDownloadDialog* dialog,
                             BaseInstance& instance,
                             ResourceProviderData provider,
-                            ResourceAPI* api,
+                            const ResourceAPI* api,
                             TexturePackResourceModel* model = nullptr);
 
    protected slots:

--- a/launcher/ui/pages/modplatform/flame/FlameModel.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameModel.cpp
@@ -164,8 +164,6 @@ void ListModel::fetchMore(const QModelIndex& parent)
 
 void ListModel::performPaginatedSearch()
 {
-    static const FlameAPI api;
-
     // activate search by id only for numerical values because all CurseForge ids are numerical
     static const QRegularExpression s_projectIdExpr("^\\#[0-9]+$");
     if (m_searchState != ResetRequested && s_projectIdExpr.match(m_currentSearchTerm).hasMatch()) {
@@ -186,7 +184,7 @@ void ListModel::performPaginatedSearch()
             };
             auto project = std::make_shared<ModPlatform::IndexedPack>();
             project->addonId = projectId;
-            if (auto job = api.getProjectInfo({ project }, std::move(callbacks), false); job) {
+            if (auto job = FlameAPI::get().getProjectInfo({ project }, std::move(callbacks), false); job) {
                 m_jobPtr = job;
                 m_jobPtr->start();
             }
@@ -205,9 +203,10 @@ void ListModel::performPaginatedSearch()
         searchRequestFailed("Aborted");
     };
 
-    auto netJob = api.searchProjects({ ModPlatform::ResourceType::Modpack, m_nextSearchOffset, m_currentSearchTerm, sort, m_filter->loaders,
-                                       m_filter->versions, ModPlatform::SideType::NoSide, m_filter->categoryIds, m_filter->openSource },
-                                     std::move(callbacks));
+    auto netJob = FlameAPI::get().searchProjects(
+        { ModPlatform::ResourceType::Modpack, m_nextSearchOffset, m_currentSearchTerm, sort, m_filter->loaders, m_filter->versions,
+          ModPlatform::SideType::NoSide, m_filter->categoryIds, m_filter->openSource },
+        std::move(callbacks));
 
     m_jobPtr = netJob;
     m_jobPtr->start();

--- a/launcher/ui/pages/modplatform/flame/FlamePage.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlamePage.cpp
@@ -203,7 +203,7 @@ void FlamePage::onSelectionChanged(QModelIndex curr, [[maybe_unused]] QModelInde
             CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->exec();
         };
 
-        auto netJob = FlameAPI().getProjectVersions({ m_current, {}, {}, ModPlatform::ResourceType::Modpack }, std::move(callbacks));
+        auto netJob = FlameAPI::get().getProjectVersions({ m_current, {}, {}, ModPlatform::ResourceType::Modpack }, std::move(callbacks));
 
         m_job = netJob;
         netJob->start();
@@ -305,7 +305,7 @@ void FlamePage::updateUi()
     }
 
     text += "<hr>";
-    text += FlameAPI().getModDescription(m_current->addonId.toInt()).toUtf8();
+    text += FlameAPI::get().getModDescription(m_current->addonId.toInt()).toUtf8();
 
     m_ui->packDescription->setHtml(StringUtils::htmlListPatch(text + m_current->description));
     m_ui->packDescription->flush();
@@ -336,7 +336,7 @@ void FlamePage::createFilterWidget()
     auto [task, response] = FlameAPI::getCategories(ModPlatform::ResourceType::Modpack);
     m_categoriesTask = task;
     connect(m_categoriesTask.get(), &Task::succeeded, this, [this, response]() {
-        auto categories = FlameAPI().loadModCategories(*response);
+        auto categories = FlameAPI::get().loadModCategories(*response);
         m_filterWidget->setCategories(categories);
     });
     m_categoriesTask->start();

--- a/launcher/ui/pages/modplatform/flame/FlameResourceModels.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameResourceModels.cpp
@@ -18,7 +18,7 @@ static bool isOptedOut(const ModPlatform::IndexedVersion& ver)
 }
 
 FlameTexturePackModel::FlameTexturePackModel(const BaseInstance& base)
-    : TexturePackResourceModel(base, new FlameAPI, Flame::debugName(), Flame::metaEntryBase())
+    : TexturePackResourceModel(base, &FlameAPI::get(), Flame::debugName(), Flame::metaEntryBase())
 {}
 
 ResourceAPI::SearchArgs FlameTexturePackModel::createSearchArguments()

--- a/launcher/ui/pages/modplatform/flame/FlameResourcePages.cpp
+++ b/launcher/ui/pages/modplatform/flame/FlameResourcePages.cpp
@@ -59,27 +59,27 @@ static ResourceProviderData prepareFlame()
 
 ShaderPackResourcePage* Flame::createShaderPackResourcePage(ResourceDownloadDialog* dialog, BaseInstance& instance)
 {
-    return new ShaderPackResourcePage(dialog, instance, prepareFlame(), new FlameAPI());
+    return new ShaderPackResourcePage(dialog, instance, prepareFlame(), &FlameAPI::get());
 }
 
 DataPackResourcePage* Flame::createDataPackResourcePage(ResourceDownloadDialog* dialog, BaseInstance& instance)
 {
-    return new DataPackResourcePage(dialog, instance, prepareFlame(), new FlameAPI());
+    return new DataPackResourcePage(dialog, instance, prepareFlame(), &FlameAPI::get());
 }
 
 ResourcePackResourcePage* Flame::createResourcePackResourcePage(ResourceDownloadDialog* dialog, BaseInstance& instance)
 {
-    return new ResourcePackResourcePage(dialog, instance, prepareFlame(), new FlameAPI());
+    return new ResourcePackResourcePage(dialog, instance, prepareFlame(), &FlameAPI::get());
 }
 
 TexturePackResourcePage* Flame::createTexturePackResourcePage(ResourceDownloadDialog* dialog, BaseInstance& instance)
 {
-    return new TexturePackResourcePage(dialog, instance, prepareFlame(), new FlameAPI(), new FlameTexturePackModel(instance));
+    return new TexturePackResourcePage(dialog, instance, prepareFlame(), &FlameAPI::get(), new FlameTexturePackModel(instance));
 }
 
 ModPage* Flame::createModPage(ResourceDownloadDialog* dialog, BaseInstance& instance)
 {
-    return new ModPage(dialog, instance, prepareFlame(), new FlameAPI(),
+    return new ModPage(dialog, instance, prepareFlame(), &FlameAPI::get(),
                        ModFilterWidget::create(&static_cast<MinecraftInstance&>(instance), false));
 }
 }  // namespace ResourceDownload

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
@@ -133,7 +133,6 @@ void ModpackListModel::performPaginatedSearch()
 {
     if (hasActiveSearchJob())
         return;
-    static const ModrinthAPI api;
 
     // Modrinth ids are not limited to numbers and can be any length
     if (m_searchState != ResetRequested && m_currentSearchTerm.startsWith("#")) {
@@ -154,7 +153,7 @@ void ModpackListModel::performPaginatedSearch()
             };
             auto project = std::make_shared<ModPlatform::IndexedPack>();
             project->addonId = projectId;
-            if (auto job = api.getProjectInfo({ project }, std::move(callbacks), false); job) {
+            if (auto job = ModrinthAPI::get().getProjectInfo({ project }, std::move(callbacks), false); job) {
                 m_jobPtr = job;
                 m_jobPtr->start();
             }
@@ -173,8 +172,8 @@ void ModpackListModel::performPaginatedSearch()
         searchRequestFailed("Aborted", 0);
     };
 
-    auto netJob = api.searchProjects({ ModPlatform::ResourceType::Modpack, m_nextSearchOffset, m_currentSearchTerm, sort, m_filter->loaders,
-                                       m_filter->versions, ModPlatform::SideType::NoSide, m_filter->categoryIds, m_filter->openSource },
+    auto netJob = ModrinthAPI::get().searchProjects({ .type=ModPlatform::ResourceType::Modpack, .offset=m_nextSearchOffset, .search=m_currentSearchTerm, .sorting=sort, .loaders=m_filter->loaders,
+                                       .versions=m_filter->versions, .side=ModPlatform::SideType::NoSide, .categoryIds=m_filter->categoryIds, .openSource=m_filter->openSource },
                                      std::move(callbacks));
 
     m_jobPtr = netJob;

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.cpp
@@ -167,7 +167,7 @@ void ModrinthPage::onSelectionChanged(QModelIndex curr, [[maybe_unused]] QModelI
             suggestCurrent();
             updateUI();
         };
-        if (auto netJob = m_api.getProjectInfo({ m_current }, std::move(callbacks)); netJob) {
+        if (auto netJob = ModrinthAPI::get().getProjectInfo({ m_current }, std::move(callbacks)); netJob) {
             m_job = netJob;
             m_job->start();
         }
@@ -222,7 +222,7 @@ void ModrinthPage::onSelectionChanged(QModelIndex curr, [[maybe_unused]] QModelI
             CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->exec();
         };
 
-        auto netJob = m_api.getProjectVersions({ m_current, {}, {}, ModPlatform::ResourceType::Modpack }, std::move(callbacks));
+        auto netJob = ModrinthAPI::get().getProjectVersions({ m_current, {}, {}, ModPlatform::ResourceType::Modpack }, std::move(callbacks));
 
         m_job2 = netJob;
         m_job2->start();
@@ -381,7 +381,7 @@ void ModrinthPage::createFilterWidget()
     connect(m_ui->filterButton, &QPushButton::clicked, this, [this] { m_filterWidget->setHidden(!m_filterWidget->isHidden()); });
 
     connect(m_filterWidget.get(), &ModFilterWidget::filterChanged, this, &ModrinthPage::triggerSearch);
-    auto [categoriesTask, response] = ModrinthAPI().getModCategories();
+    auto [categoriesTask, response] = ModrinthAPI::get().getModCategories();
     m_categoriesTask = categoriesTask;
     connect(m_categoriesTask.get(), &Task::succeeded, this, [this, response]() {
         auto categories = ModrinthAPI::loadCategories(*response, "modpack");

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthPage.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthPage.h
@@ -106,7 +106,6 @@ class ModrinthPage : public QWidget, public ModpackProviderBasePage {
     std::unique_ptr<ModFilterWidget> m_filterWidget;
     Task::Ptr m_categoriesTask;
 
-    ModrinthAPI m_api;
     Task::Ptr m_job;
     Task::Ptr m_job2;
 };

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthResourcePages.cpp
@@ -57,27 +57,27 @@ static ResourceProviderData prepareModrinth()
 
 ShaderPackResourcePage* Modrinth::createShaderPackResourcePage(ResourceDownloadDialog* dialog, BaseInstance& instance)
 {
-    return new ShaderPackResourcePage(dialog, instance, prepareModrinth(), new ModrinthAPI());
+    return new ShaderPackResourcePage(dialog, instance, prepareModrinth(), &ModrinthAPI::get());
 }
 
 DataPackResourcePage* Modrinth::createDataPackResourcePage(ResourceDownloadDialog* dialog, BaseInstance& instance)
 {
-    return new DataPackResourcePage(dialog, instance, prepareModrinth(), new ModrinthAPI());
+    return new DataPackResourcePage(dialog, instance, prepareModrinth(), &ModrinthAPI::get());
 }
 
 ResourcePackResourcePage* Modrinth::createResourcePackResourcePage(ResourceDownloadDialog* dialog, BaseInstance& instance)
 {
-    return new ResourcePackResourcePage(dialog, instance, prepareModrinth(), new ModrinthAPI());
+    return new ResourcePackResourcePage(dialog, instance, prepareModrinth(), &ModrinthAPI::get());
 }
 
 TexturePackResourcePage* Modrinth::createTexturePackResourcePage(ResourceDownloadDialog* dialog, BaseInstance& instance)
 {
-    return new TexturePackResourcePage(dialog, instance, prepareModrinth(), new ModrinthAPI());
+    return new TexturePackResourcePage(dialog, instance, prepareModrinth(), &ModrinthAPI::get());
 }
 
 ModPage* Modrinth::createModPage(ResourceDownloadDialog* dialog, BaseInstance& instance)
 {
-    return new ModPage(dialog, instance, prepareModrinth(), new ModrinthAPI(),
+    return new ModPage(dialog, instance, prepareModrinth(), &ModrinthAPI::get(),
                        ModFilterWidget::create(&static_cast<MinecraftInstance&>(instance), true));
 }
 }  // namespace ResourceDownload


### PR DESCRIPTION
No need to worry about managing instances of ModrinthAPI and FlameAPI any more (some of the methods have lambdas that capture `this`, so you can't just temporarily construct an instance everywhere)
Also prevent constructing or deleting them manually to enforce this change

Fixes #5898