### PR TITLE
Use AppContainers on Windows for sandboxing Minecraft

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -157,6 +157,7 @@
 #endif
 #include <windows.h>
 #include <QStyleHints>
+#include "windows/WindowsAppContainer.h"
 #endif
 
 #include "console/Console.h"
@@ -321,6 +322,12 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
           { "show-window", "Show the main launcher window (useful in combination with --launch)" },
           { { "I", "import" }, "Import instance or resource from specified local path or URL", "url" },
           { "show", "Opens the window for the specified instance (by instance ID)", "show" } });
+
+#ifdef Q_OS_WIN32
+    // Not meant for users
+    parser.addOption({"internal-denied-traverse-path", {}, "path"});
+#endif
+
     // Has to be positional for some OS to handle that properly
     parser.addPositionalArgument("URL", "Import the resource(s) at the given URL(s) (same as -I / --import)", "[URL...]");
 
@@ -328,6 +335,25 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
     parser.addVersionOption();
 
     parser.process(arguments());
+
+#ifdef Q_OS_WIN32
+    const auto traversePaths = parser.values("internal-denied-traverse-path");
+    if (!traversePaths.isEmpty()) {
+        auto containerResult = WindowsAppContainer::create();
+        if (!containerResult) {
+            qFatal() << "Could not create AppContainer:" << Qt::hex << containerResult.error();
+        }
+        const auto container = std::move(containerResult.value());
+
+        for (const QString& path : traversePaths) {
+            if (const auto result = container->grantFSAccess(path, WindowsAppContainer::AccessMode::Traverse); !result) {
+                qFatal() << "Could not grant traverse access to path:" << path << "-" << result.error().message();
+            }
+        }
+
+        ::exit(0);
+    }
+#endif
 
     m_instanceIdToLaunch = parser.value("launch");
     m_serverToJoin = parser.value("server");

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -1198,6 +1198,8 @@ if(WIN32)
     set(LAUNCHER_SOURCES
         console/WindowsConsole.h
         console/WindowsConsole.cpp
+        windows/WindowsAppContainer.h
+        windows/WindowsAppContainer.cpp
         ${LAUNCHER_SOURCES}
     )
 endif()
@@ -1272,6 +1274,12 @@ if(TARGET PkgConfig::libarchive)
     target_link_libraries(Launcher_logic PkgConfig::libarchive)
 else()
     target_link_libraries(Launcher_logic LibArchive::LibArchive)
+endif()
+
+if (CMAKE_SYSTEM_NAME STREQUAL "Windows")
+    target_link_libraries(Launcher_logic
+        windowsapp # Required for DeriveCapabilitySidsFromName
+    )
 endif()
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")

--- a/launcher/ExpectedHelpers.h
+++ b/launcher/ExpectedHelpers.h
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2026 Octol1ttle <l1ttleofficial@outlook.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#ifdef Q_OS_WIN32
+#define UNEXPECTED_WIN32_ERROR_LAST (std::unexpected{ std::error_code{ static_cast<int>(GetLastError()), std::system_category() } })
+#define UNEXPECTED_WIN32_ERROR(x) (std::unexpected{ std::error_code{ static_cast<int>(x), std::system_category() } })
+#endif
+
+#define TRY(expected) if (const auto _result = expected; !_result) { return std::unexpected{ _result.error() }; }

--- a/launcher/minecraft/launch/LauncherPartLaunch.cpp
+++ b/launcher/minecraft/launch/LauncherPartLaunch.cpp
@@ -40,11 +40,14 @@
 
 #include "Application.h"
 #include "Commandline.h"
+#include "ExpectedHelpers.h"
 #include "FileSystem.h"
 #include "launch/LaunchTask.h"
 #include "minecraft/MinecraftInstance.h"
 
-#ifdef Q_OS_LINUX
+#ifdef Q_OS_WIN32
+#include "windows/WindowsAppContainer.h"
+#elifdef Q_OS_LINUX
 #include "gamemode_client.h"
 #endif
 
@@ -68,6 +71,8 @@ LauncherPartLaunch::LauncherPartLaunch(LaunchTask* parent)
     connect(&m_process, &LoggedProcess::log, this, &LauncherPartLaunch::logLines);
     connect(&m_process, &LoggedProcess::stateChanged, this, &LauncherPartLaunch::on_state);
 }
+
+LauncherPartLaunch::~LauncherPartLaunch() = default;
 
 void LauncherPartLaunch::executeTask()
 {
@@ -105,10 +110,23 @@ void LauncherPartLaunch::executeTask()
     m_process.setDetachable(true);
 
     auto classPath = instance->getClassPath();
+    QStringList extraSandboxPaths;
     classPath.prepend(jarPath);
+    extraSandboxPaths.prepend(jarPath);
 
-    if (!legacyJarPath.isEmpty())
+    if (!legacyJarPath.isEmpty()) {
         classPath.prepend(legacyJarPath);
+        extraSandboxPaths.prepend(legacyJarPath);
+    }
+
+    if (const auto result = setupSandbox(javaPath, extraSandboxPaths); !result) {
+        constexpr auto reason = QT_TR_NOOP("Unable to set up sandbox: %1");
+        const auto error = QString::fromStdString(result.error().message());
+
+        emit logLine(tr(reason).arg(error), MessageLevel::Fatal);
+        emitFailed(QString(reason).arg(error));
+        return;
+    }
 
     auto natPath = instance->getNativePath();
 #ifdef Q_OS_WIN
@@ -207,6 +225,46 @@ void LauncherPartLaunch::on_state(LoggedProcess::State state)
         default:
             break;
     }
+}
+
+std::expected<void, std::error_code> LauncherPartLaunch::setupSandbox(const QString& javaPath, const QStringList& extraPaths)
+{
+#ifdef Q_OS_WIN32
+    auto appContainerResult = WindowsAppContainer::create();
+    if (!appContainerResult) {
+        return UNEXPECTED_WIN32_ERROR(appContainerResult.error());
+    }
+    m_appContainer = std::move(appContainerResult.value());
+
+    auto splitPath = javaPath.split('/'); // java/bin/javaw.exe
+    splitPath.removeLast(); // java/bin
+    splitPath.removeLast(); // java
+    const auto javaDir = splitPath.join('/');
+    TRY(m_appContainer->grantFSAccess(javaDir, WindowsAppContainer::AccessMode::Read));
+
+    for (const QString& path : extraPaths) {
+        TRY(m_appContainer->grantFSAccess(path, WindowsAppContainer::AccessMode::Read));
+    }
+
+    TRY(m_appContainer->grantFSAccess(m_parent->instance()->librariesPath().path(), WindowsAppContainer::AccessMode::ReadWrite));  // Write access needed for ForgeWrapper
+
+    if (auto nativePath = m_parent->instance()->getNativePath(); QFileInfo::exists(nativePath)) {
+        TRY(m_appContainer->grantFSAccess(nativePath, WindowsAppContainer::AccessMode::Read));
+    }
+
+    auto assetsPath = QDir::current().absoluteFilePath("assets");
+    auto skinsPath = QDir::current().absoluteFilePath("assets/skins");
+    FS::ensureFolderPathExists(assetsPath);
+    FS::ensureFolderPathExists(skinsPath);
+    TRY(m_appContainer->grantFSAccess(assetsPath, WindowsAppContainer::AccessMode::Read));
+    TRY(m_appContainer->grantFSAccess(skinsPath, WindowsAppContainer::AccessMode::ReadWrite));
+
+    TRY(m_appContainer->grantFSAccess(m_process.workingDirectory(), WindowsAppContainer::AccessMode::ReadWrite));
+
+    return m_appContainer->finalizeSetup(&m_process);
+#else
+    return {};
+#endif
 }
 
 void LauncherPartLaunch::setWorkingDirectory(const QString& wd)

--- a/launcher/minecraft/launch/LauncherPartLaunch.h
+++ b/launcher/minecraft/launch/LauncherPartLaunch.h
@@ -21,11 +21,17 @@
 
 #include "MinecraftTarget.h"
 
+#include <expected>
+
+#ifdef Q_OS_WIN32
+class WindowsAppContainer;
+#endif
+
 class LauncherPartLaunch : public LaunchStep {
     Q_OBJECT
    public:
     explicit LauncherPartLaunch(LaunchTask* parent);
-    virtual ~LauncherPartLaunch() = default;
+    virtual ~LauncherPartLaunch();
 
     virtual void executeTask();
     virtual bool abort();
@@ -40,6 +46,9 @@ class LauncherPartLaunch : public LaunchStep {
     void on_state(LoggedProcess::State state);
 
    private:
+    std::expected<void, std::error_code> setupSandbox(const QString& javaPath, const QStringList& extraPaths);
+
+   private:
     LoggedProcess m_process;
     QString m_command;
     AuthSessionPtr m_session;
@@ -47,4 +56,8 @@ class LauncherPartLaunch : public LaunchStep {
     MinecraftTarget::Ptr m_targetToJoin;
 
     bool mayProceed = false;
+
+#ifdef Q_OS_WIN32
+    std::unique_ptr<WindowsAppContainer> m_appContainer;
+#endif
 };

--- a/launcher/windows/WindowsAppContainer.cpp
+++ b/launcher/windows/WindowsAppContainer.cpp
@@ -1,0 +1,489 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2026 Octol1ttle <l1ttleofficial@outlook.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "WindowsAppContainer.h"
+
+#include <aclapi.h>
+#include <securitybaseapi.h>
+#include <shellapi.h>
+#include <userenv.h>
+
+#include "ExpectedHelpers.h"
+
+namespace {
+template <typename F>
+void runLater(F f)
+{
+    QMetaObject::invokeMethod(qApp, [f] { f(); }, Qt::QueuedConnection);
+}
+}  // namespace
+
+constexpr auto g_prismCapabilityName = "prismlauncher.grantWinstaWriteAttributesCapability_NydcoL6P93pwtIlf";
+
+WindowsAppContainer::WindowsAppContainer(const PSID appContainerSid) : m_appContainerSid{ appContainerSid, &FreeSid }
+{
+    Q_ASSERT(IsValidSid(m_appContainerSid.get()));
+
+    // Reference:
+    // https://github.com/Moulberry/PandoraLauncher/blob/4a3e4cd0296fbdbcdef564abbc2890db1176c818/crates/command/src/windows/appcontainer.rs#L41
+
+    addCapability("internetClientServer");
+    addCapability("privateNetworkClientServer");
+    addCapability(g_prismCapabilityName);
+}
+
+std::expected<void, std::error_code> WindowsAppContainer::prepareStartupInfo()
+{
+    // Reference: https://learn.microsoft.com/en-us/windows/win32/secauthz/implementing-an-appcontainer#launching-the-appcontainer-or-lpac
+
+    LPPROC_THREAD_ATTRIBUTE_LIST attributeList = nullptr;
+    constexpr DWORD attributesCount = 1;
+    SIZE_T attributesSize = 0;
+
+    const BOOL result = InitializeProcThreadAttributeList(nullptr, attributesCount, 0, &attributesSize);
+    // https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-initializeprocthreadattributelist#remarks
+    Q_ASSERT(result == FALSE);
+    if (const auto error = GetLastError(); error != ERROR_INSUFFICIENT_BUFFER) {
+        return UNEXPECTED_WIN32_ERROR(error);
+    }
+
+    attributeList = static_cast<LPPROC_THREAD_ATTRIBUTE_LIST>(HeapAlloc(GetProcessHeap(), 0, attributesSize));
+    if (!attributeList) {
+        return UNEXPECTED_WIN32_ERROR(ERROR_NOT_ENOUGH_MEMORY);
+    }
+    runLater([attributeList] { DeleteProcThreadAttributeList(attributeList); });
+
+    if (InitializeProcThreadAttributeList(attributeList, attributesCount, 0, &attributesSize) == FALSE) {
+        return UNEXPECTED_WIN32_ERROR_LAST;
+    }
+
+    auto* capabilities = new SECURITY_CAPABILITIES{};
+    runLater([capabilities] {
+        delete capabilities;
+    });
+    capabilities->AppContainerSid = m_appContainerSid.get();
+
+    TRY(buildCapabilities(&capabilities->Capabilities, &capabilities->CapabilityCount));
+
+    if (UpdateProcThreadAttribute(attributeList, 0, PROC_THREAD_ATTRIBUTE_SECURITY_CAPABILITIES, capabilities,
+                                  sizeof(SECURITY_CAPABILITIES), nullptr, nullptr) == FALSE) {
+        return UNEXPECTED_WIN32_ERROR_LAST;
+    }
+
+    m_startupInfo = std::make_unique<STARTUPINFOEXW>();
+    m_startupInfo->lpAttributeList = attributeList;
+
+    return {};
+}
+
+std::expected<std::unique_ptr<WindowsAppContainer>, HRESULT> WindowsAppContainer::create()
+{
+    // Reference: https://learn.microsoft.com/en-us/windows/win32/secauthz/implementing-an-appcontainer#creating-the-profile
+
+    const std::wstring containerName = appContainerId();
+    const std::wstring displayName = BuildConfig.LAUNCHER_DISPLAYNAME.toStdWString();
+    const std::wstring description = QObject::tr("Minecraft (Sandbox)").toStdWString();
+
+    PSID appContainerSid{};  // MEMORY: Ownership is passed to created WindowsAppContainer
+    HRESULT hr = CreateAppContainerProfile(containerName.c_str(), displayName.c_str(), description.c_str(), nullptr, 0, &appContainerSid);
+
+    if (FAILED(hr)) {
+        if (hr != HRESULT_FROM_WIN32(ERROR_ALREADY_EXISTS)) {
+            return std::unexpected(hr);
+        }
+        hr = DeriveAppContainerSidFromAppContainerName(containerName.c_str(), &appContainerSid);
+        if (FAILED(hr)) {
+            return std::unexpected(hr);
+        }
+    }
+
+    return std::unique_ptr<WindowsAppContainer>(new WindowsAppContainer(appContainerSid));
+}
+
+std::expected<void, HRESULT> WindowsAppContainer::deleteProfile()
+{
+    const auto name = appContainerId();
+    if (const HRESULT hr = DeleteAppContainerProfile(name.c_str()); hr != ERROR_SUCCESS) {
+        return std::unexpected(hr);
+    }
+    return {};
+}
+
+void WindowsAppContainer::attach(QProcess* process)
+{
+    process->setCreateProcessArgumentsModifier([this](QProcess::CreateProcessArguments* args) {
+        Q_ASSERT(m_startupInfo);
+        m_startupInfo->StartupInfo = *args->startupInfo;
+        m_startupInfo->StartupInfo.cb = sizeof(STARTUPINFOEXW);
+
+        args->startupInfo = &m_startupInfo->StartupInfo;
+        args->flags |= EXTENDED_STARTUPINFO_PRESENT;
+
+        runLater([this] {
+            m_startupInfo.reset();
+        });
+    });
+}
+
+std::expected<void, std::error_code> WindowsAppContainer::grantFSAccess(const QString& path, const AccessMode mode)
+{
+    DWORD permissions{};
+    QString modeString;
+    switch (mode) {
+        case AccessMode::Traverse:
+            permissions = FILE_LIST_DIRECTORY | SYNCHRONIZE;
+            modeString = "traverse";
+            break;
+        case AccessMode::Read:
+            permissions = FILE_GENERIC_READ | FILE_GENERIC_EXECUTE;
+            modeString = "read";
+            break;
+        case AccessMode::ReadWrite:
+            permissions = FILE_ALL_ACCESS;
+            modeString = "read-write";
+            break;
+    }
+
+    const DWORD inheritance = mode != AccessMode::Traverse ? SUB_CONTAINERS_AND_OBJECTS_INHERIT : NO_INHERITANCE;
+    if (const auto result = addGrantToFileAcl(path, permissions, inheritance); !result) {
+        if (result.error().value() != ERROR_ACCESS_DENIED) {
+            return std::unexpected{ result.error() };
+        }
+
+        qWarning() << "Access denied when granting container" << modeString << "access to" << path;
+        if (mode != AccessMode::Read) {
+            return std::unexpected{ result.error() };
+        }
+        // This may be alright. The file may already have permissions set for ALL APPLICATION PACKAGES, so we shouldn't fail right away.
+    } else {
+        qInfo() << "Granted container" << modeString << "access to" << path;
+    }
+
+    if (mode == AccessMode::Traverse) {
+        return {};
+    }
+
+    return grantParentsTraverseAccess(path);
+}
+
+std::expected<void, std::error_code> WindowsAppContainer::finalizeSetup(QProcess* process)
+{
+    Q_ASSERT_X(!m_allowedTraversePaths.isEmpty(), "WindowsAppContainer::finalizeSetup", "No filesystem access has been granted. Call grantFSAccess");
+
+    const auto containerFolder = QString("%1/Packages/%2/AC").arg(qEnvironmentVariable("LOCALAPPDATA"), appContainerId());
+    TRY(grantParentsTraverseAccess(containerFolder));
+    TRY(grantWindowStationWritePermissions());
+    TRY(elevateToRetryGrants());
+    TRY(prepareStartupInfo());
+
+    attach(process);
+
+    return {};
+}
+
+void WindowsAppContainer::addCapability(const QString& capability)
+{
+    m_requestedCapabilities << capability;
+}
+
+std::wstring WindowsAppContainer::appContainerId()
+{
+    return BuildConfig.LAUNCHER_APPID.toStdWString();
+}
+
+std::expected<LocalPtr<std::remove_pointer_t<PSID>>, std::error_code> WindowsAppContainer::getCapabilitySid(const QString& name)
+{
+    // Reference: https://learn.microsoft.com/en-us/windows/win32/secauthz/implementing-an-appcontainer#constructing-the-capabilities
+
+    const std::wstring wName = name.toStdWString();
+
+    LocalPtr<PSID> groupSids{};
+    DWORD groupSidCount{};
+    LocalPtr<PSID> capabilitySids{};
+    DWORD capabilitySidCount{};
+
+    if (DeriveCapabilitySidsFromName(wName.c_str(), std::out_ptr(groupSids), &groupSidCount, std::out_ptr(capabilitySids),
+                                     &capabilitySidCount) == FALSE) {
+        return UNEXPECTED_WIN32_ERROR_LAST;
+    }
+
+    // NOLINTBEGIN(*-pro-bounds-pointer-arithmetic)
+    LocalFree(groupSids.get()[0]);
+    const PSID capability = capabilitySids.get()[0];
+    // NOLINTEND(*-pro-bounds-pointer-arithmetic)
+
+    return LocalPtr<std::remove_pointer_t<PSID>>(capability);
+}
+
+std::expected<bool, std::error_code> WindowsAppContainer::aclsEqual(PACL acl1, PACL acl2)
+{
+    // Reference:
+    // https://github.com/Moulberry/PandoraLauncher/blob/4a3e4cd0296fbdbcdef564abbc2890db1176c818/crates/command/src/windows/appcontainer.rs#L445
+    if (acl1->AceCount != acl2->AceCount) {
+        return false;
+    }
+
+    for (WORD i = 0; i < acl1->AceCount; ++i) {
+        void* ace1{};
+        void* ace2{};
+        if (GetAce(acl1, i, &ace1) == FALSE || GetAce(acl2, i, &ace2) == FALSE) {
+            return UNEXPECTED_WIN32_ERROR_LAST;
+        }
+
+        const auto* header1 = static_cast<PACE_HEADER>(ace1);
+        const auto* header2 = static_cast<PACE_HEADER>(ace2);
+        if (header1->AceSize != header2->AceSize || header1->AceFlags != header2->AceFlags || header1->AceType != header2->AceType) {
+            return false;
+        }
+
+        const std::span ace1Data{ static_cast<std::byte*>(ace1), header1->AceSize };
+        const std::span ace2Data{ static_cast<std::byte*>(ace2), header2->AceSize };
+        if (!std::ranges::equal(ace1Data, ace2Data)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+std::expected<void, std::error_code> WindowsAppContainer::buildCapabilities(PSID_AND_ATTRIBUTES* capabilities, DWORD* capabilityCount) const
+{
+    Q_ASSERT_X(!m_requestedCapabilities.isEmpty(), "WindowsAppContainer::buildCapabilities", "No capabilities have been requested");
+
+    // Reference: https://learn.microsoft.com/en-us/windows/win32/secauthz/implementing-an-appcontainer#constructing-the-capabilities
+
+    *capabilities = nullptr;
+    *capabilityCount = 0;
+
+    std::vector<PSID> capabilitySids{};
+    capabilitySids.reserve(m_requestedCapabilities.size());
+    auto freeSids = [&capabilitySids] {
+        for (auto* sid : capabilitySids) {
+            LocalFree(sid);
+        }
+    };
+
+    for (const auto& capability : m_requestedCapabilities) {
+        auto sidResult = getCapabilitySid(capability);
+        if (!sidResult) {
+            freeSids();
+            return std::unexpected{ sidResult.error() };
+        }
+        auto* sid = sidResult.value().release(); // scary!
+
+        capabilitySids.emplace_back(sid);
+    }
+
+    auto* localCapabilities =
+        static_cast<PSID_AND_ATTRIBUTES>(HeapAlloc(GetProcessHeap(), 0, capabilitySids.size() * sizeof(SID_AND_ATTRIBUTES)));
+    if (!localCapabilities) {
+        freeSids();
+        return UNEXPECTED_WIN32_ERROR(ERROR_NOT_ENOUGH_MEMORY);
+    }
+
+    for (size_t i = 0; i < capabilitySids.size(); ++i) {
+        // NOLINTBEGIN(*-pro-bounds-pointer-arithmetic)
+        localCapabilities[i].Sid = capabilitySids.at(i);
+        localCapabilities[i].Attributes = SE_GROUP_ENABLED;
+        // NOLINTEND(*-pro-bounds-pointer-arithmetic)
+    }
+
+    *capabilities = localCapabilities;
+    *capabilityCount = static_cast<DWORD>(capabilitySids.size());
+    return {};
+}
+
+std::expected<void, std::error_code> WindowsAppContainer::grantParentsTraverseAccess(const QString& path)
+{
+    const QFileInfo fileInfo(path);
+    QDir parent = fileInfo.dir();  // Note: always returns the *parent* dir, even when the object itself is a dir
+
+    do {  // NOLINT(*-avoid-do-while)
+        if (const QString parentPath = parent.path();
+            !m_allowedTraversePaths.contains(parentPath) && !m_deniedTraversePaths.contains(parentPath)) {
+            if (const auto result = grantFSAccess(parentPath, AccessMode::Traverse); !result) {
+                if (result.error().value() == ERROR_ACCESS_DENIED) {
+                    m_deniedTraversePaths << parentPath;
+                    continue;
+                }
+
+                return std::unexpected{ result.error() };
+            }
+
+            m_allowedTraversePaths << parentPath;
+        }
+    } while (parent.cdUp());
+
+    return {};
+}
+
+std::expected<void, std::error_code> WindowsAppContainer::addGrantToFileAcl(const QString& path,
+                                                                            const DWORD permissions,
+                                                                            const DWORD inheritance) const
+{
+    const std::wstring wPath = path.toStdWString();
+
+    PACL existingDacl = nullptr;  // MEMORY: This is part of the security descriptor and should *not* be freed separately
+    LocalPtr<SECURITY_DESCRIPTOR> unusedSd{};
+    if (const DWORD error = GetNamedSecurityInfoW(wPath.c_str(), SE_FILE_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, &existingDacl,
+                                                  nullptr, std::out_ptr(unusedSd));
+        error != ERROR_SUCCESS) {
+        return UNEXPECTED_WIN32_ERROR(error);
+    }
+
+    EXPLICIT_ACCESSW ea{};
+    ea.grfAccessMode = GRANT_ACCESS;
+    ea.grfAccessPermissions = permissions;
+    ea.grfInheritance = inheritance;
+    ea.Trustee.MultipleTrusteeOperation = NO_MULTIPLE_TRUSTEE;
+    ea.Trustee.pMultipleTrustee = nullptr;
+    ea.Trustee.TrusteeForm = TRUSTEE_IS_SID;
+    ea.Trustee.TrusteeType = TRUSTEE_IS_GROUP;
+    ea.Trustee.ptstrName = static_cast<LPWSTR>(m_appContainerSid.get());
+
+    LocalPtr<ACL> newDacl{};
+    if (const DWORD error = SetEntriesInAclW(1, &ea, existingDacl, std::out_ptr(newDacl)); error != ERROR_SUCCESS) {
+        return UNEXPECTED_WIN32_ERROR(error);
+    }
+
+    // https://serverfault.com/a/965346
+    if (inheritance == NO_INHERITANCE) {
+        // Only compare ACLs if inheritance is disabled.
+        // Sometimes children don't properly inherit the ACLs, so we need to be sure to apply them even if the parent is correct
+        const auto equalResult = aclsEqual(existingDacl, newDacl.get());
+        if (!equalResult.has_value()) {
+            qWarning() << "Could not compare ACLs:" << equalResult.error().message();
+        }
+        if (equalResult.has_value() && equalResult.value()) {
+            return {};
+        }
+
+        const LocalPtr<SECURITY_DESCRIPTOR> sd{ static_cast<SECURITY_DESCRIPTOR*>(LocalAlloc(LPTR, SECURITY_DESCRIPTOR_MIN_LENGTH)) };
+
+        if (InitializeSecurityDescriptor(sd.get(), SECURITY_DESCRIPTOR_REVISION) == FALSE) {
+            return UNEXPECTED_WIN32_ERROR_LAST;
+        }
+
+        if (SetSecurityDescriptorDacl(sd.get(), TRUE, newDacl.get(), FALSE) == FALSE) {
+            return UNEXPECTED_WIN32_ERROR_LAST;
+        }
+
+        if (SetFileSecurityW(wPath.c_str(), DACL_SECURITY_INFORMATION, sd.get()) == FALSE) {
+            return UNEXPECTED_WIN32_ERROR_LAST;
+        }
+
+        return {};
+    }
+
+    if (const DWORD error = SetNamedSecurityInfoW(const_cast<LPWSTR>(wPath.c_str()), SE_FILE_OBJECT, DACL_SECURITY_INFORMATION,
+                                                  nullptr,  // NOLINT(*-pro-type-const-cast)
+                                                  nullptr, newDacl.get(), nullptr);
+        error != ERROR_SUCCESS) {
+        return UNEXPECTED_WIN32_ERROR(error);
+    }
+
+    return {};
+}
+
+std::expected<void, std::error_code> WindowsAppContainer::elevateToRetryGrants()
+{
+    if (m_deniedTraversePaths.isEmpty()) {
+        return {};
+    }
+
+    QStringList args;
+    for (const QString& path : m_deniedTraversePaths) {
+        args << QString("--internal-denied-traverse-path=\"%1\"").arg(path);
+    }
+
+    const std::wstring currentExe = QApplication::applicationFilePath().toStdWString();
+    const std::wstring wArgs = args.join(' ').toStdWString();
+
+    SHELLEXECUTEINFOW info{};
+    info.cbSize = sizeof(info);
+    info.fMask = SEE_MASK_NOCLOSEPROCESS | SEE_MASK_NOASYNC;
+    info.lpVerb = L"runas";
+    info.lpFile = currentExe.c_str();
+    info.lpParameters = wArgs.c_str();
+    info.nShow = SW_HIDE;
+
+    if (ShellExecuteExW(&info) == FALSE) {
+        return UNEXPECTED_WIN32_ERROR_LAST;
+    }
+
+    if (info.hProcess != nullptr) {
+        WaitForSingleObject(info.hProcess, INFINITE);
+        CloseHandle(info.hProcess);
+    }
+
+    m_allowedTraversePaths << m_deniedTraversePaths;
+    m_deniedTraversePaths.clear();
+
+    return {};
+}
+
+std::expected<void, std::error_code> WindowsAppContainer::grantWindowStationWritePermissions()
+{
+    // Allows use of ClipCursor / SetCursorPos / etc.
+    // Reference:
+    // https://github.com/Moulberry/PandoraLauncher/blob/4a3e4cd0296fbdbcdef564abbc2890db1176c818/crates/command/src/windows/appcontainer.rs#L249
+
+    auto prismCapabilitySidResult = getCapabilitySid(g_prismCapabilityName);
+    if (!prismCapabilitySidResult) {
+        return std::unexpected { prismCapabilitySidResult.error() };
+    }
+    const auto prismCapabilitySid = std::move(prismCapabilitySidResult.value());
+    Q_ASSERT(IsValidSid(prismCapabilitySid.get()));
+
+    auto* winsta = OpenWindowStationW(L"winsta0", FALSE, READ_CONTROL | WRITE_DAC);
+    if (!winsta) {
+        return UNEXPECTED_WIN32_ERROR_LAST;
+    }
+    runLater([winsta] { CloseWindowStation(winsta); });
+
+    // TODO: a bit of code duplication from addGrantToFileAcl
+    PACL existingDacl = nullptr;  // MEMORY: This is part of the security descriptor and should *not* be freed separately
+    LocalPtr<SECURITY_DESCRIPTOR> unusedSd{};
+    if (const DWORD error = GetSecurityInfo(winsta, SE_WINDOW_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, &existingDacl, nullptr,
+                                            std::out_ptr(unusedSd));
+        error != ERROR_SUCCESS) {
+        return UNEXPECTED_WIN32_ERROR(error);
+    }
+
+    EXPLICIT_ACCESSW ea{};
+    ea.grfAccessMode = GRANT_ACCESS;
+    ea.grfAccessPermissions = WINSTA_WRITEATTRIBUTES;
+    ea.grfInheritance = NO_INHERITANCE;
+    ea.Trustee.MultipleTrusteeOperation = NO_MULTIPLE_TRUSTEE;
+    ea.Trustee.pMultipleTrustee = nullptr;
+    ea.Trustee.TrusteeForm = TRUSTEE_IS_SID;
+    ea.Trustee.TrusteeType = TRUSTEE_IS_GROUP;
+    ea.Trustee.ptstrName = static_cast<LPWSTR>(prismCapabilitySid.get());
+
+    LocalPtr<ACL> newDacl{};
+    if (const DWORD error = SetEntriesInAclW(1, &ea, existingDacl, std::out_ptr(newDacl)); error != ERROR_SUCCESS) {
+        return UNEXPECTED_WIN32_ERROR(error);
+    }
+
+    if (const DWORD error = SetSecurityInfo(winsta, SE_WINDOW_OBJECT, DACL_SECURITY_INFORMATION, nullptr, nullptr, newDacl.get(), nullptr);
+        error != ERROR_SUCCESS) {
+        return UNEXPECTED_WIN32_ERROR_LAST;
+    }
+
+    return {};
+}

--- a/launcher/windows/WindowsAppContainer.h
+++ b/launcher/windows/WindowsAppContainer.h
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2026 Octol1ttle <l1ttleofficial@outlook.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#ifdef Q_OS_WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#endif
+
+#include <expected>
+
+template <typename T>
+struct LocalFreeDeleter {
+    void operator()(T* ptr) { LocalFree(ptr); }  // NOLINT(*-multi-level-implicit-pointer-conversion)
+};
+
+template <typename T>
+using LocalPtr = std::unique_ptr<T, LocalFreeDeleter<T>>;
+
+class WindowsAppContainer final {
+   public:
+    enum class AccessMode : std::uint8_t {
+        Traverse,
+        Read,
+        ReadWrite,
+    };
+
+    static std::expected<std::unique_ptr<WindowsAppContainer>, HRESULT> create();
+    static std::expected<void, HRESULT> deleteProfile();
+
+    ~WindowsAppContainer() = default;
+
+    std::expected<void, std::error_code> grantFSAccess(const QString& path, AccessMode mode);
+    std::expected<void, std::error_code> finalizeSetup(QProcess* process);
+    void addCapability(const QString& capability);
+
+   private:
+    static std::wstring appContainerId();
+    static std::expected<LocalPtr<std::remove_pointer_t<PSID>>, std::error_code> getCapabilitySid(const QString& name);
+    static std::expected<bool, std::error_code> aclsEqual(PACL acl1, PACL acl2);
+    static std::expected<void, std::error_code> grantWindowStationWritePermissions();
+
+    explicit WindowsAppContainer(PSID appContainerSid);
+
+    std::expected<void, std::error_code> addGrantToFileAcl(const QString& path, DWORD permissions, DWORD inheritance) const;
+    std::expected<void, std::error_code> grantParentsTraverseAccess(const QString& path);
+    std::expected<void, std::error_code> elevateToRetryGrants();
+
+    std::expected<void, std::error_code> buildCapabilities(PSID_AND_ATTRIBUTES* capabilities, DWORD* capabilityCount) const;
+    std::expected<void, std::error_code> prepareStartupInfo();
+
+    void attach(QProcess* process);
+
+   private:
+    std::unique_ptr<std::remove_pointer_t<PSID>, decltype(&FreeSid)> m_appContainerSid;
+    QStringList m_requestedCapabilities;
+    QStringList m_allowedTraversePaths;
+    QStringList m_deniedTraversePaths;
+    std::unique_ptr<STARTUPINFOEXW> m_startupInfo;
+};


### PR DESCRIPTION
the code is kinda bad but the feature works

TODO:
- [ ] Add option to disable sandboxing globally and for each instance with an associated warning
- [ ] (Maybe) Show a warning before elevating so the user knows whats up
- [ ] Structure the code better (help me here)
- [x] Fix the #ifdefs so it builds on all platforms
- [ ] Resolve the TODOs (in the code)

Blocked on #5911 