### PR TITLE
Fix JavaChecker UAF

### DIFF
--- a/launcher/java/JavaChecker.cpp
+++ b/launcher/java/JavaChecker.cpp
@@ -83,10 +83,10 @@ void JavaChecker::executeTask()
     m_process->setProcessEnvironment(CleanEnviroment());
     qDebug() << "Running java checker:" << m_path << args.join(" ");
 
-    connect(m_process.get(), &QProcess::finished, this, &JavaChecker::finished);
-    connect(m_process.get(), &QProcess::errorOccurred, this, &JavaChecker::error);
-    connect(m_process.get(), &QProcess::readyReadStandardOutput, this, &JavaChecker::stdoutReady);
-    connect(m_process.get(), &QProcess::readyReadStandardError, this, &JavaChecker::stderrReady);
+    connect(m_process.get(), &QProcess::finished, this, &JavaChecker::finished, Qt::QueuedConnection);
+    connect(m_process.get(), &QProcess::errorOccurred, this, &JavaChecker::error, Qt::QueuedConnection);
+    connect(m_process.get(), &QProcess::readyReadStandardOutput, this, &JavaChecker::stdoutReady, Qt::QueuedConnection);
+    connect(m_process.get(), &QProcess::readyReadStandardError, this, &JavaChecker::stderrReady, Qt::QueuedConnection);
     connect(&m_killTimer, &QTimer::timeout, this, &JavaChecker::timeout);
     m_killTimer.setSingleShot(true);
     m_killTimer.start(15000);


### PR DESCRIPTION
Parent PR: #5876
There was another use-after-free with closing settings I didn't catch because I can only get it to happen without asan or asserts for some reason?

Somehow even though we are using deleteLater, and the context for the connect is `this`, it's still invoked after ~JavaChecker.
I don't understand the Qt event loop enough to really understand why this fixes it, but it does