### PR TITLE
Change config saving to be explicit

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -637,6 +637,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
     {
         // Provide a fallback for migration from PolyMC
         m_settings.reset(new INISettingsObject({ BuildConfig.LAUNCHER_CONFIGFILE, "polymc.cfg", "multimc.cfg" }, this));
+        SettingsObject::Lock saveLock{m_settings.get()};
 
         // Theming
         m_settings->registerSetting("IconTheme", QString());
@@ -847,6 +848,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
                 m_settings->set("PastebinType", PasteUpload::PasteType::NullPointer);
                 m_settings->set("PastebinCustomAPIBase", pastebinURL);
                 m_settings->reset("PastebinURL");
+                m_settings->doSave();
             }
 
             bool ok;
@@ -855,12 +857,14 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
             if (!ok || !(PasteUpload::PasteType::First <= pasteType && pasteType <= PasteUpload::PasteType::Last)) {
                 m_settings->reset("PastebinType");
                 m_settings->reset("PastebinCustomAPIBase");
+                m_settings->doSave();
             }
         }
         {
             auto resetIfInvalid = [this](const Setting* setting) {
                 if (const QUrl url(setting->get().toString()); !url.isValid() || (url.scheme() != "http" && url.scheme() != "https")) {
                     m_settings->reset(setting->id());
+                    m_settings->doSave();
                 }
             };
 
@@ -893,6 +897,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
             if (!flameKey.isEmpty())
                 m_settings->set("FlameKeyOverride", flameKey);
             m_settings->reset("CFKeyOverride");
+            m_settings->doSave();
         }
         m_settings->registerSetting("FallbackMRBlockedMods", true);
         m_settings->registerSetting("ModrinthToken", "");
@@ -1228,6 +1233,7 @@ bool Application::createSetupWizard()
         QString oldHostName = settings()->get("LastHostname").toString();
         if (currentHostName != oldHostName) {
             settings()->set("LastHostname", currentHostName);
+            settings()->doSave();
             return true;
         }
         QString currentJavaPath = settings()->get("JavaPath").toString();
@@ -1245,8 +1251,10 @@ bool Application::createSetupWizard()
     bool wizardRequired = javaRequired || languageRequired || pasteInterventionRequired || themeInterventionRequired || askjava || login;
     if (wizardRequired) {
         // set default theme after going into theme wizard
-        if (!validIcons)
+        if (!validIcons) {
             settings()->set("IconTheme", QString("pe_colored"));
+            settings()->doSave();
+        }
         if (!validWidgets) {
 #if defined(Q_OS_WIN32) && QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
             const QString style =
@@ -1256,6 +1264,7 @@ bool Application::createSetupWizard()
 #endif
 
             settings()->set("ApplicationTheme", style);
+            settings()->doSave();
         }
 
         m_themeManager->applyCurrentlySelectedTheme(true);

--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -80,6 +80,7 @@ BaseInstance::BaseInstance(SettingsObject* globalSettings, std::unique_ptr<Setti
     m_settings->registerSetting("totalTimePlayed", 0);
     if (m_settings->get("totalTimePlayed").toLongLong() < 0) {
         m_settings->reset("totalTimePlayed");
+        m_settings->doSave();
     }
     m_settings->registerSetting("lastTimePlayed", 0);
 
@@ -191,6 +192,7 @@ void BaseInstance::setManagedPack(const QString& type,
     m_settings->set("ManagedPackName", name);
     m_settings->set("ManagedPackVersionID", versionId);
     m_settings->set("ManagedPackVersionName", version);
+    m_settings->doSave();
 }
 
 QStringList BaseInstance::getLinkedInstances() const
@@ -202,6 +204,7 @@ QStringList BaseInstance::getLinkedInstances() const
 void BaseInstance::setLinkedInstances(const QStringList& list)
 {
     m_settings->set("linkedInstances", Json::fromStringList(list));
+    m_settings->doSave();
 }
 
 void BaseInstance::addLinkedInstanceId(const QString& id)
@@ -261,6 +264,7 @@ void BaseInstance::regenerateUuid()
 {
     const auto newUUID = QUuid::createUuid().toString(QUuid::Id128);
     m_settings->set("uuid", newUUID);
+    m_settings->doSave();
     m_uuid = newUUID;
 }
 
@@ -295,6 +299,7 @@ void BaseInstance::setMinecraftRunning(bool running)
         qint64 current = settings()->get("totalTimePlayed").toLongLong();
         settings()->set("totalTimePlayed", current + m_timeStarted.secsTo(timeEnded));
         settings()->set("lastTimePlayed", m_timeStarted.secsTo(timeEnded));
+        settings()->doSave();
 
         emit propertiesChanged();
     }
@@ -328,6 +333,7 @@ void BaseInstance::resetTimePlayed()
 {
     settings()->reset("totalTimePlayed");
     settings()->reset("lastTimePlayed");
+    settings()->doSave();
 }
 
 QString BaseInstance::instanceType() const
@@ -364,15 +370,17 @@ qint64 BaseInstance::lastLaunch() const
 
 void BaseInstance::setLastLaunch(qint64 val)
 {
-    // FIXME: if no change, do not set. setting involves saving a file.
+    // FIXME: if no change, do not save.
     m_settings->set("lastLaunchTime", val);
+    m_settings->doSave();
     emit propertiesChanged();
 }
 
 void BaseInstance::setNotes(const QString& val)
 {
-    // FIXME: if no change, do not set. setting involves saving a file.
+    // FIXME: if no change, do not save.
     m_settings->set("notes", val);
+    m_settings->doSave();
 }
 
 QString BaseInstance::notes() const
@@ -384,6 +392,7 @@ void BaseInstance::setIconKey(const QString& val)
 {
     // FIXME: if no change, do not set. setting involves saving a file.
     m_settings->set("iconKey", val);
+    m_settings->doSave();
     emit propertiesChanged();
 }
 
@@ -396,6 +405,7 @@ void BaseInstance::setName(const QString& val)
 {
     // FIXME: if no change, do not set. setting involves saving a file.
     m_settings->set("name", val);
+    m_settings->doSave();
     emit propertiesChanged();
 }
 
@@ -424,6 +434,7 @@ void BaseInstance::setShortcuts(const QList<ShortcutData>& shortcuts)
     QJsonDocument document;
     document.setArray(array);
     m_settings->set("shortcuts", QString::fromUtf8(document.toJson(QJsonDocument::Compact)));
+    m_settings->doSave();
 }
 
 QList<ShortcutData> BaseInstance::shortcuts() const

--- a/launcher/InstanceDirUpdate.cpp
+++ b/launcher/InstanceDirUpdate.cpp
@@ -90,6 +90,7 @@ QString askToUpdateInstanceDirName(BaseInstance* instance, const QString& oldNam
                 APPLICATION->settings()->set("InstRenamingMode", "PhysicalDir");
             else
                 APPLICATION->settings()->set("InstRenamingMode", "MetadataOnly");
+            APPLICATION->settings()->doSave();
         }
         if (res == QMessageBox::No)
             return QString();

--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -268,6 +268,7 @@ QString LaunchController::askOfflineName(const QString& playerName, bool* ok)
 
     usedname = dialog.getUsername();
     APPLICATION->settings()->set("LastOfflinePlayerName", usedname);
+    APPLICATION->settings()->doSave();
 
     if (ok != nullptr) {
         *ok = true;

--- a/launcher/launch/steps/CheckJava.cpp
+++ b/launcher/launch/steps/CheckJava.cpp
@@ -136,6 +136,7 @@ void CheckJava::checkJavaFinished(const JavaChecker::Result& result)
             instance->settings()->set("JavaRealArchitecture", result.realPlatform);
             instance->settings()->set("JavaVendor", result.javaVendor);
             instance->settings()->set("JavaSignature", m_javaSignature);
+            instance->settings()->doSave();
             m_parent->instance()->updateRuntimeContext();
             emitSucceeded();
             return;

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -240,7 +240,10 @@ void MinecraftInstance::loadSpecificSettings()
         auto envSetting = m_settings->registerSetting("OverrideEnv", false);
         m_settings->registerOverride(global_settings->getSetting("Env"), envSetting);
 
-        m_settings->set("InstanceType", "OneSix");
+        if (m_settings->get("InstanceType").toString() != "OneSix") {
+            m_settings->set("InstanceType", "OneSix");
+            m_settings->doSave();
+        }
     }
 
     // Join server on launch, this does not have a global override
@@ -323,6 +326,7 @@ void MinecraftInstance::populateLaunchMenu(QMenu* menu)
     profilers->setExclusive(true);
     connect(profilers, &QActionGroup::triggered, this, [this](QAction* action) {
         settings()->set("Profiler", action->data());
+        settings()->doSave();
         emit profilerChanged();
     });
 

--- a/launcher/minecraft/launch/AutoInstallJava.cpp
+++ b/launcher/minecraft/launch/AutoInstallJava.cpp
@@ -135,6 +135,7 @@ void AutoInstallJava::setJavaPath(QString path)
     settings->set("OverrideJavaLocation", true);
     settings->set("JavaPath", path);
     settings->set("AutomaticJava", true);
+    settings->doSave();
     emit logLine(tr("Compatible Java found at: %1.").arg(path), MessageLevel::Launcher);
     emitSucceeded();
 }

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -674,6 +674,7 @@ void ResourceFolderModel::saveColumns(QTreeView* tree)
 
     auto stateSetting = m_instance->settings()->getSetting(stateSettingName);
     stateSetting->set(QString::fromUtf8(tree->header()->saveState().toBase64()));
+    m_instance->settings()->doSave();
 
     // neither passthrough nor override settings works for this usecase as I need to only set the global when the gate is false
     auto* settings = m_instance->settings();
@@ -688,6 +689,7 @@ void ResourceFolderModel::saveColumns(QTreeView* tree)
         }
     }
     settings->set(visibilitySettingName, Json::fromMap(visibility));
+    settings->doSave();
 }
 
 void ResourceFolderModel::loadColumns(QTreeView* tree)
@@ -746,6 +748,7 @@ QMenu* ResourceFolderModel::createHeaderContextMenu(QTreeView* tree)
 
         connect(act, &QAction::toggled, tree, [this, tree, overrideSettingName](bool toggled) {
             m_instance->settings()->set(overrideSettingName, toggled);
+            m_instance->settings()->doSave();
             saveColumns(tree);
         });
 

--- a/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
+++ b/launcher/modplatform/flame/FlameInstanceCreationTask.cpp
@@ -494,6 +494,7 @@ void FlameCreationTask::createInstance()
 
         m_newInstance->settings()->set("OverrideMemory", true);
         m_newInstance->settings()->set("MaxMemAlloc", recommendedRAM);
+        m_newInstance->settings()->doSave();
     }
 
     QString jarmodsPath = FS::PathCombine(m_stagingPath, "minecraft", "jarmods");

--- a/launcher/modplatform/import_ftb/PackInstallTask.cpp
+++ b/launcher/modplatform/import_ftb/PackInstallTask.cpp
@@ -61,6 +61,7 @@ void PackInstallTask::copySettings()
             m_instance->settings()->set("OverrideJavaArgs", true);
             m_instance->settings()->set("JvmArgs", m_pack.jvmArgs.toString());
         }
+        m_instance->settings()->doSave();
 
         auto* components = m_instance->getPackProfile();
         components->buildingFromScratch();

--- a/launcher/settings/INISettingsObject.cpp
+++ b/launcher/settings/INISettingsObject.cpp
@@ -84,7 +84,6 @@ void INISettingsObject::changeSetting(const Setting& setting, QVariant value)
             for (auto iter : setting.configKeys())
                 m_ini.remove(iter);
         }
-        doSave();
     }
 }
 
@@ -103,7 +102,6 @@ void INISettingsObject::resetSetting(const Setting& setting)
     if (contains(setting.id())) {
         for (auto iter : setting.configKeys())
             m_ini.remove(iter);
-        doSave();
     }
 }
 

--- a/launcher/settings/INISettingsObject.h
+++ b/launcher/settings/INISettingsObject.h
@@ -48,6 +48,7 @@ class INISettingsObject : public SettingsObject {
 
     void suspendSave() override;
     void resumeSave() override;
+    void doSave() override;
 
    protected slots:
     virtual void changeSetting(const Setting& setting, QVariant value) override;
@@ -55,7 +56,6 @@ class INISettingsObject : public SettingsObject {
 
    protected:
     virtual QVariant retrieveValue(const Setting& setting) override;
-    void doSave();
 
    protected:
     INIFile m_ini;

--- a/launcher/settings/SettingsObject.h
+++ b/launcher/settings/SettingsObject.h
@@ -172,6 +172,7 @@ class SettingsObject : public QObject {
 
     virtual void suspendSave() = 0;
     virtual void resumeSave() = 0;
+    virtual void doSave() = 0;
    signals:
     /*!
      * \brief Signal emitted when one of this SettingsObject object's settings changes.

--- a/launcher/tools/MCEditTool.cpp
+++ b/launcher/tools/MCEditTool.cpp
@@ -17,6 +17,7 @@ MCEditTool::MCEditTool(SettingsObject* settings)
 void MCEditTool::setPath(QString& path)
 {
     m_settings->set("MCEditPath", path);
+    m_settings->doSave();
 }
 
 QString MCEditTool::path() const

--- a/launcher/translations/TranslationsModel.cpp
+++ b/launcher/translations/TranslationsModel.cpp
@@ -214,6 +214,7 @@ void TranslationsModel::indexReceived()
         }
         selectLanguage(language);
         APPLICATION->settings()->set("Language", selectedLanguage());
+        APPLICATION->settings()->doSave();
         d->m_noLanguageSet = false;
     }
 
@@ -443,6 +444,7 @@ std::optional<Language> TranslationsModel::findLanguageAsOptional(const QString&
 void TranslationsModel::setUseSystemLocale(const bool useSystemLocale) const
 {
     APPLICATION->settings()->set("UseSystemLocale", useSystemLocale);
+    APPLICATION->settings()->doSave();
     QLocale::setDefault(useSystemLocale ? QLocale::system() : QLocale(selectedLanguage()));
 }
 

--- a/launcher/ui/InstanceWindow.cpp
+++ b/launcher/ui/InstanceWindow.cpp
@@ -223,6 +223,7 @@ void InstanceWindow::closeEvent(QCloseEvent* event)
 
     APPLICATION->settings()->set("ConsoleWindowState", QString::fromUtf8(saveState().toBase64()));
     APPLICATION->settings()->set("ConsoleWindowGeometry", QString::fromUtf8(saveGeometry().toBase64()));
+    APPLICATION->settings()->doSave();
     emit isClosing();
     event->accept();
 }

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -495,6 +495,7 @@ void MainWindow::setStatusBarVisibility(bool state)
 {
     statusBar()->setVisible(state);
     APPLICATION->settings()->set("StatusBarVisible", state);
+    APPLICATION->settings()->doSave();
 }
 void MainWindow::lockToolbars(bool state)
 {
@@ -502,6 +503,7 @@ void MainWindow::lockToolbars(bool state)
     ui->instanceToolBar->setMovable(!state);
     ui->newsToolBar->setMovable(!state);
     APPLICATION->settings()->set("ToolbarsLocked", state);
+    APPLICATION->settings()->doSave();
 }
 
 void MainWindow::konamiTriggered()
@@ -634,6 +636,7 @@ void MainWindow::updateThemeMenu()
         connect(themeAction, &QAction::triggered, APPLICATION, [theme]() {
             APPLICATION->themeManager()->setApplicationTheme(theme->id());
             APPLICATION->settings()->set("ApplicationTheme", theme->id());
+            APPLICATION->settings()->doSave();
         });
     }
 
@@ -846,6 +849,7 @@ void MainWindow::onCatToggled(bool state)
 {
     setCatBackground(state);
     APPLICATION->settings()->set("TheCat", state);
+    APPLICATION->settings()->doSave();
 }
 
 void MainWindow::setCatBackground(bool enabled)
@@ -918,6 +922,7 @@ void MainWindow::addInstance(const QString& url, const QMap<QString, QString>& e
 
     APPLICATION->settings()->set("LastUsedGroupForNewInstance", newInstDlg.instGroup());
     APPLICATION->settings()->set("LastUsedInstDirForNewInstance", newInstDlg.instDir());
+    APPLICATION->settings()->doSave();
 
     InstanceTask* creationTask = newInstDlg.extractTask();
     if (creationTask) {
@@ -1374,6 +1379,7 @@ void MainWindow::globalSettingsClosed()
     // This needs to be done to prevent UI elements disappearing in the event the config is changed
     // but Prism Launcher exits abnormally, causing the window state to never be saved:
     APPLICATION->settings()->set("MainWindowState", QString::fromUtf8(saveState().toBase64()));
+    APPLICATION->settings()->doSave();
     update();
 }
 
@@ -1520,6 +1526,7 @@ void MainWindow::on_actionDeleteInstance_triggered()
         APPLICATION->instances()->deleteInstance(id);
     }
     APPLICATION->settings()->set("SelectedInstance", QString());
+    APPLICATION->settings()->doSave();
     selectionBad();
 }
 
@@ -1575,6 +1582,7 @@ void MainWindow::closeEvent(QCloseEvent* event)
     APPLICATION->settings()->set("MainWindowState", QString::fromUtf8(saveState().toBase64()));
     APPLICATION->settings()->set("MainWindowGeometry", QString::fromUtf8(saveGeometry().toBase64()));
     instanceToolbarSetting->set(QString::fromUtf8(ui->instanceToolBar->getVisibilityState().toBase64()));
+    APPLICATION->settings()->doSave();
     event->accept();
     emit isClosing();
 }
@@ -1644,6 +1652,7 @@ void MainWindow::instanceChanged(const QModelIndex& current, [[maybe_unused]] co
 {
     if (!current.isValid()) {
         APPLICATION->settings()->set("SelectedInstance", QString());
+        APPLICATION->settings()->doSave();
         selectionBad();
         return;
     }
@@ -1668,11 +1677,13 @@ void MainWindow::instanceChanged(const QModelIndex& current, [[maybe_unused]] co
         updateLaunchButton();
 
         APPLICATION->settings()->set("SelectedInstance", m_selectedInstance->id());
+        APPLICATION->settings()->doSave();
 
         connect(m_selectedInstance, &BaseInstance::runningStatusChanged, this, &MainWindow::refreshCurrentInstance);
         connect(m_selectedInstance, &BaseInstance::profilerChanged, this, &MainWindow::refreshCurrentInstance);
     } else {
         APPLICATION->settings()->set("SelectedInstance", QString());
+        APPLICATION->settings()->doSave();
         selectionBad();
         return;
     }

--- a/launcher/ui/dialogs/ExportPackDialog.cpp
+++ b/launcher/ui/dialogs/ExportPackDialog.cpp
@@ -156,6 +156,8 @@ void ExportPackDialog::done(int result)
             settings->reset("ExportRecommendedRAM");
     }
 
+    settings->doSave();
+
     if (result == Accepted) {
         const QString name = m_ui->name->text().isEmpty() ? m_instance->name() : m_ui->name->text();
         const QString filename = FS::RemoveInvalidFilenameChars(name);

--- a/launcher/ui/dialogs/NewInstanceDialog.cpp
+++ b/launcher/ui/dialogs/NewInstanceDialog.cpp
@@ -157,6 +157,7 @@ NewInstanceDialog::NewInstanceDialog(const QString& initialGroup,
 void NewInstanceDialog::reject()
 {
     APPLICATION->settings()->set("NewInstanceGeometry", QString::fromUtf8(saveGeometry().toBase64()));
+    APPLICATION->settings()->doSave();
 
     // This is just so that the pages get the close() call and can react to it, if needed.
     m_container->prepareToClose();
@@ -178,6 +179,7 @@ void NewInstanceDialog::accept()
     }
 
     APPLICATION->settings()->set("NewInstanceGeometry", QString::fromUtf8(saveGeometry().toBase64()));
+    APPLICATION->settings()->doSave();
     importIconNow();
 
     // This is just so that the pages get the close() call and can react to it, if needed.
@@ -387,6 +389,7 @@ void NewInstanceDialog::importIconNow()
         m_importIcon = false;
     }
     APPLICATION->settings()->set("NewInstanceGeometry", QString::fromUtf8(saveGeometry().toBase64()));
+    APPLICATION->settings()->doSave();
 }
 
 bool NewInstanceDialog::eventFilter(QObject* watched, QEvent* event)

--- a/launcher/ui/dialogs/NewsDialog.cpp
+++ b/launcher/ui/dialogs/NewsDialog.cpp
@@ -30,6 +30,7 @@ NewsDialog::NewsDialog(QList<NewsEntryPtr> entries, QWidget* parent) : QDialog(p
 
     connect(this, &QDialog::finished, this, [this] {
         APPLICATION->settings()->set("NewsGeometry", QString::fromUtf8(saveGeometry().toBase64()));
+        APPLICATION->settings()->doSave();
     });
     const QByteArray base64Geometry = APPLICATION->settings()->get("NewsGeometry").toString().toUtf8();
     restoreGeometry(QByteArray::fromBase64(base64Geometry));

--- a/launcher/ui/dialogs/ResourceDownloadDialog.cpp
+++ b/launcher/ui/dialogs/ResourceDownloadDialog.cpp
@@ -98,6 +98,7 @@ void ResourceDownloadDialog::accept()
 {
     if (!geometrySaveKey().isEmpty()) {
         APPLICATION->settings()->set(geometrySaveKey(), QString::fromUtf8(saveGeometry().toBase64()));
+        APPLICATION->settings()->doSave();
     }
 
     QDialog::accept();
@@ -120,6 +121,7 @@ void ResourceDownloadDialog::reject()
 
     if (!geometrySaveKey().isEmpty()) {
         APPLICATION->settings()->set(geometrySaveKey(), QString::fromUtf8(saveGeometry().toBase64()));
+        APPLICATION->settings()->doSave();
     }
 
     QDialog::reject();

--- a/launcher/ui/pagedialog/PageDialog.cpp
+++ b/launcher/ui/pagedialog/PageDialog.cpp
@@ -77,6 +77,7 @@ bool PageDialog::handleClose()
 
     qDebug() << "Paged dialog close approved";
     APPLICATION->settings()->set("PagedGeometry", QString::fromUtf8(saveGeometry().toBase64()));
+    APPLICATION->settings()->doSave();
     qDebug() << "Paged dialog geometry saved";
 
     emit applied();

--- a/launcher/ui/pages/global/APIPage.cpp
+++ b/launcher/ui/pages/global/APIPage.cpp
@@ -204,6 +204,8 @@ void APIPage::applySettings()
     s->set("ModrinthToken", modrinthToken);
     s->set("UserAgentOverride", ui->userAgentLineEdit->text());
     s->set("TechnicClientID", ui->technicClientID->text());
+
+    s->doSave();
 }
 
 bool APIPage::apply()

--- a/launcher/ui/pages/global/ExternalToolsPage.cpp
+++ b/launcher/ui/pages/global/ExternalToolsPage.cpp
@@ -91,6 +91,7 @@ void ExternalToolsPage::applySettings()
         }
     }
     s->set("JsonEditor", jsonEditor);
+    s->doSave();
 }
 
 void ExternalToolsPage::on_jprofilerPathBtn_clicked()

--- a/launcher/ui/pages/global/LanguagePage.cpp
+++ b/launcher/ui/pages/global/LanguagePage.cpp
@@ -64,6 +64,7 @@ void LanguagePage::applySettings()
     auto settings = APPLICATION->settings();
     QString key = mainWidget->getSelectedLanguageKey();
     settings->set("Language", key);
+    settings->doSave();
 }
 
 void LanguagePage::loadSettings()

--- a/launcher/ui/pages/global/LauncherPage.cpp
+++ b/launcher/ui/pages/global/LauncherPage.cpp
@@ -287,6 +287,8 @@ void LauncherPage::applySettings()
     s->set("ShowModIncompat", ui->showModIncompatCheckBox->isChecked());
     s->set("SkipModpackUpdatePrompt", !ui->modpackUpdatePromptBtn->isChecked());
     s->set("DownloadGameFilesDuringInstanceCreation", ui->downloadGameFilesBtn->isChecked());
+
+    s->doSave();
 }
 void LauncherPage::loadSettings()
 {

--- a/launcher/ui/pages/global/ProxyPage.cpp
+++ b/launcher/ui/pages/global/ProxyPage.cpp
@@ -95,6 +95,7 @@ void ProxyPage::applySettings()
     s->set("ProxyPort", ui->proxyPortEdit->value());
     s->set("ProxyUser", ui->proxyUserEdit->text());
     s->set("ProxyPass", ui->proxyPassEdit->text());
+    s->doSave();
 
     APPLICATION->updateProxySettings(proxyType, ui->proxyAddrEdit->text(), ui->proxyPortEdit->value(), ui->proxyUserEdit->text(),
                                      ui->proxyPassEdit->text());

--- a/launcher/ui/pages/instance/ExternalResourcesPage.cpp
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.cpp
@@ -157,6 +157,7 @@ void ExternalResourcesPage::closedImpl()
     m_model->stopWatching();
 
     m_wide_bar_setting->set(QString::fromUtf8(ui->actionsToolbar->getVisibilityState().toBase64()));
+    APPLICATION->settings()->doSave();
 }
 
 void ExternalResourcesPage::retranslate()

--- a/launcher/ui/pages/instance/ManagedPackPage.cpp
+++ b/launcher/ui/pages/instance/ManagedPackPage.cpp
@@ -69,8 +69,10 @@ ManagedPackPage::ManagedPackPage(BaseInstance* inst, InstanceWindow* instanceWin
         QDesktopServices::openUrl(url);
     });
 
-    connect(ui->urlLine, &QLineEdit::textChanged, this,
-            [this](const QString& text) { m_inst->settings()->set("ManagedPackURL", text.trimmed()); });
+    connect(ui->urlLine, &QLineEdit::textChanged, this, [this](const QString& text) {
+        m_inst->settings()->set("ManagedPackURL", text.trimmed());
+        m_inst->settings()->doSave();
+    });
 }
 
 ManagedPackPage::~ManagedPackPage()

--- a/launcher/ui/pages/instance/ScreenshotsPage.cpp
+++ b/launcher/ui/pages/instance/ScreenshotsPage.cpp
@@ -598,6 +598,7 @@ void ScreenshotsPage::openedImpl()
 void ScreenshotsPage::closedImpl()
 {
     m_wide_bar_setting->set(QString::fromUtf8(ui->toolBar->getVisibilityState().toBase64()));
+    APPLICATION->settings()->doSave();
 }
 
 #include "ScreenshotsPage.moc"

--- a/launcher/ui/pages/instance/ServersPage.cpp
+++ b/launcher/ui/pages/instance/ServersPage.cpp
@@ -709,6 +709,7 @@ void ServersPage::closedImpl()
     m_model->unobserve();
 
     m_wide_bar_setting->set(QString::fromUtf8(ui->toolBar->getVisibilityState().toBase64()));
+    APPLICATION->settings()->doSave();
 }
 
 void ServersPage::on_actionAdd_triggered()

--- a/launcher/ui/pages/instance/VersionPage.cpp
+++ b/launcher/ui/pages/instance/VersionPage.cpp
@@ -123,7 +123,7 @@ void VersionPage::retranslate()
 
 void VersionPage::openedImpl()
 {
-    auto const setting_name = QString("WideBarVisibility_%1").arg(id());
+    const auto setting_name = QString("WideBarVisibility_%1").arg(id());
     m_wide_bar_setting = APPLICATION->settings()->getOrRegisterSetting(setting_name);
 
     ui->toolBar->setVisibilityState(QByteArray::fromBase64(m_wide_bar_setting->get().toString().toUtf8()));
@@ -131,6 +131,7 @@ void VersionPage::openedImpl()
 void VersionPage::closedImpl()
 {
     m_wide_bar_setting->set(QString::fromUtf8(ui->toolBar->getVisibilityState().toBase64()));
+    APPLICATION->settings()->doSave();
 }
 
 QMenu* VersionPage::createPopupMenu()
@@ -413,6 +414,7 @@ void VersionPage::on_actionChange_version_triggered()
             m_inst->settings()->get("OverrideJavaLocation").toBool()) {
             m_inst->settings()->set("OverrideJavaLocation", false);
             m_inst->settings()->set("JavaPath", "");
+            m_inst->settings()->doSave();
         }
     }
     m_profile->setComponentVersion(uid, vselect.selectedVersion()->descriptor(), important);

--- a/launcher/ui/pages/instance/WorldListPage.cpp
+++ b/launcher/ui/pages/instance/WorldListPage.cpp
@@ -133,6 +133,7 @@ void WorldListPage::closedImpl()
     m_worlds->stopWatching();
 
     m_wide_bar_setting->set(QString::fromUtf8(ui->toolBar->getVisibilityState().toBase64()));
+    APPLICATION->settings()->doSave();
 }
 
 WorldListPage::~WorldListPage()
@@ -273,8 +274,10 @@ void WorldListPage::on_actionData_Packs_triggered()
 
     dialog->setAttribute(Qt::WA_DeleteOnClose);
 
-    connect(dialog, &QDialog::finished, this,
-            [dialog]() { APPLICATION->settings()->set("DataPackDownloadGeometry", dialog->saveGeometry().toBase64()); });
+    connect(dialog, &QDialog::finished, this, [dialog]() {
+        APPLICATION->settings()->set("DataPackDownloadGeometry", dialog->saveGeometry().toBase64());
+        APPLICATION->settings()->doSave();
+    });
 
     dialog->open();
 }

--- a/launcher/ui/pages/modplatform/import_ftb/ListModel.cpp
+++ b/launcher/ui/pages/modplatform/import_ftb/ListModel.cpp
@@ -205,6 +205,7 @@ FilterModel::Sorting FilterModel::getCurrentSorting()
 void ListModel::setPath(QString path)
 {
     APPLICATION->settings()->set("FTBAppInstancesPath", path);
+    APPLICATION->settings()->doSave();
     update();
 }
 

--- a/launcher/ui/setupwizard/AutoJavaWizardPage.cpp
+++ b/launcher/ui/setupwizard/AutoJavaWizardPage.cpp
@@ -25,6 +25,7 @@ bool AutoJavaWizardPage::validatePage()
         s->set("AutomaticJavaDownload", true);
     }
     s->set("UserAskedAboutAutomaticJavaDownload", true);
+    s->doSave();
     return true;
 }
 

--- a/launcher/ui/setupwizard/JavaWizardPage.cpp
+++ b/launcher/ui/setupwizard/JavaWizardPage.cpp
@@ -55,27 +55,27 @@ bool JavaWizardPage::validatePage()
     settings->set("AutomaticJavaSwitch", m_java_widget->autoDetectJava());
     settings->set("AutomaticJavaDownload", m_java_widget->autoDownloadJava());
     settings->set("UserAskedAboutAutomaticJavaDownload", true);
-    switch (result) {
-        default:
-        case JavaWizardWidget::ValidationStatus::Bad: {
-            return false;
-        }
-        case JavaWizardWidget::ValidationStatus::AllOK: {
-            settings->set("JavaPath", m_java_widget->javaPath());
-        } /* fallthrough */
-        case JavaWizardWidget::ValidationStatus::JavaBad: {
-            // Memory
-            auto s = APPLICATION->settings();
-            s->set("MinMemAlloc", m_java_widget->minHeapSize());
-            s->set("MaxMemAlloc", m_java_widget->maxHeapSize());
-            if (m_java_widget->permGenEnabled()) {
-                s->set("PermGen", m_java_widget->permGenSize());
-            } else {
-                s->reset("PermGen");
-            }
-            return true;
-        }
+
+    if (result == JavaWizardWidget::ValidationStatus::Bad) {
+        settings->doSave();
+        return false;
     }
+
+    if (result == JavaWizardWidget::ValidationStatus::AllOK) {
+        settings->set("JavaPath", m_java_widget->javaPath());
+    }
+
+    // Memory
+    settings->set("MinMemAlloc", m_java_widget->minHeapSize());
+    settings->set("MaxMemAlloc", m_java_widget->maxHeapSize());
+    if (m_java_widget->permGenEnabled()) {
+        settings->set("PermGen", m_java_widget->permGenSize());
+    } else {
+        settings->reset("PermGen");
+    }
+
+    settings->doSave();
+    return true;
 }
 
 void JavaWizardPage::retranslate()

--- a/launcher/ui/setupwizard/LanguageWizardPage.cpp
+++ b/launcher/ui/setupwizard/LanguageWizardPage.cpp
@@ -36,6 +36,7 @@ bool LanguageWizardPage::validatePage()
     auto settings = APPLICATION->settings();
     QString key = mainWidget->getSelectedLanguageKey();
     settings->set("Language", key);
+    settings->doSave();
     return true;
 }
 

--- a/launcher/ui/setupwizard/PasteWizardPage.cpp
+++ b/launcher/ui/setupwizard/PasteWizardPage.cpp
@@ -28,6 +28,7 @@ bool PasteWizardPage::validatePage()
         if (!usingDefaultBase)
             s->set("PastebinCustomAPIBase", prevPasteURL);
     }
+    s->doSave();
 
     return true;
 }

--- a/launcher/ui/widgets/AppearanceWidget.cpp
+++ b/launcher/ui/widgets/AppearanceWidget.cpp
@@ -102,6 +102,7 @@ void AppearanceWidget::applySettings()
     settings->set("CatOpacity", m_ui->catOpacitySlider->value());
     auto catFit = m_ui->catFitComboBox->currentIndex();
     settings->set("CatFit", catFit == 0 ? "fit" : catFit == 1 ? "fill" : "strech");
+    settings->doSave();
 }
 
 void AppearanceWidget::loadSettings()

--- a/launcher/ui/widgets/JavaSettingsWidget.cpp
+++ b/launcher/ui/widgets/JavaSettingsWidget.cpp
@@ -95,6 +95,7 @@ JavaSettingsWidget::JavaSettingsWidget(MinecraftInstance* instance, QWidget* par
         connect(m_ui->javaPathTextBox, &QLineEdit::textChanged, this, [this](QString newValue) {
             if (m_instance->settings()->get("JavaPath").toString() != newValue) {
                 m_instance->settings()->set("AutomaticJava", false);
+                m_instance->settings()->doSave();
             }
         });
     }
@@ -224,6 +225,8 @@ void JavaSettingsWidget::saveSettings()
     } else {
         settings->reset("JvmArgs");
     }
+
+    settings->doSave();
 }
 
 void JavaSettingsWidget::onJavaBrowse()

--- a/launcher/ui/widgets/MinecraftSettingsWidget.cpp
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.cpp
@@ -105,6 +105,7 @@ MinecraftSettingsWidget::MinecraftSettingsWidget(MinecraftInstance* instance, QW
             m_instance->settings()->set("GlobalDataPacksEnabled", value);
             if (!value)
                 m_instance->settings()->reset("GlobalDataPacksPath");
+            m_instance->settings()->doSave();
         });
         connect(m_ui->dataPacksPathEdit, &QLineEdit::editingFinished, this, &MinecraftSettingsWidget::saveDataPacksPath);
         connect(m_ui->dataPacksPathBrowse, &QPushButton::clicked, this, &MinecraftSettingsWidget::selectDataPacksFolder);
@@ -113,8 +114,10 @@ MinecraftSettingsWidget::MinecraftSettingsWidget(MinecraftInstance* instance, QW
             m_instance->settings()->set("OverrideModDownloadLoaders", value);
             if (value)
                 saveSelectedLoaders();
-            else
+            else {
                 m_instance->settings()->reset("ModDownloadLoaders");
+                m_instance->settings()->doSave();
+            }
         });
 
         for (auto c : { m_ui->neoForge, m_ui->forge, m_ui->fabric, m_ui->quilt, m_ui->liteLoader, m_ui->babric, m_ui->btaBabric,
@@ -500,6 +503,8 @@ void MinecraftSettingsWidget::saveSettings()
         settings->reset("OnlineFixes");
     }
 
+    settings->doSave();
+
     if (m_javaSettings != nullptr)
         m_javaSettings->saveSettings();
 }
@@ -567,6 +572,7 @@ void MinecraftSettingsWidget::saveSelectedLoaders()
         loaders << getModLoaderAsString(ModPlatform::Rift);
 
     m_instance->settings()->set("ModDownloadLoaders", Json::fromStringList(loaders));
+    m_instance->settings()->doSave();
 }
 
 void MinecraftSettingsWidget::saveDataPacksPath()


### PR DESCRIPTION
A `set` or `reset` on `SettingsObject` conveniently automatically saves. However, this means if you forget a `SettingsObject::Lock` (or can't safely use it due to the current locked state being unknown) there may be excessive saves when only one was needed (this PR probably fixes that in a few places).

It would also seem awkward to add proper error handling for `set` and `reset`.

The main reason I want to do this, though, is the auto-save feature imposes too much of a restriction on the implementation - it needs to be possible to listen to the modification of every field.  I tried two times to create an alternative config API that met this requirement, but I didn't even succeed and it ended up being a complicated mess...

I was wanting to experiment with a more simple implementation still using QSettings for a while, and this would make it easier. It would also probably make the idea of using serde easier...