### PR TITLE
Bump C++ standard to 23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ set(CMAKE_JAVA_TARGET_OUTPUT_DIR ${PROJECT_BINARY_DIR}/jars)
 ######## Set compiler flags ########
 set(CMAKE_CXX_STANDARD_REQUIRED true)
 set(CMAKE_C_STANDARD_REQUIRED true)
-set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_C_STANDARD 11)
 include(GenerateExportHeader)
 

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
@@ -490,6 +490,21 @@ bool ModrinthCreationTask::promptForUntrustedMods()
     return dialog.exec() == QDialog::Accepted;
 }
 
+ModrinthCreationTask::ModrinthCreationTask(const QString& stagingPath,
+                                           bool trustedSource,
+                                           SettingsObject* globalSettings,
+                                           QWidget* parent,
+                                           QString id,
+                                           QString versionId,
+                                           QString originalInstanceId)
+    : m_parent(parent), m_trustedSource(trustedSource), m_managedId(std::move(id)), m_managedVersionId(std::move(versionId))
+{
+    setStagingPath(stagingPath);
+    setParentSettings(globalSettings);
+
+    m_originalInstanceId = std::move(originalInstanceId);
+}
+
 ModrinthCreationTask::~ModrinthCreationTask()
 {
     for (auto* resource : m_resources) {

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.h
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.h
@@ -32,14 +32,7 @@ class ModrinthCreationTask final : public InstanceTask {
                          QWidget* parent,
                          QString id,
                          QString versionId = {},
-                         QString originalInstanceId = {})
-        : m_parent(parent), m_trustedSource(trustedSource), m_managedId(std::move(id)), m_managedVersionId(std::move(versionId))
-    {
-        setStagingPath(stagingPath);
-        setParentSettings(globalSettings);
-
-        m_originalInstanceId = std::move(originalInstanceId);
-    }
+                         QString originalInstanceId = {});
     ~ModrinthCreationTask() override;
 
     bool abort() override;

--- a/launcher/translations/TranslationsModel.cpp
+++ b/launcher/translations/TranslationsModel.cpp
@@ -37,6 +37,7 @@
 #include "TranslationsModel.h"
 
 #include <QDebug>
+#include <algorithm>
 #include <memory>
 #include <utility>
 
@@ -292,10 +293,7 @@ void TranslationsModel::reloadLocalFiles()
         auto langIter = languages.find(langCode);
         if (langIter != languages.end()) {
             auto& language = *langIter;
-            // TODO: use std::to_underlying in C++23
-            if (static_cast<int>(fileType) > static_cast<int>(language.localFileType)) {
-                language.localFileType = fileType;
-            }
+            language.localFileType = std::max(fileType, language.localFileType);
         } else {
             if (fileType == FileType::Po) {
                 Language localFound(langCode);


### PR DESCRIPTION
Useful new things in the standard for us:
- `std::expected` and monadic operations on `std::optional`
- `std::out_ptr` - allows using modern RAII pointers when interacting with ancient APIs such as Win32
- More `std::ranges` and `std::views` features, such as `std::ranges::contains`

Using new standards expands the reach of libraries available to us:
- One particularly interesting one to me is [glaze](https://stephenberry.github.io/glaze/). It uses compiler instrinsics (for all three that we support rn) to reflect struct fields, allowing for very easy interaction with serialization (as there is no longer a need to manually write the logic to serialize and deserialize). Supports JSON and TOML.

Note: the `ModrinthInstanceCreationTask` is not unrelated, the compiler behavior is different when using the new standard
Note №2: this PR does not modernize the code to use the new features. I'll do this in separate PRs