### PR TITLE
ResourceFolderModelTest: increase timeout to 10 seconds

### DIFF
--- a/tests/ResourceFolderModel_test.cpp
+++ b/tests/ResourceFolderModel_test.cpp
@@ -51,7 +51,7 @@
     QTimer expire_timer;                                                                \
     expire_timer.callOnTimeout(&loop, &QEventLoop::quit);                               \
     expire_timer.setSingleShot(true);                                                   \
-    expire_timer.start(4000);                                                           \
+    expire_timer.start(10000);                                                          \
                                                                                         \
     VERIFY(EXEC);                                                                       \
     loop.exec();                                                                        \
@@ -94,7 +94,7 @@ class ResourceFolderModelTest : public QObject {
             QTimer expire_timer;
             expire_timer.callOnTimeout(&loop, &QEventLoop::quit);
             expire_timer.setSingleShot(true);
-            expire_timer.start(4000);
+            expire_timer.start(10000);
 
             m.installResource(folder);
 
@@ -118,7 +118,7 @@ class ResourceFolderModelTest : public QObject {
             QTimer expire_timer;
             expire_timer.callOnTimeout(&loop, &QEventLoop::quit);
             expire_timer.setSingleShot(true);
-            expire_timer.start(4000);
+            expire_timer.start(10000);
 
             m.installResource(folder);
 


### PR DESCRIPTION
Even with removal of mingw-arm64 the tests still fail frequently, especially during actions peak hours
the failure point in https://github.com/PrismLauncher/PrismLauncher/actions/runs/31017605745/job/92346002506?pr=5892 seems to be the timer, so i increased the timer wait to 10 seconds in hope that the test will have enough time to finish
