### PR TITLE
Tackle more excessive config saves

### DIFF
--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -240,7 +240,9 @@ void MinecraftInstance::loadSpecificSettings()
         auto envSetting = m_settings->registerSetting("OverrideEnv", false);
         m_settings->registerOverride(global_settings->getSetting("Env"), envSetting);
 
-        m_settings->set("InstanceType", "OneSix");
+        if (m_settings->get("InstanceType").toString() != "OneSix") {
+            m_settings->set("InstanceType", "OneSix");
+        }
     }
 
     // Join server on launch, this does not have a global override

--- a/launcher/settings/INISettingsObject.cpp
+++ b/launcher/settings/INISettingsObject.cpp
@@ -77,7 +77,7 @@ void INISettingsObject::resumeSave()
     Q_ASSERT(m_suspendSave);
     m_suspendSave = false;
     if (m_doSave) {
-        m_ini.saveFile(m_filePath);
+        doSave();
     }
 }
 
@@ -105,6 +105,7 @@ void INISettingsObject::doSave()
     if (m_suspendSave) {
         m_doSave = true;
     } else {
+        qDebug() << "Saving INI settings to " << m_filePath;
         m_ini.saveFile(m_filePath);
     }
 }

--- a/launcher/settings/INISettingsObject.cpp
+++ b/launcher/settings/INISettingsObject.cpp
@@ -51,7 +51,19 @@ void INISettingsObject::setFilePath(const QString& filePath)
 
 bool INISettingsObject::reload()
 {
-    return m_ini.loadFile(m_filePath) && SettingsObject::reload();
+    if (!m_ini.loadFile(m_filePath)) {
+        return false;
+    }
+
+    bool suspendSavePrev = m_suspendSave;
+    bool doSavePrev = m_doSave;
+
+    m_suspendSave = true;
+    bool result = SettingsObject::reload();
+
+    m_suspendSave = suspendSavePrev;
+    m_doSave = doSavePrev;
+    return result;
 }
 
 void INISettingsObject::suspendSave()


### PR DESCRIPTION
Parent PR: #5858

Currently reload triggers one save for every registered setting, and the first call to `settings()` on MinecraftInstance also triggers a save 

I'm not too happy about the hack I did in INISettingsObject::reload, so suggestions are welcome

Contains fixes which were also achieved in #5906