### PR TITLE
Fix manual refresh being skipped on active account

### DIFF
--- a/launcher/minecraft/auth/AccountList.cpp
+++ b/launcher/minecraft/auth/AccountList.cpp
@@ -628,6 +628,7 @@ void AccountList::requestRefresh(QString accountId)
         m_refreshQueue.removeAt(index);
     }
     m_refreshQueue.push_front(accountId);
+    m_explicitRefreshes.insert(accountId);
     qDebug() << "AccountList: Pushed account with internal ID" << accountId << "to the front of the queue";
     if (!isActive()) {
         tryNext();
@@ -653,7 +654,8 @@ void AccountList::tryNext()
             auto account = at(i);
             if (account->internalId() == accountId) {
                 found = true;
-                if (!account->shouldRefresh()) {
+                bool wasRequested = m_explicitRefreshes.remove(accountId);
+                if (!wasRequested && !account->shouldRefresh()) {
                     // Account no longer needs refreshing, skip it.
                     qDebug() << "RefreshSchedule: Skipping account" << account->profileName() << "with internal ID"
                              << accountId << "(no longer needs refresh)";
@@ -672,6 +674,7 @@ void AccountList::tryNext()
             }
         }
         if (!found) {
+            m_explicitRefreshes.remove(accountId);
             qDebug() << "RefreshSchedule: Account with internal ID" << accountId << "not found.";
         }
     }

--- a/launcher/minecraft/auth/AccountList.h
+++ b/launcher/minecraft/auth/AccountList.h
@@ -40,6 +40,7 @@
 
 #include <QAbstractListModel>
 #include <QObject>
+#include <QSet>
 #include <QSharedPointer>
 #include <QVariant>
 
@@ -142,6 +143,7 @@ class AccountList : public QAbstractListModel {
 
    protected:
     QList<QString> m_refreshQueue;
+    QSet<QString> m_explicitRefreshes;
     QTimer* m_refreshTimer;
     QTimer* m_nextTimer;
     shared_qobject_ptr<AuthFlow> m_currentTask;


### PR DESCRIPTION
Differentiate between manual user-initiated refreshes and automatic ones, so that a manual refresh still works even while there is a running instance on that account. This kills the active instance's session, but if the user wants to do this then we should not get in their way.

Closes: #5781