### PR TITLE
Add support for all http methods in Net::Request

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -136,8 +136,8 @@ set(NET_SOURCES
     net/RawHeaderProxy.h
     net/ApiHeaderProxy.h
     net/ApiRequest.h
-    net/NetRequest.cpp
-    net/NetRequest.h
+    net/Request.cpp
+    net/Request.h
 )
 
 # Game launch logic
@@ -641,8 +641,8 @@ set(PRISMUPDATER_SOURCES
     net/HttpMetaCache.h
     net/Logging.h
     net/Logging.cpp
-    net/NetRequest.cpp
-    net/NetRequest.h
+    net/Request.cpp
+    net/Request.h
     net/NetJob.cpp
     net/NetJob.h
     net/NetUtils.h

--- a/launcher/ResourceDownloadTask.cpp
+++ b/launcher/ResourceDownloadTask.cpp
@@ -70,7 +70,7 @@ ResourceDownloadTask::ResourceDownloadTask(ModPlatform::IndexedPack::Ptr pack,
     m_filesNetJob->setStatus(tr("Downloading resource:\n%1").arg(m_pack_version.downloadUrl));
 
     auto action = Net::ApiRequest::makeFile(
-        m_pack_version.downloadUrl, m_pack_model->dir().absoluteFilePath(getFilename()), Net::NetRequest::Option::NoOptions,
+        m_pack_version.downloadUrl, m_pack_model->dir().absoluteFilePath(getFilename()), Net::Request::Option::NoOptions,
         createModrinthMeta(m_pack_model->instance(), std::move(downloadReason), std::move(dependentOn)));
     if (!m_pack_version.hash_type.isEmpty() && !m_pack_version.hash.isEmpty()) {
         switch (Hashing::algorithmFromString(m_pack_version.hash_type)) {

--- a/launcher/java/download/ArchiveDownloadTask.cpp
+++ b/launcher/java/download/ArchiveDownloadTask.cpp
@@ -38,7 +38,7 @@ void ArchiveDownloadTask::executeTask()
     MetaEntryPtr entry = APPLICATION->metacache()->resolveEntry("java", m_url.fileName());
 
     auto download = makeShared<NetJob>(QString("JRE::DownloadJava"), APPLICATION->network());
-    auto action = Net::NetRequest::makeCached(m_url, entry);
+    auto action = Net::Request::makeCached(m_url, entry);
     if (!m_checksum_hash.isEmpty() && !m_checksum_type.isEmpty()) {
         auto hashType = QCryptographicHash::Algorithm::Sha1;
         if (m_checksum_type == "sha256") {

--- a/launcher/java/download/ManifestDownloadTask.cpp
+++ b/launcher/java/download/ManifestDownloadTask.cpp
@@ -40,7 +40,7 @@ void ManifestDownloadTask::executeTask()
     setStatus(tr("Downloading Java"));
     auto download = makeShared<NetJob>(QString("JRE::DownloadJava"), APPLICATION->network());
 
-    auto [action, files] = Net::NetRequest::makeByteArray(m_url);
+    auto [action, files] = Net::Request::makeByteArray(m_url);
     if (!m_checksum_hash.isEmpty() && !m_checksum_type.isEmpty()) {
         auto hashType = QCryptographicHash::Algorithm::Sha1;
         if (m_checksum_type == "sha256") {
@@ -103,12 +103,12 @@ void ManifestDownloadTask::downloadJava(const QJsonDocument& doc)
     }
     auto elementDownload = makeShared<NetJob>("JRE::FileDownload", APPLICATION->network());
     for (const auto& file : toDownload) {
-        auto dl = Net::NetRequest::makeFile(file.url, file.path);
+        auto dl = Net::Request::makeFile(file.url, file.path);
         if (!file.hash.isEmpty()) {
             dl->addValidator(new Net::ChecksumValidator(QCryptographicHash::Sha1, file.hash));
         }
         if (file.isExec) {
-            connect(dl.get(), &Net::NetRequest::succeeded, dl.get(),
+            connect(dl.get(), &Net::Request::succeeded, dl.get(),
                     [file] { QFile(file.path).setPermissions(QFile(file.path).permissions() | QFileDevice::Permissions(0x1111)); });
         }
         elementDownload->addNetAction(dl);

--- a/launcher/minecraft/AssetsUtils.cpp
+++ b/launcher/minecraft/AssetsUtils.cpp
@@ -50,7 +50,7 @@
 #include "net/ChecksumValidator.h"
 
 #include "Application.h"
-#include "net/NetRequest.h"
+#include "net/Request.h"
 #include "update/AssetUpdateTask.h"
 
 namespace {
@@ -277,7 +277,7 @@ bool reconstructAssets(QString assetsId, QString resourcesFolder)
 
 }  // namespace AssetsUtils
 
-Net::NetRequest::Ptr AssetObject::getDownloadAction()
+Net::Request::Ptr AssetObject::getDownloadAction()
 {
     QFileInfo objectFile(getLocalPath());
     if ((!objectFile.isFile()) || (objectFile.size() != size)) {

--- a/launcher/minecraft/AssetsUtils.h
+++ b/launcher/minecraft/AssetsUtils.h
@@ -18,13 +18,13 @@
 #include <QMap>
 #include <QString>
 #include "net/NetJob.h"
-#include "net/NetRequest.h"
+#include "net/Request.h"
 
 struct AssetObject {
     QString getRelPath();
     QUrl getUrl();
     QString getLocalPath();
-    Net::NetRequest::Ptr getDownloadAction();
+    Net::Request::Ptr getDownloadAction();
 
     QString hash;
     qint64 size;

--- a/launcher/minecraft/Library.cpp
+++ b/launcher/minecraft/Library.cpp
@@ -35,7 +35,7 @@
 
 #include "Library.h"
 #include "MinecraftInstance.h"
-#include "net/NetRequest.h"
+#include "net/Request.h"
 
 #include <BuildConfig.h>
 #include <FileSystem.h>
@@ -103,14 +103,14 @@ void Library::getApplicableFiles(const RuntimeContext& runtimeContext,
  * @param cache Pointer to the HTTP meta cache.
  * @param failedLocalFiles List to store paths for failed local files.
  * @param overridePath Optional path to override the default storage path.
- * @return QList<Net::NetRequest::Ptr> List of download requests.
+ * @return QList<Net::Request::Ptr> List of download requests.
  */
-QList<Net::NetRequest::Ptr> Library::getDownloads(const RuntimeContext& runtimeContext,
+QList<Net::Request::Ptr> Library::getDownloads(const RuntimeContext& runtimeContext,
                                                   class HttpMetaCache* cache,
                                                   QStringList& failedLocalFiles,
                                                   const QString& overridePath) const
 {
-    QList<Net::NetRequest::Ptr> out;
+    QList<Net::Request::Ptr> out;
     bool stale = isAlwaysStale();
     bool local = isLocal();
 
@@ -138,13 +138,13 @@ QList<Net::NetRequest::Ptr> Library::getDownloads(const RuntimeContext& runtimeC
         }
         if (!entry->isStale())
             return true;
-        Net::NetRequest::Options options;
+        Net::Request::Options options;
         if (stale) {
-            options |= Net::NetRequest::Option::AcceptLocalFiles;
+            options |= Net::Request::Option::AcceptLocalFiles;
         }
 
         // Don't add a time limit for the libraries cache entry validity
-        options |= Net::NetRequest::Option::MakeEternal;
+        options |= Net::Request::Option::MakeEternal;
 
         if (sha1.size()) {
             auto dl = Net::ApiRequest::makeCached(url, entry, options);

--- a/launcher/minecraft/Library.h
+++ b/launcher/minecraft/Library.h
@@ -47,7 +47,7 @@
 #include "MojangDownloadInfo.h"
 #include "Rule.h"
 #include "RuntimeContext.h"
-#include "net/NetRequest.h"
+#include "net/Request.h"
 
 class Library;
 class MinecraftInstance;
@@ -144,7 +144,7 @@ class Library {
     bool isForge() const;
 
     // Get a list of downloads for this library
-    QList<Net::NetRequest::Ptr> getDownloads(const RuntimeContext& runtimeContext,
+    QList<Net::Request::Ptr> getDownloads(const RuntimeContext& runtimeContext,
                                              class HttpMetaCache* cache,
                                              QStringList& failedLocalFiles,
                                              const QString& overridePath) const;

--- a/launcher/minecraft/auth/steps/EntitlementsStep.cpp
+++ b/launcher/minecraft/auth/steps/EntitlementsStep.cpp
@@ -9,7 +9,7 @@
 #include "Application.h"
 #include "Logging.h"
 #include "minecraft/auth/Parsers.h"
-#include "net/NetRequest.h"
+#include "net/Request.h"
 #include "net/NetJob.h"
 #include "net/RawHeaderProxy.h"
 #include "tasks/Task.h"
@@ -30,7 +30,7 @@ void EntitlementsStep::perform()
                                            { "Accept", "application/json" },
                                            { "Authorization", QString("Bearer %1").arg(m_data->yggdrasilToken.token).toUtf8() } };
 
-    auto [request, response] = Net::NetRequest::makeByteArray(url);
+    auto [request, response] = Net::Request::makeByteArray(url);
     m_request = request;
     m_request->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(headers));
     m_request->enableAutoRetry(true);

--- a/launcher/minecraft/auth/steps/EntitlementsStep.h
+++ b/launcher/minecraft/auth/steps/EntitlementsStep.h
@@ -2,7 +2,7 @@
 #include <QObject>
 
 #include "minecraft/auth/AuthStep.h"
-#include "net/NetRequest.h"
+#include "net/Request.h"
 #include "net/NetJob.h"
 
 class EntitlementsStep : public AuthStep {
@@ -21,6 +21,6 @@ class EntitlementsStep : public AuthStep {
 
    private:
     QString m_entitlements_request_id;
-    Net::NetRequest::Ptr m_request;
+    Net::Request::Ptr m_request;
     NetJob::Ptr m_task;
 };

--- a/launcher/minecraft/auth/steps/GetSkinStep.cpp
+++ b/launcher/minecraft/auth/steps/GetSkinStep.cpp
@@ -16,7 +16,7 @@ void GetSkinStep::perform()
 {
     QUrl url(m_data->minecraftProfile.skin.url);
 
-    auto [request, response] = Net::NetRequest::makeByteArray(url);
+    auto [request, response] = Net::Request::makeByteArray(url);
     m_request = request;
     m_request->enableAutoRetry(true);
 

--- a/launcher/minecraft/auth/steps/GetSkinStep.h
+++ b/launcher/minecraft/auth/steps/GetSkinStep.h
@@ -2,7 +2,7 @@
 #include <QObject>
 
 #include "minecraft/auth/AuthStep.h"
-#include "net/NetRequest.h"
+#include "net/Request.h"
 #include "net/NetJob.h"
 
 class GetSkinStep : public AuthStep {
@@ -20,6 +20,6 @@ class GetSkinStep : public AuthStep {
     void onRequestDone(QByteArray* response);
 
    private:
-    Net::NetRequest::Ptr m_request;
+    Net::Request::Ptr m_request;
     NetJob::Ptr m_task;
 };

--- a/launcher/minecraft/auth/steps/LauncherLoginStep.cpp
+++ b/launcher/minecraft/auth/steps/LauncherLoginStep.cpp
@@ -8,7 +8,7 @@
 #include "minecraft/auth/Parsers.h"
 #include "net/NetUtils.h"
 #include "net/RawHeaderProxy.h"
-#include "net/NetRequest.h"
+#include "net/Request.h"
 
 LauncherLoginStep::LauncherLoginStep(AccountData* data) : AuthStep(data) {}
 
@@ -36,7 +36,7 @@ void LauncherLoginStep::perform()
         { "Accept", "application/json" },
     };
 
-    auto [request, response] = Net::NetRequest::makeByteArray(url, requestBody.toUtf8());
+    auto [request, response] = Net::Request::makeByteArray(url, requestBody.toUtf8());
     m_request = request;
     m_request->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(headers));
     m_request->enableAutoRetry(true);

--- a/launcher/minecraft/auth/steps/LauncherLoginStep.h
+++ b/launcher/minecraft/auth/steps/LauncherLoginStep.h
@@ -3,7 +3,7 @@
 
 #include "minecraft/auth/AuthStep.h"
 #include "net/NetJob.h"
-#include "net/NetRequest.h"
+#include "net/Request.h"
 
 class LauncherLoginStep : public AuthStep {
     Q_OBJECT
@@ -20,6 +20,6 @@ class LauncherLoginStep : public AuthStep {
     void onRequestDone(QByteArray* response);
 
    private:
-    Net::NetRequest::Ptr m_request;
+    Net::Request::Ptr m_request;
     NetJob::Ptr m_task;
 };

--- a/launcher/minecraft/auth/steps/MSADeviceCodeStep.cpp
+++ b/launcher/minecraft/auth/steps/MSADeviceCodeStep.cpp
@@ -66,7 +66,7 @@ void MSADeviceCodeStep::perform()
         { "Content-Type", "application/x-www-form-urlencoded" },
         { "Accept", "application/json" },
     };
-    auto [request, response] = Net::NetRequest::makeByteArray(url, payload);
+    auto [request, response] = Net::Request::makeByteArray(url, payload);
     m_request = request;
     m_request->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(headers));
     m_request->enableAutoRetry(true);
@@ -181,7 +181,7 @@ void MSADeviceCodeStep::authenticateUser()
         { "Content-Type", "application/x-www-form-urlencoded" },
         { "Accept", "application/json" },
     };
-    auto [request, response] = Net::NetRequest::makeByteArray(url, payload);
+    auto [request, response] = Net::Request::makeByteArray(url, payload);
     m_request = request;
     m_request->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(headers));
 

--- a/launcher/minecraft/auth/steps/MSADeviceCodeStep.h
+++ b/launcher/minecraft/auth/steps/MSADeviceCodeStep.h
@@ -39,7 +39,7 @@
 
 #include "minecraft/auth/AuthStep.h"
 #include "net/NetJob.h"
-#include "net/NetRequest.h"
+#include "net/Request.h"
 
 class MSADeviceCodeStep : public AuthStep {
     Q_OBJECT
@@ -72,6 +72,6 @@ class MSADeviceCodeStep : public AuthStep {
     QTimer m_pool_timer;
     QTimer m_expiration_timer;
 
-    Net::NetRequest::Ptr m_request;
+    Net::Request::Ptr m_request;
     NetJob::Ptr m_task;
 };

--- a/launcher/minecraft/auth/steps/MinecraftProfileStep.cpp
+++ b/launcher/minecraft/auth/steps/MinecraftProfileStep.cpp
@@ -21,7 +21,7 @@ void MinecraftProfileStep::perform()
                                            { "Accept", "application/json" },
                                            { "Authorization", QString("Bearer %1").arg(m_data->yggdrasilToken.token).toUtf8() } };
 
-    auto [request, response] = Net::NetRequest::makeByteArray(url);
+    auto [request, response] = Net::Request::makeByteArray(url);
     m_request = request;
     m_request->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(headers));
     m_request->enableAutoRetry(true);

--- a/launcher/minecraft/auth/steps/MinecraftProfileStep.h
+++ b/launcher/minecraft/auth/steps/MinecraftProfileStep.h
@@ -2,7 +2,7 @@
 #include <QObject>
 
 #include "minecraft/auth/AuthStep.h"
-#include "net/NetRequest.h"
+#include "net/Request.h"
 #include "net/NetJob.h"
 
 class MinecraftProfileStep : public AuthStep {
@@ -20,6 +20,6 @@ class MinecraftProfileStep : public AuthStep {
     void onRequestDone(QByteArray* response);
 
    private:
-    Net::NetRequest::Ptr m_request;
+    Net::Request::Ptr m_request;
     NetJob::Ptr m_task;
 };

--- a/launcher/minecraft/auth/steps/XboxAuthorizationStep.cpp
+++ b/launcher/minecraft/auth/steps/XboxAuthorizationStep.cpp
@@ -9,7 +9,7 @@
 #include "minecraft/auth/Parsers.h"
 #include "net/NetUtils.h"
 #include "net/RawHeaderProxy.h"
-#include "net/NetRequest.h"
+#include "net/Request.h"
 
 XboxAuthorizationStep::XboxAuthorizationStep(AccountData* data, Token* token, QString relyingParty, QString authorizationKind)
     : AuthStep(data), m_token(token), m_relyingParty(std::move(relyingParty)), m_authorizationKind(std::move(authorizationKind))
@@ -40,7 +40,7 @@ void XboxAuthorizationStep::perform()
     auto headers = QList<Net::HeaderPair>{ { .headerName = "Content-Type", .headerValue = "application/json" },
                                            { .headerName = "Accept", .headerValue = "application/json" },
                                            { .headerName = "x-xbl-contract-version", .headerValue = "1" } };
-    auto [request, response] = Net::NetRequest::makeByteArray(url, xboxAuthData.toUtf8());
+    auto [request, response] = Net::Request::makeByteArray(url, xboxAuthData.toUtf8());
     m_request = request;
     m_request->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(headers));
     m_request->enableAutoRetry(true);

--- a/launcher/minecraft/auth/steps/XboxAuthorizationStep.h
+++ b/launcher/minecraft/auth/steps/XboxAuthorizationStep.h
@@ -3,7 +3,7 @@
 
 #include "minecraft/auth/AuthStep.h"
 #include "net/NetJob.h"
-#include "net/NetRequest.h"
+#include "net/Request.h"
 
 class XboxAuthorizationStep : public AuthStep {
     Q_OBJECT
@@ -27,6 +27,6 @@ class XboxAuthorizationStep : public AuthStep {
     QString m_relyingParty;
     QString m_authorizationKind;
 
-    Net::NetRequest::Ptr m_request;
+    Net::Request::Ptr m_request;
     NetJob::Ptr m_task;
 };

--- a/launcher/minecraft/auth/steps/XboxUserStep.cpp
+++ b/launcher/minecraft/auth/steps/XboxUserStep.cpp
@@ -37,7 +37,7 @@ void XboxUserStep::perform()
         // https://learn.microsoft.com/en-us/gaming/gdk/_content/gc/reference/live/rest/additional/httpstandardheaders
         { "x-xbl-contract-version", "1" }
     };
-    auto [request, response] = Net::NetRequest::makeByteArray(url, xbox_auth_data.toUtf8());
+    auto [request, response] = Net::Request::makeByteArray(url, xbox_auth_data.toUtf8());
     m_request = request;
     m_request->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(headers));
     m_request->enableAutoRetry(true);

--- a/launcher/minecraft/auth/steps/XboxUserStep.h
+++ b/launcher/minecraft/auth/steps/XboxUserStep.h
@@ -3,7 +3,7 @@
 
 #include "minecraft/auth/AuthStep.h"
 #include "net/NetJob.h"
-#include "net/NetRequest.h"
+#include "net/Request.h"
 
 class XboxUserStep : public AuthStep {
     Q_OBJECT
@@ -20,6 +20,6 @@ class XboxUserStep : public AuthStep {
     void onRequestDone(QByteArray* response);
 
    private:
-    Net::NetRequest::Ptr m_request;
+    Net::Request::Ptr m_request;
     NetJob::Ptr m_task;
 };

--- a/launcher/minecraft/skins/CapeChange.cpp
+++ b/launcher/minecraft/skins/CapeChange.cpp
@@ -40,7 +40,7 @@
 #include <memory>
 #include "net/RawHeaderProxy.h"
 
-CapeChange::CapeChange(QString cape) : NetRequest(), m_capeId(cape)
+CapeChange::CapeChange(QString cape) : Request(), m_capeId(cape)
 {
     m_logCat = taskMCSkinsLogC;
 }

--- a/launcher/minecraft/skins/CapeChange.h
+++ b/launcher/minecraft/skins/CapeChange.h
@@ -18,9 +18,9 @@
 
 #pragma once
 
-#include "net/NetRequest.h"
+#include "net/Request.h"
 
-class CapeChange : public Net::NetRequest {
+class CapeChange : public Net::Request {
     Q_OBJECT
    public:
     using Ptr = shared_qobject_ptr<CapeChange>;

--- a/launcher/minecraft/skins/SkinDelete.cpp
+++ b/launcher/minecraft/skins/SkinDelete.cpp
@@ -39,7 +39,7 @@
 #include <net/DummySink.h>
 #include "net/RawHeaderProxy.h"
 
-SkinDelete::SkinDelete() : NetRequest()
+SkinDelete::SkinDelete() : Request()
 {
     m_logCat = taskMCSkinsLogC;
 }

--- a/launcher/minecraft/skins/SkinDelete.h
+++ b/launcher/minecraft/skins/SkinDelete.h
@@ -18,9 +18,9 @@
 
 #pragma once
 
-#include "net/NetRequest.h"
+#include "net/Request.h"
 
-class SkinDelete : public Net::NetRequest {
+class SkinDelete : public Net::Request {
     Q_OBJECT
    public:
     using Ptr = shared_qobject_ptr<SkinDelete>;

--- a/launcher/minecraft/skins/SkinUpload.cpp
+++ b/launcher/minecraft/skins/SkinUpload.cpp
@@ -42,7 +42,7 @@
 #include "net/DummySink.h"
 #include "net/RawHeaderProxy.h"
 
-SkinUpload::SkinUpload(QString path, QString variant) : NetRequest(), m_path(path), m_variant(variant)
+SkinUpload::SkinUpload(QString path, QString variant) : Request(), m_path(path), m_variant(variant)
 {
     m_logCat = taskMCSkinsLogC;
 }

--- a/launcher/minecraft/skins/SkinUpload.h
+++ b/launcher/minecraft/skins/SkinUpload.h
@@ -18,9 +18,9 @@
 
 #pragma once
 
-#include "net/NetRequest.h"
+#include "net/Request.h"
 
-class SkinUpload : public Net::NetRequest {
+class SkinUpload : public Net::Request {
     Q_OBJECT
    public:
     using Ptr = shared_qobject_ptr<SkinUpload>;

--- a/launcher/minecraft/update/LegacyFMLLibrariesTask.cpp
+++ b/launcher/minecraft/update/LegacyFMLLibrariesTask.cpp
@@ -60,7 +60,7 @@ void LegacyFMLLibrariesTask::executeTask()
     setStatus(tr("Downloading FML libraries..."));
     NetJob::Ptr dljob{ new NetJob("FML libraries", APPLICATION->network()) };
     auto metacache = APPLICATION->metacache();
-    Net::NetRequest::Options options = Net::NetRequest::Option::MakeEternal;
+    Net::Request::Options options = Net::Request::Option::MakeEternal;
     const QString base = baseUrl();
     for (auto& lib : fmlLibsToProcess) {
         auto entry = metacache->resolveEntry("fmllibs", lib.filename);

--- a/launcher/modplatform/ftb/FTBPackInstallTask.cpp
+++ b/launcher/modplatform/ftb/FTBPackInstallTask.cpp
@@ -97,7 +97,7 @@ void PackInstallTask::executeTask()
 
     auto searchUrl = QString(BuildConfig.FTB_API_BASE_URL + "/modpack/%1/%2").arg(m_pack.id).arg(version.id);
 
-    auto [action, response] = Net::NetRequest::makeByteArray(QUrl(searchUrl));
+    auto [action, response] = Net::Request::makeByteArray(QUrl(searchUrl));
     netJob->addNetAction(action);
 
     QObject::connect(netJob.get(), &NetJob::succeeded, this, [this, response] { onManifestDownloadSucceeded(response); });
@@ -315,7 +315,7 @@ void PackInstallTask::downloadPack()
 
         const QFileInfo fileInfo(file.name);
 
-        auto dl = Net::NetRequest::makeFile(file.url, path);
+        auto dl = Net::Request::makeFile(file.url, path);
         if (!file.sha1.isEmpty()) {
             dl->addValidator(new Net::ChecksumValidator(QCryptographicHash::Sha1, file.sha1));
         }

--- a/launcher/modplatform/legacy_ftb/PackFetchTask.cpp
+++ b/launcher/modplatform/legacy_ftb/PackFetchTask.cpp
@@ -60,7 +60,7 @@ void PackFetchTask::fetch()
     QUrl thirdPartyUrl = QUrl(BuildConfig.LEGACY_FTB_CDN_BASE_URL + "static/thirdparty.xml");
     qDebug() << "Downloading thirdparty version info from" << thirdPartyUrl.toString();
 
-    auto [thirdPartyAction, thirdPartyResponse] = Net::NetRequest::makeByteArray(thirdPartyUrl);
+    auto [thirdPartyAction, thirdPartyResponse] = Net::Request::makeByteArray(thirdPartyUrl);
     jobPtr->addNetAction(thirdPartyAction);
 
     connect(jobPtr.get(), &NetJob::succeeded, this,

--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
@@ -282,7 +282,7 @@ void ModrinthCreationTask::createInstance()
                                         .dependentOn = !m_managedId.isEmpty() ? m_managedVersionId : "" };
 
         QUrl downloadUrl = file.downloads.dequeue();
-        auto dl = Net::ApiRequest::makeFile(downloadUrl, filePath, Net::NetRequest::Option::NoOptions, meta);
+        auto dl = Net::ApiRequest::makeFile(downloadUrl, filePath, Net::Request::Option::NoOptions, meta);
         dl->addValidator(new Net::ChecksumValidator(file.hashAlgorithm, file.hash));
         downloadMods->addNetAction(dl);
         if (!file.downloads.empty()) {
@@ -291,7 +291,7 @@ void ModrinthCreationTask::createInstance()
             auto param = dl.toWeakRef();
             connect(dl.get(), &Task::failed, dl.get(), [&file, filePath, param, downloadMods, meta] {
                 QUrl fallbackUrl = file.downloads.dequeue();
-                auto ndl = Net::ApiRequest::makeFile(fallbackUrl, filePath, Net::NetRequest::Option::NoOptions, meta);
+                auto ndl = Net::ApiRequest::makeFile(fallbackUrl, filePath, Net::Request::Option::NoOptions, meta);
                 ndl->addValidator(new Net::ChecksumValidator(file.hashAlgorithm, file.hash));
                 downloadMods->addNetAction(ndl);
                 if (auto shared = param.lock()) {

--- a/launcher/net/ApiRequest.h
+++ b/launcher/net/ApiRequest.h
@@ -25,34 +25,34 @@
 #include <utility>
 
 #include "net/ApiHeaderProxy.h"
-#include "net/NetRequest.h"
+#include "net/Request.h"
 
 namespace Net {
 
 namespace ApiRequest {
-inline NetRequest::Ptr makeCached(const QUrl& url, MetaEntryPtr entry, NetRequest::Options options = NetRequest::Option::NoOptions)
+inline Request::Ptr makeCached(const QUrl& url, MetaEntryPtr entry, Request::Options options = Request::Option::NoOptions)
 {
-    return NetRequest::makeCached(url, std::move(entry), options | NetRequest::Option::AddAPIHeaders);
+    return Request::makeCached(url, std::move(entry), options | Request::Option::AddAPIHeaders);
 }
 
-inline std::pair<NetRequest::Ptr, QByteArray*> makeByteArray(const QUrl& url, NetRequest::Options options = NetRequest::Option::NoOptions)
+inline std::pair<Request::Ptr, QByteArray*> makeByteArray(const QUrl& url, Request::Options options = Request::Option::NoOptions)
 {
-    return NetRequest::makeByteArray(url, options | NetRequest::Option::AddAPIHeaders);
+    return Request::makeByteArray(url, options | Request::Option::AddAPIHeaders);
 }
 
-inline std::pair<NetRequest::Ptr, QByteArray*> makeByteArray(const QUrl& url,
+inline std::pair<Request::Ptr, QByteArray*> makeByteArray(const QUrl& url,
                                                              QByteArray postData,
-                                                             NetRequest::Options options = NetRequest::Option::NoOptions)
+                                                             Request::Options options = Request::Option::NoOptions)
 {
-    return NetRequest::makeByteArray(url, std::move(postData), options | NetRequest::Option::AddAPIHeaders);
+    return Request::makeByteArray(url, std::move(postData), options | Request::Option::AddAPIHeaders);
 }
 
-inline NetRequest::Ptr makeFile(const QUrl& url,
+inline Request::Ptr makeFile(const QUrl& url,
                                 const QString& path,
-                                NetRequest::Options options = NetRequest::Option::NoOptions,
+                                Request::Options options = Request::Option::NoOptions,
                                 ModrinthDownloadMeta meta = ModrinthDownloadMeta())
 {
-    auto req = NetRequest::makeFile(url, path, options);
+    auto req = Request::makeFile(url, path, options);
     req->addHeaderProxy(std::make_unique<ApiHeaderProxy>(std::move(meta)));
     return req;
 }

--- a/launcher/net/NetJob.cpp
+++ b/launcher/net/NetJob.cpp
@@ -37,7 +37,7 @@
 
 #include "NetJob.h"
 #include <QNetworkReply>
-#include "net/NetRequest.h"
+#include "net/Request.h"
 #include "tasks/ConcurrentTask.h"
 #if defined(LAUNCHER_APPLICATION)
 #include "Application.h"
@@ -55,7 +55,7 @@ NetJob::NetJob(QString job_name, QNetworkAccessManager* network, int max_concurr
         setMaxConcurrent(max_concurrent);
 }
 
-auto NetJob::addNetAction(Net::NetRequest::Ptr action) -> bool
+auto NetJob::addNetAction(Net::Request::Ptr action) -> bool
 {
     action->setNetwork(m_network);
 
@@ -71,7 +71,7 @@ void NetJob::executeNextSubTask()
         m_try += 1;
         m_failed.removeIf([this](QHash<Task*, Task::Ptr>::iterator task) {
             // there is no point in retying on 404 Not Found
-            if (static_cast<Net::NetRequest*>(task->get())->replyStatusCode() == 404) {
+            if (static_cast<Net::Request*>(task->get())->replyStatusCode() == 404) {
                 return false;
             }
             m_done.remove(task->get());
@@ -130,11 +130,11 @@ auto NetJob::abort() -> bool
     return fullyAborted;
 }
 
-auto NetJob::getFailedActions() -> QList<Net::NetRequest*>
+auto NetJob::getFailedActions() -> QList<Net::Request*>
 {
-    QList<Net::NetRequest*> failed;
+    QList<Net::Request*> failed;
     for (auto index : m_failed) {
-        failed.push_back(dynamic_cast<Net::NetRequest*>(index.get()));
+        failed.push_back(dynamic_cast<Net::Request*>(index.get()));
     }
     return failed;
 }
@@ -143,7 +143,7 @@ auto NetJob::getFailedFiles() -> QList<QString>
 {
     QList<QString> failed;
     for (auto index : m_failed) {
-        failed.append(static_cast<Net::NetRequest*>(index.get())->url().toString());
+        failed.append(static_cast<Net::Request*>(index.get())->url().toString());
     }
     return failed;
 }

--- a/launcher/net/NetJob.h
+++ b/launcher/net/NetJob.h
@@ -39,7 +39,7 @@
 #include <QtNetwork>
 
 #include <QObject>
-#include "net/NetRequest.h"
+#include "net/Request.h"
 #include "tasks/ConcurrentTask.h"
 
 // Those are included so that they are also included by anyone using NetJob
@@ -58,9 +58,9 @@ class NetJob : public ConcurrentTask {
     auto size() const -> int;
 
     auto canAbort() const -> bool override;
-    auto addNetAction(Net::NetRequest::Ptr action) -> bool;
+    auto addNetAction(Net::Request::Ptr action) -> bool;
 
-    auto getFailedActions() -> QList<Net::NetRequest*>;
+    auto getFailedActions() -> QList<Net::Request*>;
     auto getFailedFiles() -> QList<QString>;
     void setAskRetry(bool askRetry);
 

--- a/launcher/net/PasteUpload.h
+++ b/launcher/net/PasteUpload.h
@@ -36,7 +36,7 @@
 #pragma once
 
 #include "net/ByteArraySink.h"
-#include "net/NetRequest.h"
+#include "net/Request.h"
 #include "tasks/Task.h"
 
 #include <QNetworkReply>
@@ -47,7 +47,7 @@
 #include <memory>
 #include <utility>
 
-class PasteUpload : public Net::NetRequest {
+class PasteUpload : public Net::Request {
    public:
     enum PasteType : int {
         // 0x0.st

--- a/launcher/net/Request.cpp
+++ b/launcher/net/Request.cpp
@@ -41,12 +41,16 @@
 
 #include <QDateTime>
 #include <QFileInfo>
+#include <QHttpMultiPart>
+#include <QIODevice>
 #include <QLocale>
+#include <QNetworkAccessManager>
 #include <QNetworkReply>
 #include <QUrl>
 #include <cstdint>
 #include <memory>
 #include <utility>
+#include <variant>
 
 #if defined(LAUNCHER_APPLICATION)
 #include "Application.h"
@@ -65,32 +69,46 @@
 
 namespace Net {
 
-Request::Request()
+namespace {
+auto logCatForMethod(HttpMethod method) -> Request::LogCatFunc
+{
+    switch (method.value()) {
+        case HttpMethod::Get:
+            return taskDownloadLogC;
+        case HttpMethod::Post:
+            return taskUploadLogC;
+        default:
+            break;
+    }
+    return taskNetLogC;
+}
+}  // namespace
+
+Request::Request() : Request(Spec{}) {}
+
+Request::Request(const QUrl& url, Options options, const QString& name)
+    : Request(Spec{ .method = HttpMethod::Get, .url = url, .data = std::monostate{}, .options = options, .name = name })
+{}
+
+Request::Request(const QUrl& url, QByteArray postData, Options options)
+    : Request(Spec{ .method = HttpMethod::Post, .url = url, .data = std::move(postData), .options = options })
+{}
+
+Request::Request(const Spec& spec) : m_options(spec.options), m_url(spec.url), m_httpMethod(spec.method), m_postData(spec.data)
 {
     connect(&m_retryTimer, &QTimer::timeout, this, &Request::executeTask);
-}
 
-Request::Request(const QUrl& url, Options options, const QString& name) : Request()
-{
-    m_url = url;
-    m_options = options;
-    if (name.isEmpty()) {
+    if (spec.name.isEmpty()) {
         setObjectName(QString("BYTES:") + m_url.toString());
     } else {
-        setObjectName(name);
+        setObjectName(spec.name);
     }
-    m_logCat = taskDownloadLogC;
+    m_logCat = logCatForMethod(m_httpMethod);
 #if defined(LAUNCHER_APPLICATION)
-    if (options.testFlag(Option::AddAPIHeaders)) {
+    if (spec.options.testFlag(Option::AddAPIHeaders)) {
         addHeaderProxy(std::make_unique<ApiHeaderProxy>());
     }
 #endif
-}
-
-Request::Request(const QUrl& url, QByteArray postData, Options options) : Request(url, options)
-{
-    m_postData = std::move(postData);
-    m_logCat = taskUploadLogC;
 }
 
 void Request::addValidator(Validator* v)
@@ -102,6 +120,16 @@ void Request::executeTask()
 {
     setStatus(tr("Requesting %1").arg(StringUtils::truncateUrlHumanFriendly(m_url, 80)));
 
+    if (m_network == nullptr) {
+#if defined(LAUNCHER_APPLICATION)
+        m_network = APPLICATION->network();
+#else
+        qCCritical(m_logCat) << getUid().toString() << "No network manager set for request:" << m_url.toString();
+        emit failed("No network manager set for request");
+        emit finished();
+        return;
+#endif
+    }
     if (getState() == Task::State::AbortedByUser) {
         qCWarning(m_logCat) << getUid().toString() << "Attempt to start an aborted Request:" << m_url.toString();
         emit aborted();
@@ -207,10 +235,18 @@ void Request::downloadError(QNetworkReply::NetworkError error)
             auto retryAfter = m_reply->rawHeader("Retry-After");
             if (retryAfter.trimmed().endsWith("GMT")) /* HTTP Date format */ {
                 auto afterTimestamp = QDateTime::fromString(QString::fromUtf8(retryAfter.trimmed()), "ddd, dd MMM yyyy HH:mm:ss 'GMT'");
-                auto now = QDateTime::currentDateTime();
-                delay = now.secsTo(afterTimestamp);
+                if (afterTimestamp.isValid()) {
+                    auto seconds = QDateTime::currentDateTime().secsTo(afterTimestamp);
+                    if (seconds > 0) {
+                        delay = seconds;
+                    }
+                }
             } else {
-                delay = retryAfter.toLong();
+                bool ok = false;
+                auto seconds = retryAfter.toLongLong(&ok);
+                if (ok && seconds > 0) {
+                    delay = seconds;
+                }
             }
         }
         handleAutoRetry(delay);
@@ -278,7 +314,8 @@ auto Request::handleRedirect() -> bool
         }
 
         /*
-         * Next, make sure the URL is parsed in tolerant mode. Qt doesn't parse the location header in tolerant mode, which causes issues.
+         * Next, make sure the URL is parsed in tolerant mode. Qt doesn't parse the location header in tolerant mode, which causes
+         * issues.
          * FIXME: report Qt bug for this
          */
         redirect = QUrl(redirectStr, QUrl::TolerantMode);
@@ -294,6 +331,12 @@ auto Request::handleRedirect() -> bool
 
     m_url = QUrl(redirect.toString());
     qCDebug(m_logCat) << getUid().toString() << "Following redirect to" << m_url.toString();
+    if (++m_redirectCount > 10) {
+        qCWarning(m_logCat) << getUid().toString() << "Too many redirects for" << m_url.toString();
+        m_sink->abort();
+        emitFailed(tr("Too many redirects"));
+        return true;
+    }
     executeTask();
 
     return true;
@@ -406,10 +449,14 @@ void Request::downloadReadyRead()
 
 auto Request::abort() -> bool
 {
+    m_retryTimer.stop();
     m_state = State::AbortedByUser;
-    if (m_reply) {
+    if (m_reply && !m_reply->isFinished()) {
         disconnect(m_reply.get(), &QNetworkReply::errorOccurred, nullptr, nullptr);
         m_reply->abort();
+    } else {
+        emit aborted();
+        emit finished();
     }
     return true;
 }
@@ -445,19 +492,44 @@ void Request::enableAutoRetry(bool enable)
 
 QNetworkReply* Request::getReply(QNetworkRequest& request)
 {
-    if (m_postData.has_value()) {
-        if (!request.hasRawHeader("Content-Type")) {
-            request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
-        }
-        return m_network->post(request, *m_postData);
+    if (m_httpMethod == HttpMethod::Get) {
+        Q_ASSERT(std::holds_alternative<std::monostate>(m_postData));
+        return m_network->get(request);
     }
-    return m_network->get(request);
+    return std::visit(
+        [this, &request](const auto& data) -> QNetworkReply* {
+            using T = std::remove_cvref_t<decltype(data)>;
+            const auto verb = m_httpMethod.toString().toUtf8();
+            if constexpr (std::is_same_v<T, QByteArray>) {
+                if (m_httpMethod == HttpMethod::Post && !request.hasRawHeader("Content-Type")) {
+                    request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
+                }
+                return m_network->sendCustomRequest(request, verb, data);
+            } else if constexpr (std::is_same_v<T, std::monostate>) {
+                return m_network->sendCustomRequest(request, verb);
+            } else if constexpr (std::is_same_v<T, DeviceFactory>) {
+                if (QIODevice* device = data(); device != nullptr) {
+                    device->setParent(this);
+                    return m_network->sendCustomRequest(request, verb, device);
+                }
+                return m_network->sendCustomRequest(request, verb);
+            } else if constexpr (std::is_same_v<T, MultiPartFactory>) {
+                if (QHttpMultiPart* multiPart = data(); multiPart != nullptr) {
+                    if (multiPart->parent() == nullptr) {
+                        multiPart->setParent(this);
+                    }
+                    return m_network->sendCustomRequest(request, verb, multiPart);
+                }
+                return m_network->sendCustomRequest(request, verb);
+            }
+        },
+        m_postData);
 }
 
 #if defined(LAUNCHER_APPLICATION)
 auto Request::makeCached(const QUrl& url, MetaEntryPtr entry, Options options) -> Ptr
 {
-    auto dl = makeShared<Request>(url, options, (QString("CACHE:") + url.toString()));
+    auto dl = Ptr(new Request(url, options, (QString("CACHE:") + url.toString())));
     auto* md5Node = new ChecksumValidator(QCryptographicHash::Md5);
     auto* cachedNode = new MetaCacheSink(std::move(entry), md5Node, options.testFlag(Option::MakeEternal));
     dl->m_sink.reset(cachedNode);
@@ -467,7 +539,7 @@ auto Request::makeCached(const QUrl& url, MetaEntryPtr entry, Options options) -
 
 auto Request::makeByteArray(const QUrl& url, QByteArray postData, Options options) -> std::pair<Ptr, QByteArray*>
 {
-    auto dl = makeShared<Request>(url, std::move(postData), options);
+    auto dl = Ptr(new Request(url, std::move(postData), options));
 
     auto sink = std::make_unique<ByteArraySink>();
     auto* response = sink->output();
@@ -478,7 +550,7 @@ auto Request::makeByteArray(const QUrl& url, QByteArray postData, Options option
 
 auto Request::makeByteArray(const QUrl& url, Options options) -> std::pair<Ptr, QByteArray*>
 {
-    auto dl = makeShared<Request>(url, options);
+    auto dl = Ptr(new Request(url, options));
 
     auto sink = std::make_unique<ByteArraySink>();
     auto* response = sink->output();
@@ -489,10 +561,15 @@ auto Request::makeByteArray(const QUrl& url, Options options) -> std::pair<Ptr, 
 
 auto Request::makeFile(const QUrl& url, const QString& path, Options options) -> Ptr
 {
-    auto dl = makeShared<Request>(url, options, QString("FILE:") + url.toString());
+    auto dl = Ptr(new Request(url, options, QString("FILE:") + url.toString()));
     dl->m_sink = std::make_unique<FileSink>(path);
 
     return dl;
+}
+
+auto Request::makeCustomRequest(const Spec& spec) -> Ptr
+{
+    return Ptr(new Request(spec));
 }
 
 }  // namespace Net

--- a/launcher/net/Request.cpp
+++ b/launcher/net/Request.cpp
@@ -37,7 +37,7 @@
  *      limitations under the License.
  */
 
-#include "NetRequest.h"
+#include "Request.h"
 
 #include <QDateTime>
 #include <QFileInfo>
@@ -65,12 +65,12 @@
 
 namespace Net {
 
-NetRequest::NetRequest()
+Request::Request()
 {
-    connect(&m_retryTimer, &QTimer::timeout, this, &NetRequest::executeTask);
+    connect(&m_retryTimer, &QTimer::timeout, this, &Request::executeTask);
 }
 
-NetRequest::NetRequest(const QUrl& url, Options options, const QString& name) : NetRequest()
+Request::Request(const QUrl& url, Options options, const QString& name) : Request()
 {
     m_url = url;
     m_options = options;
@@ -87,18 +87,18 @@ NetRequest::NetRequest(const QUrl& url, Options options, const QString& name) : 
 #endif
 }
 
-NetRequest::NetRequest(const QUrl& url, QByteArray postData, Options options) : NetRequest(url, options)
+Request::Request(const QUrl& url, QByteArray postData, Options options) : Request(url, options)
 {
     m_postData = std::move(postData);
     m_logCat = taskUploadLogC;
 }
 
-void NetRequest::addValidator(Validator* v)
+void Request::addValidator(Validator* v)
 {
     m_sink->addValidator(v);
 }
 
-void NetRequest::executeTask()
+void Request::executeTask()
 {
     setStatus(tr("Requesting %1").arg(StringUtils::truncateUrlHumanFriendly(m_url, 80)));
 
@@ -156,15 +156,15 @@ void NetRequest::executeTask()
         return;
     }
     m_reply.reset(rep);
-    connect(rep, &QNetworkReply::uploadProgress, this, &NetRequest::onProgress);
-    connect(rep, &QNetworkReply::downloadProgress, this, &NetRequest::onProgress);
-    connect(rep, &QNetworkReply::finished, this, &NetRequest::downloadFinished);
-    connect(rep, &QNetworkReply::errorOccurred, this, &NetRequest::downloadError);
-    connect(rep, &QNetworkReply::sslErrors, this, &NetRequest::sslErrors);
-    connect(rep, &QNetworkReply::readyRead, this, &NetRequest::downloadReadyRead);
+    connect(rep, &QNetworkReply::uploadProgress, this, &Request::onProgress);
+    connect(rep, &QNetworkReply::downloadProgress, this, &Request::onProgress);
+    connect(rep, &QNetworkReply::finished, this, &Request::downloadFinished);
+    connect(rep, &QNetworkReply::errorOccurred, this, &Request::downloadError);
+    connect(rep, &QNetworkReply::sslErrors, this, &Request::sslErrors);
+    connect(rep, &QNetworkReply::readyRead, this, &Request::downloadReadyRead);
 }
 
-void NetRequest::onProgress(qint64 bytesReceived, qint64 bytesTotal)
+void Request::onProgress(qint64 bytesReceived, qint64 bytesTotal)
 {
     auto now = std::chrono::steady_clock::now();
     auto elapsed = now - m_lastProgressTime;
@@ -195,7 +195,7 @@ void NetRequest::onProgress(qint64 bytesReceived, qint64 bytesTotal)
     setProgress(bytesReceived, bytesTotal);
 }
 
-void NetRequest::downloadError(QNetworkReply::NetworkError error)
+void Request::downloadError(QNetworkReply::NetworkError error)
 {
     if (error == QNetworkReply::OperationCanceledError) {
         qCCritical(m_logCat) << getUid().toString() << "Aborted" << m_url.toString();
@@ -233,7 +233,7 @@ void NetRequest::downloadError(QNetworkReply::NetworkError error)
     }
 }
 
-void NetRequest::sslErrors(const QList<QSslError>& errors)
+void Request::sslErrors(const QList<QSslError>& errors)
 {
     int i = 1;
     for (const auto& error : errors) {
@@ -245,7 +245,7 @@ void NetRequest::sslErrors(const QList<QSslError>& errors)
     }
 }
 
-auto NetRequest::handleRedirect() -> bool
+auto Request::handleRedirect() -> bool
 {
     QUrl redirect = m_reply->header(QNetworkRequest::LocationHeader).toUrl();
     if (!redirect.isValid()) {
@@ -299,7 +299,7 @@ auto NetRequest::handleRedirect() -> bool
     return true;
 }
 
-void NetRequest::handleAutoRetry(int64_t delay)
+void Request::handleAutoRetry(int64_t delay)
 {
     m_retryCount++;
     if (delay > 60 || m_retryCount > 4) {
@@ -318,7 +318,7 @@ void NetRequest::handleAutoRetry(int64_t delay)
     m_retryTimer.start();
 }
 
-void NetRequest::downloadFinished()
+void Request::downloadFinished()
 {
     // currently waiting for retry
     if (m_retryTimer.isActive()) {
@@ -387,7 +387,7 @@ void NetRequest::downloadFinished()
     emit finished();
 }
 
-void NetRequest::downloadReadyRead()
+void Request::downloadReadyRead()
 {
     if (m_state == State::Running) {
         auto data = m_reply->readAll();
@@ -404,7 +404,7 @@ void NetRequest::downloadReadyRead()
     }
 }
 
-auto NetRequest::abort() -> bool
+auto Request::abort() -> bool
 {
     m_state = State::AbortedByUser;
     if (m_reply) {
@@ -414,27 +414,27 @@ auto NetRequest::abort() -> bool
     return true;
 }
 
-int NetRequest::replyStatusCode() const
+int Request::replyStatusCode() const
 {
     return m_reply ? m_reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt() : -1;
 }
 
-QNetworkReply::NetworkError NetRequest::error() const
+QNetworkReply::NetworkError Request::error() const
 {
     return m_reply ? m_reply->error() : QNetworkReply::NoError;
 }
 
-QUrl NetRequest::url() const
+QUrl Request::url() const
 {
     return m_url;
 }
 
-QString NetRequest::errorString() const
+QString Request::errorString() const
 {
     return m_reply ? m_reply->errorString() : "";
 }
 
-void NetRequest::enableAutoRetry(bool enable)
+void Request::enableAutoRetry(bool enable)
 {
     if (enable) {
         m_options |= Option::AutoRetry;
@@ -443,7 +443,7 @@ void NetRequest::enableAutoRetry(bool enable)
     }
 }
 
-QNetworkReply* NetRequest::getReply(QNetworkRequest& request)
+QNetworkReply* Request::getReply(QNetworkRequest& request)
 {
     if (m_postData.has_value()) {
         if (!request.hasRawHeader("Content-Type")) {
@@ -455,9 +455,9 @@ QNetworkReply* NetRequest::getReply(QNetworkRequest& request)
 }
 
 #if defined(LAUNCHER_APPLICATION)
-auto NetRequest::makeCached(const QUrl& url, MetaEntryPtr entry, Options options) -> Ptr
+auto Request::makeCached(const QUrl& url, MetaEntryPtr entry, Options options) -> Ptr
 {
-    auto dl = makeShared<NetRequest>(url, options, (QString("CACHE:") + url.toString()));
+    auto dl = makeShared<Request>(url, options, (QString("CACHE:") + url.toString()));
     auto* md5Node = new ChecksumValidator(QCryptographicHash::Md5);
     auto* cachedNode = new MetaCacheSink(std::move(entry), md5Node, options.testFlag(Option::MakeEternal));
     dl->m_sink.reset(cachedNode);
@@ -465,9 +465,9 @@ auto NetRequest::makeCached(const QUrl& url, MetaEntryPtr entry, Options options
 }
 #endif
 
-auto NetRequest::makeByteArray(const QUrl& url, QByteArray postData, Options options) -> std::pair<Ptr, QByteArray*>
+auto Request::makeByteArray(const QUrl& url, QByteArray postData, Options options) -> std::pair<Ptr, QByteArray*>
 {
-    auto dl = makeShared<NetRequest>(url, std::move(postData), options);
+    auto dl = makeShared<Request>(url, std::move(postData), options);
 
     auto sink = std::make_unique<ByteArraySink>();
     auto* response = sink->output();
@@ -476,9 +476,9 @@ auto NetRequest::makeByteArray(const QUrl& url, QByteArray postData, Options opt
     return { dl, response };
 }
 
-auto NetRequest::makeByteArray(const QUrl& url, Options options) -> std::pair<Ptr, QByteArray*>
+auto Request::makeByteArray(const QUrl& url, Options options) -> std::pair<Ptr, QByteArray*>
 {
-    auto dl = makeShared<NetRequest>(url, options);
+    auto dl = makeShared<Request>(url, options);
 
     auto sink = std::make_unique<ByteArraySink>();
     auto* response = sink->output();
@@ -487,9 +487,9 @@ auto NetRequest::makeByteArray(const QUrl& url, Options options) -> std::pair<Pt
     return { dl, response };
 }
 
-auto NetRequest::makeFile(const QUrl& url, const QString& path, Options options) -> Ptr
+auto Request::makeFile(const QUrl& url, const QString& path, Options options) -> Ptr
 {
-    auto dl = makeShared<NetRequest>(url, options, QString("FILE:") + url.toString());
+    auto dl = makeShared<Request>(url, options, QString("FILE:") + url.toString());
     dl->m_sink = std::make_unique<FileSink>(path);
 
     return dl;

--- a/launcher/net/Request.h
+++ b/launcher/net/Request.h
@@ -42,10 +42,14 @@
 #include <QNetworkReply>
 #include <QTimer>
 #include <QUrl>
+#include <array>
 #include <chrono>
 #include <cstdint>
+#include <functional>
 #include <utility>
+#include <variant>
 
+#include "EnumWrapper.h"
 #include "HeaderProxy.h"
 #include "HttpMetaCache.h"
 #include "Sink.h"
@@ -55,8 +59,35 @@
 #include "net/Logging.h"
 #include "tasks/Task.h"
 
+class QIODevice;
+class QHttpMultiPart;
+
 namespace Net {
 class ByteArraySink;
+
+enum class HttpMethodValue : std::uint8_t {
+    Get,
+    Post,
+    Put,
+    Patch,
+    Delete,
+    Head,
+    Options,
+    Connect,
+    Trace,
+};
+struct HttpMethod : EnumWrapper<HttpMethod, HttpMethodValue> {
+    static constexpr auto invalid() { return Get; };
+    static constexpr auto mapping()
+    {
+        return std::array{ std::pair{ Get, "GET" },         std::pair{ Post, "POST" },       std::pair{ Put, "PUT" },
+                           std::pair{ Patch, "PATCH" },     std::pair{ Delete, "DELETE" },   std::pair{ Head, "HEAD" },
+                           std::pair{ Options, "OPTIONS" }, std::pair{ Connect, "CONNECT" }, std::pair{ Trace, "TRACE" } };
+    };
+    using enum HttpMethodValue;
+    using Base = EnumWrapper<HttpMethod, HttpMethodValue>;
+    using Base::Base; /* inherit ctor */
+};
 
 class Request : public Task {
     Q_OBJECT
@@ -71,10 +102,18 @@ class Request : public Task {
     };
     Q_DECLARE_FLAGS(Options, Option)
 
-   public:
-    explicit Request();
-    explicit Request(const QUrl& url, Options options = Option::NoOptions, const QString& name = QString());
-    Request(const QUrl& url, QByteArray postData, Options options);
+    using DeviceFactory = std::function<QIODevice*()>;
+    using MultiPartFactory = std::function<QHttpMultiPart*()>;
+    using PostData = std::variant<std::monostate, QByteArray, DeviceFactory, MultiPartFactory>;
+    using LogCatFunc = const QLoggingCategory& (*)();
+
+    struct Spec {
+        HttpMethod method = HttpMethod::Get;
+        QUrl url{};
+        Request::PostData data{};
+        Options options = Option::NoOptions;
+        QString name{};
+    };
 
    public:
 #if defined(LAUNCHER_APPLICATION)
@@ -89,6 +128,7 @@ class Request : public Task {
     static auto makeByteArray(const QUrl& url, QByteArray postData, Options options = Option::NoOptions)
         -> std::pair<Request::Ptr, QByteArray*>;
     static auto makeFile(const QUrl& url, const QString& path, Options options = Option::NoOptions) -> Request::Ptr;
+    static auto makeCustomRequest(const Spec& spec) -> Request::Ptr;
 
    public:
     ~Request() override = default;
@@ -98,6 +138,8 @@ class Request : public Task {
 
     void setNetwork(QNetworkAccessManager* network) { m_network = network; }
     void addHeaderProxy(std::unique_ptr<Net::HeaderProxy> proxy) { m_headerProxies.push_back(std::move(proxy)); }
+    void setSink(std::unique_ptr<Sink> sink) { m_sink = std::move(sink); }
+    void setLogCat(LogCatFunc logCat) { m_logCat = logCat; }
 
     // automatically handle HTTP 429 Too Many Requests errors and retry
     void enableAutoRetry(bool enable);
@@ -122,11 +164,16 @@ class Request : public Task {
     void executeTask() override;
 
    protected:
+    // ToDo: Remove this constructor and use the Spec constructor instead. This is a temporary workaround to avoid breaking existing code.
+    explicit Request();
+    explicit Request(const QUrl& url, Options options = Option::NoOptions, const QString& name = QString());
+    Request(const QUrl& url, QByteArray postData, Options options);
+    explicit Request(const Spec& spec);
+
     std::unique_ptr<Sink> m_sink;
     Options m_options;
 
-    using LogCatFunc = const QLoggingCategory& (*)();
-    LogCatFunc m_logCat = taskUploadLogC;
+    LogCatFunc m_logCat = nullptr;
 
     std::chrono::time_point<std::chrono::steady_clock> m_lastProgressTime;
     qint64 m_lastProgressBytes = 0;
@@ -144,8 +191,12 @@ class Request : public Task {
     int m_retryCount = 0;
     QTimer m_retryTimer;
 
-    std::optional<QByteArray> m_postData;
+    int m_redirectCount = 0;
+
+    HttpMethod m_httpMethod = HttpMethod::Get;
+    PostData m_postData{};
 };
+
 }  // namespace Net
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(Net::Request::Options)

--- a/launcher/net/Request.h
+++ b/launcher/net/Request.h
@@ -58,10 +58,10 @@
 namespace Net {
 class ByteArraySink;
 
-class NetRequest : public Task {
+class Request : public Task {
     Q_OBJECT
    public:
-    using Ptr = shared_qobject_ptr<class NetRequest>;
+    using Ptr = shared_qobject_ptr<class Request>;
     enum class Option : std::uint8_t {
         NoOptions = 0,
         AcceptLocalFiles = 1,
@@ -72,26 +72,26 @@ class NetRequest : public Task {
     Q_DECLARE_FLAGS(Options, Option)
 
    public:
-    explicit NetRequest();
-    explicit NetRequest(const QUrl& url, Options options = Option::NoOptions, const QString& name = QString());
-    NetRequest(const QUrl& url, QByteArray postData, Options options);
+    explicit Request();
+    explicit Request(const QUrl& url, Options options = Option::NoOptions, const QString& name = QString());
+    Request(const QUrl& url, QByteArray postData, Options options);
 
    public:
 #if defined(LAUNCHER_APPLICATION)
-    static auto makeCached(const QUrl& url, MetaEntryPtr entry, Options options = Option::NoOptions) -> NetRequest::Ptr;
+    static auto makeCached(const QUrl& url, MetaEntryPtr entry, Options options = Option::NoOptions) -> Request::Ptr;
 #endif
 
     /**
      * Creates a request downloading to the returned QByteArray,.
      * The QByteArray will live as long as the Download object.
      */
-    static auto makeByteArray(const QUrl& url, Options options = Option::NoOptions) -> std::pair<NetRequest::Ptr, QByteArray*>;
+    static auto makeByteArray(const QUrl& url, Options options = Option::NoOptions) -> std::pair<Request::Ptr, QByteArray*>;
     static auto makeByteArray(const QUrl& url, QByteArray postData, Options options = Option::NoOptions)
-        -> std::pair<NetRequest::Ptr, QByteArray*>;
-    static auto makeFile(const QUrl& url, const QString& path, Options options = Option::NoOptions) -> NetRequest::Ptr;
+        -> std::pair<Request::Ptr, QByteArray*>;
+    static auto makeFile(const QUrl& url, const QString& path, Options options = Option::NoOptions) -> Request::Ptr;
 
    public:
-    ~NetRequest() override = default;
+    ~Request() override = default;
     void addValidator(Validator* v);
     auto abort() -> bool override;
     auto canAbort() const -> bool override { return true; }
@@ -148,4 +148,4 @@ class NetRequest : public Task {
 };
 }  // namespace Net
 
-Q_DECLARE_OPERATORS_FOR_FLAGS(Net::NetRequest::Options)
+Q_DECLARE_OPERATORS_FOR_FLAGS(Net::Request::Options)

--- a/launcher/news/NewsChecker.cpp
+++ b/launcher/news/NewsChecker.cpp
@@ -60,7 +60,7 @@ void NewsChecker::reloadNews()
     qDebug() << "Reloading news.";
 
     NetJob::Ptr job{ new NetJob("News RSS Feed", m_network) };
-    job->addNetAction(Net::NetRequest::makeCached(m_feedUrl, m_entry));
+    job->addNetAction(Net::Request::makeCached(m_feedUrl, m_entry));
     job->setAskRetry(false);
     connect(job.get(), &NetJob::succeeded, this, &NewsChecker::rssDownloadFinished);
     connect(job.get(), &NetJob::failed, this, &NewsChecker::rssDownloadFailed);

--- a/launcher/screenshots/ImgurAlbumCreation.cpp
+++ b/launcher/screenshots/ImgurAlbumCreation.cpp
@@ -48,7 +48,7 @@
 #include "BuildConfig.h"
 #include "net/RawHeaderProxy.h"
 
-Net::NetRequest::Ptr ImgurAlbumCreation::make(std::shared_ptr<ImgurAlbumCreation::Result> output, QList<ScreenShot::Ptr> screenshots)
+Net::Request::Ptr ImgurAlbumCreation::make(std::shared_ptr<ImgurAlbumCreation::Result> output, QList<ScreenShot::Ptr> screenshots)
 {
     auto up = makeShared<ImgurAlbumCreation>();
     up->m_url = BuildConfig.IMGUR_BASE_URL + "album";

--- a/launcher/screenshots/ImgurAlbumCreation.h
+++ b/launcher/screenshots/ImgurAlbumCreation.h
@@ -36,9 +36,9 @@
 #pragma once
 
 #include "Screenshot.h"
-#include "net/NetRequest.h"
+#include "net/Request.h"
 
-class ImgurAlbumCreation : public Net::NetRequest {
+class ImgurAlbumCreation : public Net::Request {
    public:
     virtual ~ImgurAlbumCreation() = default;
 
@@ -64,7 +64,7 @@ class ImgurAlbumCreation : public Net::NetRequest {
         QByteArray m_output;
     };
 
-    static NetRequest::Ptr make(std::shared_ptr<Result> output, QList<ScreenShot::Ptr> screenshots);
+    static Request::Ptr make(std::shared_ptr<Result> output, QList<ScreenShot::Ptr> screenshots);
     QNetworkReply* getReply(QNetworkRequest& request) override;
 
    private:

--- a/launcher/screenshots/ImgurUpload.cpp
+++ b/launcher/screenshots/ImgurUpload.cpp
@@ -115,7 +115,7 @@ auto ImgurUpload::Sink::finalize(QNetworkReply&) -> Task::State
     return Task::State::Succeeded;
 }
 
-Net::NetRequest::Ptr ImgurUpload::make(ScreenShot::Ptr m_shot)
+Net::Request::Ptr ImgurUpload::make(ScreenShot::Ptr m_shot)
 {
     auto up = makeShared<ImgurUpload>(m_shot->m_file);
     up->m_url = BuildConfig.IMGUR_BASE_URL + "image";

--- a/launcher/screenshots/ImgurUpload.h
+++ b/launcher/screenshots/ImgurUpload.h
@@ -37,9 +37,9 @@
 
 #include <QFileInfo>
 #include "Screenshot.h"
-#include "net/NetRequest.h"
+#include "net/Request.h"
 
-class ImgurUpload : public Net::NetRequest {
+class ImgurUpload : public Net::Request {
    public:
     class Sink : public Net::Sink {
        public:
@@ -60,7 +60,7 @@ class ImgurUpload : public Net::NetRequest {
     ImgurUpload(QFileInfo info) : m_fileInfo(info) {}
     virtual ~ImgurUpload() = default;
 
-    static NetRequest::Ptr make(ScreenShot::Ptr m_shot);
+    static Request::Ptr make(ScreenShot::Ptr m_shot);
 
    private:
     virtual QNetworkReply* getReply(QNetworkRequest&) override;

--- a/launcher/translations/TranslationsModel.cpp
+++ b/launcher/translations/TranslationsModel.cpp
@@ -166,7 +166,7 @@ struct TranslationsModel::Private {
     std::unique_ptr<QTranslator> m_qtTranslator;
     std::unique_ptr<QTranslator> m_appTranslator;
 
-    Net::NetRequest* m_indexTask = nullptr;
+    Net::Request* m_indexTask = nullptr;
     QString m_downloadingTranslation;
     NetJob::Ptr m_downloadJob;
     NetJob::Ptr m_indexJob;
@@ -559,7 +559,7 @@ void TranslationsModel::downloadIndex()
     d->m_indexJob.reset(new NetJob("Translations Index", APPLICATION->network()));
     const MetaEntryPtr entry = APPLICATION->metacache()->resolveEntry("translations", "index_v2.json");
     entry->setStale(true);
-    auto task = Net::NetRequest::makeCached(QUrl(BuildConfig.TRANSLATION_FILES_URL + "index_v2.json"), entry);
+    auto task = Net::Request::makeCached(QUrl(BuildConfig.TRANSLATION_FILES_URL + "index_v2.json"), entry);
     d->m_indexTask = task.get();
     d->m_indexJob->addNetAction(task);
     d->m_indexJob->setAskRetry(false);
@@ -600,7 +600,7 @@ void TranslationsModel::downloadTranslation(const QString& key)
     const MetaEntryPtr entry = APPLICATION->metacache()->resolveEntry("translations", "mmc_" + key + ".qm");
     entry->setStale(true);
 
-    auto dl = Net::NetRequest::makeCached(QUrl(BuildConfig.TRANSLATION_FILES_URL + lang->fileName), entry);
+    auto dl = Net::Request::makeCached(QUrl(BuildConfig.TRANSLATION_FILES_URL + lang->fileName), entry);
     dl->addValidator(new Net::ChecksumValidator(QCryptographicHash::Sha1, lang->fileSha1));
     dl->setProgress(dl->getProgress(), lang->fileSize);
 

--- a/launcher/ui/GuiUtil.cpp
+++ b/launcher/ui/GuiUtil.cpp
@@ -46,7 +46,7 @@
 #include "FileSystem.h"
 #include "logs/AnonymizeLog.h"
 #include "net/NetJob.h"
-#include "net/NetRequest.h"
+#include "net/Request.h"
 #include "net/PasteUpload.h"
 #include "ui/dialogs/CustomMessageBox.h"
 #include "ui/dialogs/ProgressDialog.h"
@@ -136,7 +136,7 @@ std::optional<QString> GuiUtil::uploadPaste(const QString& name, const QString& 
     auto job = NetJob::Ptr(new NetJob("Log Upload", APPLICATION->network()));
 
     auto pasteJob = new PasteUpload(textToUpload, baseURL, pasteType);
-    job->addNetAction(Net::NetRequest::Ptr(pasteJob));
+    job->addNetAction(Net::Request::Ptr(pasteJob));
     QObject::connect(job.get(), &Task::failed, parentWidget, [parentWidget](QString reason) {
         CustomMessageBox::selectable(parentWidget, QObject::tr("Failed to upload logs!"), reason, QMessageBox::Critical)->show();
     });

--- a/launcher/ui/dialogs/ProfileSetupDialog.cpp
+++ b/launcher/ui/dialogs/ProfileSetupDialog.cpp
@@ -47,7 +47,7 @@
 
 #include <Application.h>
 #include "minecraft/auth/Parsers.h"
-#include "net/NetRequest.h"
+#include "net/Request.h"
 
 ProfileSetupDialog::ProfileSetupDialog(MinecraftAccountPtr accountToSetup, QWidget* parent)
     : QDialog(parent), m_accountToSetup(accountToSetup), ui(new Ui::ProfileSetupDialog)
@@ -161,7 +161,7 @@ void ProfileSetupDialog::checkName(const QString& name)
 
     if (m_check_task)
         disconnect(m_check_task.get(), nullptr, this, nullptr);
-    auto [task, response] = Net::NetRequest::makeByteArray(url);
+    auto [task, response] = Net::Request::makeByteArray(url);
 
     m_check_task = task;
     m_check_task->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(headers));
@@ -206,7 +206,7 @@ void ProfileSetupDialog::setupProfile(const QString& profileName)
                                            { "Accept", "application/json" },
                                            { "Authorization", QString("Bearer %1").arg(m_accountToSetup->accessToken()).toUtf8() } };
 
-    auto [task, response] = Net::NetRequest::makeByteArray(url, payloadTemplate.arg(profileName).toUtf8());
+    auto [task, response] = Net::Request::makeByteArray(url, payloadTemplate.arg(profileName).toUtf8());
     m_profile_task = task;
     m_profile_task->addHeaderProxy(std::make_unique<Net::RawHeaderProxy>(headers));
 

--- a/launcher/ui/dialogs/ProfileSetupDialog.h
+++ b/launcher/ui/dialogs/ProfileSetupDialog.h
@@ -21,7 +21,7 @@
 #include <QTimer>
 
 #include <minecraft/auth/MinecraftAccount.h>
-#include "net/NetRequest.h"
+#include "net/Request.h"
 
 namespace Ui {
 class ProfileSetupDialog;
@@ -68,6 +68,6 @@ class ProfileSetupDialog : public QDialog {
 
     QTimer checkStartTimer;
 
-    Net::NetRequest::Ptr m_check_task;
-    Net::NetRequest::Ptr m_profile_task;
+    Net::Request::Ptr m_check_task;
+    Net::Request::Ptr m_profile_task;
 };

--- a/launcher/ui/dialogs/skins/SkinManageDialog.cpp
+++ b/launcher/ui/dialogs/skins/SkinManageDialog.cpp
@@ -46,7 +46,7 @@
 #include "minecraft/skins/SkinModel.h"
 #include "minecraft/skins/SkinUpload.h"
 
-#include "net/NetRequest.h"
+#include "net/Request.h"
 #include "net/NetJob.h"
 #include "tasks/Task.h"
 
@@ -228,7 +228,7 @@ void SkinManageDialog::setupCapes()
         }
         if (!cape.url.isEmpty()) {
             needsToDownload = true;
-            job->addNetAction(Net::NetRequest::makeFile(cape.url, path));
+            job->addNetAction(Net::Request::makeFile(cape.url, path));
         }
     }
     if (needsToDownload) {
@@ -416,7 +416,7 @@ void SkinManageDialog::on_urlBtn_clicked()
     job->setAskRetry(false);
 
     auto path = FS::PathCombine(m_list.getDir(), url.fileName());
-    job->addNetAction(Net::NetRequest::makeFile(url, path));
+    job->addNetAction(Net::Request::makeFile(url, path));
     ProgressDialog dlg(this);
     dlg.execWithTask(job.get());
     SkinModel s(path);
@@ -475,9 +475,9 @@ void SkinManageDialog::on_userBtn_clicked()
     auto uuidLoop = makeShared<WaitTask>();
     auto profileLoop = makeShared<WaitTask>();
 
-    auto [getUUID, uuidOut] = Net::NetRequest::makeByteArray("https://api.minecraftservices.com/minecraft/profile/lookup/name/" + user);
-    auto [getProfile, profileOut] = Net::NetRequest::makeByteArray(QUrl());
-    auto downloadSkin = Net::NetRequest::makeFile(QUrl(), path);
+    auto [getUUID, uuidOut] = Net::Request::makeByteArray("https://api.minecraftservices.com/minecraft/profile/lookup/name/" + user);
+    auto [getProfile, profileOut] = Net::Request::makeByteArray(QUrl());
+    auto downloadSkin = Net::Request::makeFile(QUrl(), path);
 
     QString failReason;
 

--- a/launcher/ui/pages/modplatform/ftb/FtbListModel.cpp
+++ b/launcher/ui/pages/modplatform/ftb/FtbListModel.cpp
@@ -96,7 +96,7 @@ void ListModel::request()
 
     auto netJob = makeShared<NetJob>("Ftb::Request", APPLICATION->network());
     auto url = QString(BuildConfig.FTB_API_BASE_URL + "/modpack/all");
-    auto [action, response] = Net::NetRequest::makeByteArray(QUrl(url));
+    auto [action, response] = Net::Request::makeByteArray(QUrl(url));
     netJob->addNetAction(action);
     m_jobPtr = netJob;
     m_jobPtr->start();
@@ -148,7 +148,7 @@ void ListModel::requestPack()
 {
     auto netJob = makeShared<NetJob>("Ftb::Search", APPLICATION->network());
     auto searchUrl = QString(BuildConfig.FTB_API_BASE_URL + "/modpack/%1").arg(m_currentPack);
-    auto [action, response] = Net::NetRequest::makeByteArray(QUrl(searchUrl));
+    auto [action, response] = Net::Request::makeByteArray(QUrl(searchUrl));
     netJob->addNetAction(action);
     m_jobPtr = netJob;
     m_jobPtr->start();
@@ -238,7 +238,7 @@ void ListModel::requestLogo(QString logo, QString url)
 
     auto job = makeShared<NetJob>(QString("FTB Icon Download %1").arg(logo), APPLICATION->network());
     job->setAskRetry(false);
-    job->addNetAction(Net::NetRequest::makeCached(QUrl(url), entry));
+    job->addNetAction(Net::Request::makeCached(QUrl(url), entry));
 
     auto fullPath = entry->getFullPath();
     QObject::connect(job.get(), &NetJob::finished, this, [this, logo, fullPath] { logoLoaded(logo); });

--- a/launcher/updater/prismupdater/PrismUpdater.cpp
+++ b/launcher/updater/prismupdater/PrismUpdater.cpp
@@ -51,7 +51,7 @@ namespace fs = std::filesystem;
 #include "Json.h"
 #include "StringUtils.h"
 
-#include "net/NetRequest.h"
+#include "net/Request.h"
 #include "net/RawHeaderProxy.h"
 
 #include "MMCZip.h"
@@ -766,7 +766,7 @@ QFileInfo PrismUpdaterApp::downloadAsset(const GitHubReleaseAsset& asset)
     auto out_file_path = FS::PathCombine(temp_dir, file_url.fileName());
 
     qDebug() << "downloading" << file_url << "to" << out_file_path;
-    auto download = Net::NetRequest::makeFile(file_url, out_file_path);
+    auto download = Net::Request::makeFile(file_url, out_file_path);
     download->setNetwork(m_network.get());
     auto progress_dialog = ProgressDialog();
     progress_dialog.adjustSize();
@@ -1136,7 +1136,7 @@ void PrismUpdaterApp::downloadReleasePage(const QString& api_url, int page)
 {
     int per_page = 30;
     auto page_url = QString("%1?per_page=%2&page=%3").arg(api_url).arg(QString::number(per_page)).arg(QString::number(page));
-    auto [download, response] = Net::NetRequest::makeByteArray(page_url);
+    auto [download, response] = Net::Request::makeByteArray(page_url);
     download->setNetwork(m_network.get());
     m_current_url = page_url;
 
@@ -1147,7 +1147,7 @@ void PrismUpdaterApp::downloadReleasePage(const QString& api_url, int page)
     });
     download->addHeaderProxy(std::move(github_api_headers));
 
-    connect(download.get(), &Net::NetRequest::succeeded, this, [this, response, per_page, api_url, page]() {
+    connect(download.get(), &Net::Request::succeeded, this, [this, response, per_page, api_url, page]() {
         int num_found = parseReleasePage(response);
         if (!(num_found < per_page)) {  // there may be more, fetch next page
             downloadReleasePage(api_url, page + 1);
@@ -1155,10 +1155,10 @@ void PrismUpdaterApp::downloadReleasePage(const QString& api_url, int page)
             run();
         }
     });
-    connect(download.get(), &Net::NetRequest::failed, this, &PrismUpdaterApp::downloadError);
+    connect(download.get(), &Net::Request::failed, this, &PrismUpdaterApp::downloadError);
 
     m_current_task.reset(download);
-    connect(download.get(), &Net::NetRequest::finished, this, [this]() {
+    connect(download.get(), &Net::Request::finished, this, [this]() {
         qDebug() << "Download" << m_current_task->getUid().toString() << "finished";
     });
 

--- a/launcher/updater/prismupdater/PrismUpdater.h
+++ b/launcher/updater/prismupdater/PrismUpdater.h
@@ -38,7 +38,7 @@
 #include <optional>
 
 #include "QObjectPtr.h"
-#include "net/NetRequest.h"
+#include "net/Request.h"
 
 #define PRISM_EXTERNAL_EXE
 #include "FileSystem.h"

--- a/tests/Library_test.cpp
+++ b/tests/Library_test.cpp
@@ -98,7 +98,7 @@ class LibraryTest : public QObject {
         auto downloads = test.getDownloads(r, cache.get(), failedFiles, QString());
         QCOMPARE(downloads.size(), 1);
         QCOMPARE(failedFiles, {});
-        Net::NetRequest::Ptr dl = downloads[0];
+        Net::Request::Ptr dl = downloads[0];
         QCOMPARE(dl->url(), QUrl("file://foo/bar/test/package/testname/testversion/testname-testversion.jar"));
     }
     void test_legacy_url_local_broken()


### PR DESCRIPTION
blocked by #5900
~~blocked by #5911 (this is not a hard block and if needed is a one line change)~~



This is spawned from https://github.com/PrismLauncher/PrismLauncher/pull/5910.
Q: Why do we need this?
A: I just want to refactor all the net code so this class to be final. 

Once this is reviewed, the Minecraft Skin API will be rewritten to only use function not sub classes: see https://github.com/PrismLauncher/PrismLauncher/pull/5937.
Next are the ImgurAPI and log upload(that need the RPCSink)