### PR TITLE
Allow multiple launch sessions per instance

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -1566,11 +1566,45 @@ bool Application::launch(MinecraftInstance* instance,
             warning.setInformativeText(
                 tr("Both Minecraft processes will use the same game folder and the same config, options, logs, and saves. "
                    "Running them together can cause conflicting writes and data loss."));
+            const auto activeSessions = instance->activeLaunchTasks();
             auto* launchButton = warning.addButton(tr("Launch Anyway"), QMessageBox::AcceptRole);
+            QPushButton* restartButton = nullptr;
+            if (activeSessions.size() == 1)
+                restartButton = warning.addButton(tr("Restart Instead"), QMessageBox::ActionRole);
             warning.addButton(tr("Cancel"), QMessageBox::RejectRole);
             QCheckBox dontShowAgain(tr("Don't show this warning again"), &warning);
             warning.setCheckBox(&dontShowAgain);
             warning.exec();
+            if (restartButton && warning.clickedButton() == restartButton) {
+                auto* session = activeSessions.first();
+                LaunchController* controller = nullptr;
+                {
+                    QMutexLocker locker(&m_instanceExtrasMutex);
+                    auto& controllers = m_instanceExtras[instance->id()].controllers;
+                    const auto iter = std::find_if(controllers.begin(), controllers.end(),
+                                                   [session](const auto& candidate) { return candidate->launcher() == session; });
+                    if (iter != controllers.end())
+                        controller = iter->get();
+                }
+                if (!controller)
+                    return false;
+
+                auto restartConnection = std::make_shared<QMetaObject::Connection>();
+                *restartConnection = connect(controller, &Task::finished, this,
+                                             [this, restartConnection, instance, mode, targetToJoin, accountToUse, offlineName] {
+                                                 disconnect(*restartConnection);
+                                                 QMetaObject::invokeMethod(
+                                                     this,
+                                                     [this, instance, mode, targetToJoin, accountToUse, offlineName] {
+                                                         launch(instance, mode, targetToJoin, accountToUse, offlineName);
+                                                     },
+                                                     Qt::QueuedConnection);
+                                             });
+                if (kill(instance, session))
+                    return true;
+                disconnect(*restartConnection);
+                return false;
+            }
             if (warning.clickedButton() != launchButton)
                 return false;
             if (dontShowAgain.isChecked())

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -83,10 +83,12 @@
 
 #include "ApplicationMessage.h"
 
+#include <algorithm>
 #include <iostream>
 #include <mutex>
 
 #include <QAccessible>
+#include <QCheckBox>
 #include <QCommandLineParser>
 #include <QDebug>
 #include <QDir>
@@ -96,6 +98,7 @@
 #include <QLibraryInfo>
 #include <QList>
 #include <QNetworkAccessManager>
+#include <QPushButton>
 #include <QStringList>
 #include <QStringLiteral>
 #include <QStyleFactory>
@@ -718,6 +721,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         m_settings->registerSetting("AutoCloseConsole", false);
         m_settings->registerSetting("ShowConsoleOnError", true);
         m_settings->registerSetting("LogPrePostOutput", true);
+        m_settings->registerSetting("SuppressConcurrentLaunchWarning", false);
 
         // Window Size
         m_settings->registerSetting({ "LaunchMaximized", "MCWindowMaximize" }, false);
@@ -1546,6 +1550,33 @@ bool Application::launch(MinecraftInstance* instance,
     if (m_updateRunning) {
         qDebug() << "Cannot launch instances while an update is running. Please try again when updates are completed.";
     } else if (instance->canLaunch()) {
+        if (instance->isRunning() && !m_settings->get("SuppressConcurrentLaunchWarning").toBool()) {
+            QWidget* parent = m_mainWindow;
+            {
+                QMutexLocker locker(&m_instanceExtrasMutex);
+                const auto iter = m_instanceExtras.find(instance->id());
+                if (iter != m_instanceExtras.end() && iter->second.window)
+                    parent = iter->second.window;
+            }
+
+            QMessageBox warning(parent);
+            warning.setWindowTitle(tr("Launch another Minecraft process?"));
+            warning.setIcon(QMessageBox::Warning);
+            warning.setText(tr("This instance is already running."));
+            warning.setInformativeText(
+                tr("Both Minecraft processes will use the same game folder and the same config, options, logs, and saves. "
+                   "Running them together can cause conflicting writes and data loss."));
+            auto* launchButton = warning.addButton(tr("Launch Anyway"), QMessageBox::AcceptRole);
+            warning.addButton(tr("Cancel"), QMessageBox::RejectRole);
+            QCheckBox dontShowAgain(tr("Don't show this warning again"), &warning);
+            warning.setCheckBox(&dontShowAgain);
+            warning.exec();
+            if (warning.clickedButton() != launchButton)
+                return false;
+            if (dontShowAgain.isChecked())
+                m_settings->set("SuppressConcurrentLaunchWarning", true);
+        }
+
         QMutexLocker locker(&m_instanceExtrasMutex);
         auto& extras = m_instanceExtras[instance->id()];
         auto window = extras.window;
@@ -1554,25 +1585,23 @@ bool Application::launch(MinecraftInstance* instance,
                 return false;
             }
         }
-        auto& controller = extras.controller;
-        controller.reset(new LaunchController());
-        controller->setInstance(instance);
-        controller->setLaunchMode(mode);
-        controller->setProfiler(profilers().value(instance->settings()->get("Profiler").toString(), nullptr).get());
-        controller->setTargetToJoin(targetToJoin);
-        controller->setAccountToUse(accountToUse);
-        controller->setOfflineName(offlineName);
+        auto controller = std::make_unique<LaunchController>();
+        auto* controllerPtr = controller.get();
+        controllerPtr->setInstance(instance);
+        controllerPtr->setLaunchMode(mode);
+        controllerPtr->setProfiler(profilers().value(instance->settings()->get("Profiler").toString(), nullptr).get());
+        controllerPtr->setTargetToJoin(targetToJoin);
+        controllerPtr->setAccountToUse(accountToUse);
+        controllerPtr->setOfflineName(offlineName);
         if (window) {
-            controller->setParentWidget(window);
+            controllerPtr->setParentWidget(window);
         } else if (m_mainWindow) {
-            controller->setParentWidget(m_mainWindow);
+            controllerPtr->setParentWidget(m_mainWindow);
         }
-        connect(controller.get(), &LaunchController::finished, this, &Application::controllerFinished);
+        connect(controllerPtr, &LaunchController::finished, this, &Application::controllerFinished);
+        extras.controllers.emplace_back(std::move(controller));
         addRunningInstance();
-        QMetaObject::invokeMethod(controller.get(), &Task::start, Qt::QueuedConnection);
-        return true;
-    } else if (instance->isRunning()) {
-        showInstanceWindow(instance, "console");
+        QMetaObject::invokeMethod(controllerPtr, &Task::start, Qt::QueuedConnection);
         return true;
     } else if (instance->canEdit()) {
         showInstanceWindow(instance);
@@ -1581,7 +1610,7 @@ bool Application::launch(MinecraftInstance* instance,
     return false;
 }
 
-bool Application::kill(BaseInstance* instance)
+bool Application::kill(MinecraftInstance* instance, LaunchTask* session)
 {
     if (!instance->isRunning()) {
         qWarning() << "Attempted to kill instance" << instance->id() << ", which isn't running.";
@@ -1589,13 +1618,24 @@ bool Application::kill(BaseInstance* instance)
     }
     QMutexLocker locker(&m_instanceExtrasMutex);
     auto& extras = m_instanceExtras[instance->id()];
-    // NOTE: copy of the shared pointer keeps it alive
-    auto& controller = extras.controller;
-    locker.unlock();
-    if (controller) {
-        return controller->abort();
+    if (!session) {
+        const auto sessions = instance->activeLaunchTasks();
+        if (sessions.size() != 1) {
+            locker.unlock();
+            showInstanceWindow(instance, "console");
+            return false;
+        }
+        session = sessions.first();
     }
-    return true;
+
+    auto controller = std::find_if(extras.controllers.begin(), extras.controllers.end(),
+                                   [session](const auto& candidate) { return candidate->launcher() == session; });
+    auto* controllerPtr = controller == extras.controllers.end() ? nullptr : controller->get();
+    locker.unlock();
+    if (controllerPtr) {
+        return controllerPtr->abort();
+    }
+    return false;
 }
 
 void Application::closeCurrentWindow()
@@ -1644,26 +1684,33 @@ void Application::controllerFinished()
     auto controller = qobject_cast<LaunchController*>(sender());
     if (!controller)
         return;
-    auto id = controller->id();
-
-    QMutexLocker locker(&m_instanceExtrasMutex);
-    auto& extras = m_instanceExtras.at(id);
-
     const bool wasSuccessful = controller->wasSuccessful();
-    // on success, do...
-    if (wasSuccessful && controller->instance()->settings()->get("AutoCloseConsole").toBool()) {
-        if (extras.window) {
-            QMetaObject::invokeMethod(extras.window, &QWidget::close, Qt::QueuedConnection);
-        }
-    }
-    extras.controller.reset();
-    subRunningInstance();
+    const auto id = controller->id();
+    auto* instance = controller->instance();
 
-    // quit when there are no more windows.
-    if (shouldExitNow()) {
-        m_status = wasSuccessful ? Succeeded : Failed;
-        exit(wasSuccessful ? 0 : 1);
-    }
+    QMetaObject::invokeMethod(
+        this,
+        [this, controller, instance, id, wasSuccessful] {
+            QMutexLocker locker(&m_instanceExtrasMutex);
+            auto& extras = m_instanceExtras.at(id);
+            const auto iter = std::find_if(extras.controllers.begin(), extras.controllers.end(),
+                                           [controller](const auto& candidate) { return candidate.get() == controller; });
+            if (iter == extras.controllers.end())
+                return;
+
+            extras.controllers.erase(iter);
+            subRunningInstance();
+            if (wasSuccessful && !instance->isRunning() && instance->settings()->get("AutoCloseConsole").toBool() && extras.window) {
+                QMetaObject::invokeMethod(extras.window, &QWidget::close, Qt::QueuedConnection);
+            }
+            locker.unlock();
+
+            if (shouldExitNow()) {
+                m_status = wasSuccessful ? Succeeded : Failed;
+                exit(wasSuccessful ? 0 : 1);
+            }
+        },
+        Qt::QueuedConnection);
 }
 
 void Application::ShowGlobalSettings(class QWidget* parent, QString open_page)
@@ -1751,8 +1798,8 @@ InstanceWindow* Application::showInstanceWindow(MinecraftInstance* instance, QSt
     if (!page.isEmpty()) {
         window->selectPage(page);
     }
-    if (extras.controller) {
-        extras.controller->setParentWidget(window);
+    for (const auto& controller : extras.controllers) {
+        controller->setParentWidget(window);
     }
     return window;
 }
@@ -1765,8 +1812,8 @@ void Application::on_windowClose()
         QMutexLocker locker(&m_instanceExtrasMutex);
         auto& extras = m_instanceExtras[instWindow->instanceId()];
         extras.window = nullptr;
-        if (extras.controller) {
-            extras.controller->setParentWidget(m_mainWindow);
+        for (const auto& controller : extras.controllers) {
+            controller->setParentWidget(m_mainWindow);
         }
     }
     auto mainWindow = qobject_cast<MainWindow*>(sender());

--- a/launcher/Application.h
+++ b/launcher/Application.h
@@ -37,6 +37,7 @@
 
 #pragma once
 
+#include <list>
 #include <memory>
 
 #include <QApplication>
@@ -52,6 +53,7 @@
 #include "minecraft/auth/MinecraftAccount.h"
 
 class LaunchController;
+class LaunchTask;
 class LocalPeer;
 class InstanceWindow;
 class MainWindow;
@@ -221,7 +223,7 @@ class Application : public QApplication {
                 std::shared_ptr<MinecraftTarget> targetToJoin = nullptr,
                 shared_qobject_ptr<MinecraftAccount> accountToUse = nullptr,
                 const QString& offlineName = QString());
-    bool kill(BaseInstance* instance);
+    bool kill(MinecraftInstance* instance, LaunchTask* session = nullptr);
     void closeCurrentWindow();
 
    private slots:
@@ -284,7 +286,7 @@ class Application : public QApplication {
     // FIXME: attach to instances instead.
     struct InstanceXtras {
         InstanceWindow* window = nullptr;
-        std::unique_ptr<LaunchController> controller;
+        std::list<std::unique_ptr<LaunchController>> controllers;
     };
     std::map<QString, InstanceXtras> m_instanceExtras;
     mutable QMutex m_instanceExtrasMutex;

--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -43,6 +43,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QUuid>
+#include <algorithm>
 
 #include "Application.h"
 #include "Json.h"
@@ -266,50 +267,81 @@ void BaseInstance::regenerateUuid()
 
 bool BaseInstance::isRunning() const
 {
-    return m_isRunning;
+    return !m_activeLaunchProcesses.isEmpty();
 }
 
-void BaseInstance::setRunning(bool running)
+void BaseInstance::launchSessionStarted(LaunchTask* task)
 {
-    if (running == m_isRunning) {
+    if (!task || m_activeLaunchProcesses.contains(task))
         return;
+
+    const bool wasRunning = isRunning();
+    if (!wasRunning) {
+        m_launchIntervalCrashed = false;
+        setCrashed(false);
     }
-
-    m_isRunning = running;
-
-    emit runningStatusChanged(running);
+    m_activeLaunchProcesses.insert(task);
+    if (!wasRunning) {
+        emit runningStatusChanged(true);
+    }
 }
 
-void BaseInstance::setMinecraftRunning(bool running)
+void BaseInstance::launchSessionFinished(LaunchTask* task, bool crashed)
 {
-    if (!settings()->get("RecordGameTime").toBool()) {
+    if (!task || !m_activeLaunchProcesses.remove(task))
         return;
+
+    setMinecraftRunning(task, false);
+    m_launchIntervalCrashed |= crashed;
+    if (!isRunning()) {
+        setCrashed(m_launchIntervalCrashed);
+        emit runningStatusChanged(false);
     }
+}
+
+void BaseInstance::setMinecraftRunning(LaunchTask* task, bool running)
+{
+    if (!task)
+        return;
 
     if (running) {
-        m_timeStarted = QDateTime::currentDateTime();
-        setLastLaunch(m_timeStarted.toMSecsSinceEpoch());
-    } else {
-        QDateTime timeEnded = QDateTime::currentDateTime();
-        qint64 secondsPlayed = m_timeStarted.secsTo(timeEnded);
+        if (m_minecraftProcesses.contains(task))
+            return;
 
-        qint64 current = settings()->get("totalTimePlayed").toLongLong();
-        settings()->set("totalTimePlayed", current + secondsPlayed);
-        settings()->set("lastTimePlayed", secondsPlayed);
-
-        if (countTimePlayed()) {
-            qint64 globalTotal = APPLICATION->playtimeSettings()->get("TotalPlayTime").toLongLong();
-            APPLICATION->playtimeSettings()->set("TotalPlayTime", globalTotal + secondsPlayed);
+        const auto now = QDateTime::currentDateTime();
+        setLastLaunch(now.toMSecsSinceEpoch());
+        if (m_minecraftProcesses.isEmpty() && settings()->get("RecordGameTime").toBool()) {
+            m_timeStarted = now;
         }
+        m_minecraftProcesses.insert(task);
+    } else {
+        if (!m_minecraftProcesses.remove(task))
+            return;
+        if (!m_minecraftProcesses.isEmpty())
+            return;
 
-        emit propertiesChanged();
+        if (settings()->get("RecordGameTime").toBool() && m_timeStarted.isValid()) {
+            const auto timeEnded = QDateTime::currentDateTime();
+            const auto elapsed = m_timeStarted.secsTo(timeEnded);
+            qint64 current = settings()->get("totalTimePlayed").toLongLong();
+            settings()->set("totalTimePlayed", current + elapsed);
+            settings()->set("lastTimePlayed", elapsed);
+
+            if (countTimePlayed()) {
+                qint64 globalTotal = APPLICATION->playtimeSettings()->get("TotalPlayTime").toLongLong();
+                APPLICATION->playtimeSettings()->set("TotalPlayTime", globalTotal + elapsed);
+            }
+
+            emit propertiesChanged();
+        }
+        m_timeStarted = {};
     }
 }
 
 int64_t BaseInstance::totalTimePlayed() const
 {
     qint64 current = m_settings->get("totalTimePlayed").toLongLong();
-    if (m_isRunning) {
+    if (!m_minecraftProcesses.isEmpty() && m_timeStarted.isValid() && m_settings->get("RecordGameTime").toBool()) {
         QDateTime timeNow = QDateTime::currentDateTime();
         return current + m_timeStarted.secsTo(timeNow);
     }
@@ -318,7 +350,7 @@ int64_t BaseInstance::totalTimePlayed() const
 
 int64_t BaseInstance::lastTimePlayed() const
 {
-    if (m_isRunning) {
+    if (!m_minecraftProcesses.isEmpty() && m_timeStarted.isValid() && m_settings->get("RecordGameTime").toBool()) {
         QDateTime timeNow = QDateTime::currentDateTime();
         return m_timeStarted.secsTo(timeNow);
     }
@@ -355,7 +387,7 @@ SettingsObject* BaseInstance::settings()
 
 bool BaseInstance::canLaunch() const
 {
-    return (!hasVersionBroken() && !isRunning());
+    return !hasVersionBroken();
 }
 
 bool BaseInstance::reloadSettings()
@@ -482,9 +514,58 @@ QStringList BaseInstance::extraArguments()
     return Commandline::splitArgs(settings()->get("JvmArgs").toString());
 }
 
-LaunchTask* BaseInstance::getLaunchTask()
+QList<LaunchTask*> BaseInstance::launchTasks() const
 {
-    return m_launchProcess.get();
+    QList<LaunchTask*> result;
+    result.reserve(static_cast<qsizetype>(m_launchProcesses.size()));
+    for (const auto& task : m_launchProcesses) {
+        result.append(task.get());
+    }
+    return result;
+}
+
+QList<LaunchTask*> BaseInstance::activeLaunchTasks() const
+{
+    QList<LaunchTask*> result;
+    result.reserve(m_activeLaunchProcesses.size());
+    for (const auto& task : m_launchProcesses) {
+        if (m_activeLaunchProcesses.contains(task.get()))
+            result.append(task.get());
+    }
+    return result;
+}
+
+bool BaseInstance::isLaunchTaskActive(LaunchTask* task) const
+{
+    return task && m_activeLaunchProcesses.contains(task);
+}
+
+LaunchTask* BaseInstance::launchTask(quint64 sessionId) const
+{
+    const auto iter = std::find_if(m_launchProcesses.begin(), m_launchProcesses.end(),
+                                   [sessionId](const auto& task) { return task->sessionId() == sessionId; });
+    return iter == m_launchProcesses.end() ? nullptr : iter->get();
+}
+
+LaunchTask* BaseInstance::adoptLaunchTask(std::unique_ptr<LaunchTask> task)
+{
+    if (!task)
+        return nullptr;
+
+    // Keep completed sessions (and their logs) available until the next
+    // independent run group starts. Overlapping launches stay grouped.
+    if (!isRunning()) {
+        for (const auto& previous : m_launchProcesses)
+            emit launchTaskRemoved(previous->sessionId());
+        m_launchProcesses.clear();
+    }
+
+    auto* result = task.get();
+    result->setSessionId(m_nextLaunchSessionId++);
+    m_launchProcesses.emplace_back(std::move(task));
+    result->init();
+    emit launchTaskAdded(result);
+    return result;
 }
 
 void BaseInstance::updateRuntimeContext()

--- a/launcher/BaseInstance.h
+++ b/launcher/BaseInstance.h
@@ -46,6 +46,7 @@
 #include <QProcess>
 #include <QSet>
 #include <cstdint>
+#include <list>
 #include "QObjectPtr.h"
 
 #include "settings/SettingsObject.h"
@@ -114,8 +115,7 @@ class BaseInstance : public QObject {
     QString uuid() const { return m_uuid; }
     void regenerateUuid();
 
-    void setMinecraftRunning(bool running);
-    void setRunning(bool running);
+    void setMinecraftRunning(LaunchTask* task, bool running);
     bool isRunning() const;
     int64_t totalTimePlayed() const;
     int64_t lastTimePlayed() const;
@@ -201,8 +201,14 @@ class BaseInstance : public QObject {
     /// returns a valid launcher (task container)
     virtual LaunchTask* createLaunchTask(AuthSessionPtr account, MinecraftTarget::Ptr targetToJoin) = 0;
 
-    /// returns the current launch task (if any)
-    LaunchTask* getLaunchTask();
+    /// Returns launch sessions from the current run group, in creation order.
+    QList<LaunchTask*> launchTasks() const;
+    QList<LaunchTask*> activeLaunchTasks() const;
+    bool isLaunchTaskActive(LaunchTask* task) const;
+    LaunchTask* launchTask(quint64 sessionId) const;
+    LaunchTask* adoptLaunchTask(std::unique_ptr<LaunchTask> task);
+    void launchSessionStarted(LaunchTask* task);
+    void launchSessionFinished(LaunchTask* task, bool crashed);
 
     /*!
      * Create envrironment variables for running the instance
@@ -290,7 +296,8 @@ class BaseInstance : public QObject {
      */
     void propertiesChanged();
 
-    void launchTaskChanged(LaunchTask*);
+    void launchTaskAdded(LaunchTask*);
+    void launchTaskRemoved(quint64 sessionId);
 
     void runningStatusChanged(bool running);
 
@@ -305,8 +312,11 @@ class BaseInstance : public QObject {
     QString m_rootDir;
     std::unique_ptr<SettingsObject> m_settings;
     // InstanceFlags m_flags;
-    bool m_isRunning = false;
-    std::unique_ptr<LaunchTask> m_launchProcess;
+    std::list<std::unique_ptr<LaunchTask>> m_launchProcesses;
+    QSet<LaunchTask*> m_activeLaunchProcesses;
+    QSet<LaunchTask*> m_minecraftProcesses;
+    quint64 m_nextLaunchSessionId = 1;
+    bool m_launchIntervalCrashed = false;
     QDateTime m_timeStarted;
     RuntimeContext m_runtimeContext;
 

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -260,6 +260,7 @@ set(MINECRAFT_SOURCES
     minecraft/launch/ModMinecraftJar.h
     minecraft/launch/ExtractNatives.cpp
     minecraft/launch/ExtractNatives.h
+    minecraft/launch/NativePath.h
     minecraft/launch/LauncherPartLaunch.cpp
     minecraft/launch/LauncherPartLaunch.h
     minecraft/launch/MinecraftTarget.cpp

--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -300,6 +300,7 @@ void LaunchController::login()
             if (ok) {
                 m_session = std::make_shared<AuthSession>();
                 m_session->MakeDemo(name, MinecraftAccount::uuidFromUsername(name).toString(QUuid::Id128));
+                m_session->account_type = "Demo";
                 launchInstance();
                 return;
             }
@@ -312,6 +313,7 @@ void LaunchController::login()
     m_session = std::make_shared<AuthSession>();
     m_session->launchMode = m_actualLaunchMode;
     m_accountToUse->fillSession(m_session);
+    m_session->account_type = m_accountToUse->accountType() == AccountType::MSA ? "Microsoft" : "Offline";
 
     if (m_accountToUse->accountType() != AccountType::Offline) {
         if (m_actualLaunchMode == LaunchMode::Normal && !m_accountToUse->hasProfile()) {
@@ -335,6 +337,9 @@ void LaunchController::login()
             m_session->MakeOffline(name);
         }
     }
+
+    if (m_actualLaunchMode == LaunchMode::Offline)
+        m_session->account_type = "Offline";
 
     launchInstance();
 }

--- a/launcher/LaunchController.cpp
+++ b/launcher/LaunchController.cpp
@@ -61,6 +61,11 @@
 
 LaunchController::LaunchController() = default;
 
+LaunchTask* LaunchController::launcher() const
+{
+    return m_launcher.data();
+}
+
 void LaunchController::executeTask()
 {
     if (!m_instance) {
@@ -390,6 +395,7 @@ void LaunchController::launchInstance()
     connect(m_launcher, &LaunchTask::readyForLaunch, this, &LaunchController::readyForLaunch);
     connect(m_launcher, &LaunchTask::succeeded, this, &LaunchController::onSucceeded);
     connect(m_launcher, &LaunchTask::failed, this, &LaunchController::onFailed);
+    connect(m_launcher, &LaunchTask::aborted, this, [this] { emitAborted(); });
     connect(m_launcher, &LaunchTask::requestProgress, this, &LaunchController::onProgressRequested);
 
     // Prepend Online and Auth Status
@@ -425,8 +431,8 @@ void LaunchController::readyForLaunch()
 
     QString error;
     if (!m_profiler->check(&error)) {
-        m_launcher->abort();
-        emitFailed("Profiler startup failed!");
+        if (!m_launcher->abort())
+            emitFailed("Profiler startup failed!");
         QMessageBox::critical(m_parentWidget, tr("Error!"), tr("Profiler check for %1 failed: %2").arg(m_profiler->name(), error));
         return;
     }
@@ -452,8 +458,8 @@ void LaunchController::readyForLaunch()
         msg.addButton(QMessageBox::Ok);
         msg.setModal(true);
         msg.exec();
-        m_launcher->abort();
-        emitFailed("Profiler startup failed!");
+        if (!m_launcher->abort())
+            emitFailed("Profiler startup failed!");
     });
     profilerInstance->beginProfiling(m_launcher);
 }

--- a/launcher/LaunchController.h
+++ b/launcher/LaunchController.h
@@ -35,6 +35,7 @@
 
 #pragma once
 #include <tools/BaseProfiler.h>
+#include <QPointer>
 
 #include "minecraft/MinecraftInstance.h"
 #include "minecraft/auth/MinecraftAccount.h"
@@ -69,6 +70,7 @@ class LaunchController : public Task {
     void setAccountToUse(MinecraftAccountPtr accountToUse) { m_accountToUse = std::move(accountToUse); }
 
     QString id() const { return m_instance->id(); }
+    LaunchTask* launcher() const;
 
     bool abort() override;
 
@@ -98,6 +100,6 @@ class LaunchController : public Task {
     InstanceWindow* m_console = nullptr;
     MinecraftAccountPtr m_accountToUse = nullptr;
     AuthSessionPtr m_session = nullptr;
-    LaunchTask* m_launcher = nullptr;
+    QPointer<LaunchTask> m_launcher;
     MinecraftTarget::Ptr m_targetToJoin = nullptr;
 };

--- a/launcher/launch/LaunchTask.cpp
+++ b/launcher/launch/LaunchTask.cpp
@@ -48,14 +48,12 @@
 
 void LaunchTask::init()
 {
-    m_instance->setRunning(true);
+    m_instance->launchSessionStarted(this);
 }
 
 std::unique_ptr<LaunchTask> LaunchTask::create(MinecraftInstance* inst)
 {
-    auto task = std::unique_ptr<LaunchTask>(new LaunchTask(inst));
-    task->init();
-    return task;
+    return std::unique_ptr<LaunchTask>(new LaunchTask(inst));
 }
 
 LaunchTask::LaunchTask(MinecraftInstance* instance) : m_instance(instance) {}
@@ -72,7 +70,6 @@ void LaunchTask::prependStep(shared_qobject_ptr<LaunchStep> step)
 
 void LaunchTask::executeTask()
 {
-    m_instance->setCrashed(false);
     if (!m_steps.size()) {
         state = LaunchTask::Finished;
         emitSucceeded();
@@ -90,6 +87,13 @@ void LaunchTask::onReadyForLaunch()
 
 void LaunchTask::onStepFinished()
 {
+    if (state == LaunchTask::Aborted) {
+        for (auto step = currentStep; step >= 0; --step)
+            m_steps[step]->finalize();
+        emitAborted();
+        return;
+    }
+
     // initial -> just start the first step
     if (currentStep == -1) {
         currentStep++;
@@ -189,10 +193,12 @@ bool LaunchTask::abort()
             if (!step->canAbort()) {
                 return false;
             }
+            const auto previousState = state;
+            state = LaunchTask::Aborted;
             if (step->abort()) {
-                state = LaunchTask::Aborted;
                 return true;
             }
+            state = previousState;
         }
         default:
             break;
@@ -215,7 +221,7 @@ shared_qobject_ptr<LogModel> LaunchTask::getLogModel()
     return m_logModel;
 }
 
-bool LaunchTask::parseXmlLogs(QString const& line, MessageLevel level)
+bool LaunchTask::parseXmlLogs(const QString& line, MessageLevel level)
 {
     LogParser* parser;
     switch (static_cast<MessageLevel::Enum>(level)) {
@@ -241,7 +247,7 @@ bool LaunchTask::parseXmlLogs(QString const& line, MessageLevel level)
         return true;
 
     auto model = getLogModel();
-    for (auto const& item : items) {
+    for (const auto& item : items) {
         if (std::holds_alternative<LogParser::LogEntry>(item)) {
             auto entry = std::get<LogParser::LogEntry>(item);
             auto msg = QString("[%1] [%2/%3] [%4]: %5")
@@ -290,15 +296,23 @@ void LaunchTask::onLogLine(QString line, MessageLevel level)
 
 void LaunchTask::emitSucceeded()
 {
-    m_instance->setRunning(false);
+    state = LaunchTask::Finished;
+    m_instance->launchSessionFinished(this, false);
     Task::emitSucceeded();
 }
 
 void LaunchTask::emitFailed(QString reason)
 {
-    m_instance->setRunning(false);
-    m_instance->setCrashed(true);
+    state = LaunchTask::Failed;
+    m_instance->launchSessionFinished(this, true);
     Task::emitFailed(reason);
+}
+
+void LaunchTask::emitAborted()
+{
+    state = LaunchTask::Aborted;
+    m_instance->launchSessionFinished(this, false);
+    Task::emitAborted();
 }
 
 QString expandVariables(const QString& input, QProcessEnvironment dict)

--- a/launcher/launch/LaunchTask.h
+++ b/launcher/launch/LaunchTask.h
@@ -46,6 +46,8 @@
 
 class LaunchTask : public Task {
     Q_OBJECT
+    friend class BaseInstance;
+
    protected:
     explicit LaunchTask(MinecraftInstance* instance);
     void init();
@@ -66,6 +68,7 @@ class LaunchTask : public Task {
     void setPid(qint64 pid) { m_pid = pid; }
 
     qint64 pid() { return m_pid; }
+    quint64 sessionId() const { return m_sessionId; }
 
     /**
      * @brief prepare the process for launch (for multi-stage launch)
@@ -93,6 +96,7 @@ class LaunchTask : public Task {
    protected: /* methods */
     virtual void emitFailed(QString reason) override;
     virtual void emitSucceeded() override;
+    virtual void emitAborted() override;
 
    signals:
     /**
@@ -113,9 +117,10 @@ class LaunchTask : public Task {
 
    private: /*methods */
     void finalizeSteps(bool successful, const QString& error);
+    void setSessionId(quint64 sessionId) { m_sessionId = sessionId; }
 
    protected:
-    bool parseXmlLogs(QString const& line, MessageLevel level);
+    bool parseXmlLogs(const QString& line, MessageLevel level);
 
    protected: /* data */
     MinecraftInstance* m_instance;
@@ -125,6 +130,7 @@ class LaunchTask : public Task {
     int currentStep = -1;
     State state = NotStarted;
     qint64 m_pid = -1;
+    quint64 m_sessionId = 0;
     LogParser m_stdoutParser;
     LogParser m_stderrParser;
 };

--- a/launcher/launch/LaunchTask.h
+++ b/launcher/launch/LaunchTask.h
@@ -36,6 +36,8 @@
  */
 
 #pragma once
+#include <utility>
+
 #include <QObjectPtr.h>
 #include <minecraft/MinecraftInstance.h>
 #include <QProcess>
@@ -69,6 +71,13 @@ class LaunchTask : public Task {
 
     qint64 pid() { return m_pid; }
     quint64 sessionId() const { return m_sessionId; }
+    const QString& accountName() const { return m_accountName; }
+    const QString& accountType() const { return m_accountType; }
+    void setAccountInfo(QString name, QString type)
+    {
+        m_accountName = std::move(name);
+        m_accountType = std::move(type);
+    }
 
     /**
      * @brief prepare the process for launch (for multi-stage launch)
@@ -131,6 +140,8 @@ class LaunchTask : public Task {
     State state = NotStarted;
     qint64 m_pid = -1;
     quint64 m_sessionId = 0;
+    QString m_accountName;
+    QString m_accountType;
     LogParser m_stdoutParser;
     LogParser m_stderrParser;
 };

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -1255,6 +1255,7 @@ LaunchTask* MinecraftInstance::createLaunchTask(AuthSessionPtr session, Minecraf
     if (m_settings->get("QuitAfterGameStop").toBool()) {
         process->appendStep(makeShared<QuitAfterGameStop>(pptr));
     }
+    process->setAccountInfo(session->player_name, session->account_type);
     return adoptLaunchTask(std::move(process));
 }
 

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -1255,9 +1255,7 @@ LaunchTask* MinecraftInstance::createLaunchTask(AuthSessionPtr session, Minecraf
     if (m_settings->get("QuitAfterGameStop").toBool()) {
         process->appendStep(makeShared<QuitAfterGameStop>(pptr));
     }
-    m_launchProcess = std::move(process);
-    emit launchTaskChanged(m_launchProcess.get());
-    return m_launchProcess.get();
+    return adoptLaunchTask(std::move(process));
 }
 
 JavaVersion MinecraftInstance::getJavaVersion()

--- a/launcher/minecraft/auth/AuthSession.h
+++ b/launcher/minecraft/auth/AuthSession.h
@@ -23,6 +23,8 @@ struct AuthSession {
     QString uuid;
     // 'msa' or 'offline', depending on account type
     QString user_type;
+    // user-facing account type for launch session labels
+    QString account_type;
     // the actual launch mode for this session
     LaunchMode launchMode;
 };

--- a/launcher/minecraft/launch/ExtractNatives.cpp
+++ b/launcher/minecraft/launch/ExtractNatives.cpp
@@ -16,6 +16,7 @@
 #include "ExtractNatives.h"
 #include <launch/LaunchTask.h>
 #include <minecraft/MinecraftInstance.h>
+#include "NativePath.h"
 
 #include <QDir>
 #include "FileSystem.h"
@@ -66,7 +67,7 @@ void ExtractNatives::executeTask()
         return;
     }
 
-    auto outputPath = instance->getNativePath();
+    const auto outputPath = launchNativePath(instance->getNativePath(), m_parent->sessionId());
     FS::ensureFolderPathExists(outputPath);
     auto javaVersion = instance->getJavaVersion();
     bool jniHackEnabled = javaVersion.major() >= 8;
@@ -84,7 +85,6 @@ void ExtractNatives::executeTask()
 void ExtractNatives::finalize()
 {
     auto instance = m_parent->instance();
-    QString target_dir = FS::PathCombine(instance->instanceRoot(), "natives/");
-    QDir dir(target_dir);
+    QDir dir(launchNativePath(instance->getNativePath(), m_parent->sessionId()));
     dir.removeRecursively();
 }

--- a/launcher/minecraft/launch/LauncherPartLaunch.cpp
+++ b/launcher/minecraft/launch/LauncherPartLaunch.cpp
@@ -43,6 +43,7 @@
 #include "FileSystem.h"
 #include "launch/LaunchTask.h"
 #include "minecraft/MinecraftInstance.h"
+#include "minecraft/launch/NativePath.h"
 
 #ifdef Q_OS_LINUX
 #include "gamemode_client.h"
@@ -110,7 +111,7 @@ void LauncherPartLaunch::executeTask()
     if (!legacyJarPath.isEmpty())
         classPath.prepend(legacyJarPath);
 
-    auto natPath = instance->getNativePath();
+    auto natPath = launchNativePath(instance->getNativePath(), m_parent->sessionId());
 #ifdef Q_OS_WIN
     natPath = FS::getPathNameInLocal8bit(natPath);
 #endif

--- a/launcher/minecraft/launch/LauncherPartLaunch.cpp
+++ b/launcher/minecraft/launch/LauncherPartLaunch.cpp
@@ -172,7 +172,7 @@ void LauncherPartLaunch::on_state(LoggedProcess::State state)
         case LoggedProcess::Aborted:
         case LoggedProcess::Crashed: {
             m_parent->setPid(-1);
-            m_parent->instance()->setMinecraftRunning(false);
+            m_parent->instance()->setMinecraftRunning(m_parent, false);
             emitFailed(tr("Game crashed."));
             return;
         }
@@ -182,7 +182,7 @@ void LauncherPartLaunch::on_state(LoggedProcess::State state)
                 APPLICATION->showMainWindow();
 
             m_parent->setPid(-1);
-            m_parent->instance()->setMinecraftRunning(false);
+            m_parent->instance()->setMinecraftRunning(m_parent, false);
             // if the exit code wasn't 0, report this as a crash
             auto exitCode = m_process.exitCode();
             if (exitCode != 0) {
@@ -217,7 +217,7 @@ void LauncherPartLaunch::setWorkingDirectory(const QString& wd)
 void LauncherPartLaunch::proceed()
 {
     if (mayProceed) {
-        m_parent->instance()->setMinecraftRunning(true);
+        m_parent->instance()->setMinecraftRunning(m_parent, true);
         QString launchString("launch\n");
         m_process.write(launchString.toUtf8());
         mayProceed = false;

--- a/launcher/minecraft/launch/NativePath.h
+++ b/launcher/minecraft/launch/NativePath.h
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+#pragma once
+
+#include <QDir>
+#include <QString>
+#include <QtGlobal>
+#include <QUuid>
+
+inline QString launchNativePath(const QString& nativeRoot, quint64 sessionId)
+{
+    static const auto processKey = QUuid::createUuid().toString(QUuid::WithoutBraces);
+    return QDir(nativeRoot).absoluteFilePath(QString("session-%1-%2").arg(processKey).arg(sessionId));
+}

--- a/launcher/ui/InstanceWindow.cpp
+++ b/launcher/ui/InstanceWindow.cpp
@@ -42,7 +42,6 @@
 #include <QMessageBox>
 #include <QPushButton>
 #include <QScrollBar>
-#include <QTimer>
 
 #include "ui/widgets/PageContainer.h"
 
@@ -94,14 +93,6 @@ InstanceWindow::InstanceWindow(MinecraftInstance* instance, QWidget* parent) : Q
         m_launchButton->setMinimumWidth(80);  // HACK!!
         horizontalLayout->addWidget(m_launchButton);
         connect(m_launchButton, &QPushButton::clicked, this, [this] { APPLICATION->launch(m_instance); });
-
-        m_restartButton = new QPushButton(this);
-        m_restartButton->setText(tr("&Restart"));
-        m_restartButton->setToolTip(tr("Restart the running instance"));
-        horizontalLayout->addWidget(m_restartButton);
-        connect(m_restartButton, &QPushButton::clicked, this, &InstanceWindow::restartInstance);
-
-        m_restartButton->hide();
 
         m_killButton = new QPushButton(this);
         m_killButton->setText(tr("&Kill"));
@@ -167,14 +158,9 @@ void InstanceWindow::on_instanceStatusChanged(BaseInstance::Status, BaseInstance
 
 void InstanceWindow::updateButtons()
 {
-    const bool running = m_instance->isRunning();
-    const auto sessions = m_instance->activeLaunchTasks();
-
     m_launchButton->setVisible(true);
-    m_restartButton->setVisible(running);
 
     m_launchButton->setEnabled(m_instance->canLaunch());
-    m_restartButton->setEnabled(sessions.size() == 1 && !m_restartQueued);
     m_killButton->setEnabled(m_instance->isLaunchTaskActive(m_proc));
 
     QMenu* launchMenu = m_launchButton->menu();
@@ -218,24 +204,7 @@ void InstanceWindow::runningStateChanged(bool running)
     m_container->refreshContainer();
     if (running) {
         selectPage("console");
-    } else if (m_restartQueued) {
-        m_restartQueued = false;
-        // Wait until the current launch controller has handled the stopped instance before launching again.
-        QTimer::singleShot(0, this, [this] {
-            APPLICATION->launch(m_instance);
-            updateButtons();
-        });
     }
-}
-
-void InstanceWindow::restartInstance()
-{
-    if (!m_instance->isRunning()) {
-        return;
-    }
-
-    m_restartQueued = APPLICATION->kill(m_instance);
-    updateButtons();
 }
 
 void InstanceWindow::closeEvent(QCloseEvent* event)

--- a/launcher/ui/InstanceWindow.cpp
+++ b/launcher/ui/InstanceWindow.cpp
@@ -47,6 +47,7 @@
 #include "ui/widgets/PageContainer.h"
 
 #include "InstancePageProvider.h"
+#include "ui/pages/instance/LogPage.h"
 
 #include "icons/IconList.h"
 
@@ -107,7 +108,7 @@ InstanceWindow::InstanceWindow(MinecraftInstance* instance, QWidget* parent) : Q
         m_killButton->setToolTip(tr("Kill the running instance"));
         m_killButton->setShortcut(QKeySequence(tr("Ctrl+K")));
         horizontalLayout->addWidget(m_killButton);
-        connect(m_killButton, &QPushButton::clicked, this, [this] { APPLICATION->kill(m_instance); });
+        connect(m_killButton, &QPushButton::clicked, this, [this] { APPLICATION->kill(m_instance, m_proc); });
 
         updateButtons();
 
@@ -132,10 +133,15 @@ InstanceWindow::InstanceWindow(MinecraftInstance* instance, QWidget* parent) : Q
 
     // set up instance and launch process recognition
     {
-        auto launchTask = m_instance->getLaunchTask();
-        instanceLaunchTaskChanged(launchTask);
-        connect(m_instance, &BaseInstance::launchTaskChanged, this, &InstanceWindow::instanceLaunchTaskChanged);
+        const auto launchTasks = m_instance->launchTasks();
+        if (!launchTasks.isEmpty())
+            m_proc = launchTasks.last();
+        connect(m_instance, &BaseInstance::launchTaskAdded, this, &InstanceWindow::instanceLaunchTaskAdded);
+        connect(m_instance, &BaseInstance::launchTaskRemoved, this, &InstanceWindow::instanceLaunchTaskRemoved);
         connect(m_instance, &BaseInstance::runningStatusChanged, this, &InstanceWindow::runningStateChanged);
+        auto* logPage = dynamic_cast<LogPage*>(m_container->getPage("console"));
+        if (logPage)
+            connect(logPage, &LogPage::selectedLaunchTaskChanged, this, &InstanceWindow::selectedLaunchTaskChanged);
     }
 
     // set up instance destruction detection
@@ -162,13 +168,14 @@ void InstanceWindow::on_instanceStatusChanged(BaseInstance::Status, BaseInstance
 void InstanceWindow::updateButtons()
 {
     const bool running = m_instance->isRunning();
+    const auto sessions = m_instance->activeLaunchTasks();
 
-    m_launchButton->setVisible(!running);
+    m_launchButton->setVisible(true);
     m_restartButton->setVisible(running);
 
     m_launchButton->setEnabled(m_instance->canLaunch());
-    m_restartButton->setEnabled(running && !m_restartQueued);
-    m_killButton->setEnabled(running);
+    m_restartButton->setEnabled(sessions.size() == 1 && !m_restartQueued);
+    m_killButton->setEnabled(m_instance->isLaunchTaskActive(m_proc));
 
     QMenu* launchMenu = m_launchButton->menu();
     if (launchMenu)
@@ -179,9 +186,30 @@ void InstanceWindow::updateButtons()
     m_launchButton->setMenu(launchMenu);
 }
 
-void InstanceWindow::instanceLaunchTaskChanged(LaunchTask* proc)
+void InstanceWindow::instanceLaunchTaskAdded(LaunchTask* proc)
 {
     m_proc = proc;
+    updateButtons();
+    selectPage("console");
+}
+
+void InstanceWindow::instanceLaunchTaskRemoved(quint64 sessionId)
+{
+    if (m_proc && m_proc->sessionId() == sessionId) {
+        const auto tasks = m_instance->launchTasks();
+        m_proc = nullptr;
+        for (auto* task : tasks) {
+            if (task->sessionId() != sessionId)
+                m_proc = task;
+        }
+    }
+    updateButtons();
+}
+
+void InstanceWindow::selectedLaunchTaskChanged(LaunchTask* proc)
+{
+    m_proc = proc;
+    updateButtons();
 }
 
 void InstanceWindow::runningStateChanged(bool running)
@@ -189,7 +217,7 @@ void InstanceWindow::runningStateChanged(bool running)
     updateButtons();
     m_container->refreshContainer();
     if (running) {
-        selectPage("log");
+        selectPage("console");
     } else if (m_restartQueued) {
         m_restartQueued = false;
         // Wait until the current launch controller has handled the stopped instance before launching again.

--- a/launcher/ui/InstanceWindow.h
+++ b/launcher/ui/InstanceWindow.h
@@ -76,7 +76,6 @@ class InstanceWindow : public QMainWindow, public BasePageContainer {
     void instanceLaunchTaskRemoved(quint64 sessionId);
     void selectedLaunchTaskChanged(LaunchTask* proc);
     void runningStateChanged(bool running);
-    void restartInstance();
     void on_instanceStatusChanged(BaseInstance::Status, BaseInstance::Status newStatus);
 
    protected:
@@ -89,10 +88,8 @@ class InstanceWindow : public QMainWindow, public BasePageContainer {
     LaunchTask* m_proc = nullptr;
     MinecraftInstance* m_instance;
     bool m_doNotSave = false;
-    bool m_restartQueued = false;
     PageContainer* m_container = nullptr;
     QPushButton* m_closeButton = nullptr;
     QToolButton* m_launchButton = nullptr;
-    QPushButton* m_restartButton = nullptr;
     QPushButton* m_killButton = nullptr;
 };

--- a/launcher/ui/InstanceWindow.h
+++ b/launcher/ui/InstanceWindow.h
@@ -72,7 +72,9 @@ class InstanceWindow : public QMainWindow, public BasePageContainer {
     void isClosing();
 
    private slots:
-    void instanceLaunchTaskChanged(LaunchTask* proc);
+    void instanceLaunchTaskAdded(LaunchTask* proc);
+    void instanceLaunchTaskRemoved(quint64 sessionId);
+    void selectedLaunchTaskChanged(LaunchTask* proc);
     void runningStateChanged(bool running);
     void restartInstance();
     void on_instanceStatusChanged(BaseInstance::Status, BaseInstance::Status newStatus);
@@ -84,7 +86,7 @@ class InstanceWindow : public QMainWindow, public BasePageContainer {
     void updateButtons();
 
    private:
-    LaunchTask* m_proc;
+    LaunchTask* m_proc = nullptr;
     MinecraftInstance* m_instance;
     bool m_doNotSave = false;
     bool m_restartQueued = false;

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -1625,7 +1625,7 @@ void MainWindow::instanceActivated(QModelIndex index)
 
 void MainWindow::on_actionLaunchInstance_triggered()
 {
-    if (m_selectedInstance && !m_selectedInstance->isRunning()) {
+    if (m_selectedInstance) {
         APPLICATION->launch(m_selectedInstance);
     }
 }
@@ -1791,6 +1791,20 @@ void MainWindow::setInstanceActionsEnabled(bool enabled)
 
 void MainWindow::refreshCurrentInstance()
 {
-    auto current = view->selectionModel()->currentIndex();
-    instanceChanged(current, current);
+    if (!m_selectedInstance)
+        return;
+
+    // Running state changes can cause the sorted instance model to move the
+    // selected row. Do not re-resolve the selection through a transient model
+    // index here: an invalid index would disable the whole instance toolbar.
+    ui->instanceToolBar->setEnabled(true);
+    setInstanceActionsEnabled(true);
+    ui->actionLaunchInstance->setEnabled(m_selectedInstance->canLaunch());
+    ui->actionKillInstance->setEnabled(m_selectedInstance->isRunning());
+    ui->actionExportInstance->setEnabled(m_selectedInstance->canExport());
+    renameButton->setText(m_selectedInstance->name());
+    m_statusLeft->setText(m_selectedInstance->getStatusbarDescription());
+    updateStatusCenter();
+    updateInstanceToolIcon(m_selectedInstance->iconKey());
+    updateLaunchButton();
 }

--- a/launcher/ui/pages/instance/LogPage.cpp
+++ b/launcher/ui/pages/instance/LogPage.cpp
@@ -149,11 +149,18 @@ LogPage::LogPage(BaseInstance* instance, QWidget* parent) : QWidget(parent), ui(
 
     // set up instance and launch process recognition
     {
-        auto launchTask = m_instance->getLaunchTask();
-        if (launchTask) {
-            setInstanceLaunchTaskChanged(launchTask, true);
+        const auto tasks = m_instance->launchTasks();
+        for (auto* task : tasks) {
+            ui->sessionCombo->addItem(tr("Minecraft #%1").arg(task->sessionId()), QVariant::fromValue<qulonglong>(task->sessionId()));
         }
-        connect(m_instance, &BaseInstance::launchTaskChanged, this, &LogPage::onInstanceLaunchTaskChanged);
+        if (!tasks.isEmpty()) {
+            ui->sessionCombo->setCurrentIndex(tasks.size() - 1);
+            setInstanceLaunchTaskChanged(tasks.last(), true);
+        }
+        ui->sessionLabel->setVisible(!tasks.isEmpty());
+        ui->sessionCombo->setVisible(!tasks.isEmpty());
+        connect(m_instance, &BaseInstance::launchTaskAdded, this, &LogPage::onInstanceLaunchTaskAdded);
+        connect(m_instance, &BaseInstance::launchTaskRemoved, this, &LogPage::onInstanceLaunchTaskRemoved);
     }
 
     auto findShortcut = new QShortcut(QKeySequence(QKeySequence::Find), this);
@@ -220,9 +227,43 @@ void LogPage::setInstanceLaunchTaskChanged(LaunchTask* proc, bool initial)
     }
 }
 
-void LogPage::onInstanceLaunchTaskChanged(LaunchTask* proc)
+int LogPage::sessionIndex(quint64 sessionId) const
 {
-    setInstanceLaunchTaskChanged(proc, false);
+    for (int index = 0; index < ui->sessionCombo->count(); ++index) {
+        if (ui->sessionCombo->itemData(index).toULongLong() == sessionId)
+            return index;
+    }
+    return -1;
+}
+
+void LogPage::on_sessionCombo_currentIndexChanged(int index)
+{
+    auto* task = index < 0 ? nullptr : m_instance->launchTask(ui->sessionCombo->itemData(index).toULongLong());
+    if (task != m_process)
+        setInstanceLaunchTaskChanged(task, false);
+    emit selectedLaunchTaskChanged(task);
+}
+
+void LogPage::onInstanceLaunchTaskAdded(LaunchTask* proc)
+{
+    ui->sessionCombo->addItem(tr("Minecraft #%1").arg(proc->sessionId()), QVariant::fromValue<qulonglong>(proc->sessionId()));
+    ui->sessionLabel->show();
+    ui->sessionCombo->show();
+    ui->sessionCombo->setCurrentIndex(ui->sessionCombo->count() - 1);
+}
+
+void LogPage::onInstanceLaunchTaskRemoved(quint64 sessionId)
+{
+    const int index = sessionIndex(sessionId);
+    if (index >= 0)
+        ui->sessionCombo->removeItem(index);
+    const bool hasSessions = ui->sessionCombo->count() > 0;
+    ui->sessionLabel->setVisible(hasSessions);
+    ui->sessionCombo->setVisible(hasSessions);
+    if (!hasSessions) {
+        setInstanceLaunchTaskChanged(nullptr, false);
+        emit selectedLaunchTaskChanged(nullptr);
+    }
 }
 
 bool LogPage::apply()

--- a/launcher/ui/pages/instance/LogPage.cpp
+++ b/launcher/ui/pages/instance/LogPage.cpp
@@ -151,7 +151,7 @@ LogPage::LogPage(BaseInstance* instance, QWidget* parent) : QWidget(parent), ui(
     {
         const auto tasks = m_instance->launchTasks();
         for (auto* task : tasks) {
-            ui->sessionCombo->addItem(tr("Minecraft #%1").arg(task->sessionId()), QVariant::fromValue<qulonglong>(task->sessionId()));
+            ui->sessionCombo->addItem(launchTaskDisplayName(task), QVariant::fromValue<qulonglong>(task->sessionId()));
         }
         if (!tasks.isEmpty()) {
             ui->sessionCombo->setCurrentIndex(tasks.size() - 1);
@@ -236,6 +236,16 @@ int LogPage::sessionIndex(quint64 sessionId) const
     return -1;
 }
 
+QString LogPage::launchTaskDisplayName(const LaunchTask* task) const
+{
+    auto name = tr("Minecraft #%1").arg(task->sessionId());
+    if (!task->accountName().isEmpty())
+        name += QString(" %1").arg(task->accountName());
+    if (!task->accountType().isEmpty())
+        name += QString(" [%1]").arg(task->accountType());
+    return name;
+}
+
 void LogPage::on_sessionCombo_currentIndexChanged(int index)
 {
     auto* task = index < 0 ? nullptr : m_instance->launchTask(ui->sessionCombo->itemData(index).toULongLong());
@@ -246,7 +256,7 @@ void LogPage::on_sessionCombo_currentIndexChanged(int index)
 
 void LogPage::onInstanceLaunchTaskAdded(LaunchTask* proc)
 {
-    ui->sessionCombo->addItem(tr("Minecraft #%1").arg(proc->sessionId()), QVariant::fromValue<qulonglong>(proc->sessionId()));
+    ui->sessionCombo->addItem(launchTaskDisplayName(proc), QVariant::fromValue<qulonglong>(proc->sessionId()));
     ui->sessionLabel->show();
     ui->sessionCombo->show();
     ui->sessionCombo->setCurrentIndex(ui->sessionCombo->count() - 1);

--- a/launcher/ui/pages/instance/LogPage.h
+++ b/launcher/ui/pages/instance/LogPage.h
@@ -99,6 +99,7 @@ class LogPage : public QWidget, public BasePage {
     void modelStateToUI();
     void UIToModelState();
     void setInstanceLaunchTaskChanged(LaunchTask* proc, bool initial);
+    QString launchTaskDisplayName(const LaunchTask* task) const;
     int sessionIndex(quint64 sessionId) const;
 
    private:

--- a/launcher/ui/pages/instance/LogPage.h
+++ b/launcher/ui/pages/instance/LogPage.h
@@ -73,6 +73,9 @@ class LogPage : public QWidget, public BasePage {
     virtual bool shouldDisplay() const override;
     void retranslate() override;
 
+   signals:
+    void selectedLaunchTaskChanged(LaunchTask* task);
+
    private slots:
     void on_btnPaste_clicked();
     void on_btnCopy_clicked();
@@ -88,17 +91,20 @@ class LogPage : public QWidget, public BasePage {
     void findNextActivated();
     void findPreviousActivated();
 
-    void onInstanceLaunchTaskChanged(LaunchTask* proc);
+    void on_sessionCombo_currentIndexChanged(int index);
+    void onInstanceLaunchTaskAdded(LaunchTask* proc);
+    void onInstanceLaunchTaskRemoved(quint64 sessionId);
 
    private:
     void modelStateToUI();
     void UIToModelState();
     void setInstanceLaunchTaskChanged(LaunchTask* proc, bool initial);
+    int sessionIndex(quint64 sessionId) const;
 
    private:
     Ui::LogPage* ui;
     BaseInstance* m_instance;
-    LaunchTask* m_process;
+    LaunchTask* m_process = nullptr;
 
     LogFormatProxyModel* m_proxy;
     shared_qobject_ptr<LogModel> m_model;

--- a/launcher/ui/pages/instance/LogPage.ui
+++ b/launcher/ui/pages/instance/LogPage.ui
@@ -42,6 +42,20 @@
    <item row="0" column="0" colspan="5">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
+      <widget class="QLabel" name="sessionLabel">
+       <property name="text">
+        <string>Process:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="sessionCombo">
+       <property name="minimumContentsLength">
+        <number>14</number>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QCheckBox" name="trackLogCheckbox">
        <property name="text">
         <string>Keep updating</string>
@@ -168,7 +182,8 @@
    <header>ui/widgets/LogView.h</header>
   </customwidget>
  </customwidgets>
- <tabstops>
+  <tabstops>
+   <tabstop>sessionCombo</tabstop>
   <tabstop>trackLogCheckbox</tabstop>
   <tabstop>wrapCheckbox</tabstop>
   <tabstop>colorCheckbox</tabstop>

--- a/tests/BaseInstance_test.cpp
+++ b/tests/BaseInstance_test.cpp
@@ -1,0 +1,122 @@
+#include <QSignalSpy>
+#include <QTemporaryDir>
+#include <QTest>
+
+#include <BaseInstance.h>
+#include <launch/LaunchTask.h>
+#include <settings/INISettingsObject.h>
+#include <tasks/Task.h>
+
+class TestLaunchTask final : public LaunchTask {
+   public:
+    TestLaunchTask() : LaunchTask(nullptr) {}
+};
+
+class TestInstance final : public BaseInstance {
+   public:
+    TestInstance(SettingsObject* globalSettings, std::unique_ptr<SettingsObject> settings, const QString& rootDir)
+        : BaseInstance(globalSettings, std::move(settings), rootDir)
+    {}
+
+    void saveNow() override {}
+    QString modsRoot() const override { return instanceRoot(); }
+    QSet<QString> traits() const override { return {}; }
+    void loadSpecificSettings() override { setSpecificSettingsLoaded(true); }
+    QList<Task::Ptr> createUpdateTask() override { return {}; }
+    LaunchTask* createLaunchTask(AuthSessionPtr, MinecraftTarget::Ptr) override { return nullptr; }
+    QProcessEnvironment createEnvironment() override { return {}; }
+    QProcessEnvironment createLaunchEnvironment() override { return {}; }
+    QStringList getLogFileSearchPaths() override { return {}; }
+    QString getStatusbarDescription() override { return {}; }
+    QString instanceConfigFolder() const override { return instanceRoot(); }
+    QMap<QString, QString> getVariables() override { return {}; }
+    bool canEdit() const override { return true; }
+    bool canExport() const override { return true; }
+    void populateLaunchMenu(QMenu*) override {}
+    QStringList verboseDescription(AuthSessionPtr, MinecraftTarget::Ptr) override { return {}; }
+};
+
+class BaseInstanceTest : public QObject {
+    Q_OBJECT
+
+   private:
+    static std::unique_ptr<INISettingsObject> createGlobalSettings(const QString& path)
+    {
+        auto settings = std::make_unique<INISettingsObject>(path);
+        settings->registerSetting("ShowGameTime", true);
+        settings->registerSetting("RecordGameTime", true);
+        settings->registerSetting("PreLaunchCommand", "");
+        settings->registerSetting("WrapperCommand", "");
+        settings->registerSetting("PostExitCommand", "");
+        settings->registerSetting("ShowConsole", false);
+        settings->registerSetting("AutoCloseConsole", false);
+        settings->registerSetting("ShowConsoleOnError", true);
+        settings->registerSetting("LogPrePostOutput", true);
+        settings->registerSetting("ConsoleMaxLines", 1000);
+        settings->registerSetting("ConsoleOverflowStop", true);
+        return settings;
+    }
+
+   private slots:
+    void aggregateRunningStateAndCanLaunch()
+    {
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        auto global = createGlobalSettings(dir.filePath("global.cfg"));
+        auto local = std::make_unique<INISettingsObject>(dir.filePath("instance.cfg"));
+        TestInstance instance(global.get(), std::move(local), dir.path());
+        TestLaunchTask first;
+        TestLaunchTask second;
+        QSignalSpy runningChanges(&instance, &BaseInstance::runningStatusChanged);
+
+        QVERIFY(instance.canLaunch());
+        instance.launchSessionStarted(&first);
+        QVERIFY(instance.isRunning());
+        QVERIFY(instance.isLaunchTaskActive(&first));
+        QVERIFY(instance.canLaunch());
+        QCOMPARE(runningChanges.count(), 1);
+        QCOMPARE(runningChanges.at(0).at(0).toBool(), true);
+
+        instance.launchSessionStarted(&second);
+        QVERIFY(instance.isRunning());
+        QVERIFY(instance.isLaunchTaskActive(&second));
+        QCOMPARE(runningChanges.count(), 1);
+
+        instance.launchSessionFinished(&first, false);
+        QVERIFY(instance.isRunning());
+        QVERIFY(!instance.isLaunchTaskActive(&first));
+        QVERIFY(instance.isLaunchTaskActive(&second));
+        QCOMPARE(runningChanges.count(), 1);
+
+        instance.launchSessionFinished(&second, false);
+        QVERIFY(!instance.isRunning());
+        QCOMPARE(runningChanges.count(), 2);
+        QCOMPARE(runningChanges.at(1).at(0).toBool(), false);
+    }
+
+    void parallelMinecraftProcessesCountWallClockTimeOnce()
+    {
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        auto global = createGlobalSettings(dir.filePath("global.cfg"));
+        auto local = std::make_unique<INISettingsObject>(dir.filePath("instance.cfg"));
+        TestInstance instance(global.get(), std::move(local), dir.path());
+        TestLaunchTask first;
+        TestLaunchTask second;
+
+        instance.setMinecraftRunning(&first, true);
+        instance.setMinecraftRunning(&second, true);
+        QTest::qWait(1100);
+        instance.setMinecraftRunning(&first, false);
+        QVERIFY(instance.totalTimePlayed() <= 2);
+        instance.setMinecraftRunning(&second, false);
+
+        QVERIFY(instance.totalTimePlayed() >= 1);
+        QVERIFY(instance.totalTimePlayed() <= 2);
+        QCOMPARE(instance.lastTimePlayed(), instance.totalTimePlayed());
+    }
+};
+
+QTEST_GUILESS_MAIN(BaseInstanceTest)
+
+#include "BaseInstance_test.moc"

--- a/tests/BaseInstance_test.cpp
+++ b/tests/BaseInstance_test.cpp
@@ -18,6 +18,14 @@ class TestInstance final : public BaseInstance {
         : BaseInstance(globalSettings, std::move(settings), rootDir)
     {}
 
+    TestLaunchTask* retainLaunchTaskForTest()
+    {
+        auto task = std::make_unique<TestLaunchTask>();
+        auto* result = task.get();
+        m_launchProcesses.emplace_back(std::move(task));
+        return result;
+    }
+
     void saveNow() override {}
     QString modsRoot() const override { return instanceRoot(); }
     QSet<QString> traits() const override { return {}; }
@@ -123,6 +131,24 @@ class BaseInstanceTest : public QObject {
 
         QCOMPARE(task.accountName(), QString("Player"));
         QCOMPARE(task.accountType(), QString("Microsoft"));
+    }
+
+    void completedLaunchTaskRetainsLog()
+    {
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        auto global = createGlobalSettings(dir.filePath("global.cfg"));
+        auto local = std::make_unique<INISettingsObject>(dir.filePath("instance.cfg"));
+        TestInstance instance(global.get(), std::move(local), dir.path());
+        auto* task = instance.retainLaunchTaskForTest();
+
+        instance.launchSessionStarted(task);
+        instance.launchSessionFinished(task, false);
+        QCoreApplication::processEvents();
+
+        QCOMPARE(instance.launchTasks().size(), 1);
+        QCOMPARE(instance.launchTasks().first(), task);
+        QVERIFY(instance.activeLaunchTasks().isEmpty());
     }
 };
 

--- a/tests/BaseInstance_test.cpp
+++ b/tests/BaseInstance_test.cpp
@@ -1,9 +1,11 @@
+#include <QFileInfo>
 #include <QSignalSpy>
 #include <QTemporaryDir>
 #include <QTest>
 
 #include <BaseInstance.h>
 #include <launch/LaunchTask.h>
+#include <minecraft/launch/NativePath.h>
 #include <settings/INISettingsObject.h>
 #include <tasks/Task.h>
 
@@ -131,6 +133,20 @@ class BaseInstanceTest : public QObject {
 
         QCOMPARE(task.accountName(), QString("Player"));
         QCOMPARE(task.accountType(), QString("Microsoft"));
+    }
+
+    void parallelLaunchTasksUseSeparateNativeDirectories()
+    {
+        QTemporaryDir dir;
+        QVERIFY(dir.isValid());
+        const auto nativeRoot = dir.filePath("natives");
+        const auto first = launchNativePath(nativeRoot, 1);
+        const auto second = launchNativePath(nativeRoot, 2);
+
+        QVERIFY(first != second);
+        QCOMPARE(first, launchNativePath(nativeRoot, 1));
+        QCOMPARE(QFileInfo(first).absolutePath(), QDir(nativeRoot).absolutePath());
+        QCOMPARE(QFileInfo(second).absolutePath(), QDir(nativeRoot).absolutePath());
     }
 
     void completedLaunchTaskRetainsLog()

--- a/tests/BaseInstance_test.cpp
+++ b/tests/BaseInstance_test.cpp
@@ -115,6 +115,15 @@ class BaseInstanceTest : public QObject {
         QVERIFY(instance.totalTimePlayed() <= 2);
         QCOMPARE(instance.lastTimePlayed(), instance.totalTimePlayed());
     }
+
+    void launchTaskStoresAccountLabel()
+    {
+        TestLaunchTask task;
+        task.setAccountInfo("Player", "Microsoft");
+
+        QCOMPARE(task.accountName(), QString("Player"));
+        QCOMPARE(task.accountType(), QString("Microsoft"));
+    }
 };
 
 QTEST_GUILESS_MAIN(BaseInstanceTest)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,9 @@ ecm_add_test(ParseUtils_test.cpp LINK_LIBRARIES Launcher_logic Qt${QT_VERSION_MA
 ecm_add_test(Task_test.cpp LINK_LIBRARIES Launcher_logic Qt${QT_VERSION_MAJOR}::Test
     TEST_NAME Task)
 
+ecm_add_test(BaseInstance_test.cpp LINK_LIBRARIES Launcher_logic Qt${QT_VERSION_MAJOR}::Test
+    TEST_NAME BaseInstance)
+
 ecm_add_test(INIFile_test.cpp LINK_LIBRARIES Launcher_logic Qt${QT_VERSION_MAJOR}::Test
     TEST_NAME INIFile)
 


### PR DESCRIPTION
Closes #250.

Keep independent launch controllers and logs for concurrent processes, and allow selecting the process to stop.