### PR TITLE
Avoid makeShared copying arguments

### DIFF
--- a/launcher/QObjectPtr.h
+++ b/launcher/QObjectPtr.h
@@ -46,8 +46,8 @@ class shared_qobject_ptr : public QSharedPointer<T> {
 };
 
 template <typename T, typename... Args>
-shared_qobject_ptr<T> makeShared(Args... args)
+shared_qobject_ptr<T> makeShared(Args&&... args)
 {
-    auto obj = new T(args...);
+    auto obj = new T(std::forward<Args>(args)...);
     return shared_qobject_ptr<T>(obj);
 }

--- a/launcher/minecraft/mod/tasks/LocalResourceUpdateTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalResourceUpdateTask.cpp
@@ -26,8 +26,8 @@
 #include <windows.h>
 #endif
 
-LocalResourceUpdateTask::LocalResourceUpdateTask(QDir index_dir, ModPlatform::IndexedPack& project, ModPlatform::IndexedVersion& version)
-    : m_index_dir(index_dir), m_project(project), m_version(version)
+LocalResourceUpdateTask::LocalResourceUpdateTask(QDir index_dir, ModPlatform::IndexedPack project, ModPlatform::IndexedVersion version)
+    : m_index_dir(index_dir), m_project(std::move(project)), m_version(std::move(version))
 {
     // Ensure a '.index' folder exists in the mods folder, and create it if it does not
     if (!FS::ensureFolderPathExists(index_dir.path())) {

--- a/launcher/minecraft/mod/tasks/LocalResourceUpdateTask.h
+++ b/launcher/minecraft/mod/tasks/LocalResourceUpdateTask.h
@@ -28,7 +28,7 @@ class LocalResourceUpdateTask : public Task {
    public:
     using Ptr = shared_qobject_ptr<LocalResourceUpdateTask>;
 
-    explicit LocalResourceUpdateTask(QDir index_dir, ModPlatform::IndexedPack& project, ModPlatform::IndexedVersion& version);
+    explicit LocalResourceUpdateTask(QDir index_dir, ModPlatform::IndexedPack project, ModPlatform::IndexedVersion version);
 
     auto canAbort() const -> bool override { return true; }
     auto abort() -> bool override;


### PR DESCRIPTION
I've already needed this in 2 prs and looks like something was changed that broke the original commit which just changed `makeShared`