### PR TITLE
fix: regenerate instance UUID on import

### DIFF
--- a/launcher/InstanceImportTask.cpp
+++ b/launcher/InstanceImportTask.cpp
@@ -363,6 +363,9 @@ void InstanceImportTask::processMultiMC()
     // reset time played on import... because packs.
     instance.resetTimePlayed();
 
+    // UUID is carried over on export, but this is a distinct instance, so give it its own
+    instance.regenerateUuid();
+
     // set a new nice name
     instance.setName(name());
 


### PR DESCRIPTION
Parent PR: #5816 

Fixes #5926 

The `uuid` in `instance.cfg` is copied into exported ZIPs, so an imported instance carried the original's.

`processMultiMC` is the only import path that inherits an existing config, so one `regenerateUuid()` there covers it.

Tested: Reimported an export, UUIDs differ and persist across restart.