### PR TITLE
Fix macOS System theme titlebar synchronization

### DIFF
--- a/launcher/ui/themes/SystemTheme.cpp
+++ b/launcher/ui/themes/SystemTheme.cpp
@@ -62,8 +62,15 @@ SystemTheme::SystemTheme(const QString& styleName, const QPalette& defaultPalett
 void SystemTheme::apply(bool initial)
 {
     // See S_NATIVE_STYLES comment
-    if (initial && S_NATIVE_STYLES.contains(m_themeName)) {
-        QApplication::setStyle(new HintOverrideProxyStyle(QStyleFactory::create(qtTheme())));
+    if (S_NATIVE_STYLES.contains(m_themeName)) {
+        if (initial) {
+            QApplication::setStyle(new HintOverrideProxyStyle(QStyleFactory::create(qtTheme())));
+        } else {
+            ITheme::apply(initial);
+        }
+        m_colorPalette = QApplication::style()->standardPalette();
+        QApplication::setPalette(m_colorPalette);
+        m_colorPalette = QApplication::palette();
         return;
     }
 

--- a/launcher/ui/themes/ThemeManager.cpp
+++ b/launcher/ui/themes/ThemeManager.cpp
@@ -181,8 +181,8 @@ void ThemeManager::initializeWidgets()
 }
 
 #ifndef Q_OS_MACOS
-void ThemeManager::setTitlebarColorOnMac(WId windowId, QColor color) {}
-void ThemeManager::setTitlebarColorOfAllWindowsOnMac(QColor color) {}
+void ThemeManager::setTitlebarColorOnMac(WId windowId, QColor color, bool useSystemWindowBackground) {}
+void ThemeManager::setTitlebarColorOfAllWindowsOnMac(QColor color, bool useSystemWindowBackground) {}
 void ThemeManager::stopSettingNewWindowColorsOnMac() {}
 #endif
 
@@ -259,7 +259,7 @@ void ThemeManager::setApplicationTheme(const QString& name, bool initial)
         auto& theme = themeIter->second;
         themeDebugLog() << "applying theme" << theme->name();
         theme->apply(initial);
-        setTitlebarColorOfAllWindowsOnMac(qApp->palette().window().color());
+        setTitlebarColorOfAllWindowsOnMac(qApp->palette().window().color(), theme->id() == QStringLiteral("system"));
 
         m_logColors = theme->logColorScheme();
     } else {

--- a/launcher/ui/themes/ThemeManager.h
+++ b/launcher/ui/themes/ThemeManager.h
@@ -81,10 +81,10 @@ class ThemeManager {
     void initializeWidgets();
 
     // On non-Mac systems, this is a no-op.
-    void setTitlebarColorOnMac(WId windowId, QColor color);
+    void setTitlebarColorOnMac(WId windowId, QColor color, bool useSystemWindowBackground);
     // This also will set the titlebar color of newly opened windows after this method is called.
     // On non-Mac systems, this is a no-op.
-    void setTitlebarColorOfAllWindowsOnMac(QColor color);
+    void setTitlebarColorOfAllWindowsOnMac(QColor color, bool useSystemWindowBackground);
     // On non-Mac systems, this is a no-op.
     void stopSettingNewWindowColorsOnMac();
 #ifdef Q_OS_MACOS

--- a/launcher/ui/themes/ThemeManager.mm
+++ b/launcher/ui/themes/ThemeManager.mm
@@ -21,7 +21,7 @@
 #include <AppKit/AppKit.h>
 #include <QApplication>
 
-void ThemeManager::setTitlebarColorOnMac(WId windowId, QColor color) {
+void ThemeManager::setTitlebarColorOnMac(WId windowId, QColor color, bool useSystemWindowBackground) {
     if (windowId == 0) {
         return;
     }
@@ -29,13 +29,15 @@ void ThemeManager::setTitlebarColorOnMac(WId windowId, QColor color) {
     NSView* view = (NSView*)windowId;
     NSWindow* window = [view window];
     window.titlebarAppearsTransparent = YES;
-    window.backgroundColor = [NSColor colorWithRed:color.redF() green:color.greenF() blue:color.blueF() alpha:color.alphaF()];
+    window.backgroundColor = useSystemWindowBackground
+                                 ? NSColor.windowBackgroundColor
+                                 : [NSColor colorWithRed:color.redF() green:color.greenF() blue:color.blueF() alpha:color.alphaF()];
 }
 
-void ThemeManager::setTitlebarColorOfAllWindowsOnMac(QColor color) {
+void ThemeManager::setTitlebarColorOfAllWindowsOnMac(QColor color, bool useSystemWindowBackground) {
     NSArray<NSWindow*>* windows = [NSApp windows];
     for (NSWindow* window : windows) {
-        setTitlebarColorOnMac((WId)window.contentView, color);
+        setTitlebarColorOnMac((WId)window.contentView, color, useSystemWindowBackground);
     }
 
     // We want to change the titlebar color of newly opened windows as well.
@@ -43,13 +45,14 @@ void ThemeManager::setTitlebarColorOfAllWindowsOnMac(QColor color) {
     // from occluded to visible, which also fires on open.
     NSNotificationCenter* center = [NSNotificationCenter defaultCenter];
     stopSettingNewWindowColorsOnMac();
-    m_windowTitlebarObserver = [center addObserverForName:NSWindowDidChangeOcclusionStateNotification
-                                                   object:nil
-                                                    queue:[NSOperationQueue mainQueue]
-                                               usingBlock:^(NSNotification* notification) {
-                                                 NSWindow* window = notification.object;
-                                                 setTitlebarColorOnMac((WId)window.contentView, qApp->palette().window().color());
-                                               }];
+    m_windowTitlebarObserver =
+        [center addObserverForName:NSWindowDidChangeOcclusionStateNotification
+                            object:nil
+                             queue:[NSOperationQueue mainQueue]
+                        usingBlock:^(NSNotification* notification) {
+                          NSWindow* window = notification.object;
+                          setTitlebarColorOnMac((WId)window.contentView, qApp->palette().window().color(), useSystemWindowBackground);
+                        }];
 }
 
 void ThemeManager::stopSettingNewWindowColorsOnMac() {

--- a/launcher/ui/themes/ThemeManager.mm
+++ b/launcher/ui/themes/ThemeManager.mm
@@ -19,9 +19,9 @@
 #include "ThemeManager.h"
 
 #include <AppKit/AppKit.h>
+#include <QApplication>
 
-void ThemeManager::setTitlebarColorOnMac(WId windowId, QColor color)
-{
+void ThemeManager::setTitlebarColorOnMac(WId windowId, QColor color) {
     if (windowId == 0) {
         return;
     }
@@ -30,11 +30,9 @@ void ThemeManager::setTitlebarColorOnMac(WId windowId, QColor color)
     NSWindow* window = [view window];
     window.titlebarAppearsTransparent = YES;
     window.backgroundColor = [NSColor colorWithRed:color.redF() green:color.greenF() blue:color.blueF() alpha:color.alphaF()];
-
 }
 
-void ThemeManager::setTitlebarColorOfAllWindowsOnMac(QColor color)
-{
+void ThemeManager::setTitlebarColorOfAllWindowsOnMac(QColor color) {
     NSArray<NSWindow*>* windows = [NSApp windows];
     for (NSWindow* window : windows) {
         setTitlebarColorOnMac((WId)window.contentView, color);
@@ -49,13 +47,12 @@ void ThemeManager::setTitlebarColorOfAllWindowsOnMac(QColor color)
                                                    object:nil
                                                     queue:[NSOperationQueue mainQueue]
                                                usingBlock:^(NSNotification* notification) {
-                                                   NSWindow* window = notification.object;
-                                                   setTitlebarColorOnMac((WId)window.contentView, color);
+                                                 NSWindow* window = notification.object;
+                                                 setTitlebarColorOnMac((WId)window.contentView, qApp->palette().window().color());
                                                }];
 }
 
-void ThemeManager::stopSettingNewWindowColorsOnMac()
-{
+void ThemeManager::stopSettingNewWindowColorsOnMac() {
     if (m_windowTitlebarObserver) {
         NSNotificationCenter* center = [NSNotificationCenter defaultCenter];
         [center removeObserver:m_windowTitlebarObserver];

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,6 +60,9 @@ ecm_add_test(MetaComponentParse_test.cpp LINK_LIBRARIES Launcher_logic Qt${QT_VE
 ecm_add_test(CatPack_test.cpp LINK_LIBRARIES Launcher_logic Qt${QT_VERSION_MAJOR}::Test
     TEST_NAME CatPack)
 
+ecm_add_test(SystemTheme_test.cpp LINK_LIBRARIES Launcher_logic Qt${QT_VERSION_MAJOR}::Test
+    TEST_NAME SystemTheme)
+
 
 ecm_add_test(XmlLogs_test.cpp LINK_LIBRARIES Launcher_logic Qt${QT_VERSION_MAJOR}::Test
     TEST_NAME XmlLogs)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,6 +63,11 @@ ecm_add_test(CatPack_test.cpp LINK_LIBRARIES Launcher_logic Qt${QT_VERSION_MAJOR
 ecm_add_test(SystemTheme_test.cpp LINK_LIBRARIES Launcher_logic Qt${QT_VERSION_MAJOR}::Test
     TEST_NAME SystemTheme)
 
+if(APPLE)
+    ecm_add_test(MacOSThemeManager_test.mm LINK_LIBRARIES Launcher_logic Qt${QT_VERSION_MAJOR}::Test
+        TEST_NAME MacOSThemeManager)
+endif()
+
 
 ecm_add_test(XmlLogs_test.cpp LINK_LIBRARIES Launcher_logic Qt${QT_VERSION_MAJOR}::Test
     TEST_NAME XmlLogs)

--- a/tests/MacOSThemeManager_test.mm
+++ b/tests/MacOSThemeManager_test.mm
@@ -11,6 +11,15 @@ QColor backgroundColor(NSWindow* window) {
     NSColor* color = [window.backgroundColor colorUsingColorSpace:NSColorSpace.sRGBColorSpace];
     return QColor::fromRgbF(color.redComponent, color.greenComponent, color.blueComponent, color.alphaComponent);
 }
+
+QColor backgroundColor(NSWindow* window, NSAppearanceName appearanceName) {
+    NSAppearance* appearance = [NSAppearance appearanceNamed:appearanceName];
+    __block QColor result;
+    [appearance performAsCurrentDrawingAppearance:^{
+      result = backgroundColor(window);
+    }];
+    return result;
+}
 }  // namespace
 
 class MacOSThemeManagerTest : public QObject {
@@ -18,6 +27,7 @@ class MacOSThemeManagerTest : public QObject {
 
    private slots:
     void observerUsesCurrentApplicationPalette();
+    void systemThemeUsesDynamicWindowBackground();
 };
 
 void MacOSThemeManagerTest::observerUsesCurrentApplicationPalette() {
@@ -26,7 +36,7 @@ void MacOSThemeManagerTest::observerUsesCurrentApplicationPalette() {
     widget.show();
     QVERIFY(QTest::qWaitForWindowExposed(&widget));
 
-    manager.setApplicationTheme("system", true);
+    manager.setApplicationTheme("bright", true);
 
     auto palette = QApplication::palette();
     const QColor currentWindowColor(12, 34, 56);
@@ -38,6 +48,22 @@ void MacOSThemeManagerTest::observerUsesCurrentApplicationPalette() {
     [[NSNotificationCenter defaultCenter] postNotificationName:NSWindowDidChangeOcclusionStateNotification object:window];
 
     QCOMPARE(backgroundColor(window), currentWindowColor);
+}
+
+void MacOSThemeManagerTest::systemThemeUsesDynamicWindowBackground() {
+    ThemeManager manager;
+    QWidget widget;
+    widget.show();
+    QVERIFY(QTest::qWaitForWindowExposed(&widget));
+
+    manager.setApplicationTheme("system", true);
+
+    NSView* view = reinterpret_cast<NSView*>(widget.winId());
+    NSWindow* window = view.window;
+    const QColor lightBackground = backgroundColor(window, NSAppearanceNameAqua);
+    const QColor darkBackground = backgroundColor(window, NSAppearanceNameDarkAqua);
+
+    QVERIFY(lightBackground != darkBackground);
 }
 
 QTEST_MAIN(MacOSThemeManagerTest)

--- a/tests/MacOSThemeManager_test.mm
+++ b/tests/MacOSThemeManager_test.mm
@@ -1,0 +1,45 @@
+#include <AppKit/AppKit.h>
+
+#include <QApplication>
+#include <QWidget>
+#include <QtTest>
+
+#include "ui/themes/ThemeManager.h"
+
+namespace {
+QColor backgroundColor(NSWindow* window) {
+    NSColor* color = [window.backgroundColor colorUsingColorSpace:NSColorSpace.sRGBColorSpace];
+    return QColor::fromRgbF(color.redComponent, color.greenComponent, color.blueComponent, color.alphaComponent);
+}
+}  // namespace
+
+class MacOSThemeManagerTest : public QObject {
+    Q_OBJECT
+
+   private slots:
+    void observerUsesCurrentApplicationPalette();
+};
+
+void MacOSThemeManagerTest::observerUsesCurrentApplicationPalette() {
+    ThemeManager manager;
+    QWidget widget;
+    widget.show();
+    QVERIFY(QTest::qWaitForWindowExposed(&widget));
+
+    manager.setApplicationTheme("system", true);
+
+    auto palette = QApplication::palette();
+    const QColor currentWindowColor(12, 34, 56);
+    palette.setColor(QPalette::Window, currentWindowColor);
+    QApplication::setPalette(palette);
+
+    NSView* view = reinterpret_cast<NSView*>(widget.winId());
+    NSWindow* window = view.window;
+    [[NSNotificationCenter defaultCenter] postNotificationName:NSWindowDidChangeOcclusionStateNotification object:window];
+
+    QCOMPARE(backgroundColor(window), currentWindowColor);
+}
+
+QTEST_MAIN(MacOSThemeManagerTest)
+
+#include "MacOSThemeManager_test.moc"

--- a/tests/SystemTheme_test.cpp
+++ b/tests/SystemTheme_test.cpp
@@ -1,0 +1,35 @@
+#include <QApplication>
+#include <QStyle>
+#include <QtTest>
+
+#include "ui/themes/SystemTheme.h"
+
+class SystemThemeTest : public QObject {
+    Q_OBJECT
+
+   private slots:
+    void reapplyUsesCurrentSystemPalette();
+};
+
+void SystemThemeTest::reapplyUsesCurrentSystemPalette()
+{
+    const auto originalPalette = QApplication::palette();
+    const auto styleName = QApplication::style()->objectName();
+
+    auto stalePalette = originalPalette;
+    const QColor staleWindowColor(1, 2, 3);
+    stalePalette.setColor(QPalette::Window, staleWindowColor);
+    QApplication::setPalette(stalePalette);
+
+    SystemTheme theme(styleName, stalePalette, true);
+    theme.apply(false);
+
+    QVERIFY(QApplication::palette().window().color() != staleWindowColor);
+    QCOMPARE(theme.colorScheme(), QApplication::palette());
+
+    QApplication::setPalette(originalPalette);
+}
+
+QTEST_MAIN(SystemThemeTest)
+
+#include "SystemTheme_test.moc"


### PR DESCRIPTION
## Summary

- refresh the native Qt palette when the System theme is reapplied
- use AppKit's semantic window background color for the System theme
- resolve explicit theme colors when a macOS window becomes visible instead of restoring a captured stale color
- add regression coverage for the Qt palette refresh and macOS titlebar behavior

## Root cause

The System theme retained a palette captured at startup, while the macOS titlebar integration assigned a fixed RGB background color and captured that color in the window occlusion observer. The rest of the application could therefore follow an OS appearance change while the titlebar and unified toolbar kept the previous background until a theme or icon setting reapplied the integration.

## User impact

When Appearance > Theme is set to System, the titlebar, unified toolbar, and application content now follow macOS light and dark appearance changes together without requiring another settings change.

## Testing

- built the complete Debug application with the macOS preset
- ran the full CTest suite: 23/23 tests passed
- added SystemTheme and macOS ThemeManager regression tests, including red/green validation against the previous behavior
- manually switched macOS appearance Dark -> Light -> Dark while the same application process remained open; the titlebar, unified toolbar, and content stayed synchronized without changing Prism Launcher settings
