### PR TITLE
Set ModrinthInstanceCreationTask abortable to fix bug where you cant abort

### DIFF
--- a/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
+++ b/launcher/modplatform/modrinth/ModrinthInstanceCreationTask.cpp
@@ -311,8 +311,9 @@ void ModrinthCreationTask::createInstance()
     connect(downloadMods.get(), &NetJob::stepProgress, this, &ModrinthCreationTask::propagateStepProgress);
 
     setStatus(tr("Downloading mods..."));
-    downloadMods->start();
     m_task = downloadMods;
+    setAbortable(true);
+    downloadMods->start();
 }
 
 bool ModrinthCreationTask::parseManifest(const QString& indexPath, std::vector<File>& files, bool setInternalData, bool showOptionalDialog)


### PR DESCRIPTION

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->

Fixes #5905 

m_can_abort was false when running the download task for Modrinth. As a result, 
the canAbort() was returning false early and causing the abort not to happen in ModrinthCreationTask::abort()

 ```cpp
  bool ModrinthCreationTask::abort()
  {
      if (!canAbort()) {
          return false;
      }

      if (m_task) {
          m_task->abort();
      }
      return InstanceTask::abort();
  }
```

With this change, we explicitly set the task as abortable in void ModrinthCreationTask::createInstance()
This matches patterns found elsewhere in PrismLauncher and allows the abort to happen successfully! 

