### PR TITLE
feat: Added Trashing for Flatpak

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -1298,7 +1298,7 @@ target_link_libraries(Launcher_logic
     Launcher_rainbow
 )
 if (TARGET ${Launcher_QT_DBUS})
-    add_compile_definitions(WITH_QTDBUS)
+    target_compile_definitions(Launcher_logic PUBLIC WITH_QTDBUS)
 endif()
 
 if(APPLE)

--- a/launcher/FileSystem.cpp
+++ b/launcher/FileSystem.cpp
@@ -86,6 +86,13 @@ namespace fs = std::filesystem;
 #include <linux/fs.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
+
+#if defined(WITH_QTDBUS)
+#include <QDBusConnection>
+#include <QDBusReply>
+#include <QDBusUnixFileDescriptor>
+#endif
+
 #elif defined(Q_OS_MACOS)
 #include <sys/attr.h>
 #include <sys/clonefile.h>
@@ -712,9 +719,36 @@ bool deleteContents(const QString& path)
 
 bool trash(QString path, QString* pathInTrash)
 {
-    // FIXME: Figure out trash in Flatpak. Qt seemingly doesn't use the Trash portal
-    if (DesktopServices::isFlatpak())
+#ifdef Q_OS_LINUX
+    if (DesktopServices::isFlatpak()) {
+#if defined(WITH_QTDBUS)
+        const int file = open(path.toUtf8().data(), O_PATH | O_CLOEXEC, 0);
+        if (file == -1) {
+            return false;
+        }
+        const QDBusUnixFileDescriptor fileDescriptor(file);
+        close(file);
+
+        QDBusMessage message = QDBusMessage::createMethodCall("org.freedesktop.portal.Desktop", "/org/freedesktop/portal/desktop",
+                                                              "org.freedesktop.portal.Trash", "TrashFile");
+
+        message << QVariant::fromValue(fileDescriptor);
+
+        const QDBusReply<uint32_t> reply = QDBusConnection::sessionBus().call(message);
+        if (!reply.isValid()) {
+            qWarning() << "Error while trying to trash the file" << path << reply.error().name() << ":" << reply.error().message();
+            return false;
+        }
+        if (pathInTrash) {
+            *pathInTrash = QString();  // No info provided by the API, use the same semantics as QFile::moveToTrash
+        }
+
+        return reply.value() != 0;
+#else
         return false;
+#endif
+    }
+#endif
 #if defined Q_OS_WIN32
     if (IsWindowsServer())
         return false;


### PR DESCRIPTION
Flatpak trashing via xdg portals !

Things to note :
- Portals are really sensitive to trash permission, it HAS to be 700 for that folder and child folders (if it's not, it fails to trash, and provides no specific error message or code...), this has been fixed very recently, not in any released version yet (see https://github.com/flatpak/xdg-desktop-portal/issues/2052)
- It is impossible to undo trashing if it's been trashed via Portals (currently shows the undo button, and attempting to undo, fails and recommends the user to manually restore the files, probably doesn't need to be changed)
- If trashing fails the default behavior is to permanently delete anyways, maybe a prompt for confirmation before deleting would be nice ? if that's done we can also remove that "maybe permanent" in the prompt for trashing, but that's probably gonna be for another pr
 