### PR TITLE
Make resources in the update resources dialogue easilly mass select o…

### DIFF
--- a/launcher/ui/dialogs/ResourceUpdateDialog.cpp
+++ b/launcher/ui/dialogs/ResourceUpdateDialog.cpp
@@ -254,19 +254,19 @@ void ResourceUpdateDialog::checkCandidates()
     }
 
     // If there's no resource to be updated
-    if (ui->modTreeWidget->topLevelItemCount() == 0) {
+    if (ui->modTreeWidget->topLevelItem(0)->childCount() == 0) {
         m_noUpdates = true;
     } else {
         // FIXME: Find a more efficient way of doing this!
 
         // Sort major items in alphabetical order (also sorts the children unfortunately)
-        ui->modTreeWidget->sortItems(0, Qt::SortOrder::AscendingOrder);
+        ui->modTreeWidget->topLevelItem(0)->sortChildren(0, Qt::SortOrder::AscendingOrder);
 
         // Re-sort the children
-        auto* item = ui->modTreeWidget->topLevelItem(0);
+        auto* item = ui->modTreeWidget->topLevelItem(0)->child(0);
         for (int i = 1; item != nullptr; ++i) {
             item->sortChildren(0, Qt::SortOrder::DescendingOrder);
-            item = ui->modTreeWidget->topLevelItem(i);
+            item = ui->modTreeWidget->topLevelItem(0)->child(i);
         }
     }
 
@@ -451,7 +451,7 @@ void ResourceUpdateDialog::onMetadataFailed(Resource* resource, bool tryOthers, 
 
 void ResourceUpdateDialog::appendResource(const CheckUpdateTask::Update& info, QStringList requiredBy)
 {
-    auto* itemTop = new QTreeWidgetItem(ui->modTreeWidget);
+    auto* itemTop = new QTreeWidgetItem(ui->modTreeWidget->topLevelItem(0));
     itemTop->setCheckState(0, info.enabled ? Qt::CheckState::Checked : Qt::CheckState::Unchecked);
     if (!info.enabled) {
         itemTop->setToolTip(0, tr("Mod was disabled as it may be already installed."));
@@ -513,22 +513,20 @@ void ResourceUpdateDialog::appendResource(const CheckUpdateTask::Update& info, Q
     changelogArea->setVerticalScrollBarPolicy(Qt::ScrollBarPolicy::ScrollBarAsNeeded);
 
     ui->modTreeWidget->setItemWidget(changelog, 0, changelogArea);
-
-    ui->modTreeWidget->addTopLevelItem(itemTop);
 }
 
 auto ResourceUpdateDialog::getTasks() -> const QList<ResourceDownloadTask::Ptr>
 {
     QList<ResourceDownloadTask::Ptr> list;
 
-    auto* item = ui->modTreeWidget->topLevelItem(0);
+    auto* item = ui->modTreeWidget->topLevelItem(0)->child(0);
 
     for (int i = 1; item != nullptr; ++i) {
         if (item->checkState(0) == Qt::CheckState::Checked) {
             list.push_back(m_tasks.find(item->text(0)).value());
         }
 
-        item = ui->modTreeWidget->topLevelItem(i);
+        item = ui->modTreeWidget->topLevelItem(0)->child(i);
     }
 
     return list;

--- a/launcher/ui/dialogs/ReviewMessageBox.cpp
+++ b/launcher/ui/dialogs/ReviewMessageBox.cpp
@@ -17,6 +17,7 @@ ReviewMessageBox::ReviewMessageBox(QWidget* parent, [[maybe_unused]] QString con
     ui->modTreeWidget->header()->setSectionResizeMode(0, QHeaderView::Stretch);
     ui->modTreeWidget->header()->setStretchLastSection(false);
     ui->modTreeWidget->header()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
+    ui->modTreeWidget->topLevelItem(0)->setExpanded(true);
 
     connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &ReviewMessageBox::accept);
     connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &ReviewMessageBox::reject);
@@ -57,7 +58,7 @@ auto ReviewMessageBox::create(QWidget* parent, QString&& title, QString&& icon) 
 
 void ReviewMessageBox::appendResource(ResourceInformation&& info)
 {
-    auto itemTop = new QTreeWidgetItem(ui->modTreeWidget);
+    auto itemTop = new QTreeWidgetItem(ui->modTreeWidget->topLevelItem(0));
     itemTop->setCheckState(0, info.enabled ? Qt::CheckState::Checked : Qt::CheckState::Unchecked);
     itemTop->setText(0, info.name);
     if (!info.enabled) {
@@ -92,22 +93,20 @@ void ReviewMessageBox::appendResource(ResourceInformation&& info)
     auto versionTypeItem = new QTreeWidgetItem(itemTop);
     versionTypeItem->setText(0, tr("Version Type: %1").arg(info.version_type));
     versionTypeItem->setData(0, Qt::UserRole, info.version_type);
-
-    ui->modTreeWidget->addTopLevelItem(itemTop);
 }
 
 auto ReviewMessageBox::deselectedResources() -> QStringList
 {
     QStringList list;
 
-    auto* item = ui->modTreeWidget->topLevelItem(0);
+    auto* item = ui->modTreeWidget->topLevelItem(0)->child(0);
 
     for (int i = 1; item != nullptr; ++i) {
         if (item->checkState(0) == Qt::CheckState::Unchecked) {
             list.append(item->text(0));
         }
 
-        item = ui->modTreeWidget->topLevelItem(i);
+        item = ui->modTreeWidget->topLevelItem(0)->child(i);
     }
 
     return list;

--- a/launcher/ui/dialogs/ReviewMessageBox.cpp
+++ b/launcher/ui/dialogs/ReviewMessageBox.cpp
@@ -17,7 +17,28 @@ ReviewMessageBox::ReviewMessageBox(QWidget* parent, [[maybe_unused]] QString con
     ui->modTreeWidget->header()->setSectionResizeMode(0, QHeaderView::Stretch);
     ui->modTreeWidget->header()->setStretchLastSection(false);
     ui->modTreeWidget->header()->setSectionResizeMode(1, QHeaderView::ResizeToContents);
-    ui->modTreeWidget->topLevelItem(0)->setExpanded(true);
+
+    auto* resourcesItem = ui->modTreeWidget->topLevelItem(0);
+    resourcesItem->setExpanded(true);
+    connect(ui->modTreeWidget, &QTreeWidget::itemCollapsed, this, [resourcesItem](QTreeWidgetItem* item) {
+        if (item != resourcesItem) {
+            return;
+        }
+
+        bool expandChildren = true;
+        for (int i = 0; i < resourcesItem->childCount(); ++i) {
+            if (resourcesItem->child(i)->isExpanded()) {
+                expandChildren = false;
+                break;
+            }
+        }
+
+        // Keep the resource rows visible and apply the root's toggle to their details instead.
+        resourcesItem->setExpanded(true);
+        for (int i = 0; i < resourcesItem->childCount(); ++i) {
+            resourcesItem->child(i)->setExpanded(expandChildren);
+        }
+    });
 
     connect(ui->buttonBox, &QDialogButtonBox::accepted, this, &ReviewMessageBox::accept);
     connect(ui->buttonBox, &QDialogButtonBox::rejected, this, &ReviewMessageBox::reject);
@@ -93,6 +114,8 @@ void ReviewMessageBox::appendResource(ResourceInformation&& info)
     auto versionTypeItem = new QTreeWidgetItem(itemTop);
     versionTypeItem->setText(0, tr("Version Type: %1").arg(info.version_type));
     versionTypeItem->setData(0, Qt::UserRole, info.version_type);
+
+    itemTop->setExpanded(true);
 }
 
 auto ReviewMessageBox::deselectedResources() -> QStringList

--- a/launcher/ui/dialogs/ReviewMessageBox.ui
+++ b/launcher/ui/dialogs/ReviewMessageBox.ui
@@ -41,6 +41,17 @@
        <string/>
       </property>
      </column>
+     <item>
+      <property name="text">
+       <string>Resources</string>
+      </property>
+      <property name="checkState">
+       <enum>Checked</enum>
+      </property>
+      <property name="flags">
+       <set>ItemIsSelectable|ItemIsUserCheckable|ItemIsEnabled|ItemIsAutoTristate</set>
+      </property>
+     </item>
     </widget>
    </item>
    <item row="1" column="0">


### PR DESCRIPTION
…r deselectable.

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
fixes #3244 

This changes the update resource page to have an extra parent tree item called "Resources". You can then collapse, select, and deselect all the items under this parent item. This makes it easy to mass select and deselect items

<img width="804" height="739" alt="Screenshot from 2026-08-14 00-12-32" src="https://github.com/user-attachments/assets/3272cd92-6196-4390-b050-bc7c4d0e9833" />

<img width="801" height="741" alt="Screenshot from 2026-08-14 00-33-11" src="https://github.com/user-attachments/assets/d3dac9bc-f0ed-4fa9-85a1-28f6f8b9c7f0" />

<img width="801" height="734" alt="Screenshot from 2026-08-14 00-33-54" src="https://github.com/user-attachments/assets/ae26f425-8128-46f3-ab2c-d69ff8913d6a" />
