### PR TITLE
fix: set entity state before emitting success

### DIFF
--- a/launcher/meta/BaseEntity.cpp
+++ b/launcher/meta/BaseEntity.cpp
@@ -143,7 +143,7 @@ void BaseEntityLoadTask::executeTask()
             }
 
         } catch (const Exception& e) {
-            qDebug() << QString("Unable to parse file %1: %2").arg(fname, e.cause());
+            qCritical() << QString("Unable to parse file %1: %2").arg(fname, e.cause());
             // just make sure it's gone and we never consider it again.
             FS::deletePath(fname);
             m_entity->m_load_status = BaseEntity::LoadStatus::NotLoaded;
@@ -177,10 +177,10 @@ void BaseEntityLoadTask::executeTask()
     m_task->addNetAction(dl);
     m_task->setAskRetry(false);
     connect(m_task.get(), &Task::failed, this, &BaseEntityLoadTask::emitFailed);
-    connect(m_task.get(), &Task::succeeded, this, &BaseEntityLoadTask::emitSucceeded);
     connect(m_task.get(), &Task::succeeded, this, [this]() {
         m_entity->m_load_status = BaseEntity::LoadStatus::Remote;
         m_entity->m_file_sha256 = m_entity->m_sha256;
+        emitSucceeded();
     });
 
     connect(m_task.get(), &Task::progress, this, &Task::setProgress);


### PR DESCRIPTION
extracted from  https://github.com/PrismLauncher/PrismLauncher/pull/4470/
this is the exact commit: https://github.com/PrismLauncher/PrismLauncher/pull/4470/changes/940e378f31bb5e9c16ab0de68fa4189a7758fc5b