### PR TITLE
feat: install instance shortcuts via DynamicLauncher portal (fixes #1038)

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -101,6 +101,10 @@ set(CORE_SOURCES
 
     # Assertion helper
     AssertHelpers.h
+
+    # XDG Desktop Portal DynamicLauncher support for installing shortcuts on Linux
+    DynamicLauncherPortal.h
+    DynamicLauncherPortal.cpp
 )
 if (UNIX AND NOT CYGWIN AND NOT APPLE)
     set(CORE_SOURCES

--- a/launcher/DynamicLauncherPortal.cpp
+++ b/launcher/DynamicLauncherPortal.cpp
@@ -1,0 +1,273 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2026 utophii <pos18411@gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "DynamicLauncherPortal.h"
+
+#include <BuildConfig.h>
+
+#include <QDebug>
+#include <QFile>
+#include <QRegularExpression>
+#include <QTimer>
+#include <QVariantMap>
+
+#ifdef WITH_QTDBUS
+#include <QtDBus/QtDBus>
+#endif
+
+struct PortalBytesIcon
+{
+    QString type;
+    QByteArray data;
+};
+
+Q_DECLARE_METATYPE(PortalBytesIcon)
+
+// (sv) = ("bytes", v: ay)
+QDBusArgument& operator<<(QDBusArgument& arg, const PortalBytesIcon& icon)
+{
+    arg.beginStructure();
+    arg << icon.type;
+    arg << QDBusVariant(QVariant::fromValue(icon.data));
+    arg.endStructure();
+    return arg;
+}
+
+const QDBusArgument& operator>>(const QDBusArgument& arg, PortalBytesIcon& icon)
+{
+    arg.beginStructure();
+    arg >> icon.type;
+    QVariant data;
+    arg >> data;
+    icon.data = data.toByteArray();
+    arg.endStructure();
+    return arg;
+}
+
+namespace DynamicLauncherPortal {
+
+static const QString PORTAL_SERVICE = QStringLiteral("org.freedesktop.portal.Desktop");
+static const QString PORTAL_OBJECT_PATH = QStringLiteral("/org/freedesktop/portal/desktop");
+static const QString PORTAL_INTERFACE = QStringLiteral("org.freedesktop.portal.DynamicLauncher");
+static const QString REQUEST_INTERFACE = QStringLiteral("org.freedesktop.portal.Request");
+
+bool isPortalAvailable()
+{
+#ifdef WITH_QTDBUS
+    if (!QDBusConnection::sessionBus().isConnected())
+        return false;
+
+    QDBusInterface portal(PORTAL_SERVICE, PORTAL_OBJECT_PATH, PORTAL_INTERFACE, QDBusConnection::sessionBus());
+    return portal.isValid();
+#else
+    return false;
+#endif
+}
+
+bool installLauncher(const QString& name, const QString& iconPath, const QString& desktopEntry)
+{
+#ifdef WITH_QTDBUS
+    if (!QDBusConnection::sessionBus().isConnected()) {
+        qWarning() << "DynamicLauncherPortal: D-Bus session bus not available";
+        return false;
+    }
+
+    QDBusInterface portal(PORTAL_SERVICE, PORTAL_OBJECT_PATH, PORTAL_INTERFACE, QDBusConnection::sessionBus());
+    if (!portal.isValid()) {
+        qWarning() << "DynamicLauncherPortal: Portal interface not available";
+        return false;
+    }
+
+    // Register the custom icon type once (idempotent, thread-safe static init).
+    // qDBusRegisterMetaType<T>() derives the D-Bus signature from the streaming
+    // operators; here the signature is "(sv)"
+    qDBusRegisterMetaType<PortalBytesIcon>();
+
+    // Read the icon file
+    QByteArray iconData;
+    QFile iconFile(iconPath);
+    if (iconFile.open(QIODevice::ReadOnly)) {
+        iconData = iconFile.readAll();
+        iconFile.close();
+        qDebug() << "DynamicLauncherPortal: Read icon from" << iconPath << "(" << iconData.size() << "bytes)";
+    } else {
+        qWarning() << "DynamicLauncherPortal: Could not read icon file" << iconPath;
+    }
+
+    // Build the serialized GBytesIcon: (sv) = ("bytes", v: ay[data])
+    PortalBytesIcon icon;
+    icon.type = QStringLiteral("bytes");
+    icon.data = iconData;
+
+    // Call PrepareInstall - this shows a dialog to the user
+    QDBusMessage prepareCall = QDBusMessage::createMethodCall(
+        PORTAL_SERVICE, PORTAL_OBJECT_PATH, PORTAL_INTERFACE, QStringLiteral("PrepareInstall"));
+
+    QVariantMap prepareOptions;
+    prepareOptions[QStringLiteral("editable_name")] = false;
+    prepareOptions[QStringLiteral("editable_icon")] = false;
+    prepareOptions[QStringLiteral("launcher_type")] = 1u;  // 1 = Application
+
+    // icon_v must be a D-Bus variant (v) containing the (sv) struct
+    prepareCall << QString()  // parent_window (empty = no parent window)
+                << name          // name
+                << QVariant::fromValue(QDBusVariant(QVariant::fromValue(icon)))  // icon_v
+                << QVariant::fromValue(prepareOptions);  // options
+
+    QDBusMessage prepareReply = QDBusConnection::sessionBus().call(prepareCall, QDBus::BlockWithGui, 30000);
+
+    if (prepareReply.type() == QDBusMessage::ErrorMessage) {
+        qWarning() << "DynamicLauncherPortal: PrepareInstall failed:" << prepareReply.errorMessage();
+        return false;
+    }
+
+    if (prepareReply.arguments().isEmpty()) {
+        qWarning() << "DynamicLauncherPortal: PrepareInstall returned no arguments";
+        return false;
+    }
+
+    QDBusObjectPath handle = prepareReply.arguments().at(0).value<QDBusObjectPath>();
+    qDebug() << "DynamicLauncherPortal: Got handle path:" << handle.path();
+
+    // Set up the Request interface to listen for the Response signal
+    QDBusInterface requestIface(PORTAL_SERVICE, handle.path(), REQUEST_INTERFACE, QDBusConnection::sessionBus());
+    if (!requestIface.isValid()) {
+        qWarning() << "DynamicLauncherPortal: Could not create Request interface";
+        return false;
+    }
+
+    QEventLoop loop;
+    QTimer timeoutTimer;
+    timeoutTimer.setSingleShot(true);
+    QString receivedToken;
+    bool userAccepted = false;
+
+    PortalResponseReceiver receiver;
+    receiver.loop = &loop;
+    receiver.outToken = &receivedToken;
+    receiver.outAccepted = &userAccepted;
+
+    // Connect to the Response signal using Qt SIGNAL/SLOT macros (works with MOC)
+    QMetaObject::Connection signalConn = QObject::connect(
+        &requestIface,
+        SIGNAL(Response(uint,QVariantMap)),
+        &receiver, SLOT(portalResponse(uint,QVariantMap))
+    );
+    if (!signalConn) {
+        qWarning() << "DynamicLauncherPortal: Failed to connect to Response signal";
+        return false;
+    }
+
+    // Connect timeout using the 4-arg QObject::connect with context
+    QMetaObject::Connection timeoutConn = QObject::connect(
+        &timeoutTimer, &QTimer::timeout,
+        &receiver,
+        [&userAccepted, &loop]() {
+            userAccepted = false;
+            loop.quit();
+        }
+    );
+
+    // Wait for user response
+    timeoutTimer.start(300000);
+    loop.exec();
+    timeoutTimer.stop();
+
+    // Disconnect both
+    QObject::disconnect(signalConn);
+    QObject::disconnect(timeoutConn);
+    if (!userAccepted || receivedToken.isEmpty()) {
+        qDebug() << "DynamicLauncherPortal: User did not accept";
+        return false;
+    }
+
+    // Build desktop_file_id
+    QString appId = BuildConfig.LAUNCHER_APPID;
+    QString safeName = name;
+    safeName.replace(QRegularExpression(QStringLiteral("[^a-zA-Z0-9_\\-.]")), QStringLiteral("_"));
+
+    QString desktopFileId;
+    if (!appId.endsWith('.'))
+        desktopFileId = appId + '.' + safeName + ".desktop";
+    else
+        desktopFileId = appId + safeName + ".desktop";
+
+    // Call Install with the token
+    QDBusMessage installCall = QDBusMessage::createMethodCall(
+        PORTAL_SERVICE, PORTAL_OBJECT_PATH, PORTAL_INTERFACE, QStringLiteral("Install"));
+
+    QVariantMap installOptions;
+    installCall << receivedToken                // token (s)
+                << desktopFileId                 // desktop_file_id (s)
+                << desktopEntry                  // desktop_entry (s)
+                << QVariant::fromValue(installOptions);  // options (a{sv})
+
+    QDBusMessage installReply = QDBusConnection::sessionBus().call(installCall, QDBus::BlockWithGui, 30000);
+
+    if (installReply.type() == QDBusMessage::ErrorMessage) {
+        qWarning() << "DynamicLauncherPortal: Install failed:" << installReply.errorMessage();
+        return false;
+    }
+
+    qDebug() << "DynamicLauncherPortal: Successfully installed launcher" << desktopFileId;
+    return true;
+#else
+    Q_UNUSED(name);
+    Q_UNUSED(iconPath);
+    Q_UNUSED(desktopEntry);
+    qWarning() << "DynamicLauncherPortal: Qt DBus support not compiled in";
+    return false;
+#endif
+}
+
+bool uninstallLauncher(const QString& desktopFileId)
+{
+#ifdef WITH_QTDBUS
+    if (!QDBusConnection::sessionBus().isConnected()) {
+        qWarning() << "DynamicLauncherPortal: D-Bus session bus not available";
+        return false;
+    }
+
+    QDBusInterface portal(PORTAL_SERVICE, PORTAL_OBJECT_PATH, PORTAL_INTERFACE, QDBusConnection::sessionBus());
+    if (!portal.isValid()) {
+        qWarning() << "DynamicLauncherPortal: Portal interface not available";
+        return false;
+    }
+
+    QDBusMessage uninstallCall = QDBusMessage::createMethodCall(
+        PORTAL_SERVICE, PORTAL_OBJECT_PATH, PORTAL_INTERFACE, QStringLiteral("Uninstall"));
+
+    QVariantMap options;
+    uninstallCall << desktopFileId
+                  << QVariant::fromValue(options);
+
+    QDBusMessage uninstallReply = QDBusConnection::sessionBus().call(uninstallCall, QDBus::BlockWithGui, 30000);
+    if (uninstallReply.type() == QDBusMessage::ErrorMessage) {
+        qWarning() << "DynamicLauncherPortal: Uninstall failed:" << uninstallReply.errorMessage();
+        return false;
+    }
+    qDebug() << "DynamicLauncherPortal: Successfully uninstalled launcher" << desktopFileId;
+    return true;
+#else
+    Q_UNUSED(desktopFileId);
+    qWarning() << "DynamicLauncherPortal: Qt DBus support not compiled in";
+    return false;
+#endif
+}
+
+} // namespace DynamicLauncherPortal

--- a/launcher/DynamicLauncherPortal.h
+++ b/launcher/DynamicLauncherPortal.h
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2026 utophii <pos18411@gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QObject>
+#include <QString>
+#include <QEventLoop>
+#include <QVariantMap>
+
+namespace DynamicLauncherPortal {
+
+/// A QObject subclass needed to receive the D-Bus Response signal from the portal.
+/// Defined in the header so that MOC can process it
+class PortalResponseReceiver : public QObject
+{
+    Q_OBJECT
+public:
+    explicit PortalResponseReceiver(QObject* parent = nullptr) : QObject(parent) {}
+
+    QEventLoop* loop = nullptr;
+    QString* outToken = nullptr;
+    bool* outAccepted = nullptr;
+
+public slots:
+    void portalResponse(uint responseCode, QVariantMap results)
+    {
+        if (outAccepted)
+            *outAccepted = (responseCode == 0);
+        if (outToken && responseCode == 0)
+            *outToken = results.value(QStringLiteral("token")).toString();
+        if (loop)
+            loop->quit();
+    }
+};
+
+/// Check if the DynamicLauncher portal is available on the session bus
+bool isPortalAvailable();
+
+/// Install a shortcut via the DynamicLauncher portal.
+/// This shows a confirmation dialog to the user through the portal.
+/// @param name   The display name of the shortcut
+/// @param iconPath  Path to a PNG icon file (will be read and sent to the portal)
+/// @param desktopEntry The contents of the .desktop file (without Name= and Icon= lines)
+/// @return true if the launcher was successfully installed
+bool installLauncher(const QString& name, const QString& iconPath, const QString& desktopEntry);
+
+/// Remove a previously installed shortcut via the DynamicLauncher portal.
+/// @param desktopFileId The .desktop file id (e.g. "org.prismlauncher.PrismLauncher.MyInstance.desktop")
+/// @return true if successfully uninstalled
+bool uninstallLauncher(const QString& desktopFileId);
+
+}  // namespace DynamicLauncherPortal

--- a/launcher/minecraft/ShortcutUtils.cpp
+++ b/launcher/minecraft/ShortcutUtils.cpp
@@ -4,6 +4,7 @@
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
  *  Copyright (C) 2023 TheKodeToad <TheKodeToad@proton.me>
  *  Copyright (C) 2025 Yihe Li <winmikedows@hotmail.com>
+ *  Copyright (C) 2026 utophii <pos18411@gmail.com>
  *
  *  parent program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -37,16 +38,61 @@
 
 #include "ShortcutUtils.h"
 
+#include "DynamicLauncherPortal.h"
 #include "FileSystem.h"
 
 #include <QApplication>
 #include <QFileDialog>
+#include <QRegularExpression>
 
 #include <BuildConfig.h>
 #include <DesktopServices.h>
 #include <icons/IconList.h>
 
 namespace ShortcutUtils {
+
+/// Quote a single argument for use in a .desktop file Exec line.
+/// Single quotes are used, with embedded single quotes escaped per the desktop entry spec
+static inline QString quoteDesktopArg(const QString& arg)
+{
+    QString result = arg;
+    // The desktop entry spec says: ' '' ' can be used to escape a single quote inside a single-quoted string
+    // This means: close quote, escaped quote (literally \'), reopen quote
+    // In practice: 'text'with'quotes' -> 'text'\''with'\''quotes'
+    result.replace(QStringLiteral("'"), QStringLiteral("'\\''"));
+    return QStringLiteral("'") + result + QStringLiteral("'");
+}
+
+/// Construct the desktop entry text for use with the DynamicLauncher portal.
+/// Omits Name= and Icon= lines since the portal supplies those from the PrepareInstall dialog.
+/// The Exec= line uses proper desktop entry quoting
+static QString buildDesktopEntry(const QString& appPath, const QStringList& args)
+{
+    QString desktopEntry;
+    desktopEntry += QStringLiteral("[Desktop Entry]\n");
+    desktopEntry += QStringLiteral("Type=Application\n");
+    desktopEntry += QStringLiteral("Categories=Game\n");
+
+    // Build Exec= line per the desktop entry specification
+    // The executable path is double-quoted if it contains spaces
+    QString execValue = appPath;
+    if (appPath.contains(QLatin1Char(' ')) || appPath.contains(QLatin1Char('\t'))) {
+        execValue = QStringLiteral("\"") + appPath + QStringLiteral("\"");
+    }
+
+    for (const auto& arg : args) {
+        bool needsQuoting = arg.contains(QLatin1Char(' ')) || arg.contains(QLatin1Char('\t')) || arg.contains(QLatin1Char('\'')) || arg.isEmpty();
+        if (needsQuoting) {
+            execValue += QLatin1Char(' ') + quoteDesktopArg(arg);
+        } else {
+            execValue += QLatin1Char(' ') + arg;
+        }
+    }
+
+    desktopEntry += QStringLiteral("Exec=") + execValue + QStringLiteral("\n");
+
+    return desktopEntry;
+}
 
 bool createInstanceShortcut(const Shortcut& shortcut, const QString& filePath)
 {
@@ -122,7 +168,7 @@ bool createInstanceShortcut(const Shortcut& shortcut, const QString& filePath)
     iconPath = FS::PathCombine(shortcut.instance->instanceRoot(), "icon.ico");
 
     // part of fix for weird bug involving the window icon being replaced
-    // dunno why it happens, but parent 2-line fix seems to be enough, so w/e
+    // dunno why it happens, but this 2-line fix seems to be enough, so w/e
     auto appIcon = APPLICATION->logo();
 
     QFile iconFile(iconPath);
@@ -163,10 +209,124 @@ bool createInstanceShortcut(const Shortcut& shortcut, const QString& filePath)
     return true;
 }
 
+bool createInstanceShortcutViaPortal(const Shortcut& shortcut)
+{
+    if (!shortcut.instance)
+        return false;
+
+    if (!DynamicLauncherPortal::isPortalAvailable()) {
+        qWarning() << "ShortcutUtils: DynamicLauncher portal is not available";
+        return false;
+    }
+
+    // Set up the application path and arguments (similar to createInstanceShortcut)
+    QString appPath = QApplication::applicationFilePath();
+    auto icon = APPLICATION->icons()->icon(shortcut.iconKey.isEmpty() ? shortcut.instance->iconKey() : shortcut.iconKey);
+    if (icon == nullptr) {
+        icon = APPLICATION->icons()->icon("grass");
+    }
+    QString iconPath;
+    QStringList args;
+
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD) || defined(Q_OS_OPENBSD)
+    if (appPath.startsWith("/tmp/.mount_")) {
+        // AppImage!
+        appPath = QProcessEnvironment::systemEnvironment().value(QStringLiteral("APPIMAGE"));
+        if (appPath.isEmpty()) {
+            QMessageBox::critical(
+                shortcut.parent, QObject::tr("Create Shortcut"),
+                QObject::tr("Launcher is running as misconfigured AppImage? ($APPIMAGE environment variable is missing)"));
+            return false;
+        }
+        if (appPath.endsWith("/")) {
+            appPath.chop(1);
+        }
+    }
+
+    // NOTE: For the portal flow, we do NOT adjust appPath for Flatpak here.
+    // The DynamicLauncher portal detects sandboxing automatically
+    // and rewrites the Exec= line to use "flatpak run <app-id>" when needed.
+    // If we added "flatpak run ...", we'd get double-wrapping on Flatpak.
+#else
+    // DynamicLauncher portal is Linux-specific (part of xdg-desktop-portal)
+    Q_UNUSED(appPath);
+    Q_UNUSED(icon);
+    Q_UNUSED(iconPath);
+    Q_UNUSED(args);
+    return false;
+#endif
+
+    args.append({ "--launch", shortcut.instance->uuid() });
+    args.append(shortcut.extraArgs);
+
+    // Save the icon as a PNG file (the portal reads it)
+    iconPath = FS::PathCombine(shortcut.instance->instanceRoot(), "icon.png");
+    {
+        QFile iconFile(iconPath);
+        if (!iconFile.open(QFile::WriteOnly)) {
+            QMessageBox::critical(shortcut.parent, QObject::tr("Create Shortcut"),
+                                  QObject::tr("Failed to create icon for shortcut: %1").arg(iconFile.errorString()));
+            return false;
+        }
+        bool success = icon->icon().pixmap(64, 64).save(&iconFile, "PNG");
+        iconFile.close();
+
+        if (!success) {
+            iconFile.remove();
+            QMessageBox::critical(shortcut.parent, QObject::tr("Create Shortcut"), QObject::tr("Failed to create icon for shortcut."));
+            return false;
+        }
+    }
+
+    // Build the desktop entry content (without Name= and Icon= lines, portal handles those)
+    QString desktopEntry = buildDesktopEntry(appPath, args);
+
+    // Call the portal to install the launcher
+    bool success = DynamicLauncherPortal::installLauncher(shortcut.name, iconPath, desktopEntry);
+
+    // Clean up the temporary icon file (the portal has already read it)
+    QFile::remove(iconPath);
+
+    if (!success) {
+        QMessageBox::critical(shortcut.parent, QObject::tr("Create Shortcut"),
+                              QObject::tr("Failed to create %1 shortcut via the system portal!").arg(shortcut.targetString));
+        return false;
+    }
+
+    // Build a synthetic path to register, since the portal manages the actual file location
+    // We use the desktop file id format: appId.InstanceName.desktop
+    QString appId = BuildConfig.LAUNCHER_APPID;
+    QString safeName = shortcut.name;
+    safeName.replace(QRegularExpression(QStringLiteral("[^a-zA-Z0-9_\\-.]")), QStringLiteral("_"));
+    QString registeredShortcutPath = appId + QStringLiteral(".") + safeName + QStringLiteral(".desktop");
+
+    shortcut.instance->registerShortcut({ shortcut.name, registeredShortcutPath, ShortcutTarget::Applications });
+
+    qDebug() << "ShortcutUtils: Successfully created shortcut via portal:" << shortcut.name;
+    return true;
+}
+
 bool createInstanceShortcutOnDesktop(const Shortcut& shortcut)
 {
     if (!shortcut.instance)
         return false;
+
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD) || defined(Q_OS_OPENBSD)
+    // In Flatpak, we can't write directly to the desktop, so try the portal
+    if (DesktopServices::isFlatpak() && DynamicLauncherPortal::isPortalAvailable()) {
+        // For desktop shortcuts via portal, we need a modified shortcut that targets Applications
+        Shortcut portalShortcut = shortcut;
+        portalShortcut.target = ShortcutTarget::Applications;
+        if (createInstanceShortcutViaPortal(portalShortcut)) {
+            QMessageBox::information(shortcut.parent, QObject::tr("Create Shortcut"),
+                                     QObject::tr("Created a shortcut to this %1!\n"
+                                                 "It was installed via the system portal and will appear in your app launcher.")
+                                         .arg(shortcut.targetString));
+            return true;
+        }
+        // Fall through to desktop file method if portal fails
+    }
+#endif
 
     QString desktopDir = FS::getDesktopDir();
     if (desktopDir.isEmpty()) {
@@ -186,6 +346,21 @@ bool createInstanceShortcutInApplications(const Shortcut& shortcut)
 {
     if (!shortcut.instance)
         return false;
+
+#if defined(Q_OS_LINUX) || defined(Q_OS_FREEBSD) || defined(Q_OS_OPENBSD)
+    // Try the DynamicLauncher portal first (works in Flatpak and provides better integration)
+    if (DynamicLauncherPortal::isPortalAvailable()) {
+        if (createInstanceShortcutViaPortal(shortcut)) {
+            QMessageBox::information(shortcut.parent, QObject::tr("Create Shortcut"),
+                                     QObject::tr("Created a shortcut to this %1!\n"
+                                                 "It was installed via the system portal and will appear in your app launcher.")
+                                         .arg(shortcut.targetString));
+            return true;
+        }
+        qDebug() << "ShortcutUtils: Portal installation failed, falling back to direct .desktop file";
+        // Fall through to direct method
+    }
+#endif
 
     QString applicationsDir = FS::getApplicationsDir();
     if (applicationsDir.isEmpty()) {

--- a/launcher/minecraft/ShortcutUtils.h
+++ b/launcher/minecraft/ShortcutUtils.h
@@ -4,6 +4,7 @@
  *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
  *  Copyright (C) 2023 TheKodeToad <TheKodeToad@proton.me>
  *  Copyright (C) 2025 Yihe Li <winmikedows@hotmail.com>
+ *  Copyright (C) 2026 utophii <pos18411@gmail.com>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -61,9 +62,16 @@ bool createInstanceShortcut(const Shortcut& shortcut, const QString& filePath);
 bool createInstanceShortcutOnDesktop(const Shortcut& shortcut);
 
 /// Create an instance shortcut in the Applications directory
+/// This will try to use the DynamicLauncher portal first (if available),
+/// falling back to directly writing the .desktop file
 bool createInstanceShortcutInApplications(const Shortcut& shortcut);
 
 /// Create an instance shortcut in other directories
 bool createInstanceShortcutInOther(const Shortcut& shortcut);
+
+/// Create an instance shortcut via the DynamicLauncher portal.
+/// This shows a confirmation dialog to the user through the portal.
+/// Returns true if the shortcut was successfully installed via the portal
+bool createInstanceShortcutViaPortal(const Shortcut& shortcut);
 
 }  // namespace ShortcutUtils

--- a/launcher/ui/dialogs/CreateShortcutDialog.cpp
+++ b/launcher/ui/dialogs/CreateShortcutDialog.cpp
@@ -46,6 +46,7 @@
 
 #include "BaseInstance.h"
 #include "DesktopServices.h"
+#include "DynamicLauncherPortal.h"
 #include "FileSystem.h"
 #include "InstanceList.h"
 #include "icons/IconList.h"
@@ -76,14 +77,15 @@ CreateShortcutDialog::CreateShortcutDialog(MinecraftInstance* instance, QWidget*
     }
 
     // Populate save targets
-    if (!DesktopServices::isFlatpak()) {
+    bool portalAvailable = DynamicLauncherPortal::isPortalAvailable();
+    if (!DesktopServices::isFlatpak() || portalAvailable) {
         QString desktopDir = FS::getDesktopDir();
         QString applicationDir = FS::getApplicationsDir();
 
         if (!desktopDir.isEmpty())
             ui->saveTargetSelectionBox->addItem(tr("Desktop"), QVariant::fromValue(ShortcutTarget::Desktop));
 
-        if (!applicationDir.isEmpty())
+        if (!applicationDir.isEmpty() || portalAvailable)
             ui->saveTargetSelectionBox->addItem(tr("Applications"), QVariant::fromValue(ShortcutTarget::Applications));
     }
     ui->saveTargetSelectionBox->addItem(tr("Other..."), QVariant::fromValue(ShortcutTarget::Other));


### PR DESCRIPTION
Implements support for installing instance shortcuts via the
[org.freedesktop.portal.DynamicLauncher](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.DynamicLauncher.html)
D-Bus portal, as requested in #1038

The XDG Desktop Portal `DynamicLauncher` interface (introduced in xdg-desktop-portal
1.1.8 and used by GNOME Web, KDE, etc.) installs the launcher to the correct location for the current desktop
environment, working identically from inside and outside a sandbox.

#### Icon serialization note
The portal expects the icon as a `GBytesIcon` serialized with `g_icon_serialize()`.
Starting with GLib 2.82, the format simplified from `(sv): "bytes", v((sv): "<content_type>", v( ay[data]))` to `(sv): "bytes", v(ay[data])`. I use the new (GLib ≥ 2.82) format. The Qt serialization uses
a custom registered metatype (`PortalBytesIcon`) with the signature derived from
its streaming operators, which sidesteps QtDBus's known issues with nesting
`QDBusArgument` inside `QVariant` for variant parameters.

Signed-off-by: utophii pos18411@gmail.com