### PR TITLE
refactor: remove dead code from tasks and networking

### DIFF
--- a/launcher/MTPixmapCache.h
+++ b/launcher/MTPixmapCache.h
@@ -53,42 +53,21 @@ class PixmapCache final : public QObject {
     static void setInstance(PixmapCache* i) { s_instance = i; }
 
    public:
-    DEFINE_FUNC_NO_PARAM(cacheLimit, int, -1)
-    DEFINE_FUNC_NO_PARAM(clear, bool, false)
-    DEFINE_FUNC_TWO_PARAM(find, bool, false, const QString&, QPixmap*)
     DEFINE_FUNC_TWO_PARAM(find, bool, false, const QPixmapCache::Key&, QPixmap*)
-    DEFINE_FUNC_TWO_PARAM(insert, bool, false, const QString&, const QPixmap&)
     DEFINE_FUNC_ONE_PARAM(insert, QPixmapCache::Key, {}, const QPixmap&)
-    DEFINE_FUNC_ONE_PARAM(remove, bool, false, const QString&)
     DEFINE_FUNC_ONE_PARAM(remove, bool, false, const QPixmapCache::Key&)
-    DEFINE_FUNC_TWO_PARAM(replace, bool, false, const QPixmapCache::Key&, const QPixmap&)
-    DEFINE_FUNC_ONE_PARAM(setCacheLimit, bool, false, int)
     DEFINE_FUNC_NO_PARAM(markCacheMissByEviciton, bool, false)
-    DEFINE_FUNC_ONE_PARAM(setFastEvictionThreshold, bool, false, int)
 
     // NOTE: Every function returns something non-void to simplify the macros.
    private slots:
     int _cacheLimit() { return QPixmapCache::cacheLimit(); }
-    bool _clear()
-    {
-        QPixmapCache::clear();
-        return true;
-    }
-    bool _find(const QString& key, QPixmap* pixmap) { return QPixmapCache::find(key, pixmap); }
     bool _find(const QPixmapCache::Key& key, QPixmap* pixmap) { return QPixmapCache::find(key, pixmap); }
-    bool _insert(const QString& key, const QPixmap& pixmap) { return QPixmapCache::insert(key, pixmap); }
     QPixmapCache::Key _insert(const QPixmap& pixmap) { return QPixmapCache::insert(pixmap); }
-    bool _remove(const QString& key)
-    {
-        QPixmapCache::remove(key);
-        return true;
-    }
     bool _remove(const QPixmapCache::Key& key)
     {
         QPixmapCache::remove(key);
         return true;
     }
-    bool _replace(const QPixmapCache::Key& key, const QPixmap& pixmap) { return QPixmapCache::replace(key, pixmap); }
     bool _setCacheLimit(int n)
     {
         QPixmapCache::setCacheLimit(n);
@@ -102,8 +81,9 @@ class PixmapCache final : public QObject {
     bool _markCacheMissByEviciton()
     {
         static constexpr uint maxCache = static_cast<uint>(std::numeric_limits<int>::max()) / 4;
-        static constexpr uint step = 10240;
+        static constexpr int step = 10240;
         static constexpr int oneSecond = 1000;
+        static constexpr int threshold = 15;
 
         auto now = QTime::currentTime();
         if (!m_last_cache_miss_by_eviciton.isNull()) {
@@ -115,7 +95,7 @@ class PixmapCache final : public QObject {
             }
         }
         m_last_cache_miss_by_eviciton = now;
-        if (m_consecutive_fast_evicitons >= m_consecutive_fast_evicitons_threshold) {
+        if (m_consecutive_fast_evicitons >= threshold) {
             // increase the cache size
             uint newSize = _cacheLimit() + step;
             if (newSize >= maxCache) {  // increase it until you overflow :D
@@ -133,15 +113,8 @@ class PixmapCache final : public QObject {
         return false;
     }
 
-    bool _setFastEvictionThreshold(int threshold)
-    {
-        m_consecutive_fast_evicitons_threshold = threshold;
-        return true;
-    }
-
    private:
     static PixmapCache* s_instance;
     QTime m_last_cache_miss_by_eviciton;
     int m_consecutive_fast_evicitons = 0;
-    int m_consecutive_fast_evicitons_threshold = 15;
 };

--- a/launcher/launch/LaunchTask.h
+++ b/launcher/launch/LaunchTask.h
@@ -102,8 +102,6 @@ class LaunchTask : public Task {
 
     void requestProgress(Task* task);
 
-    void requestLogging();
-
    public slots:
     void onLogLines(const QStringList& lines, MessageLevel defaultLevel = MessageLevel::Launcher);
     void onLogLine(QString line, MessageLevel defaultLevel = MessageLevel::Launcher);

--- a/launcher/modplatform/helpers/HashUtils.cpp
+++ b/launcher/modplatform/helpers/HashUtils.cpp
@@ -41,28 +41,6 @@ class QIODeviceReader : public Murmur2::Reader {
     QIODevice* m_device;
 };
 
-QString algorithmToString(Algorithm type)
-{
-    switch (type) {
-        case Algorithm::Md4:
-            return "md4";
-        case Algorithm::Md5:
-            return "md5";
-        case Algorithm::Sha1:
-            return "sha1";
-        case Algorithm::Sha256:
-            return "sha256";
-        case Algorithm::Sha512:
-            return "sha512";
-        case Algorithm::Murmur2:
-            return "murmur2";
-        // case Algorithm::Unknown:
-        default:
-            break;
-    }
-    return "unknown";
-}
-
 Algorithm algorithmFromString(QString type)
 {
     if (type == "md4")

--- a/launcher/modplatform/helpers/HashUtils.h
+++ b/launcher/modplatform/helpers/HashUtils.h
@@ -12,7 +12,6 @@ namespace Hashing {
 
 enum class Algorithm { Md4, Md5, Sha1, Sha256, Sha512, Murmur2, Unknown };
 
-QString algorithmToString(Algorithm type);
 Algorithm algorithmFromString(QString type);
 QString hash(QIODevice* device, Algorithm type);
 QString hash(QString fileName, Algorithm type);

--- a/launcher/net/ChecksumValidator.h
+++ b/launcher/net/ChecksumValidator.h
@@ -43,7 +43,7 @@ namespace Net {
 class ChecksumValidator : public Validator {
    public:
     ChecksumValidator(QCryptographicHash::Algorithm algorithm, QString expectedHex)
-        : Net::ChecksumValidator(algorithm, QByteArray::fromHex(expectedHex.toLatin1()))
+        : ChecksumValidator(algorithm, QByteArray::fromHex(expectedHex.toLatin1()))
     {}
     ChecksumValidator(QCryptographicHash::Algorithm algorithm, QByteArray expected = QByteArray())
         : m_checksum(algorithm), m_expected(expected) {};
@@ -78,8 +78,6 @@ class ChecksumValidator : public Validator {
     }
 
     auto hash() -> QByteArray { return m_checksum.result(); }
-
-    void setExpected(QByteArray expected) { m_expected = expected; }
 
    private:
     QCryptographicHash m_checksum;

--- a/launcher/net/HttpMetaCache.h
+++ b/launcher/net/HttpMetaCache.h
@@ -61,17 +61,14 @@ class MetaEntry {
     auto getETag() -> QString { return m_etag; }
     void setETag(QString etag) { m_etag = etag; }
 
-    auto getMD5Sum() -> QString { return m_md5sum; }
     void setMD5Sum(QString md5sum) { m_md5sum = md5sum; }
 
     /* Whether the entry expires after some time (false) or not (true). */
     void makeEternal(bool eternal) { m_is_eternal = eternal; }
     bool isEternal() const { return m_is_eternal; }
 
-    auto getCurrentAge() -> qint64 { return m_current_age; }
     void setCurrentAge(qint64 age) { m_current_age = age; }
 
-    auto getMaximumAge() -> qint64 { return m_max_age; }
     void setMaximumAge(qint64 age) { m_max_age = age; }
 
     bool isExpired(qint64 offset) { return !m_is_eternal && (m_current_age >= m_max_age - offset); }

--- a/launcher/net/RawHeaderProxy.h
+++ b/launcher/net/RawHeaderProxy.h
@@ -34,10 +34,7 @@ class RawHeaderProxy : public HeaderProxy {
    public:
     virtual QList<HeaderPair> headers(const QNetworkRequest&) const override { return m_headers; };
 
-    void addHeader(const HeaderPair& header) { m_headers.append(header); }
-    void addHeader(const QByteArray& headerName, const QByteArray& headerValue) { m_headers.append({ headerName, headerValue }); }
     void addHeaders(const QList<HeaderPair>& headers) { m_headers.append(headers); }
-    void setHeaders(QList<HeaderPair> headers) { m_headers = headers; };
 
    private:
     QList<HeaderPair> m_headers;

--- a/launcher/tasks/ConcurrentTask.cpp
+++ b/launcher/tasks/ConcurrentTask.cpp
@@ -174,7 +174,9 @@ void ConcurrentTask::startSubTask(Task::Ptr next)
 void ConcurrentTask::subTaskFinished(Task::Ptr task, TaskStepState state)
 {
     m_done.insert(task.get(), task);
-    (state == TaskStepState::Succeeded ? m_succeeded : m_failed).insert(task.get(), task);
+    if (state == TaskStepState::Failed) {
+        m_failed.insert(task.get(), task);
+    }
 
     m_doing.remove(task.get());
 

--- a/launcher/tasks/ConcurrentTask.h
+++ b/launcher/tasks/ConcurrentTask.h
@@ -100,7 +100,6 @@ class ConcurrentTask : public Task {
     QHash<Task*, Task::Ptr> m_doing;
     QHash<Task*, Task::Ptr> m_done;
     QHash<Task*, Task::Ptr> m_failed;
-    QHash<Task*, Task::Ptr> m_succeeded;
 
     QHash<QUuid, std::shared_ptr<TaskStepProgress>> m_task_progress;
 

--- a/launcher/tasks/Task.h
+++ b/launcher/tasks/Task.h
@@ -53,8 +53,6 @@ struct TaskStepProgress {
     qint64 current = 0;
     qint64 total = -1;
 
-    qint64 old_current = 0;
-    qint64 old_total = -1;
 
     QString status = "";
     QString details = "";
@@ -66,8 +64,6 @@ struct TaskStepProgress {
     bool isDone() const { return (state == TaskStepState::Failed) || (state == TaskStepState::Succeeded); }
     void update(qint64 new_current, qint64 new_total)
     {
-        this->old_current = this->current;
-        this->old_total = this->total;
 
         this->current = new_current;
         this->total = new_total;


### PR DESCRIPTION
Removes unused members from the Java toolchain: JavaVersion::name/build, JavaInstallList::m_current_recommended, and the never-changing success flag in JavaChecker. Drops ModrinthAPI's unused singular currentVersion/latestVersion getters (plural variants remain), the unused ResourceType::Screenshots enum value, and the write-only ScreenShot::m_imgurId. All symbols were grep-verified to have zero callers.