### PR TITLE
Fix translation language equality check

### DIFF
--- a/launcher/translations/TranslationsModel.cpp
+++ b/launcher/translations/TranslationsModel.cpp
@@ -123,7 +123,7 @@ struct Language {
     bool isIdenticalTo(const Language& other) const
     {
         return (key == other.key && fileName == other.fileName && fileSize == other.fileSize && fileSha1 == other.fileSha1 &&
-                translated == other.translated && fuzzy == other.fuzzy && total == other.fuzzy && localFileType == other.localFileType);
+                translated == other.translated && fuzzy == other.fuzzy && total == other.total && localFileType == other.localFileType);
     }
 
     Language& apply(const Language& other)


### PR DESCRIPTION
`Language::isIdenticalTo()` compares `total` against `other.fuzzy`
instead of `other.total`.

This causes unchanged language entries to be treated as changed when
translation metadata is reloaded.

This fixes the comparison to use the corresponding `total` field.