### PR TITLE
Add enabled mod count to mod window title. Fixes #5955

### DIFF
--- a/launcher/ui/pages/instance/ExternalResourcesPage.cpp
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.cpp
@@ -341,10 +341,18 @@ void ExternalResourcesPage::updateFrame(const QModelIndex& current, [[maybe_unus
 
 QString ExternalResourcesPage::extraHeaderInfoString()
 {
+    auto all = m_model->allResources();
+    auto enabledCount = std::count_if(all.cbegin(), all.cend(), [](Resource* res) { return res->enabled(); });
+    auto installedCount = m_model->size();
+
     if (ui && ui->treeView && ui->treeView->selectionModel()) {
         auto selection = m_filterModel->mapSelectionToSource(ui->treeView->selectionModel()->selection()).indexes();
         if (auto count = std::count_if(selection.cbegin(), selection.cend(), [](auto v) { return v.column() == 0; }); count != 0)
-            return tr(" (%1 installed, %2 selected)").arg(m_model->size()).arg(count);
+            return tr(" (%1 installed, %2 enabled, %3 selected)").arg(installedCount).arg(enabledCount).arg(count);
     }
-    return tr(" (%1 installed)").arg(m_model->size());
+
+    if (installedCount == 0)
+        return tr(" (%1 installed)").arg(installedCount);
+
+    return tr(" (%1 installed, %2 enabled)").arg(installedCount).arg(enabledCount);
 }

--- a/launcher/ui/pages/instance/ExternalResourcesPage.cpp
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.cpp
@@ -342,7 +342,7 @@ void ExternalResourcesPage::updateFrame(const QModelIndex& current, [[maybe_unus
 QString ExternalResourcesPage::extraHeaderInfoString()
 {
     auto all = m_model->allResources();
-    auto enabledCount = std::count_if(all.cbegin(), all.cend(), [](Resource* res) { return res->enabled(); });
+    auto enabledCount = std::ranges::count_if(all, [](Resource* res) { return res->enabled(); });
     auto installedCount = m_model->size();
 
     if (ui && ui->treeView && ui->treeView->selectionModel()) {
@@ -351,8 +351,8 @@ QString ExternalResourcesPage::extraHeaderInfoString()
             return tr(" (%1 installed, %2 enabled, %3 selected)").arg(installedCount).arg(enabledCount).arg(count);
     }
 
-    if (installedCount == 0)
-        return tr(" (%1 installed)").arg(installedCount);
+    if (enabledCount != 0)
+        return tr(" (%1 installed, %2 enabled)").arg(installedCount).arg(enabledCount);
 
-    return tr(" (%1 installed, %2 enabled)").arg(installedCount).arg(enabledCount);
+    return tr(" (%1 installed)").arg(installedCount);
 }


### PR DESCRIPTION
Added the number of enabled mods to the mod window title of the instance edit window. Fixes #5955

Since this was done by modifying ExternalResourcesPage it also affects all the other applicable windows (ex: Resource Packs).

Checked with clang-tidy, which complained about the body of the if-statements not being inside brackets. However, I kept it the same since that was how the function was already formatted.

**Before:**
<img width="423" height="82" alt="2026-08-24-224139_hyprshot" src="https://github.com/user-attachments/assets/022fd86b-b9b0-42e9-b8de-b73bdc8eb1f4" />

**After:**
<img width="409" height="82" alt="2026-08-24-223956_hyprshot" src="https://github.com/user-attachments/assets/63e266ef-71bf-441c-8de9-fe49c3a9f5ae" />
