### PR TITLE
UI tooltip to display mod dependencies. Fixes #5366

### DIFF
--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -136,6 +136,26 @@ QVariant ModFolderModel::data(const QModelIndex& index, int role) const
                 return QSize(32, 32);
             }
             break;
+        case Qt::ToolTipRole:
+            switch (column) {
+                case RequiredByColumn: {
+                    const auto list = requiredByList(at(row).mod_id());
+                    if (!list.isEmpty()) {
+                        return list.join(QLatin1Char('\n'));
+                    }
+                    break;
+                }
+                case RequiresColumn: {
+                    const auto list = requiresList(at(row).mod_id());
+                    if (!list.isEmpty()) {
+                        return list.join(QLatin1Char('\n'));
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
+            break;
         default:
             break;
     }
@@ -495,14 +515,14 @@ QStringList reqToList(const QSet<Mod*>& l)
 }
 }  // namespace
 
-QStringList ModFolderModel::requiresList(const QString& id)
+QStringList ModFolderModel::requiresList(const QString& id) const
 {
-    return reqToList(m_requires[id]);
+    return reqToList(m_requires.value(id));
 }
 
-QStringList ModFolderModel::requiredByList(const QString& id)
+QStringList ModFolderModel::requiredByList(const QString& id) const
 {
-    return reqToList(m_requiredBy[id]);
+    return reqToList(m_requiredBy.value(id));
 }
 
 bool ModFolderModel::deleteResources(const QModelIndexList& indexes)

--- a/launcher/minecraft/mod/ModFolderModel.h
+++ b/launcher/minecraft/mod/ModFolderModel.h
@@ -97,8 +97,8 @@ class ModFolderModel : public ResourceFolderModel {
     RESOURCE_HELPERS(Mod)
 
    public:
-    QStringList requiresList(const QString& id);
-    QStringList requiredByList(const QString& id);
+    QStringList requiresList(const QString& id) const;
+    QStringList requiredByList(const QString& id) const;
 
    private slots:
     void onParseSucceeded(int ticket, const QString& resourceId) override;


### PR DESCRIPTION
Added a UI tooltip to columns 'Requires' and 'Required By' that shows the relevant mods names. Fixes #5366 

### Relevant changes
Refactored `ModFolderModel::requiresList()` and `ModFolderModel::requiredByList()` to use `QHash::value()`. This makes the methods `const` correct so they can be called from `ModFolderModel::data`.

### Result
<img width="148" height="139" alt="2026-08-26-010631_hyprshot" src="https://github.com/user-attachments/assets/a14b641d-00be-4836-a1f8-d8d1a7233e29" />


