### PR TITLE
Decrease low RAM warning threshold

### DIFF
--- a/launcher/minecraft/launch/EnsureAvailableMemory.cpp
+++ b/launcher/minecraft/launch/EnsureAvailableMemory.cpp
@@ -79,7 +79,7 @@ void EnsureAvailableMemory::executeTask()
     const uint64_t settingMax = m_instance->settings()->get("MaxMemAlloc").toUInt();
     const uint64_t max = std::max(settingMin, settingMax);
 
-    if (static_cast<double>(max) * 0.9 > static_cast<double>(available)) {
+    if (static_cast<double>(max) * 0.7 > static_cast<double>(available)) {
         bool shouldAbort = false;
 
         if (m_instance->settings()->get("LowMemWarning").toBool()) {


### PR DESCRIPTION
| Maximum allocation | `develop` threshold (90%) | This PR threshold (70%) |
|--------|--------|--------|
| 4096 | 3686 | 2867 |
| 8192 | 7373 | 5734 |
| 12288 | 11059 | 8601 | 

If users keep complaining I will make a PR removing this entirely