### PR TITLE
fix(fabric): correctly parse dictionary mod icons

### DIFF
--- a/launcher/minecraft/mod/tasks/LocalModParseTask.cpp
+++ b/launcher/minecraft/mod/tasks/LocalModParseTask.cpp
@@ -340,20 +340,19 @@ ModDetails ReadFabricModInfo(QByteArray contents)
                 auto obj = icon.toObject();
                 // take the largest icon
                 int largest = 0;
-                for (auto key : obj.keys()) {
+                QString bestIcon;
+                for (const auto& key : obj.keys()) {
                     auto size = key.split('x').first().toInt();
                     if (size > largest) {
                         largest = size;
+                        bestIcon = obj.value(key).toString();
                     }
                 }
-                if (largest > 0) {
-                    auto key = QString::number(largest) + "x" + QString::number(largest);
-                    details.icon_file = obj.value(key).toString();
-                } else {  // parsing the sizes failed
+                if (!bestIcon.isEmpty()) {
+                    details.icon_file = bestIcon;
+                } else if (!obj.isEmpty()) {
                     // take the first
-                    if (auto it = obj.begin(); it != obj.end()) {
-                        details.icon_file = it->toString();
-                    }
+                    details.icon_file = obj.begin().value().toString();
                 }
             } else if (icon.isString()) {
                 details.icon_file = icon.toString();


### PR DESCRIPTION
Fixes #5993
Signed-off-by: AhmedAliElashmawy <ahmedelashmawy.dev@gmail.com>
### Summary of Changes  

According to the `fabric.mod.json` specification, when `icon` is provided as an object/dictionary, keys represent image widths as integers (e.g. `"64": "assets/mod/icon_64.png"`),rather than full dimensions (`"64x64"`).

- Added support for parsing integer keys directly.
- Kept fallback support for `<width>x<height>` formats.
- Saved icon path directly during iteration instead of reconstructing a lookup key.

### Screenshots
#### Before
<img width="1005" height="737" alt="Screenshot from 2026-08-30 15-39-39" src="https://github.com/user-attachments/assets/20dec7cd-9b81-4103-948b-fe59a3bffdc8" />

#### After
<img width="1010" height="751" alt="Screenshot from 2026-08-30 15-53-06" src="https://github.com/user-attachments/assets/fc2e1150-44ee-4e58-83ce-6d07fa6fbce2" />


