### PR TITLE
Remove duplicate InstanceList reload

### DIFF
--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -1375,8 +1375,6 @@ void MainWindow::on_actionSettings_triggered()
 
 void MainWindow::globalSettingsClosed()
 {
-    // FIXME: quick HACK to make this work. improve, optimize.
-    APPLICATION->instances()->loadList();
     proxymodel->invalidate();
     proxymodel->sort(0);
     updateMainToolBar();


### PR DESCRIPTION
We reload when the setting changes anyway so we probably don't need this
I just see in the log that instance discovery runs twice for the same dir if the setting is changed
Delaying to 12.0.0 just in case somehow there's a reason for htis