### PR TITLE
UI alignment fixes

### DIFF
--- a/launcher/ui/dialogs/NewInstanceDialog.ui
+++ b/launcher/ui/dialogs/NewInstanceDialog.ui
@@ -3,14 +3,14 @@
  <class>NewInstanceDialog</class>
  <widget class="QDialog" name="NewInstanceDialog">
   <property name="windowModality">
-   <enum>Qt::ApplicationModal</enum>
+   <enum>Qt::WindowModality::ApplicationModal</enum>
   </property>
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
     <width>730</width>
-    <height>127</height>
+    <height>157</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -73,7 +73,7 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="0" rowspan="2">
+     <item row="0" column="0" rowspan="3">
       <widget class="QToolButton" name="iconButton">
        <property name="iconSize">
         <size>
@@ -88,7 +88,7 @@
    <item>
     <widget class="Line" name="line">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
     </widget>
    </item>

--- a/launcher/ui/widgets/JavaSettingsWidget.ui
+++ b/launcher/ui/widgets/JavaSettingsWidget.ui
@@ -193,6 +193,9 @@
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <item>
        <layout class="QFormLayout" name="formLayout">
+        <property name="labelAlignment">
+         <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+        </property>
         <item row="0" column="0">
          <widget class="QLabel" name="labelMinMem">
           <property name="text">


### PR DESCRIPTION
Before I forget, fixed the off-centre layout here which was driving me crazy:
<img width="718" height="152" alt="image" src="https://github.com/user-attachments/assets/8ff9c17c-4fd2-40de-b6a3-69c67497ab1c" />
<img width="715" height="148" alt="image" src="https://github.com/user-attachments/assets/9cf85b32-a419-434d-b05e-60515c47f708" />

Also fixed the memory settings label alignment - everywhere else we force left alignment:
<img width="481" height="116" alt="image" src="https://github.com/user-attachments/assets/5e76f384-777b-46c9-818a-a7b26fb33562" />
