### PR TITLE
Implement instance offloading. Fixes #5597

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -104,6 +104,7 @@
 
 #include "InstanceList.h"
 #include "MTPixmapCache.h"
+#include "RestoreInstanceTask.h"
 
 #include <minecraft/auth/AccountList.h>
 #include "icons/IconList.h"
@@ -1539,6 +1540,26 @@ bool Application::launch(MinecraftInstance* instance,
 {
     if (m_updateRunning) {
         qDebug() << "Cannot launch instances while an update is running. Please try again when updates are completed.";
+    } else if (instance->isOffloaded()) {
+        auto reply = QMessageBox::question(m_mainWindow, tr("Restore Instance"),
+                                           tr("This instance is currently offloaded and cannot be launched. Do you want to download the "
+                                              "missing files and restore it now?"),
+                                           QMessageBox::Yes | QMessageBox::No);
+
+        if (reply == QMessageBox::Yes) {
+            Task::Ptr task(new RestoreInstanceTask(instance));
+            ProgressDialog prog(m_mainWindow);
+            prog.setSkipButton(true, tr("Abort"));
+            prog.execWithTask(task.get());
+
+            if (task->wasSuccessful()) {
+                // Task succeeded, mark as not offloaded and proceed to launch
+                instance->setOffloaded(false);
+                return launch(instance, mode, targetToJoin, accountToUse, offlineName);
+            }
+        }
+
+        return false;
     } else if (instance->canLaunch()) {
         QMutexLocker locker(&m_instanceExtrasMutex);
         auto& extras = m_instanceExtras[instance->id()];

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -1554,6 +1554,7 @@ bool Application::launch(MinecraftInstance* instance,
 
             if (task->wasSuccessful()) {
                 // Task succeeded, mark as not offloaded and proceed to launch
+                instance->setOffloadedDisabledFiles(QStringList());
                 instance->setOffloaded(false);
                 return launch(instance, mode, targetToJoin, accountToUse, offlineName);
             }

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -1547,7 +1547,7 @@ bool Application::launch(MinecraftInstance* instance,
                                            QMessageBox::Yes | QMessageBox::No);
 
         if (reply == QMessageBox::Yes) {
-            Task::Ptr task(new RestoreInstanceTask(instance));
+            const Task::Ptr task(new RestoreInstanceTask(instance));
             ProgressDialog prog(m_mainWindow);
             prog.setSkipButton(true, tr("Abort"));
             prog.execWithTask(task.get());

--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -131,6 +131,8 @@ BaseInstance::BaseInstance(SettingsObject* globalSettings, std::unique_ptr<Setti
     m_settings->registerSetting("ManagedPackVersionName", "");
     m_settings->registerSetting("ManagedPackURL", "");
 
+    m_settings->registerSetting("Offloaded", false);
+
     m_settings->registerSetting("Profiler", "");
 }
 
@@ -152,6 +154,17 @@ QString BaseInstance::getPostExitCommand()
 bool BaseInstance::isManagedPack() const
 {
     return m_settings->get("ManagedPack").toBool();
+}
+
+bool BaseInstance::isOffloaded() const
+{
+    return m_settings->get("Offloaded").toBool();
+}
+
+void BaseInstance::setOffloaded(bool offloaded)
+{
+    m_settings->set("Offloaded", offloaded);
+    emit propertiesChanged();
 }
 
 QString BaseInstance::getManagedPackType() const

--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -131,7 +131,9 @@ BaseInstance::BaseInstance(SettingsObject* globalSettings, std::unique_ptr<Setti
     m_settings->registerSetting("ManagedPackVersionName", "");
     m_settings->registerSetting("ManagedPackURL", "");
 
+    // Instance Offloading
     m_settings->registerSetting("Offloaded", false);
+    m_settings->registerSetting("OffloadedDisabledFiles", "[]");
 
     m_settings->registerSetting("Profiler", "");
 }
@@ -165,6 +167,17 @@ void BaseInstance::setOffloaded(bool offloaded)
 {
     m_settings->set("Offloaded", offloaded);
     emit propertiesChanged();
+}
+
+QStringList BaseInstance::getOffloadedDisabledFiles() const
+{
+    auto setting = m_settings->get("OffloadedDisabledFiles").toString();
+    return Json::toStringList(setting);
+}
+
+void BaseInstance::setOffloadedDisabledFiles(const QStringList& list)
+{
+    m_settings->set("OffloadedDisabledFiles", Json::fromStringList(list));
 }
 
 QString BaseInstance::getManagedPackType() const

--- a/launcher/BaseInstance.h
+++ b/launcher/BaseInstance.h
@@ -162,6 +162,8 @@ class BaseInstance : public QObject {
 
     bool isOffloaded() const;
     void setOffloaded(bool offloaded);
+    QStringList getOffloadedDisabledFiles() const;
+    void setOffloadedDisabledFiles(const QStringList& list);
 
     QString getManagedPackType() const;
     QString getManagedPackID() const;

--- a/launcher/BaseInstance.h
+++ b/launcher/BaseInstance.h
@@ -159,6 +159,10 @@ class BaseInstance : public QObject {
     QString getWrapperCommand();
 
     bool isManagedPack() const;
+
+    bool isOffloaded() const;
+    void setOffloaded(bool offloaded);
+
     QString getManagedPackType() const;
     QString getManagedPackID() const;
     QString getManagedPackName() const;

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -14,6 +14,10 @@ set(CORE_SOURCES
     InstanceList.cpp
     InstanceTask.h
     InstanceTask.cpp
+    OffloadInstanceTask.h
+    OffloadInstanceTask.cpp
+    RestoreInstanceTask.h
+    RestoreInstanceTask.cpp
     LoggedProcess.h
     LoggedProcess.cpp
     MessageLevel.cpp

--- a/launcher/OffloadInstanceTask.cpp
+++ b/launcher/OffloadInstanceTask.cpp
@@ -1,7 +1,7 @@
 #include "OffloadInstanceTask.h"
-#include <qdir.h>
 #include <QTimer>
 #include <memory>
+#include <QDir>
 
 #include "BaseInstance.h"
 #include "FileSystem.h"
@@ -59,6 +59,7 @@ void OffloadInstanceTask::processResourceFolder(const QString& folderName)
 
         QString fileToRemove;
         QFileInfo fileToRemoveInfo;
+        bool isDisabled = false;
 
         const QString targetFile = FS::PathCombine(resourcePath, mod.filename);
         QFileInfo targetFileInfo(targetFile);
@@ -76,12 +77,25 @@ void OffloadInstanceTask::processResourceFolder(const QString& folderName)
                 fileToRemove = disabledFile;
                 fileToRemoveInfo = disabledFileInfo;
 
-                m_disabledFiles.append(mod.filename);
+                isDisabled = true;
             }
             else
             {
                 continue;
             }
+        }
+
+        // Skip if it's a symlink
+        // using isSymLink() would not work if the whole resource folder was symlinked
+        if (fileToRemoveInfo.canonicalFilePath() != fileToRemoveInfo.absoluteFilePath())
+        {
+            qDebug() << "Found Symlink while offloading. Skipping.";
+            continue;
+        }
+
+        if (isDisabled)
+        {
+            m_disabledFiles.append(mod.filename);
         }
 
 

--- a/launcher/OffloadInstanceTask.cpp
+++ b/launcher/OffloadInstanceTask.cpp
@@ -223,3 +223,13 @@ void OffloadInstanceTask::finishOffload()
         emitSucceeded();
     });
 }
+
+int OffloadInstanceTask::filesFreed() const
+{
+    return m_filesFreed;
+}
+
+qint64 OffloadInstanceTask::bytesFreed() const
+{
+    return m_bytesFreed;
+}

--- a/launcher/OffloadInstanceTask.cpp
+++ b/launcher/OffloadInstanceTask.cpp
@@ -1,0 +1,179 @@
+#include "OffloadInstanceTask.h"
+#include <qdir.h>
+#include <QTimer>
+#include <memory>
+
+#include "BaseInstance.h"
+#include "FileSystem.h"
+#include "modplatform/flame/FileResolvingTask.h"
+#include "modplatform/packwiz/Packwiz.h"
+
+
+OffloadInstanceTask::OffloadInstanceTask(BaseInstance* baseInstance)
+    : Task(true), m_instance(baseInstance)
+{
+
+}
+
+void OffloadInstanceTask::executeTask()
+{
+    setStatus(tr("Scanning for offloadable files..."));
+
+    processResourceFolder("mods");
+    processResourceFolder("resourcepacks");
+    processResourceFolder("shaderpacks");
+
+    resolveCurseForgeFiles();
+}
+
+
+void OffloadInstanceTask::processResourceFolder(const QString& folderName)
+{
+    const QString resourcePath = FS::PathCombine(m_instance->instanceRoot(), "minecraft", folderName);
+    const QString indexPath = FS::PathCombine(resourcePath, ".index");
+
+    QDir indexDir(indexPath);
+    if (!indexDir.exists())
+    {
+        return;
+    }
+
+
+    const auto indexFiles = indexDir.entryList({"*.pw.toml"}, QDir::Files);
+    for (const auto& fileName : indexFiles)
+    {
+        QString stripped = fileName;
+        stripped.remove(".pw.toml");
+
+        // Packwiz uses 'mod' for every resource
+        auto mod = Packwiz::V1::getIndexForMod(indexDir, stripped);
+        if (!mod.isValid()){
+            continue;
+        }
+
+        const QString targetFile = FS::PathCombine(resourcePath, mod.filename);
+        QFileInfo targetFileInfo(targetFile);
+        if(!targetFileInfo.exists()){
+            // already missing or offloaded
+            qDebug() << "Attempting to offload a file that doesn't exist. Skipping.";
+            continue;
+        }
+
+        qint64 size = targetFileInfo.size();
+        if (mod.mode == "url" && !mod.url.isEmpty())
+        {
+            // Modrinth
+            if (QFile::remove(targetFile))
+            {
+                m_filesFreed++;
+                m_bytesFreed += size;
+                qDebug() << "Offloading file: " << targetFile;
+            }
+            else {
+                qWarning() << "Failed to remove offloaded file:" << targetFile;
+            }
+        }
+        else if (mod.mode == "metadata:curseforge")
+        {
+            // Curseforge, need to check with API first
+            m_curseForgeFiles.insert(mod.file_id.toInt(),
+                    CurseForgeOffloadTarget {
+                    .projectId = mod.project_id.toInt(),
+                    .targetFile = targetFile,
+                    .fileSize = size});
+        }
+        else
+        {
+            qDebug() << "Unexpected mod mode when offloading: " << mod.name;
+        }
+
+    }
+}
+
+
+void OffloadInstanceTask::resolveCurseForgeFiles()
+{
+    if (m_curseForgeFiles.isEmpty())
+    {
+        finishOffload();
+        return;
+    }
+
+    setStatus(tr("Checking CurseForge mods for third-party block..."));
+    qDebug() << "Resolving CurseForge Files. Count:" << m_curseForgeFiles.count();
+
+    // Create the manifest
+    Flame::Manifest manifest;
+    QMapIterator<int, CurseForgeOffloadTarget> i(m_curseForgeFiles);
+    while (i.hasNext())
+    {
+        i.next();
+        Flame::File f;
+        f.fileId = i.key();
+        f.projectId = i.value().projectId;
+        f.required = true;
+        manifest.files.insert(f.fileId, f);
+    }
+
+    auto resolveTask =
+        std::make_shared<Flame::FileResolvingTask>(manifest);
+    m_flameApiJob = resolveTask;
+
+    connect(resolveTask.get(), &Task::succeeded, this,
+            [this, resolveTask]() {
+                const Flame::Manifest& results = resolveTask->getResults();
+
+                // check if we have the downloadUrl
+                for (const auto& resolvedFile : results.files)
+                {
+                    auto targetInfo =
+                        m_curseForgeFiles.value(resolvedFile.fileId);
+
+                    // mod is blocked and there is no Modrinth alternative
+                    if (resolvedFile.version.downloadUrl.isEmpty())
+                    {
+                        qDebug() << "Skipping blocked mod:" << targetInfo.targetFile;
+                        continue;
+                    }
+
+                    // URL is valid so it's safe to offload
+                    if (QFile::remove(targetInfo.targetFile))
+                    {
+                        m_filesFreed++;
+                        m_bytesFreed += targetInfo.fileSize;
+                        qDebug() << "Offloaded CurseForge file:" << targetInfo.targetFile;
+                    }
+                    else {
+                        qDebug() << "Failed to offload CurseForge file:"
+                            << targetInfo.targetFile;
+                    }
+                }
+
+                finishOffload();
+            });
+
+    connect(resolveTask.get(), &Task::failed, this,
+            [this](const QString& reason) {
+                emitFailed(tr("Failed to resolve CurseForge files: %1").arg(reason));
+            });
+
+    connect(resolveTask.get(), &Task::progress, this, &Task::setProgress);
+    connect(resolveTask.get(), &Task::status, this, &Task::setStatus);
+
+    resolveTask->start();
+
+}
+
+
+void OffloadInstanceTask::finishOffload()
+{
+    m_instance->setOffloaded(true);
+    qDebug() << "Offload Complete. Freed" << m_filesFreed << "files (" << m_bytesFreed << ") bytes";
+
+    // Delay emitSucceeded() to the next event loop iteration.
+    // If the task completes synchronously, the ProgressDialog gets destroyed too quickly,
+    // which leaves the main window dimmed until the next input event.
+    QTimer::singleShot(0, this, [this]() {
+        emitSucceeded();
+    });
+}

--- a/launcher/OffloadInstanceTask.cpp
+++ b/launcher/OffloadInstanceTask.cpp
@@ -30,7 +30,13 @@ void OffloadInstanceTask::executeTask()
 void OffloadInstanceTask::processResourceFolder(const QString& folderName)
 {
     const QString resourcePath = FS::PathCombine(m_instance->instanceRoot(), "minecraft", folderName);
-    const QString indexPath = FS::PathCombine(resourcePath, ".index");
+    
+    QString indexPath;
+    if (folderName == "shaderpacks") {
+        indexPath = resourcePath;
+    } else {
+        indexPath = FS::PathCombine(resourcePath, ".index");
+    }
 
     QDir indexDir(indexPath);
     if (!indexDir.exists())

--- a/launcher/OffloadInstanceTask.cpp
+++ b/launcher/OffloadInstanceTask.cpp
@@ -1,19 +1,14 @@
 #include "OffloadInstanceTask.h"
+#include <QDir>
 #include <QTimer>
 #include <memory>
-#include <QDir>
 
 #include "BaseInstance.h"
 #include "FileSystem.h"
 #include "modplatform/flame/FileResolvingTask.h"
 #include "modplatform/packwiz/Packwiz.h"
 
-
-OffloadInstanceTask::OffloadInstanceTask(BaseInstance* baseInstance)
-    : Task(true), m_instance(baseInstance)
-{
-
-}
+OffloadInstanceTask::OffloadInstanceTask(BaseInstance* baseInstance) : Task(true), m_instance(baseInstance) {}
 
 void OffloadInstanceTask::executeTask()
 {
@@ -26,7 +21,6 @@ void OffloadInstanceTask::executeTask()
     resolveCurseForgeFiles();
 }
 
-
 void OffloadInstanceTask::processResourceFolder(const QString& folderName)
 {
     const QString resourcePath = FS::PathCombine(m_instance->instanceRoot(), "minecraft", folderName);
@@ -38,22 +32,19 @@ void OffloadInstanceTask::processResourceFolder(const QString& folderName)
         indexPath = FS::PathCombine(resourcePath, ".index");
     }
 
-    QDir indexDir(indexPath);
-    if (!indexDir.exists())
-    {
+    const QDir indexDir(indexPath);
+    if (!indexDir.exists()) {
         return;
     }
 
-
-    const auto indexFiles = indexDir.entryList({"*.pw.toml"}, QDir::Files);
-    for (const auto& fileName : indexFiles)
-    {
+    const auto indexFiles = indexDir.entryList({ "*.pw.toml" }, QDir::Files);
+    for (const auto& fileName : indexFiles) {
         QString stripped = fileName;
         stripped.remove(".pw.toml");
 
         // Packwiz uses 'mod' for every resource
         auto mod = Packwiz::V1::getIndexForMod(indexDir, stripped);
-        if (!mod.isValid()){
+        if (!mod.isValid()) {
             continue;
         }
 
@@ -62,79 +53,59 @@ void OffloadInstanceTask::processResourceFolder(const QString& folderName)
         bool isDisabled = false;
 
         const QString targetFile = FS::PathCombine(resourcePath, mod.filename);
-        QFileInfo targetFileInfo(targetFile);
-        if (targetFileInfo.exists())
-        {
+        const QFileInfo targetFileInfo(targetFile);
+        if (targetFileInfo.exists()) {
             fileToRemove = targetFile;
             fileToRemoveInfo = targetFileInfo;
-        }
-        else
-        {
+        } else {
             // Check if the file is disabled
             const QString disabledFile = targetFile + ".disabled";
-            QFileInfo disabledFileInfo(disabledFile);
+            const QFileInfo disabledFileInfo(disabledFile);
             if (disabledFileInfo.exists()) {
                 fileToRemove = disabledFile;
                 fileToRemoveInfo = disabledFileInfo;
 
                 isDisabled = true;
-            }
-            else
-            {
+            } else {
                 continue;
             }
         }
 
         // Skip if it's a symlink
         // using isSymLink() would not work if the whole resource folder was symlinked
-        if (fileToRemoveInfo.canonicalFilePath() != fileToRemoveInfo.absoluteFilePath())
-        {
+        if (fileToRemoveInfo.canonicalFilePath() != fileToRemoveInfo.absoluteFilePath()) {
             qDebug() << "Found Symlink while offloading. Skipping.";
             continue;
         }
 
-        if (isDisabled)
-        {
+        if (isDisabled) {
             m_disabledFiles.append(mod.filename);
         }
 
-
-        qint64 size = fileToRemoveInfo.size();
-        if (mod.mode == "url" && !mod.url.isEmpty())
-        {
+        const qint64 size = fileToRemoveInfo.size();
+        if (mod.mode == "url" && !mod.url.isEmpty()) {
             // Modrinth
-            if (QFile::remove(fileToRemove))
-            {
+            if (QFile::remove(fileToRemove)) {
                 m_filesFreed++;
                 m_bytesFreed += size;
                 qDebug() << "Offloading file: " << fileToRemove;
-            }
-            else {
+            } else {
                 qWarning() << "Failed to remove offloaded file:" << fileToRemove;
             }
-        }
-        else if (mod.mode == "metadata:curseforge")
-        {
+        } else if (mod.mode == "metadata:curseforge") {
             // Curseforge, need to check with API first
-            m_curseForgeFiles.insert(mod.file_id.toInt(),
-                    CurseForgeOffloadTarget {
-                    .projectId = mod.project_id.toInt(),
-                    .fileToRemove = fileToRemove,
-                    .fileSize = size});
-        }
-        else
-        {
+            m_curseForgeFiles.insert(
+                mod.file_id.toInt(),
+                CurseForgeOffloadTarget{ .projectId = mod.project_id.toInt(), .fileToRemove = fileToRemove, .fileSize = size });
+        } else {
             qDebug() << "Unexpected mod mode when offloading: " << mod.name;
         }
-
     }
 }
 
-
 void OffloadInstanceTask::resolveCurseForgeFiles()
 {
-    if (m_curseForgeFiles.isEmpty())
-    {
+    if (m_curseForgeFiles.isEmpty()) {
         finishOffload();
         return;
     }
@@ -145,8 +116,7 @@ void OffloadInstanceTask::resolveCurseForgeFiles()
     // Create the manifest
     Flame::Manifest manifest;
     QMapIterator<int, CurseForgeOffloadTarget> i(m_curseForgeFiles);
-    while (i.hasNext())
-    {
+    while (i.hasNext()) {
         i.next();
         Flame::File f;
         f.fileId = i.key();
@@ -155,59 +125,48 @@ void OffloadInstanceTask::resolveCurseForgeFiles()
         manifest.files.insert(f.fileId, f);
     }
 
-    auto resolveTask =
-        std::make_shared<Flame::FileResolvingTask>(manifest);
+    auto resolveTask = std::make_shared<Flame::FileResolvingTask>(manifest);
     m_flameApiJob = resolveTask;
 
-    connect(resolveTask.get(), &Task::succeeded, this,
-            [this, resolveTask]() {
-                const Flame::Manifest& results = resolveTask->getResults();
+    connect(resolveTask.get(), &Task::succeeded, this, [this, resolveTask]() {
+        const Flame::Manifest& results = resolveTask->getResults();
 
-                // check if we have the downloadUrl
-                for (const auto& resolvedFile : results.files)
-                {
-                    auto targetInfo =
-                        m_curseForgeFiles.value(resolvedFile.fileId);
+        // check if we have the downloadUrl
+        for (const auto& resolvedFile : results.files) {
+            auto targetInfo = m_curseForgeFiles.value(resolvedFile.fileId);
 
-                    // mod is blocked and there is no Modrinth alternative
-                    if (resolvedFile.version.downloadUrl.isEmpty())
-                    {
-                        qDebug() << "Skipping blocked mod:" << targetInfo.fileToRemove;
-                        continue;
-                    }
+            // mod is blocked and there is no Modrinth alternative
+            if (resolvedFile.version.downloadUrl.isEmpty()) {
+                qDebug() << "Skipping blocked mod:" << targetInfo.fileToRemove;
+                continue;
+            }
 
-                    // URL is valid so it's safe to offload
-                    if (QFile::remove(targetInfo.fileToRemove))
-                    {
-                        m_filesFreed++;
-                        m_bytesFreed += targetInfo.fileSize;
-                        qDebug() << "Offloaded CurseForge file:" << targetInfo.fileToRemove;
-                    }
-                    else {
-                        qDebug() << "Failed to offload CurseForge file:"
-                            << targetInfo.fileToRemove;
-                    }
-                }
+            // URL is valid so it's safe to offload
+            if (QFile::remove(targetInfo.fileToRemove)) {
+                m_filesFreed++;
+                m_bytesFreed += targetInfo.fileSize;
+                qDebug() << "Offloaded CurseForge file:" << targetInfo.fileToRemove;
+            } else {
+                qDebug() << "Failed to offload CurseForge file:" << targetInfo.fileToRemove;
+            }
+        }
 
-                finishOffload();
-            });
+        finishOffload();
+    });
 
-    connect(resolveTask.get(), &Task::failed, this,
-            [this](const QString& reason) {
-                // Modrinth or CurseForge files could have been deleted, flag as offloaded
-                m_instance->setOffloadedDisabledFiles(m_disabledFiles);
-                m_instance->setOffloaded(true);
+    connect(resolveTask.get(), &Task::failed, this, [this](const QString& reason) {
+        // Modrinth or CurseForge files could have been deleted, flag as offloaded
+        m_instance->setOffloadedDisabledFiles(m_disabledFiles);
+        m_instance->setOffloaded(true);
 
-                emitFailed(tr("Failed to resolve CurseForge files: %1").arg(reason));
-            });
+        emitFailed(tr("Failed to resolve CurseForge files: %1").arg(reason));
+    });
 
     connect(resolveTask.get(), &Task::progress, this, &Task::setProgress);
     connect(resolveTask.get(), &Task::status, this, &Task::setStatus);
 
     resolveTask->start();
-
 }
-
 
 void OffloadInstanceTask::finishOffload()
 {
@@ -219,9 +178,7 @@ void OffloadInstanceTask::finishOffload()
     // Delay emitSucceeded() to the next event loop iteration.
     // If the task completes synchronously, the ProgressDialog gets destroyed too quickly,
     // which leaves the main window dimmed until the next input event.
-    QTimer::singleShot(0, this, [this]() {
-        emitSucceeded();
-    });
+    QTimer::singleShot(0, this, [this]() { emitSucceeded(); });
 }
 
 int OffloadInstanceTask::filesFreed() const

--- a/launcher/OffloadInstanceTask.cpp
+++ b/launcher/OffloadInstanceTask.cpp
@@ -30,7 +30,7 @@ void OffloadInstanceTask::executeTask()
 void OffloadInstanceTask::processResourceFolder(const QString& folderName)
 {
     const QString resourcePath = FS::PathCombine(m_instance->instanceRoot(), "minecraft", folderName);
-    
+
     QString indexPath;
     if (folderName == "shaderpacks") {
         indexPath = resourcePath;
@@ -57,26 +57,46 @@ void OffloadInstanceTask::processResourceFolder(const QString& folderName)
             continue;
         }
 
+        QString fileToRemove;
+        QFileInfo fileToRemoveInfo;
+
         const QString targetFile = FS::PathCombine(resourcePath, mod.filename);
         QFileInfo targetFileInfo(targetFile);
-        if(!targetFileInfo.exists()){
-            // already missing or offloaded
-            qDebug() << "Attempting to offload a file that doesn't exist. Skipping.";
-            continue;
+        if (targetFileInfo.exists())
+        {
+            fileToRemove = targetFile;
+            fileToRemoveInfo = targetFileInfo;
+        }
+        else
+        {
+            // Check if the file is disabled
+            const QString disabledFile = targetFile + ".disabled";
+            QFileInfo disabledFileInfo(disabledFile);
+            if (disabledFileInfo.exists()) {
+                fileToRemove = disabledFile;
+                fileToRemoveInfo = disabledFileInfo;
+
+                m_disabledFiles.append(mod.filename);
+            }
+            else
+            {
+                continue;
+            }
         }
 
-        qint64 size = targetFileInfo.size();
+
+        qint64 size = fileToRemoveInfo.size();
         if (mod.mode == "url" && !mod.url.isEmpty())
         {
             // Modrinth
-            if (QFile::remove(targetFile))
+            if (QFile::remove(fileToRemove))
             {
                 m_filesFreed++;
                 m_bytesFreed += size;
-                qDebug() << "Offloading file: " << targetFile;
+                qDebug() << "Offloading file: " << fileToRemove;
             }
             else {
-                qWarning() << "Failed to remove offloaded file:" << targetFile;
+                qWarning() << "Failed to remove offloaded file:" << fileToRemove;
             }
         }
         else if (mod.mode == "metadata:curseforge")
@@ -85,7 +105,7 @@ void OffloadInstanceTask::processResourceFolder(const QString& folderName)
             m_curseForgeFiles.insert(mod.file_id.toInt(),
                     CurseForgeOffloadTarget {
                     .projectId = mod.project_id.toInt(),
-                    .targetFile = targetFile,
+                    .fileToRemove = fileToRemove,
                     .fileSize = size});
         }
         else
@@ -138,20 +158,20 @@ void OffloadInstanceTask::resolveCurseForgeFiles()
                     // mod is blocked and there is no Modrinth alternative
                     if (resolvedFile.version.downloadUrl.isEmpty())
                     {
-                        qDebug() << "Skipping blocked mod:" << targetInfo.targetFile;
+                        qDebug() << "Skipping blocked mod:" << targetInfo.fileToRemove;
                         continue;
                     }
 
                     // URL is valid so it's safe to offload
-                    if (QFile::remove(targetInfo.targetFile))
+                    if (QFile::remove(targetInfo.fileToRemove))
                     {
                         m_filesFreed++;
                         m_bytesFreed += targetInfo.fileSize;
-                        qDebug() << "Offloaded CurseForge file:" << targetInfo.targetFile;
+                        qDebug() << "Offloaded CurseForge file:" << targetInfo.fileToRemove;
                     }
                     else {
                         qDebug() << "Failed to offload CurseForge file:"
-                            << targetInfo.targetFile;
+                            << targetInfo.fileToRemove;
                     }
                 }
 
@@ -160,6 +180,10 @@ void OffloadInstanceTask::resolveCurseForgeFiles()
 
     connect(resolveTask.get(), &Task::failed, this,
             [this](const QString& reason) {
+                // Modrinth or CurseForge files could have been deleted, flag as offloaded
+                m_instance->setOffloadedDisabledFiles(m_disabledFiles);
+                m_instance->setOffloaded(true);
+
                 emitFailed(tr("Failed to resolve CurseForge files: %1").arg(reason));
             });
 
@@ -173,7 +197,9 @@ void OffloadInstanceTask::resolveCurseForgeFiles()
 
 void OffloadInstanceTask::finishOffload()
 {
+    m_instance->setOffloadedDisabledFiles(m_disabledFiles);
     m_instance->setOffloaded(true);
+
     qDebug() << "Offload Complete. Freed" << m_filesFreed << "files (" << m_bytesFreed << ") bytes";
 
     // Delay emitSucceeded() to the next event loop iteration.

--- a/launcher/OffloadInstanceTask.h
+++ b/launcher/OffloadInstanceTask.h
@@ -2,6 +2,7 @@
 
 #include "tasks/Task.h"
 
+#include <QStringList>
 #include <QMap>
 #include <memory>
 class BaseInstance;
@@ -21,12 +22,9 @@ class OffloadInstanceTask : public Task
         struct CurseForgeOffloadTarget
         {
             int projectId;
-            QString targetFile;
+            QString fileToRemove;
             qint64 fileSize;
         };
-        void processResourceFolder(const QString& folderName);
-        void resolveCurseForgeFiles();
-        void finishOffload();
 
         BaseInstance* m_instance;
         std::shared_ptr<Task> m_flameApiJob;
@@ -36,4 +34,10 @@ class OffloadInstanceTask : public Task
 
         // Maps curseforge file ID to the offload target struct
         QMap<int, CurseForgeOffloadTarget> m_curseForgeFiles;
+        QStringList m_disabledFiles;
+
+        void processResourceFolder(const QString& folderName);
+        void resolveCurseForgeFiles();
+        void finishOffload();
+
 };

--- a/launcher/OffloadInstanceTask.h
+++ b/launcher/OffloadInstanceTask.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "tasks/Task.h"
+
+#include <QMap>
+#include <memory>
+class BaseInstance;
+
+class OffloadInstanceTask : public Task
+{
+     Q_OBJECT
+    public:
+        explicit OffloadInstanceTask(BaseInstance* instance);
+        ~OffloadInstanceTask() override = default;
+
+    protected:
+        void executeTask() override;
+
+    private:
+
+        struct CurseForgeOffloadTarget
+        {
+            int projectId;
+            QString targetFile;
+            qint64 fileSize;
+        };
+        void processResourceFolder(const QString& folderName);
+        void resolveCurseForgeFiles();
+        void finishOffload();
+
+        BaseInstance* m_instance;
+        std::shared_ptr<Task> m_flameApiJob;
+
+        int m_filesFreed = 0;
+        qint64 m_bytesFreed = 0;
+
+        // Maps curseforge file ID to the offload target struct
+        QMap<int, CurseForgeOffloadTarget> m_curseForgeFiles;
+};

--- a/launcher/OffloadInstanceTask.h
+++ b/launcher/OffloadInstanceTask.h
@@ -2,45 +2,41 @@
 
 #include "tasks/Task.h"
 
-#include <QStringList>
 #include <QMap>
+#include <QStringList>
 #include <memory>
 class BaseInstance;
 
-class OffloadInstanceTask : public Task
-{
-     Q_OBJECT
-    public:
-        explicit OffloadInstanceTask(BaseInstance* instance);
-        ~OffloadInstanceTask() override = default;
+class OffloadInstanceTask : public Task {
+    Q_OBJECT
+   public:
+    explicit OffloadInstanceTask(BaseInstance* instance);
+    ~OffloadInstanceTask() override = default;
 
-        int filesFreed() const;
-        qint64 bytesFreed() const;
+    int filesFreed() const;
+    qint64 bytesFreed() const;
 
-    protected:
-        void executeTask() override;
+   protected:
+    void executeTask() override;
 
-    private:
+   private:
+    struct CurseForgeOffloadTarget {
+        int projectId;
+        QString fileToRemove;
+        qint64 fileSize;
+    };
 
-        struct CurseForgeOffloadTarget
-        {
-            int projectId;
-            QString fileToRemove;
-            qint64 fileSize;
-        };
+    BaseInstance* m_instance;
+    std::shared_ptr<Task> m_flameApiJob;
 
-        BaseInstance* m_instance;
-        std::shared_ptr<Task> m_flameApiJob;
+    int m_filesFreed = 0;
+    qint64 m_bytesFreed = 0;
 
-        int m_filesFreed = 0;
-        qint64 m_bytesFreed = 0;
+    // Maps curseforge file ID to the offload target struct
+    QMap<int, CurseForgeOffloadTarget> m_curseForgeFiles;
+    QStringList m_disabledFiles;
 
-        // Maps curseforge file ID to the offload target struct
-        QMap<int, CurseForgeOffloadTarget> m_curseForgeFiles;
-        QStringList m_disabledFiles;
-
-        void processResourceFolder(const QString& folderName);
-        void resolveCurseForgeFiles();
-        void finishOffload();
-
+    void processResourceFolder(const QString& folderName);
+    void resolveCurseForgeFiles();
+    void finishOffload();
 };

--- a/launcher/OffloadInstanceTask.h
+++ b/launcher/OffloadInstanceTask.h
@@ -14,6 +14,9 @@ class OffloadInstanceTask : public Task
         explicit OffloadInstanceTask(BaseInstance* instance);
         ~OffloadInstanceTask() override = default;
 
+        int filesFreed() const;
+        qint64 bytesFreed() const;
+
     protected:
         void executeTask() override;
 

--- a/launcher/RestoreInstanceTask.cpp
+++ b/launcher/RestoreInstanceTask.cpp
@@ -3,9 +3,35 @@
 #include "BaseInstance.h"
 #include "FileSystem.h"
 #include "modplatform/flame/FileResolvingTask.h"
+#include "modplatform/helpers/HashUtils.h"
 #include "modplatform/packwiz/Packwiz.h"
 #include "net/ApiRequest.h"
 #include "net/ChecksumValidator.h"
+
+namespace {
+void addDownloadHashValidator(const Net::NetRequest::Ptr& action, const QString& hashFormat, const QString& hash)
+{
+    switch (Hashing::algorithmFromString(hashFormat)) {
+        case Hashing::Algorithm::Md4:
+            action->addValidator(new Net::ChecksumValidator(QCryptographicHash::Algorithm::Md4, hash));
+            break;
+        case Hashing::Algorithm::Md5:
+            action->addValidator(new Net::ChecksumValidator(QCryptographicHash::Algorithm::Md5, hash));
+            break;
+        case Hashing::Algorithm::Sha1:
+            action->addValidator(new Net::ChecksumValidator(QCryptographicHash::Algorithm::Sha1, hash));
+            break;
+        case Hashing::Algorithm::Sha256:
+            action->addValidator(new Net::ChecksumValidator(QCryptographicHash::Algorithm::Sha256, hash));
+            break;
+        case Hashing::Algorithm::Sha512:
+            action->addValidator(new Net::ChecksumValidator(QCryptographicHash::Algorithm::Sha512, hash));
+            break;
+        default:
+            break;
+    }
+}
+}  // namespace
 
 RestoreInstanceTask::RestoreInstanceTask(BaseInstance* instance) : Task(true), m_instance(instance)
 {
@@ -18,6 +44,8 @@ void RestoreInstanceTask::executeTask()
     qDebug() << "Starting Restore for offloaded instance.";
     NetJob::Ptr job{ new NetJob(tr("Restoring offloaded files"), APPLICATION->network()) };
     m_netJob.reset(job);
+
+    m_disabledFilenames = m_instance->getOffloadedDisabledFiles();
 
     // Manifest for all the curseforge files
     Flame::Manifest cfManifest;
@@ -39,7 +67,7 @@ void RestoreInstanceTask::executeTask()
 void RestoreInstanceTask::restoreResourceFolder(const QString& folderName, Flame::Manifest& manifest)
 {
     const QString resourcePath = FS::PathCombine(m_instance->instanceRoot(), "minecraft", folderName);
-    
+
     QString indexPath;
     if (folderName == "shaderpacks") {
         indexPath = resourcePath;
@@ -69,20 +97,24 @@ void RestoreInstanceTask::restoreResourceFolder(const QString& folderName, Flame
             continue;
         }
 
-        const QString targetFile = FS::PathCombine(resourcePath, mod.filename);
+        bool isDisabled = false;
+        QString targetFile;
+        if (m_disabledFilenames.contains(mod.filename))
+        {
+            // Resource is disabled
+            targetFile = FS::PathCombine(resourcePath, mod.filename + ".disabled");
+            isDisabled = true;
+        }
+        else {
+            targetFile = FS::PathCombine(resourcePath, mod.filename);
+        }
 
         // Modrinth
         if (mod.mode == "url" && !mod.url.isEmpty()) {
             auto action = Net::ApiRequest::makeFile(mod.url.toString(), targetFile);
 
             // validate the download if we have the hash
-            if (!mod.hash.isEmpty()) {
-                if (mod.hash_format == "sha1") {
-                    action->addValidator(new Net::ChecksumValidator(QCryptographicHash::Algorithm::Sha1, mod.hash));
-                } else if (mod.hash_format == "sha512") {
-                    action->addValidator(new Net::ChecksumValidator(QCryptographicHash::Algorithm::Sha512, mod.hash));
-                }
-            }
+            addDownloadHashValidator(action, mod.hash_format, mod.hash);
 
             m_netJob->addNetAction(action);
 
@@ -92,6 +124,10 @@ void RestoreInstanceTask::restoreResourceFolder(const QString& folderName, Flame
             cfFile.fileId = mod.file_id.toInt();
             cfFile.targetFolder = resourcePath;
             manifest.files.insert(cfFile.fileId, cfFile);
+
+            if (isDisabled) {
+                m_disabledCFFileIds.insert(cfFile.fileId);
+            }
         } else {
             qDebug() << "Unexpected mod mode when restoring: " << mod.name;
         }
@@ -116,7 +152,16 @@ void RestoreInstanceTask::resolveCurseForgeFiles(Flame::Manifest& manifest)
 
         for (const auto& result : results.files) {
             // get file path
-            const QString targetPath = FS::PathCombine(result.targetFolder, result.version.fileName);
+            QString fileName;
+            if (m_disabledCFFileIds.contains(result.fileId))
+            {
+                fileName = result.version.fileName + ".disabled";
+            }
+            else {
+                fileName = result.version.fileName;
+            }
+
+            const QString targetPath = FS::PathCombine(result.targetFolder, fileName);
 
             if (result.version.downloadUrl.isEmpty()) {
                 qDebug() << "Skipping file with empty download URL (likely a blocked mod with no Modrinth fallback):" << targetPath;
@@ -124,6 +169,10 @@ void RestoreInstanceTask::resolveCurseForgeFiles(Flame::Manifest& manifest)
             }
 
             auto action = Net::ApiRequest::makeFile(result.version.downloadUrl, targetPath);
+
+            // validate
+            addDownloadHashValidator(action, result.version.hash_type, result.version.hash);
+
             m_netJob->addNetAction(action);
             qDebug() << "Added action to file:" << targetPath;
         }

--- a/launcher/RestoreInstanceTask.cpp
+++ b/launcher/RestoreInstanceTask.cpp
@@ -1,4 +1,5 @@
 #include "RestoreInstanceTask.h"
+#include <QFileInfo>
 #include "Application.h"
 #include "BaseInstance.h"
 #include "FileSystem.h"
@@ -7,7 +8,6 @@
 #include "modplatform/packwiz/Packwiz.h"
 #include "net/ApiRequest.h"
 #include "net/ChecksumValidator.h"
-#include <QFileInfo>
 
 namespace {
 void addDownloadHashValidator(const Net::NetRequest::Ptr& action, const QString& hashFormat, const QString& hash)
@@ -43,7 +43,7 @@ void RestoreInstanceTask::executeTask()
 {
     setStatus(tr("Restoring offloaded instance..."));
     qDebug() << "Starting Restore for offloaded instance.";
-    NetJob::Ptr job{ new NetJob(tr("Restoring offloaded files"), APPLICATION->network()) };
+    const NetJob::Ptr job{ new NetJob(tr("Restoring offloaded files"), APPLICATION->network()) };
     m_netJob.reset(job);
 
     m_disabledFilenames = m_instance->getOffloadedDisabledFiles();
@@ -76,15 +76,14 @@ void RestoreInstanceTask::restoreResourceFolder(const QString& folderName, Flame
         indexPath = FS::PathCombine(resourcePath, ".index");
     }
 
-    QDir indexDir(indexPath);
+    const QDir indexDir(indexPath);
     if (!indexDir.exists()) {
         qDebug() << "Attempting to restore resource folder with no .index directory:" << indexPath << "does not exist. Skipping.";
         return;
     }
 
     const auto indexFiles = indexDir.entryList({ "*.pw.toml" }, QDir::Files);
-    if (indexFiles.count() == 0)
-    {
+    if (indexFiles.count() == 0) {
         qDebug() << "Metadata directory exists but has no entries. Skipping.";
         return;
     }
@@ -100,19 +99,16 @@ void RestoreInstanceTask::restoreResourceFolder(const QString& folderName, Flame
 
         bool isDisabled = false;
         QString targetFile;
-        if (m_disabledFilenames.contains(mod.filename))
-        {
+        if (m_disabledFilenames.contains(mod.filename)) {
             // Resource is disabled
             targetFile = FS::PathCombine(resourcePath, mod.filename + ".disabled");
             isDisabled = true;
-        }
-        else {
+        } else {
             targetFile = FS::PathCombine(resourcePath, mod.filename);
         }
 
         // Handles symlink and adds general robustness
-        if (QFileInfo(targetFile).exists())
-        {
+        if (QFileInfo(targetFile).exists()) {
             qDebug() << "File:" << targetFile << "already exists. Skipping.";
             continue;
         }
@@ -161,11 +157,9 @@ void RestoreInstanceTask::resolveCurseForgeFiles(Flame::Manifest& manifest)
         for (const auto& result : results.files) {
             // get file path
             QString fileName;
-            if (m_disabledCFFileIds.contains(result.fileId))
-            {
+            if (m_disabledCFFileIds.contains(result.fileId)) {
                 fileName = result.version.fileName + ".disabled";
-            }
-            else {
+            } else {
                 fileName = result.version.fileName;
             }
 

--- a/launcher/RestoreInstanceTask.cpp
+++ b/launcher/RestoreInstanceTask.cpp
@@ -7,6 +7,7 @@
 #include "modplatform/packwiz/Packwiz.h"
 #include "net/ApiRequest.h"
 #include "net/ChecksumValidator.h"
+#include <QFileInfo>
 
 namespace {
 void addDownloadHashValidator(const Net::NetRequest::Ptr& action, const QString& hashFormat, const QString& hash)
@@ -107,6 +108,13 @@ void RestoreInstanceTask::restoreResourceFolder(const QString& folderName, Flame
         }
         else {
             targetFile = FS::PathCombine(resourcePath, mod.filename);
+        }
+
+        // Handles symlink and adds general robustness
+        if (QFileInfo(targetFile).exists())
+        {
+            qDebug() << "File:" << targetFile << "already exists. Skipping.";
+            continue;
         }
 
         // Modrinth

--- a/launcher/RestoreInstanceTask.cpp
+++ b/launcher/RestoreInstanceTask.cpp
@@ -1,0 +1,168 @@
+#include "RestoreInstanceTask.h"
+#include "Application.h"
+#include "BaseInstance.h"
+#include "FileSystem.h"
+#include "modplatform/flame/FileResolvingTask.h"
+#include "modplatform/packwiz/Packwiz.h"
+#include "net/ApiRequest.h"
+#include "net/ChecksumValidator.h"
+
+RestoreInstanceTask::RestoreInstanceTask(BaseInstance* instance) : Task(true), m_instance(instance)
+{
+    setAbortable(true);
+}
+
+void RestoreInstanceTask::executeTask()
+{
+    setStatus(tr("Restoring offloaded instance..."));
+    qDebug() << "Starting Restore for offloaded instance.";
+    NetJob::Ptr job{ new NetJob(tr("Restoring offloaded files"), APPLICATION->network()) };
+    m_netJob.reset(job);
+
+    // Manifest for all the curseforge files
+    Flame::Manifest cfManifest;
+
+    restoreResourceFolder("mods", cfManifest);
+    restoreResourceFolder("resourcepacks", cfManifest);
+    restoreResourceFolder("shaderpacks", cfManifest);
+
+    // Resolve CurseForge files
+    if (!cfManifest.files.isEmpty()) {
+        resolveCurseForgeFiles(cfManifest);
+    } else {
+        // No CurseForge files, just start the download job
+        qDebug() << "No CurseForge Files, starting download job.";
+        startDownloadJob();
+    }
+}
+
+void RestoreInstanceTask::restoreResourceFolder(const QString& folderName, Flame::Manifest& manifest)
+{
+    const QString resourcePath = FS::PathCombine(m_instance->instanceRoot(), "minecraft", folderName);
+    
+    QString indexPath;
+    if (folderName == "shaderpacks") {
+        indexPath = resourcePath;
+    } else {
+        indexPath = FS::PathCombine(resourcePath, ".index");
+    }
+
+    QDir indexDir(indexPath);
+    if (!indexDir.exists()) {
+        qDebug() << "Attempting to restore resource folder with no .index directory:" << indexPath << "does not exist. Skipping.";
+        return;
+    }
+
+    const auto indexFiles = indexDir.entryList({ "*.pw.toml" }, QDir::Files);
+    if (indexFiles.count() == 0)
+    {
+        qDebug() << "Metadata directory exists but has no entries. Skipping.";
+        return;
+    }
+
+    for (const auto& fileName : indexFiles) {
+        QString stripped = fileName;
+        stripped.remove(".pw.toml");
+
+        auto mod = Packwiz::V1::getIndexForMod(indexPath, stripped);
+        if (!mod.isValid()) {
+            continue;
+        }
+
+        const QString targetFile = FS::PathCombine(resourcePath, mod.filename);
+
+        // Modrinth
+        if (mod.mode == "url" && !mod.url.isEmpty()) {
+            auto action = Net::ApiRequest::makeFile(mod.url.toString(), targetFile);
+
+            // validate the download if we have the hash
+            if (!mod.hash.isEmpty()) {
+                if (mod.hash_format == "sha1") {
+                    action->addValidator(new Net::ChecksumValidator(QCryptographicHash::Algorithm::Sha1, mod.hash));
+                } else if (mod.hash_format == "sha512") {
+                    action->addValidator(new Net::ChecksumValidator(QCryptographicHash::Algorithm::Sha512, mod.hash));
+                }
+            }
+
+            m_netJob->addNetAction(action);
+
+        } else if (mod.mode == "metadata:curseforge") {
+            Flame::File cfFile;
+            cfFile.projectId = mod.project_id.toInt();
+            cfFile.fileId = mod.file_id.toInt();
+            cfFile.targetFolder = resourcePath;
+            manifest.files.insert(cfFile.fileId, cfFile);
+        } else {
+            qDebug() << "Unexpected mod mode when restoring: " << mod.name;
+        }
+    }
+}
+
+void RestoreInstanceTask::resolveCurseForgeFiles(Flame::Manifest& manifest)
+{
+    if (manifest.files.isEmpty()) {
+        qDebug() << "CurseForge manifest is empty. No files to restore.";
+        return;
+    }
+
+    setStatus(tr("Resolving CurseForge URLs..."));
+    qDebug() << "Resolving CurseForge files.";
+
+    auto resolveTask = std::make_shared<Flame::FileResolvingTask>(manifest);
+    m_resolveTask = resolveTask;
+
+    connect(resolveTask.get(), &Task::succeeded, this, [this, resolveTask]() {
+        auto results = resolveTask->getResults();
+
+        for (const auto& result : results.files) {
+            // get file path
+            const QString targetPath = FS::PathCombine(result.targetFolder, result.version.fileName);
+
+            if (result.version.downloadUrl.isEmpty()) {
+                qDebug() << "Skipping file with empty download URL (likely a blocked mod with no Modrinth fallback):" << targetPath;
+                continue;
+            }
+
+            auto action = Net::ApiRequest::makeFile(result.version.downloadUrl, targetPath);
+            m_netJob->addNetAction(action);
+            qDebug() << "Added action to file:" << targetPath;
+        }
+
+        startDownloadJob();
+    });
+
+    connect(resolveTask.get(), &Task::failed, this,
+            [this](const QString& reason) { emitFailed(tr("Failed to resolve CurseForge files: %1").arg(reason)); });
+
+    resolveTask->start();
+}
+
+void RestoreInstanceTask::startDownloadJob()
+{
+    setStatus(tr("Downloading offloaded files..."));
+
+    // in the chance that there is no action (all blocked mods?)
+    if (m_netJob->size() == 0) {
+        qDebug() << "NetJob has nothing to do. No files to restore.";
+        emitSucceeded();
+        return;
+    }
+
+    connect(m_netJob.get(), &NetJob::progress, this, &Task::setProgress);
+    connect(m_netJob.get(), &NetJob::succeeded, this, &RestoreInstanceTask::emitSucceeded);
+    connect(m_netJob.get(), &NetJob::failed, this,
+            [this](const QString& reason) { emitFailed(tr("Failed to download restored files: %1").arg(reason)); });
+
+    m_netJob->start();
+}
+
+bool RestoreInstanceTask::abort()
+{
+    if (m_resolveTask) {
+        m_resolveTask->abort();
+    }
+    if (m_netJob) {
+        m_netJob->abort();
+    }
+    return Task::abort();
+}

--- a/launcher/RestoreInstanceTask.h
+++ b/launcher/RestoreInstanceTask.h
@@ -4,6 +4,9 @@
 #include "net/NetJob.h"
 #include "tasks/Task.h"
 
+#include <QStringList>
+#include <QSet>
+
 class BaseInstance;
 
 class RestoreInstanceTask : public Task
@@ -22,6 +25,9 @@ private:
     BaseInstance* m_instance;
     NetJob::Ptr m_netJob;
     std::shared_ptr<Task> m_resolveTask;
+
+    QStringList m_disabledFilenames;
+    QSet<int> m_disabledCFFileIds;
 
     void restoreResourceFolder(const QString& folderName, Flame::Manifest& manifest);
     void resolveCurseForgeFiles(Flame::Manifest& manifest);

--- a/launcher/RestoreInstanceTask.h
+++ b/launcher/RestoreInstanceTask.h
@@ -4,24 +4,23 @@
 #include "net/NetJob.h"
 #include "tasks/Task.h"
 
-#include <QStringList>
 #include <QSet>
+#include <QStringList>
 
 class BaseInstance;
 
-class RestoreInstanceTask : public Task
-{
+class RestoreInstanceTask : public Task {
     Q_OBJECT
-public:
+   public:
     explicit RestoreInstanceTask(BaseInstance* instance);
     ~RestoreInstanceTask() override = default;
 
-protected:
+   protected:
     void executeTask() override;
 
     bool abort() override;
 
-private:
+   private:
     BaseInstance* m_instance;
     NetJob::Ptr m_netJob;
     std::shared_ptr<Task> m_resolveTask;

--- a/launcher/RestoreInstanceTask.h
+++ b/launcher/RestoreInstanceTask.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "modplatform/flame/PackManifest.h"
+#include "net/NetJob.h"
+#include "tasks/Task.h"
+
+class BaseInstance;
+
+class RestoreInstanceTask : public Task
+{
+    Q_OBJECT
+public:
+    explicit RestoreInstanceTask(BaseInstance* instance);
+    ~RestoreInstanceTask() override = default;
+
+protected:
+    void executeTask() override;
+
+    bool abort() override;
+
+private:
+    BaseInstance* m_instance;
+    NetJob::Ptr m_netJob;
+    std::shared_ptr<Task> m_resolveTask;
+
+    void restoreResourceFolder(const QString& folderName, Flame::Manifest& manifest);
+    void resolveCurseForgeFiles(Flame::Manifest& manifest);
+    void startDownloadJob();
+};

--- a/launcher/minecraft/mod/Resource.cpp
+++ b/launcher/minecraft/mod/Resource.cpp
@@ -306,6 +306,11 @@ bool Resource::isSymLinkUnder(const QString& instPath) const
         return true;
     }
 
+    // Don't treat a missing file as a symlink.
+    if (!m_fileInfo.exists()) {
+        return false;
+    }
+
     auto instDir = QDir(instPath);
 
     auto relAbsPath = instDir.relativeFilePath(m_fileInfo.absoluteFilePath());

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -583,6 +583,10 @@ QVariant ResourceFolderModel::data(const QModelIndex& index, int role) const
                 if (at(row).isMoreThanOneHardLink()) {
                     tooltip += tr("\nWarning: This resource is hard linked elsewhere. Editing it will also change the original.");
                 }
+
+                if (instance()->isOffloaded() && !at(row).fileinfo().exists()) {
+                    tooltip += tr("\nOffloaded — this resource will be re-downloaded when the instance is restored.");
+                }
             }
 
             return tooltip;
@@ -604,6 +608,8 @@ QVariant ResourceFolderModel::data(const QModelIndex& index, int role) const
                 return m_resources[row]->enabled() ? Qt::Checked : Qt::Unchecked;
             }
             return {};
+        case OffloadedRole:
+            return instance()->isOffloaded() && !m_resources[row]->fileinfo().exists();
         default:
             return {};
     }

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -439,7 +439,12 @@ void ResourceFolderModel::onParseSucceeded(int ticket, const QString& resourceId
 Task* ResourceFolderModel::createUpdateTask()
 {
     auto indexDir2 = indexDir();
-    auto* task = new ResourceFolderLoadTask(dir(), indexDir2, m_isIndexed, m_firstFolderLoad,
+    bool shouldCleanOrphan = m_firstFolderLoad;
+    if (m_instance && m_instance->isOffloaded()) {
+        shouldCleanOrphan = false;
+    }
+
+    auto* task = new ResourceFolderLoadTask(dir(), indexDir2, m_isIndexed, shouldCleanOrphan,
                                             [this](const QFileInfo& file) { return createResource(file); });
     m_firstFolderLoad = false;
     return task;

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -609,7 +609,7 @@ QVariant ResourceFolderModel::data(const QModelIndex& index, int role) const
             }
             return {};
         case OffloadedRole:
-            return instance()->isOffloaded() && !m_resources[row]->fileinfo().exists();
+            return instance()->isOffloaded() && !at(row).fileinfo().exists();
         default:
             return {};
     }

--- a/launcher/minecraft/mod/ResourceFolderModel.h
+++ b/launcher/minecraft/mod/ResourceFolderModel.h
@@ -140,6 +140,9 @@ class ResourceFolderModel : public QAbstractListModel {
     /* Basic columns */
     enum Columns : std::uint8_t { ActiveColumn = 0, NameColumn, DateColumn, ProviderColumn, SizeColumn, FileNameColumn, NumColumns };
 
+    /* Custom roles */
+    enum Roles { OffloadedRole = Qt::UserRole };
+
     QStringList columnNames(bool translated = true) const { return translated ? m_columnNamesTranslated : m_columnNames; }
 
     int rowCount(const QModelIndex& parent = {}) const override { return parent.isValid() ? 0 : static_cast<int>(size()); }

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -1565,8 +1565,7 @@ void MainWindow::on_actionOffloadInstance_triggered()
     }
 
     std::unique_ptr<Task> task(new OffloadInstanceTask(m_selectedInstance));
-    connect(task.get(), &Task::succeeded, this, [this]() {
-        // Redraw instance view
+    connect(task.get(), &Task::finished, this, [this](){
         view->viewport()->update();
     });
 

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -41,6 +41,7 @@
 #include "Application.h"
 #include "BuildConfig.h"
 #include "FileSystem.h"
+#include "StringUtils.h"
 
 #include "MainWindow.h"
 #include "ui_MainWindow.h"
@@ -106,6 +107,7 @@
 #include "ui/dialogs/NewsDialog.h"
 #include "ui/dialogs/ProgressDialog.h"
 #include "OffloadInstanceTask.h"
+#include "RestoreInstanceTask.h"
 #include "ui/dialogs/skins/SkinManageDialog.h"
 #include "ui/instanceview/InstanceDelegate.h"
 #include "ui/instanceview/InstanceProxyModel.h"
@@ -1544,14 +1546,15 @@ void MainWindow::on_actionOffloadInstance_triggered()
     }
 
     if (m_selectedInstance->isRunning()) {
-        CustomMessageBox::selectable(this, tr("Cannot Offload Running Instance"),
-                                     tr("The selected instance is currently running and cannot be offloaded. Please stop the instance before attempting to offload it."),
+        CustomMessageBox::selectable(this, tr("Cannot Offload or Restore Running Instance"),
+                                     tr("The selected instance is currently running and cannot be offloaded or restored. Please stop the instance before continuing."),
                                      QMessageBox::Warning, QMessageBox::Ok)->exec();
         return;
     }
 
     if (m_selectedInstance->isOffloaded()) {
-        return; // Already offloaded
+        restoreOffloadedInstance();
+        return;
     }
 
     auto response = CustomMessageBox::selectable(this, tr("Confirm Offload"),
@@ -1564,14 +1567,82 @@ void MainWindow::on_actionOffloadInstance_triggered()
         return;
     }
 
+    int filesFreed = 0;
+    qint64 bytesFreed = 0;
+    bool offloadSucceeded = false;
+
     std::unique_ptr<Task> task(new OffloadInstanceTask(m_selectedInstance));
-    connect(task.get(), &Task::finished, this, [this](){
+    auto* offloadTask = static_cast<OffloadInstanceTask*>(task.get());
+    connect(offloadTask, &Task::finished, this, [this, offloadTask, &filesFreed, &bytesFreed, &offloadSucceeded]() {
         view->viewport()->update();
+
+        if (offloadTask->wasSuccessful()) {
+            offloadSucceeded = true;
+            filesFreed = offloadTask->filesFreed();
+            bytesFreed = offloadTask->bytesFreed();
+        }
+        setOffloadActionState();
     });
 
     ProgressDialog progressDialog(this);
-    //progressDialog.setSkipButton(true, tr("Abort"));
     progressDialog.execWithTask(std::move(task));
+
+    if (offloadSucceeded) {
+        CustomMessageBox::selectable(this, tr("Offload Complete"),
+                                     tr("Offloaded %1 files, freeing %2 of disk space.")
+                                         .arg(filesFreed)
+                                         .arg(StringUtils::humanReadableFileSize(bytesFreed)),
+                                     QMessageBox::Information, QMessageBox::Ok)->exec();
+    }
+}
+
+void MainWindow::restoreOffloadedInstance()
+{
+    auto response = CustomMessageBox::selectable(this, tr("Confirm Restore"),
+                                                 tr("You are about to restore \"%1\".\n"
+                                                    "This will re-download the mods and resource packs that were offloaded.\n\n"
+                                                    "Are you sure?").arg(m_selectedInstance->name()),
+                                                 QMessageBox::Question, QMessageBox::Yes | QMessageBox::No, QMessageBox::No)->exec();
+
+    if (response != QMessageBox::Yes) {
+        return;
+    }
+
+    std::unique_ptr<Task> task(new RestoreInstanceTask(m_selectedInstance));
+    auto* restoreTask = task.get();
+    connect(restoreTask, &Task::finished, this, [this, restoreTask]() {
+        view->viewport()->update();
+
+        if (restoreTask->wasSuccessful()) {
+            m_selectedInstance->setOffloadedDisabledFiles(QStringList());
+            m_selectedInstance->setOffloaded(false);
+        }
+        setOffloadActionState();
+    });
+
+    ProgressDialog progressDialog(this);
+    progressDialog.execWithTask(std::move(task));
+}
+
+void MainWindow::setOffloadActionState()
+{
+    if (!m_selectedInstance) {
+        ui->actionOffloadInstance->setEnabled(false);
+        return;
+    }
+
+    const bool offloaded = m_selectedInstance->isOffloaded();
+    ui->actionOffloadInstance->setEnabled(offloaded || !m_selectedInstance->isRunning());
+
+    if (offloaded) {
+        ui->actionOffloadInstance->setText(tr("Restore..."));
+        ui->actionOffloadInstance->setIcon(QIcon::fromTheme("refresh"));
+        ui->actionOffloadInstance->setToolTip(tr("Restores offloaded files by re-downloading them for the selected instance."));
+    } else {
+        ui->actionOffloadInstance->setText(tr("Offload..."));
+        ui->actionOffloadInstance->setIcon(QIcon::fromTheme("delete"));
+        ui->actionOffloadInstance->setToolTip(tr("Offloads heavy mod files from the selected instance to free up disk space."));
+    }
 }
 
 void MainWindow::on_actionExportInstanceZip_triggered()
@@ -1722,7 +1793,7 @@ void MainWindow::instanceChanged(const QModelIndex& current, [[maybe_unused]] co
 
         ui->actionKillInstance->setEnabled(m_selectedInstance->isRunning());
         ui->actionExportInstance->setEnabled(m_selectedInstance->canExport());
-        ui->actionOffloadInstance->setEnabled(!m_selectedInstance->isOffloaded() && !m_selectedInstance->isRunning());
+        setOffloadActionState();
         renameButton->setText(m_selectedInstance->name());
         m_statusLeft->setText(m_selectedInstance->getStatusbarDescription());
         updateStatusCenter();
@@ -1826,7 +1897,7 @@ void MainWindow::setInstanceActionsEnabled(bool enabled)
     ui->actionDeleteInstance->setEnabled(enabled);
     ui->actionCopyInstance->setEnabled(enabled);
     ui->actionCreateInstanceShortcut->setEnabled(enabled);
-    ui->actionOffloadInstance->setEnabled(enabled && m_selectedInstance && !m_selectedInstance->isOffloaded());
+    setOffloadActionState();
 }
 
 void MainWindow::refreshCurrentInstance()

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -105,6 +105,7 @@
 #include "ui/dialogs/NewInstanceDialog.h"
 #include "ui/dialogs/NewsDialog.h"
 #include "ui/dialogs/ProgressDialog.h"
+#include "OffloadInstanceTask.h"
 #include "ui/dialogs/skins/SkinManageDialog.h"
 #include "ui/instanceview/InstanceDelegate.h"
 #include "ui/instanceview/InstanceProxyModel.h"
@@ -1536,6 +1537,44 @@ void MainWindow::on_actionDeleteInstance_triggered()
     selectionBad();
 }
 
+void MainWindow::on_actionOffloadInstance_triggered()
+{
+    if (!m_selectedInstance) {
+        return;
+    }
+
+    if (m_selectedInstance->isRunning()) {
+        CustomMessageBox::selectable(this, tr("Cannot Offload Running Instance"),
+                                     tr("The selected instance is currently running and cannot be offloaded. Please stop the instance before attempting to offload it."),
+                                     QMessageBox::Warning, QMessageBox::Ok)->exec();
+        return;
+    }
+
+    if (m_selectedInstance->isOffloaded()) {
+        return; // Already offloaded
+    }
+
+    auto response = CustomMessageBox::selectable(this, tr("Confirm Offload"),
+                                                 tr("You are about to offload \"%1\".\n"
+                                                    "This will delete downloaded mods and resource packs from disk, but keep the metadata needed to download them again.\n\n"
+                                                    "Are you sure?").arg(m_selectedInstance->name()),
+                                                 QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No, QMessageBox::No)->exec();
+
+    if (response != QMessageBox::Yes) {
+        return;
+    }
+
+    std::unique_ptr<Task> task(new OffloadInstanceTask(m_selectedInstance));
+    connect(task.get(), &Task::succeeded, this, [this]() {
+        // Redraw instance view
+        view->viewport()->update();
+    });
+
+    ProgressDialog progressDialog(this);
+    //progressDialog.setSkipButton(true, tr("Abort"));
+    progressDialog.execWithTask(std::move(task));
+}
+
 void MainWindow::on_actionExportInstanceZip_triggered()
 {
     if (m_selectedInstance) {
@@ -1680,10 +1719,11 @@ void MainWindow::instanceChanged(const QModelIndex& current, [[maybe_unused]] co
     if (m_selectedInstance) {
         ui->instanceToolBar->setEnabled(true);
         setInstanceActionsEnabled(true);
-        ui->actionLaunchInstance->setEnabled(m_selectedInstance->canLaunch());
+        ui->actionLaunchInstance->setEnabled(m_selectedInstance->canLaunch() || m_selectedInstance->isOffloaded());
 
         ui->actionKillInstance->setEnabled(m_selectedInstance->isRunning());
         ui->actionExportInstance->setEnabled(m_selectedInstance->canExport());
+        ui->actionOffloadInstance->setEnabled(!m_selectedInstance->isOffloaded() && !m_selectedInstance->isRunning());
         renameButton->setText(m_selectedInstance->name());
         m_statusLeft->setText(m_selectedInstance->getStatusbarDescription());
         updateStatusCenter();
@@ -1787,6 +1827,7 @@ void MainWindow::setInstanceActionsEnabled(bool enabled)
     ui->actionDeleteInstance->setEnabled(enabled);
     ui->actionCopyInstance->setEnabled(enabled);
     ui->actionCreateInstanceShortcut->setEnabled(enabled);
+    ui->actionOffloadInstance->setEnabled(enabled && m_selectedInstance && !m_selectedInstance->isOffloaded());
 }
 
 void MainWindow::refreshCurrentInstance()

--- a/launcher/ui/MainWindow.cpp
+++ b/launcher/ui/MainWindow.cpp
@@ -1591,7 +1591,7 @@ void MainWindow::on_actionOffloadInstance_triggered()
         CustomMessageBox::selectable(this, tr("Offload Complete"),
                                      tr("Offloaded %1 files, freeing %2 of disk space.")
                                          .arg(filesFreed)
-                                         .arg(StringUtils::humanReadableFileSize(bytesFreed)),
+                                         .arg(StringUtils::humanReadableFileSize(static_cast<double>(bytesFreed))),
                                      QMessageBox::Information, QMessageBox::Ok)->exec();
     }
 }

--- a/launcher/ui/MainWindow.h
+++ b/launcher/ui/MainWindow.h
@@ -165,6 +165,8 @@ class MainWindow : public QMainWindow {
     void on_actionExportInstanceFlamePack_triggered();
 
     void on_actionOffloadInstance_triggered();
+    void restoreOffloadedInstance();
+    void setOffloadActionState();
 
     void on_actionRenameInstance_triggered();
 

--- a/launcher/ui/MainWindow.h
+++ b/launcher/ui/MainWindow.h
@@ -164,6 +164,8 @@ class MainWindow : public QMainWindow {
     void on_actionExportInstanceMrPack_triggered();
     void on_actionExportInstanceFlamePack_triggered();
 
+    void on_actionOffloadInstance_triggered();
+
     void on_actionRenameInstance_triggered();
 
     void on_actionEditInstance_triggered();

--- a/launcher/ui/MainWindow.ui
+++ b/launcher/ui/MainWindow.ui
@@ -120,6 +120,7 @@
    <addaction name="actionEditInstance"/>
    <addaction name="actionChangeInstGroup"/>
    <addaction name="actionViewSelectedInstFolder"/>
+   <addaction name="actionOffloadInstance"/>
    <addaction name="actionExportInstance"/>
    <addaction name="actionCopyInstance"/>
    <addaction name="actionDeleteInstance"/>
@@ -149,6 +150,7 @@
     <addaction name="actionEditInstance"/>
     <addaction name="actionChangeInstGroup"/>
     <addaction name="actionViewSelectedInstFolder"/>
+    <addaction name="actionOffloadInstance"/>
     <addaction name="actionExportInstance"/>
     <addaction name="actionCopyInstance"/>
     <addaction name="actionDeleteInstance"/>
@@ -458,6 +460,17 @@
    </property>
    <property name="toolTip">
     <string>Export the selected instance to supported formats.</string>
+   </property>
+  </action>
+  <action name="actionOffloadInstance">
+   <property name="icon">
+    <iconset theme="clean"/>
+   </property>
+   <property name="text">
+    <string>Offload...</string>
+   </property>
+   <property name="toolTip">
+    <string>Offloads heavy mod files from the selected instance to free up disk space.</string>
    </property>
   </action>
   <action name="actionExportInstanceZip">

--- a/launcher/ui/MainWindow.ui
+++ b/launcher/ui/MainWindow.ui
@@ -464,7 +464,7 @@
   </action>
   <action name="actionOffloadInstance">
    <property name="icon">
-    <iconset theme="clean"/>
+    <iconset theme="delete"/>
    </property>
    <property name="text">
     <string>Offload...</string>

--- a/launcher/ui/instanceview/InstanceDelegate.cpp
+++ b/launcher/ui/instanceview/InstanceDelegate.cpp
@@ -134,6 +134,9 @@ void drawBadges(QPainter* painter, const QStyleOptionViewItem& option, BaseInsta
     if (instance->hasUpdateAvailable()) {
         pixmaps.append("checkupdate");
     }
+    if (instance->isOffloaded()) {
+        pixmaps.append("clean"); // pick a final icon
+    }
 
     static const int itemSide = 24;
     static const int spacing = 1;
@@ -182,6 +185,11 @@ void ListViewDelegate::paint(QPainter* painter, const QStyleOptionViewItem& opti
     initStyleOption(&opt, index);
     painter->save();
     painter->setClipRect(opt.rect);
+
+    auto inst = (BaseInstance*)index.data(InstanceList::InstancePointerRole).value<void*>();
+    if (inst && inst->isOffloaded()) {
+        painter->setOpacity(0.5);
+    }
 
     opt.features |= QStyleOptionViewItem::WrapText;
     opt.text = index.data().toString();

--- a/launcher/ui/instanceview/InstanceDelegate.cpp
+++ b/launcher/ui/instanceview/InstanceDelegate.cpp
@@ -186,7 +186,7 @@ void ListViewDelegate::paint(QPainter* painter, const QStyleOptionViewItem& opti
     painter->save();
     painter->setClipRect(opt.rect);
 
-    auto inst = (BaseInstance*)index.data(InstanceList::InstancePointerRole).value<void*>();
+    auto* inst = static_cast<BaseInstance*>(index.data(InstanceList::InstancePointerRole).value<void*>());
     if (inst && inst->isOffloaded()) {
         painter->setOpacity(0.5);
     }

--- a/launcher/ui/instanceview/InstanceDelegate.cpp
+++ b/launcher/ui/instanceview/InstanceDelegate.cpp
@@ -135,7 +135,7 @@ void drawBadges(QPainter* painter, const QStyleOptionViewItem& option, BaseInsta
         pixmaps.append("checkupdate");
     }
     if (instance->isOffloaded()) {
-        pixmaps.append("clean"); // pick a final icon
+        pixmaps.append("delete");
     }
 
     static const int itemSide = 24;

--- a/launcher/ui/pages/instance/ExternalResourcesPage.cpp
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.cpp
@@ -41,6 +41,7 @@
 #include "Version.h"
 #include "minecraft/mod/ResourceFolderModel.h"
 #include "ui/GuiUtil.h"
+#include "ui/widgets/ModListView.h"
 
 #include <QHeaderView>
 #include <QKeyEvent>
@@ -63,6 +64,7 @@ ExternalResourcesPage::ExternalResourcesPage(MinecraftInstance* instance, Resour
     ui->treeView->setModel(m_filterModel);
     // must come after setModel
     ui->treeView->setResizeModes(m_model->columnResizeModes());
+    ui->treeView->setItemDelegate(new ModListViewDelegate(ui->treeView));
 
     ui->treeView->installEventFilter(this);
     ui->treeView->sortByColumn(1, Qt::AscendingOrder);

--- a/launcher/ui/widgets/ModListView.cpp
+++ b/launcher/ui/widgets/ModListView.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "ModListView.h"
+#include "minecraft/mod/ResourceFolderModel.h"
 #include <QDrag>
 #include <QHeaderView>
 #include <QMouseEvent>
@@ -65,5 +66,22 @@ void ModListView::setResizeModes(const QList<QHeaderView::ResizeMode>& modes)
     auto head = header();
     for (int i = 0; i < modes.count(); i++) {
         head->setSectionResizeMode(i, modes[i]);
+    }
+}
+
+void ModListViewDelegate::paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const
+{
+    // All resource lists share the same logical columns
+    const auto offloadedIndex = index.siblingAtColumn(ResourceFolderModel::ActiveColumn);
+    if (offloadedIndex.isValid() && offloadedIndex.data(ResourceFolderModel::OffloadedRole).toBool())
+    {
+        painter->save();
+        painter->setOpacity(0.5);
+        QStyledItemDelegate::paint(painter, option, index);
+        painter->restore();
+    }
+    else
+    {
+        QStyledItemDelegate::paint(painter, option, index);
     }
 }

--- a/launcher/ui/widgets/ModListView.h
+++ b/launcher/ui/widgets/ModListView.h
@@ -15,6 +15,7 @@
 
 #pragma once
 #include <QHeaderView>
+#include <QStyledItemDelegate>
 #include <QTreeView>
 
 class ModListView : public QTreeView {
@@ -23,4 +24,12 @@ class ModListView : public QTreeView {
     explicit ModListView(QWidget* parent = 0);
     virtual void setModel(QAbstractItemModel* model);
     virtual void setResizeModes(const QList<QHeaderView::ResizeMode>& modes);
+};
+
+// Fades out rows whose resources are not present on disk, such as offloaded resources.
+class ModListViewDelegate : public QStyledItemDelegate {
+    Q_OBJECT
+   public:
+    explicit ModListViewDelegate(ModListView* parent) : QStyledItemDelegate(parent) {}
+    void paint(QPainter* painter, const QStyleOptionViewItem& option, const QModelIndex& index) const override;
 };


### PR DESCRIPTION
Implemented instance offloading. Fixes #5597.

Lets users free up disk space by removing an instance's downloaded resources while keeping their packwiz metadata, so that the instance may be restored at any time.

### Features
**Offloading:** deletes an instance's resources while keeping the metadata.
**Restoring:** redownloads everything and restores the instance to a launchable state.

### Implementation
New persistent state `Offloaded` and `OffloadedDisabledFiles` as instance settings.

**OffloadInstanceTask**
- Iterates mods, resourcepacks and shaderpacks metadata.
- Modrinth files are removed directly while CurseForge files are resolved through the Flame API first so that blocked mods are skipped instead of offloaded.
- Disabled resources (`.disabled`) are handled and their names recorded for restore.
- Symlinked files are skipped (whole symlinked folders are also handled)

**RestoreInstanceTask**
- Re-downloads via packwiz and the Flame file-resolving task, re-adding checksum validators so downloads are verified.
- Restores disabled files.
- Uses the same behaviour for SymLinks as the offload task.

- Offloaded metadata entries are not classified as orphans and deleted.

**UI/UX**
- Launching an offloaded instance prompts the user to restore it first.
- Offloaded instances are shown with faded opacity in the instance list.
- Resource pages show an "Offloaded" tooltip state for resources that are offloaded.
- Actions switch between "Offload" and "Restore" depending on the state of the instance.
- Shows a summary when offloading an instance, reporting the number of files offloaded and freed up space.

- Ran clang-tidy and clang-format

### Notes
- Offloading Modrinth instances will only work after #6004 is merged since that PR fixes the metadata directory for those instances.
- The metadata directory for the shaderpacks is the actual `shaderpacks/` directory as opposed to `.index` for the other resources. Which I assume is because shaderpacks lookup is less 'aggressive'.
- Offloading doesn't have an icon in the UI, so it currently uses the 'delete' icon.





