### PR TITLE
feat(mods): add release channel filtering for mod updates (#3404)

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -789,7 +789,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         m_settings->registerSetting("SkipModpackUpdatePrompt", false);
         m_settings->registerSetting("ShowModIncompat", false);
         m_settings->registerSetting("DownloadGameFilesDuringInstanceCreation", true);
-        m_settings->registerSetting("ModUpdateReleaseTypes", QStringList());
+        m_settings->registerSetting("ModUpdateReleaseTypes", "[]");
 
         // Minecraft offline player name
         m_settings->registerSetting("LastOfflinePlayerName", "");

--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -789,6 +789,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         m_settings->registerSetting("SkipModpackUpdatePrompt", false);
         m_settings->registerSetting("ShowModIncompat", false);
         m_settings->registerSetting("DownloadGameFilesDuringInstanceCreation", true);
+        m_settings->registerSetting("ModUpdateReleaseTypes", QStringList());
 
         // Minecraft offline player name
         m_settings->registerSetting("LastOfflinePlayerName", "");

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -241,6 +241,9 @@ void MinecraftInstance::loadSpecificSettings()
         auto envSetting = m_settings->registerSetting("OverrideEnv", false);
         m_settings->registerOverride(global_settings->getSetting("Env"), envSetting);
 
+        auto modUpdateReleaseTypesOverride = m_settings->registerSetting("OverrideModUpdateReleaseTypes", false);
+        m_settings->registerOverride(global_settings->getSetting("ModUpdateReleaseTypes"), modUpdateReleaseTypesOverride);
+
         if (m_settings->get("InstanceType").toString() != "OneSix") {
             m_settings->set("InstanceType", "OneSix");
         }
@@ -272,11 +275,7 @@ void MinecraftInstance::loadSpecificSettings()
     m_settings->registerSetting("OverrideModDownloadLoaders", false);
     m_settings->registerSetting("ModDownloadLoaders", "[]");
 
-    auto modUpdateReleaseTypesOverride = m_settings->registerSetting("OverrideModUpdateReleaseTypes", false);
-    if (auto global_settings = globalSettings()) {
-        m_settings->registerOverride(global_settings->getSetting("ModUpdateReleaseTypes"), modUpdateReleaseTypesOverride);
-    }
-    m_settings->registerSetting("ModUpdateReleaseTypes", QStringList());
+    m_settings->registerSetting("ModUpdateReleaseTypes", "[]");
 
     qDebug() << "Instance-type specific settings were loaded!";
 

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -272,6 +272,12 @@ void MinecraftInstance::loadSpecificSettings()
     m_settings->registerSetting("OverrideModDownloadLoaders", false);
     m_settings->registerSetting("ModDownloadLoaders", "[]");
 
+    auto modUpdateReleaseTypesOverride = m_settings->registerSetting("OverrideModUpdateReleaseTypes", false);
+    if (auto global_settings = globalSettings()) {
+        m_settings->registerOverride(global_settings->getSetting("ModUpdateReleaseTypes"), modUpdateReleaseTypesOverride);
+    }
+    m_settings->registerSetting("ModUpdateReleaseTypes", QStringList());
+
     qDebug() << "Instance-type specific settings were loaded!";
 
     setSpecificSettingsLoaded(true);

--- a/launcher/modplatform/CheckUpdateTask.h
+++ b/launcher/modplatform/CheckUpdateTask.h
@@ -14,8 +14,13 @@ class CheckUpdateTask : public Task {
     CheckUpdateTask(QList<Resource*>& resources,
                     std::vector<Version>& mcVersions,
                     QList<ModPlatform::ModLoaderType> loadersList,
-                    ResourceFolderModel* resourceModel)
-        : m_resources(resources), m_gameVersions(mcVersions), m_loadersList(std::move(loadersList)), m_resourceModel(resourceModel)
+                    ResourceFolderModel* resourceModel,
+                    std::vector<ModPlatform::IndexedVersionType> releaseTypes = {})
+        : m_resources(resources)
+        , m_gameVersions(mcVersions)
+        , m_loadersList(std::move(loadersList))
+        , m_resourceModel(resourceModel)
+        , m_releaseTypes(std::move(releaseTypes))
     {}
 
     struct Update {
@@ -68,4 +73,5 @@ class CheckUpdateTask : public Task {
 
     std::vector<Update> m_updates;
     QList<std::shared_ptr<GetModDependenciesTask::PackDependency>> m_deps;
+    std::vector<ModPlatform::IndexedVersionType> m_releaseTypes;
 };

--- a/launcher/modplatform/ModIndex.h
+++ b/launcher/modplatform/ModIndex.h
@@ -176,10 +176,34 @@ struct IndexedVersionType : EnumWrapper<IndexedVersionType, IndexedVersionTypeVa
                            std::pair{ Alpha, "Alpha" } };
     };
 
+    static IndexedVersionType fromString(const QString& str)
+    {
+        for (auto&& [e, name] : mapping()) {
+            if (str.compare(name, Qt::CaseInsensitive) == 0) {
+                return IndexedVersionType(e);
+            }
+        }
+        return IndexedVersionType(invalid());
+    }
+
     using enum IndexedVersionTypeValue;
     using Base = EnumWrapper<IndexedVersionType, IndexedVersionTypeValue>;
     using Base::Base; /* inherit ctor */
 };
+
+inline QString indexedVersionTypeToModrinth(IndexedVersionType type)
+{
+    switch (type.value()) {
+        case IndexedVersionTypeValue::Release:
+            return "release";
+        case IndexedVersionTypeValue::Beta:
+            return "beta";
+        case IndexedVersionTypeValue::Alpha:
+            return "alpha";
+        default:
+            return {};
+    }
+}
 
 struct Dependency {
     QVariant addonId;

--- a/launcher/modplatform/ModIndex.h
+++ b/launcher/modplatform/ModIndex.h
@@ -186,24 +186,24 @@ struct IndexedVersionType : EnumWrapper<IndexedVersionType, IndexedVersionTypeVa
         return IndexedVersionType(invalid());
     }
 
+    [[nodiscard]] auto toModrinth() const -> QString
+    {
+        switch (value()) {
+            case Release:
+                return "release";
+            case Beta:
+                return "beta";
+            case Alpha:
+                return "alpha";
+            default:
+                return {};
+        }
+    }
+
     using enum IndexedVersionTypeValue;
     using Base = EnumWrapper<IndexedVersionType, IndexedVersionTypeValue>;
     using Base::Base; /* inherit ctor */
 };
-
-inline QString indexedVersionTypeToModrinth(IndexedVersionType type)
-{
-    switch (type.value()) {
-        case IndexedVersionTypeValue::Release:
-            return "release";
-        case IndexedVersionTypeValue::Beta:
-            return "beta";
-        case IndexedVersionTypeValue::Alpha:
-            return "alpha";
-        default:
-            return {};
-    }
-}
 
 struct Dependency {
     QVariant addonId;

--- a/launcher/modplatform/flame/FlameAPI.cpp
+++ b/launcher/modplatform/flame/FlameAPI.cpp
@@ -246,12 +246,17 @@ QList<ModPlatform::Category> FlameAPI::loadModCategories(const QByteArray& respo
 std::optional<ModPlatform::IndexedVersion> FlameAPI::getLatestVersion(const QList<ModPlatform::IndexedVersion>& versions,
                                                                       const QList<ModPlatform::ModLoaderType>& instanceLoaders,
                                                                       ModPlatform::ModLoaderTypes fallback,
-                                                                      bool checkLoaders)
+                                                                      bool checkLoaders,
+                                                                      std::vector<ModPlatform::IndexedVersionType> releaseTypes)
 {
     static const auto s_noLoader = ModPlatform::ModLoaderType(0);
     if (!checkLoaders) {
         std::optional<ModPlatform::IndexedVersion> ver;
         for (const auto& fileTmp : versions) {
+            if (!releaseTypes.empty() &&
+                std::find(releaseTypes.cbegin(), releaseTypes.cend(), fileTmp.versionType) == releaseTypes.cend()) {
+                continue;
+            }
             if (!ver.has_value() || fileTmp.date > ver->date) {
                 ver = fileTmp;
             }
@@ -270,6 +275,9 @@ std::optional<ModPlatform::IndexedVersion> FlameAPI::getLatestVersion(const QLis
         }
     };
     for (const auto& fileTmp : versions) {
+        if (!releaseTypes.empty() && std::find(releaseTypes.cbegin(), releaseTypes.cend(), fileTmp.versionType) == releaseTypes.cend()) {
+            continue;
+        }
         auto loaders = ModPlatform::modLoaderTypesToList(fileTmp.loaders);
         if (loaders.isEmpty()) {
             checkVersion(fileTmp, s_noLoader);

--- a/launcher/modplatform/flame/FlameAPI.cpp
+++ b/launcher/modplatform/flame/FlameAPI.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 
 #include "FlameAPI.h"
+#include <algorithm>
 #include <optional>
 #include "BuildConfig.h"
 
@@ -253,8 +254,7 @@ std::optional<ModPlatform::IndexedVersion> FlameAPI::getLatestVersion(const QLis
     if (!checkLoaders) {
         std::optional<ModPlatform::IndexedVersion> ver;
         for (const auto& fileTmp : versions) {
-            if (!releaseTypes.empty() &&
-                std::find(releaseTypes.cbegin(), releaseTypes.cend(), fileTmp.versionType) == releaseTypes.cend()) {
+            if (!releaseTypes.empty() && !std::ranges::contains(releaseTypes, fileTmp.versionType)) {
                 continue;
             }
             if (!ver.has_value() || fileTmp.date > ver->date) {
@@ -275,7 +275,7 @@ std::optional<ModPlatform::IndexedVersion> FlameAPI::getLatestVersion(const QLis
         }
     };
     for (const auto& fileTmp : versions) {
-        if (!releaseTypes.empty() && std::find(releaseTypes.cbegin(), releaseTypes.cend(), fileTmp.versionType) == releaseTypes.cend()) {
+        if (!releaseTypes.empty() && !std::ranges::contains(releaseTypes, fileTmp.versionType)) {
             continue;
         }
         auto loaders = ModPlatform::modLoaderTypesToList(fileTmp.loaders);

--- a/launcher/modplatform/flame/FlameAPI.h
+++ b/launcher/modplatform/flame/FlameAPI.h
@@ -29,7 +29,8 @@ class FlameAPI final : public ResourceAPI {
     static std::optional<ModPlatform::IndexedVersion> getLatestVersion(const QList<ModPlatform::IndexedVersion>& versions,
                                                                        const QList<ModPlatform::ModLoaderType>& instanceLoaders,
                                                                        ModPlatform::ModLoaderTypes fallback,
-                                                                       bool checkLoaders);
+                                                                       bool checkLoaders,
+                                                                       std::vector<ModPlatform::IndexedVersionType> releaseTypes = {});
 
     std::pair<Task::Ptr, QByteArray*> getProjects(QStringList addonIds) const override;
     static std::pair<Task::Ptr, QByteArray*> matchFingerprints(const QList<uint>& fingerprints);

--- a/launcher/modplatform/flame/FlameCheckUpdate.cpp
+++ b/launcher/modplatform/flame/FlameCheckUpdate.cpp
@@ -87,7 +87,8 @@ void FlameCheckUpdate::getLatestVersionCallback(Resource* resource, QByteArray* 
         qCritical() << e.what();
         qDebug() << doc;
     }
-    auto latestVer = FlameAPI::getLatestVersion(pack->versions, m_loadersList, resource->metadata()->loaders, !m_loadersList.isEmpty());
+    auto latestVer =
+        FlameAPI::getLatestVersion(pack->versions, m_loadersList, resource->metadata()->loaders, !m_loadersList.isEmpty(), m_releaseTypes);
 
     setStatus(tr("Parsing the API response from CurseForge for '%1'...").arg(resource->name()));
 

--- a/launcher/modplatform/flame/FlameCheckUpdate.h
+++ b/launcher/modplatform/flame/FlameCheckUpdate.h
@@ -9,8 +9,9 @@ class FlameCheckUpdate : public CheckUpdateTask {
     FlameCheckUpdate(QList<Resource*>& resources,
                      std::vector<Version>& mcVersions,
                      QList<ModPlatform::ModLoaderType> loadersList,
-                     ResourceFolderModel* resourceModel)
-        : CheckUpdateTask(resources, mcVersions, std::move(loadersList), resourceModel)
+                     ResourceFolderModel* resourceModel,
+                     std::vector<ModPlatform::IndexedVersionType> releaseTypes = {})
+        : CheckUpdateTask(resources, mcVersions, std::move(loadersList), resourceModel, std::move(releaseTypes))
     {}
 
    public slots:

--- a/launcher/modplatform/modrinth/ModrinthAPI.cpp
+++ b/launcher/modplatform/modrinth/ModrinthAPI.cpp
@@ -43,7 +43,8 @@ std::pair<Task::Ptr, QByteArray*> ModrinthAPI::currentVersions(const QStringList
 std::pair<Task::Ptr, QByteArray*> ModrinthAPI::latestVersion(const QString& hash,
                                                              const QString& hashFormat,
                                                              std::optional<std::vector<Version>> mcVersions,
-                                                             std::optional<ModPlatform::ModLoaderTypes> loaders) const
+                                                             std::optional<ModPlatform::ModLoaderTypes> loaders,
+                                                             std::optional<std::vector<ModPlatform::IndexedVersionType>> releaseTypes) const
 {
     auto netJob = makeShared<NetJob>(QString("Modrinth::GetLatestVersion"), APPLICATION->network());
 
@@ -61,6 +62,19 @@ std::pair<Task::Ptr, QByteArray*> ModrinthAPI::latestVersion(const QString& hash
         Json::writeStringList(bodyObj, "game_versions", gameVersions);
     }
 
+    if (releaseTypes.has_value() && !releaseTypes->empty()) {
+        QStringList versionTypes;
+        for (const auto& type : releaseTypes.value()) {
+            const auto s = indexedVersionTypeToModrinth(type);
+            if (!s.isEmpty()) {
+                versionTypes.append(s);
+            }
+        }
+        if (!versionTypes.isEmpty()) {
+            Json::writeStringList(bodyObj, "version_types", versionTypes);
+        }
+    }
+
     QJsonDocument body(bodyObj);
     auto bodyRaw = body.toJson();
 
@@ -71,10 +85,12 @@ std::pair<Task::Ptr, QByteArray*> ModrinthAPI::latestVersion(const QString& hash
     return { netJob, response };
 }
 
-std::pair<Task::Ptr, QByteArray*> ModrinthAPI::latestVersions(const QStringList& hashes,
-                                                              const QString& hashFormat,
-                                                              std::optional<std::vector<Version>> mcVersions,
-                                                              std::optional<ModPlatform::ModLoaderTypes> loaders) const
+std::pair<Task::Ptr, QByteArray*> ModrinthAPI::latestVersions(
+    const QStringList& hashes,
+    const QString& hashFormat,
+    std::optional<std::vector<Version>> mcVersions,
+    std::optional<ModPlatform::ModLoaderTypes> loaders,
+    std::optional<std::vector<ModPlatform::IndexedVersionType>> releaseTypes) const
 {
     auto netJob = makeShared<NetJob>(QString("Modrinth::GetLatestVersions"), APPLICATION->network());
 
@@ -93,6 +109,19 @@ std::pair<Task::Ptr, QByteArray*> ModrinthAPI::latestVersions(const QStringList&
             gameVersions.append(mapMCVersionToModrinth(ver));
         }
         Json::writeStringList(bodyObj, "game_versions", gameVersions);
+    }
+
+    if (releaseTypes.has_value() && !releaseTypes->empty()) {
+        QStringList versionTypes;
+        for (const auto& type : releaseTypes.value()) {
+            const auto s = indexedVersionTypeToModrinth(type);
+            if (!s.isEmpty()) {
+                versionTypes.append(s);
+            }
+        }
+        if (!versionTypes.isEmpty()) {
+            Json::writeStringList(bodyObj, "version_types", versionTypes);
+        }
     }
 
     QJsonDocument body(bodyObj);

--- a/launcher/modplatform/modrinth/ModrinthAPI.cpp
+++ b/launcher/modplatform/modrinth/ModrinthAPI.cpp
@@ -65,7 +65,7 @@ std::pair<Task::Ptr, QByteArray*> ModrinthAPI::latestVersion(const QString& hash
     if (releaseTypes.has_value() && !releaseTypes->empty()) {
         QStringList versionTypes;
         for (const auto& type : releaseTypes.value()) {
-            const auto s = indexedVersionTypeToModrinth(type);
+            const auto s = type.toModrinth();
             if (!s.isEmpty()) {
                 versionTypes.append(s);
             }
@@ -114,7 +114,7 @@ std::pair<Task::Ptr, QByteArray*> ModrinthAPI::latestVersions(
     if (releaseTypes.has_value() && !releaseTypes->empty()) {
         QStringList versionTypes;
         for (const auto& type : releaseTypes.value()) {
-            const auto s = indexedVersionTypeToModrinth(type);
+            const auto s = type.toModrinth();
             if (!s.isEmpty()) {
                 versionTypes.append(s);
             }

--- a/launcher/modplatform/modrinth/ModrinthAPI.h
+++ b/launcher/modplatform/modrinth/ModrinthAPI.h
@@ -27,15 +27,19 @@ class ModrinthAPI final : public ResourceAPI {
 
     static std::pair<Task::Ptr, QByteArray*> currentVersions(const QStringList& hashes, const QString& hashFormat);
 
-    std::pair<Task::Ptr, QByteArray*> latestVersion(const QString& hash,
-                                                    const QString& hashFormat,
-                                                    std::optional<std::vector<Version>> mcVersions,
-                                                    std::optional<ModPlatform::ModLoaderTypes> loaders) const;
+    std::pair<Task::Ptr, QByteArray*> latestVersion(
+        const QString& hash,
+        const QString& hashFormat,
+        std::optional<std::vector<Version>> mcVersions,
+        std::optional<ModPlatform::ModLoaderTypes> loaders,
+        std::optional<std::vector<ModPlatform::IndexedVersionType>> releaseTypes = std::nullopt) const;
 
-    std::pair<Task::Ptr, QByteArray*> latestVersions(const QStringList& hashes,
-                                                     const QString& hashFormat,
-                                                     std::optional<std::vector<Version>> mcVersions,
-                                                     std::optional<ModPlatform::ModLoaderTypes> loaders) const;
+    std::pair<Task::Ptr, QByteArray*> latestVersions(
+        const QStringList& hashes,
+        const QString& hashFormat,
+        std::optional<std::vector<Version>> mcVersions,
+        std::optional<ModPlatform::ModLoaderTypes> loaders,
+        std::optional<std::vector<ModPlatform::IndexedVersionType>> releaseTypes = std::nullopt) const;
 
     std::pair<Task::Ptr, QByteArray*> getProjects(QStringList addonIds) const override;
 

--- a/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
+++ b/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
@@ -16,8 +16,9 @@
 ModrinthCheckUpdate::ModrinthCheckUpdate(QList<Resource*>& resources,
                                          std::vector<Version>& mcVersions,
                                          QList<ModPlatform::ModLoaderType> loadersList,
-                                         ResourceFolderModel* resourceModel)
-    : CheckUpdateTask(resources, mcVersions, std::move(loadersList), resourceModel)
+                                         ResourceFolderModel* resourceModel,
+                                         std::vector<ModPlatform::IndexedVersionType> releaseTypes)
+    : CheckUpdateTask(resources, mcVersions, std::move(loadersList), resourceModel, std::move(releaseTypes))
     , m_hashType(ModPlatform::ProviderCapabilities::hashType(ModPlatform::ResourceProvider::MODRINTH).first())
 {
     if (!m_loadersList.isEmpty()) {  // this is for mods so append all the other posible loaders to the initial list
@@ -104,7 +105,7 @@ void ModrinthCheckUpdate::getUpdateModsForLoader(std::optional<ModPlatform::ModL
         return;
     }
 
-    auto [job, response] = ModrinthAPI::get().latestVersions(hashes, m_hashType, m_gameVersions, loader);
+    auto [job, response] = ModrinthAPI::get().latestVersions(hashes, m_hashType, m_gameVersions, loader, m_releaseTypes);
 
     connect(job.get(), &Task::succeeded, this, [this, response, loader] { checkVersionsResponse(response, loader); });
 

--- a/launcher/modplatform/modrinth/ModrinthCheckUpdate.h
+++ b/launcher/modplatform/modrinth/ModrinthCheckUpdate.h
@@ -9,7 +9,8 @@ class ModrinthCheckUpdate : public CheckUpdateTask {
     ModrinthCheckUpdate(QList<Resource*>& resources,
                         std::vector<Version>& mcVersions,
                         QList<ModPlatform::ModLoaderType> loadersList,
-                        ResourceFolderModel* resourceModel);
+                        ResourceFolderModel* resourceModel,
+                        std::vector<ModPlatform::IndexedVersionType> releaseTypes = {});
 
    public slots:
     bool abort() override;

--- a/launcher/ui/dialogs/ResourceUpdateDialog.cpp
+++ b/launcher/ui/dialogs/ResourceUpdateDialog.cpp
@@ -53,7 +53,8 @@ ResourceUpdateDialog::ResourceUpdateDialog(QWidget* parent,
                                            ResourceFolderModel* resourceModel,
                                            QList<Resource*>& searchFor,
                                            bool includeDeps,
-                                           QList<ModPlatform::ModLoaderType> loadersList)
+                                           QList<ModPlatform::ModLoaderType> loadersList,
+                                           std::vector<ModPlatform::IndexedVersionType> releaseTypes)
     : ReviewMessageBox(parent, tr("Confirm resources to update"), "")
     , m_parent(parent)
     , m_resourceModel(resourceModel)
@@ -62,8 +63,24 @@ ResourceUpdateDialog::ResourceUpdateDialog(QWidget* parent,
     , m_instance(instance)
     , m_includeDeps(includeDeps)
     , m_loadersList(std::move(loadersList))
+    , m_releaseTypes(std::move(releaseTypes))
 {
     ReviewMessageBox::setGeometry(0, 0, 800, 600);
+
+    if (m_releaseTypes.empty()) {
+        auto settingVal =
+            m_instance ? m_instance->settings()->get("ModUpdateReleaseTypes") : APPLICATION->settings()->get("ModUpdateReleaseTypes");
+        auto typesList = settingVal.toStringList();
+        if (typesList.isEmpty() && !settingVal.toString().isEmpty()) {
+            typesList = settingVal.toString().split(',', Qt::SkipEmptyParts);
+        }
+        for (const auto& t : typesList) {
+            auto type = ModPlatform::IndexedVersionType::fromString(t);
+            if (type.isValid()) {
+                m_releaseTypes.push_back(type);
+            }
+        }
+    }
 
     ui->explainLabel->setText(tr("You're about to update the following resources:"));
     ui->onlyCheckedLabel->setText(tr("Only resources with a check will be updated!"));
@@ -104,7 +121,7 @@ void ResourceUpdateDialog::checkCandidates()
     SequentialTask checkTask(tr("Checking for updates"));
 
     if (!m_modrinthToUpdate.empty()) {
-        m_modrinthCheckTask.reset(new ModrinthCheckUpdate(m_modrinthToUpdate, versions, m_loadersList, m_resourceModel));
+        m_modrinthCheckTask.reset(new ModrinthCheckUpdate(m_modrinthToUpdate, versions, m_loadersList, m_resourceModel, m_releaseTypes));
         connect(m_modrinthCheckTask.get(), &CheckUpdateTask::checkFailed, this,
                 [this](Resource* resource, const QString& reason, const QUrl& recoverUrl) {
                     m_failedCheckUpdate.append({ resource, reason, recoverUrl });
@@ -113,7 +130,7 @@ void ResourceUpdateDialog::checkCandidates()
     }
 
     if (!m_flameToUpdate.empty()) {
-        m_flameCheckTask.reset(new FlameCheckUpdate(m_flameToUpdate, versions, m_loadersList, m_resourceModel));
+        m_flameCheckTask.reset(new FlameCheckUpdate(m_flameToUpdate, versions, m_loadersList, m_resourceModel, m_releaseTypes));
         connect(m_flameCheckTask.get(), &CheckUpdateTask::checkFailed, this,
                 [this](Resource* resource, const QString& reason, const QUrl& recoverUrl) {
                     m_failedCheckUpdate.append({ resource, reason, recoverUrl });

--- a/launcher/ui/dialogs/ResourceUpdateDialog.cpp
+++ b/launcher/ui/dialogs/ResourceUpdateDialog.cpp
@@ -2,6 +2,7 @@
 #include "Application.h"
 #include "ChooseProviderDialog.h"
 #include "CustomMessageBox.h"
+#include "Json.h"
 #include "ProgressDialog.h"
 #include "ScrollMessageBox.h"
 #include "StringUtils.h"
@@ -70,10 +71,7 @@ ResourceUpdateDialog::ResourceUpdateDialog(QWidget* parent,
     if (m_releaseTypes.empty()) {
         auto settingVal =
             m_instance ? m_instance->settings()->get("ModUpdateReleaseTypes") : APPLICATION->settings()->get("ModUpdateReleaseTypes");
-        auto typesList = settingVal.toStringList();
-        if (typesList.isEmpty() && !settingVal.toString().isEmpty()) {
-            typesList = settingVal.toString().split(',', Qt::SkipEmptyParts);
-        }
+        const auto typesList = Json::toStringList(settingVal.toString());
         for (const auto& t : typesList) {
             auto type = ModPlatform::IndexedVersionType::fromString(t);
             if (type.isValid()) {

--- a/launcher/ui/dialogs/ResourceUpdateDialog.h
+++ b/launcher/ui/dialogs/ResourceUpdateDialog.h
@@ -21,7 +21,8 @@ class ResourceUpdateDialog final : public ReviewMessageBox {
                                   ResourceFolderModel* resourceModel,
                                   QList<Resource*>& searchFor,
                                   bool includeDeps,
-                                  QList<ModPlatform::ModLoaderType> loadersList = {});
+                                  QList<ModPlatform::ModLoaderType> loadersList = {},
+                                  std::vector<ModPlatform::IndexedVersionType> releaseTypes = {});
 
     void checkCandidates();
 
@@ -65,4 +66,5 @@ class ResourceUpdateDialog final : public ReviewMessageBox {
     bool m_aborted = false;
     bool m_includeDeps = false;
     QList<ModPlatform::ModLoaderType> m_loadersList;
+    std::vector<ModPlatform::IndexedVersionType> m_releaseTypes;
 };

--- a/launcher/ui/pages/global/LauncherPage.cpp
+++ b/launcher/ui/pages/global/LauncherPage.cpp
@@ -289,6 +289,19 @@ void LauncherPage::applySettings()
     s->set("ShowModIncompat", ui->showModIncompatCheckBox->isChecked());
     s->set("SkipModpackUpdatePrompt", !ui->modpackUpdatePromptBtn->isChecked());
     s->set("DownloadGameFilesDuringInstanceCreation", ui->downloadGameFilesBtn->isChecked());
+
+    switch (ui->modUpdateChannelComboBox->currentIndex()) {
+        case 1:
+            s->set("ModUpdateReleaseTypes", QStringList{ "release" });
+            break;
+        case 2:
+            s->set("ModUpdateReleaseTypes", QStringList{ "release", "beta" });
+            break;
+        case 0:
+        default:
+            s->set("ModUpdateReleaseTypes", QStringList{});
+            break;
+    }
 }
 void LauncherPage::loadSettings()
 {
@@ -346,6 +359,16 @@ void LauncherPage::loadSettings()
     ui->showModIncompatCheckBox->setChecked(s->get("ShowModIncompat").toBool());
     ui->modpackUpdatePromptBtn->setChecked(!s->get("SkipModpackUpdatePrompt").toBool());
     ui->downloadGameFilesBtn->setChecked(s->get("DownloadGameFilesDuringInstanceCreation").toBool());
+
+    auto releaseTypesSetting = s->get("ModUpdateReleaseTypes").toStringList();
+    if (releaseTypesSetting.size() == 1 && releaseTypesSetting.contains("release", Qt::CaseInsensitive)) {
+        ui->modUpdateChannelComboBox->setCurrentIndex(1);
+    } else if (releaseTypesSetting.size() == 2 && releaseTypesSetting.contains("release", Qt::CaseInsensitive) &&
+               releaseTypesSetting.contains("beta", Qt::CaseInsensitive)) {
+        ui->modUpdateChannelComboBox->setCurrentIndex(2);
+    } else {
+        ui->modUpdateChannelComboBox->setCurrentIndex(0);
+    }
 }
 
 void LauncherPage::retranslate()

--- a/launcher/ui/pages/global/LauncherPage.cpp
+++ b/launcher/ui/pages/global/LauncherPage.cpp
@@ -49,6 +49,7 @@
 #include "Application.h"
 #include "BuildConfig.h"
 #include "DesktopServices.h"
+#include "Json.h"
 #include "settings/SettingsObject.h"
 #include "ui/themes/ITheme.h"
 #include "ui/themes/ThemeManager.h"
@@ -292,14 +293,14 @@ void LauncherPage::applySettings()
 
     switch (ui->modUpdateChannelComboBox->currentIndex()) {
         case 1:
-            s->set("ModUpdateReleaseTypes", QStringList{ "release" });
+            s->set("ModUpdateReleaseTypes", Json::fromStringList({ "release" }));
             break;
         case 2:
-            s->set("ModUpdateReleaseTypes", QStringList{ "release", "beta" });
+            s->set("ModUpdateReleaseTypes", Json::fromStringList({ "release", "beta" }));
             break;
         case 0:
         default:
-            s->set("ModUpdateReleaseTypes", QStringList{});
+            s->set("ModUpdateReleaseTypes", "[]");
             break;
     }
 }
@@ -360,7 +361,7 @@ void LauncherPage::loadSettings()
     ui->modpackUpdatePromptBtn->setChecked(!s->get("SkipModpackUpdatePrompt").toBool());
     ui->downloadGameFilesBtn->setChecked(s->get("DownloadGameFilesDuringInstanceCreation").toBool());
 
-    auto releaseTypesSetting = s->get("ModUpdateReleaseTypes").toStringList();
+    const auto releaseTypesSetting = Json::toStringList(s->get("ModUpdateReleaseTypes").toString());
     if (releaseTypesSetting.size() == 1 && releaseTypesSetting.contains("release", Qt::CaseInsensitive)) {
         ui->modUpdateChannelComboBox->setCurrentIndex(1);
     } else if (releaseTypesSetting.size() == 2 && releaseTypesSetting.contains("release", Qt::CaseInsensitive) &&

--- a/launcher/ui/pages/global/LauncherPage.ui
+++ b/launcher/ui/pages/global/LauncherPage.ui
@@ -498,6 +498,42 @@
             </property>
            </widget>
           </item>
+          <item>
+           <layout class="QHBoxLayout" name="modUpdateChannelLayout">
+            <item>
+             <widget class="QLabel" name="modUpdateChannelLabel">
+              <property name="toolTip">
+               <string>Select the preferred release channel when checking for mod updates.</string>
+              </property>
+              <property name="text">
+               <string>Mod update channel:</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="modUpdateChannelComboBox">
+              <property name="toolTip">
+               <string>Select the preferred release channel when checking for mod updates.</string>
+              </property>
+              <item>
+               <property name="text">
+                <string>All (Release, Beta, Alpha)</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Release only</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Release and Beta</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+           </layout>
+          </item>
          </layout>
         </widget>
        </item>

--- a/launcher/ui/pages/instance/ModFolderPage.cpp
+++ b/launcher/ui/pages/instance/ModFolderPage.cpp
@@ -78,13 +78,20 @@ ModFolderPage::ModFolderPage(MinecraftInstance* inst, ModFolderModel* model, QWi
     connect(ui->actionDownloadItem, &QAction::triggered, this, &ModFolderPage::downloadMods);
 
     ui->actionUpdateItem->setToolTip(tr("Try to check or update all selected mods (all mods if none are selected)"));
-    connect(ui->actionUpdateItem, &QAction::triggered, this, &ModFolderPage::updateMods);
+    connect(ui->actionUpdateItem, &QAction::triggered, this, [this] { updateMods(); });
     ui->actionsToolbar->insertActionBefore(ui->actionAddItem, ui->actionUpdateItem);
 
     auto* updateMenu = new QMenu(this);
 
     auto* update = updateMenu->addAction(tr("Check for Updates"));
-    connect(update, &QAction::triggered, this, &ModFolderPage::updateMods);
+    connect(update, &QAction::triggered, this, [this] { updateMods(); });
+
+    auto* updateReleasesOnly = updateMenu->addAction(tr("Check for Updates (Release only)"));
+    connect(updateReleasesOnly, &QAction::triggered, this, [this] { updateMods(false, { ModPlatform::IndexedVersionType::Release }); });
+
+    auto* updateIncludeBetas = updateMenu->addAction(tr("Check for Updates (Release and Beta)"));
+    connect(updateIncludeBetas, &QAction::triggered, this,
+            [this] { updateMods(false, { ModPlatform::IndexedVersionType::Release, ModPlatform::IndexedVersionType::Beta }); });
 
     updateMenu->addAction(ui->actionVerifyItemDependencies);
     connect(ui->actionVerifyItemDependencies, &QAction::triggered, this, [this] { updateMods(true); });
@@ -184,9 +191,8 @@ void ModFolderPage::downloadDialogFinished(int result)
 {
     if (result != 0) {
         ConcurrentTask tasks(tr("Download Mods"), APPLICATION->settings()->get("NumberOfConcurrentDownloads").toInt());
-        connect(&tasks, &Task::failed, this, [this](const QString& reason) {
-            CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show();
-        });
+        connect(&tasks, &Task::failed, this,
+                [this](const QString& reason) { CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show(); });
         connect(&tasks, &Task::succeeded, this, [this, &tasks]() {
             QStringList warnings = tasks.warnings();
             if (warnings.count()) {
@@ -213,7 +219,7 @@ void ModFolderPage::downloadDialogFinished(int result)
     }
 }
 
-void ModFolderPage::updateMods(bool includeDeps)
+void ModFolderPage::updateMods(bool includeDeps, std::vector<ModPlatform::IndexedVersionType> releaseTypes)
 {
     auto* profile = m_instance->getPackProfile();
     if (!profile->getModLoaders().has_value() && handleNoModLoader()) {
@@ -223,6 +229,7 @@ void ModFolderPage::updateMods(bool includeDeps)
         QMessageBox::critical(this, tr("Error"), tr("Mod updates are unavailable when metadata is disabled!"));
         return;
     }
+
     if (m_instance != nullptr && m_instance->isRunning()) {
         auto response =
             CustomMessageBox::selectable(this, tr("Confirm Update"),
@@ -244,7 +251,22 @@ void ModFolderPage::updateMods(bool includeDeps)
         modsList = m_model->allResources();
     }
 
-    ResourceUpdateDialog updateDialog(this, m_instance, m_model, modsList, includeDeps, profile->getModLoadersList());
+    if (releaseTypes.empty()) {
+        auto settingVal =
+            m_instance ? m_instance->settings()->get("ModUpdateReleaseTypes") : APPLICATION->settings()->get("ModUpdateReleaseTypes");
+        auto typesList = settingVal.toStringList();
+        if (typesList.isEmpty() && !settingVal.toString().isEmpty()) {
+            typesList = settingVal.toString().split(',', Qt::SkipEmptyParts);
+        }
+        for (const auto& t : typesList) {
+            auto type = ModPlatform::IndexedVersionType::fromString(t);
+            if (type.isValid()) {
+                releaseTypes.push_back(type);
+            }
+        }
+    }
+
+    ResourceUpdateDialog updateDialog(this, m_instance, m_model, modsList, includeDeps, profile->getModLoadersList(), releaseTypes);
     updateDialog.checkCandidates();
 
     if (updateDialog.aborted()) {
@@ -265,9 +287,8 @@ void ModFolderPage::updateMods(bool includeDeps)
 
     if (updateDialog.exec() != 0) {
         ConcurrentTask tasks("Download Mods", APPLICATION->settings()->get("NumberOfConcurrentDownloads").toInt());
-        connect(&tasks, &Task::failed, this, [this](const QString& reason) {
-            CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show();
-        });
+        connect(&tasks, &Task::failed, this,
+                [this](const QString& reason) { CustomMessageBox::selectable(this, tr("Error"), reason, QMessageBox::Critical)->show(); });
         connect(&tasks, &Task::succeeded, this, [this, &tasks]() {
             QStringList warnings = tasks.warnings();
             if (warnings.count()) {

--- a/launcher/ui/pages/instance/ModFolderPage.cpp
+++ b/launcher/ui/pages/instance/ModFolderPage.cpp
@@ -94,6 +94,12 @@ ModFolderPage::ModFolderPage(MinecraftInstance* inst, ModFolderModel* model, QWi
     connect(updateIncludeBetas, &QAction::triggered, this,
             [this] { updateMods(false, { ModPlatform::IndexedVersionType::Release, ModPlatform::IndexedVersionType::Beta }); });
 
+    auto* updateIncludeAlphas = updateMenu->addAction(tr("Check for Updates (Release, Beta and Alpha)"));
+    connect(updateIncludeAlphas, &QAction::triggered, this, [this] {
+        updateMods(false, { ModPlatform::IndexedVersionType::Release, ModPlatform::IndexedVersionType::Beta,
+                            ModPlatform::IndexedVersionType::Alpha });
+    });
+
     updateMenu->addAction(ui->actionVerifyItemDependencies);
     connect(ui->actionVerifyItemDependencies, &QAction::triggered, this, [this] { updateMods(true); });
 

--- a/launcher/ui/pages/instance/ModFolderPage.cpp
+++ b/launcher/ui/pages/instance/ModFolderPage.cpp
@@ -53,6 +53,7 @@
 #include <memory>
 
 #include "Application.h"
+#include "Json.h"
 
 #include "ui/dialogs/CustomMessageBox.h"
 #include "ui/dialogs/ResourceDownloadDialog.h"
@@ -254,10 +255,7 @@ void ModFolderPage::updateMods(bool includeDeps, std::vector<ModPlatform::Indexe
     if (releaseTypes.empty()) {
         auto settingVal =
             m_instance ? m_instance->settings()->get("ModUpdateReleaseTypes") : APPLICATION->settings()->get("ModUpdateReleaseTypes");
-        auto typesList = settingVal.toStringList();
-        if (typesList.isEmpty() && !settingVal.toString().isEmpty()) {
-            typesList = settingVal.toString().split(',', Qt::SkipEmptyParts);
-        }
+        const auto typesList = Json::toStringList(settingVal.toString());
         for (const auto& t : typesList) {
             auto type = ModPlatform::IndexedVersionType::fromString(t);
             if (type.isValid()) {

--- a/launcher/ui/pages/instance/ModFolderPage.h
+++ b/launcher/ui/pages/instance/ModFolderPage.h
@@ -68,7 +68,7 @@ class ModFolderPage : public ExternalResourcesPage {
 
     void downloadMods();
     void downloadDialogFinished(int result);
-    void updateMods(bool includeDeps = false);
+    void updateMods(bool includeDeps = false, std::vector<ModPlatform::IndexedVersionType> releaseTypes = {});
     void deleteModMetadata();
     void exportModMetadata();
     void changeModVersion();


### PR DESCRIPTION
# Summary
Closes #3404
When downloading new mods, Prism Launcher lets you choose which release type you want (Release, Beta, Alpha), but when checking for updates on existing mods, it didn't have that option and always pulled whatever the latest build was (often grabbing experimental alphas/betas).
This PR adds release channel filtering to the update check so you can stick to stable releases or include betas if you want.
# Changes
- Added a "Mod update channel" dropdown in **Settings -> General -> Mods and Modpacks**.
- Added quick "Check for Updates (Release only)" and "Check for Updates (Release and Beta)" actions to the **Check for Updates** dropdown button.
- Passed `version_types` to the Modrinth API and added version type filtering to FlameAPI.
- Default behavior is unchanged (checks all channels by default unless filtered).
# Screenshots
<img width="829" height="617" alt="644697909-5787e702-0323-4f92-9333-fdae98ae1c71" src="https://github.com/user-attachments/assets/539f4311-8a64-4b29-9a64-9b450c1a74d7" />
<img width="1645" height="965" alt="644698035-a44bc4a9-8a8b-47d8-89e5-12cfcd99d011" src="https://github.com/user-attachments/assets/be0c7611-1d34-4dae-ad09-50d302ba0f35" />

---

For full transparency, parts of this PR were drafted with AI assistance. All the changes have been thoroughly reviewed, formatted to project standards, compiled with `-Werror`, and tested locally against the test suite (and in-launcher) to make sure everything works as expected.

