### PR TITLE
feat(Mods Tab): add User-defined Tabs/Groups for the Mods Tab

### DIFF
--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -322,6 +322,7 @@ set(MINECRAFT_SOURCES
     minecraft/mod/ModDetails.h
     minecraft/mod/ModFolderModel.h
     minecraft/mod/ModFolderModel.cpp
+    minecraft/mod/ModProfileKeys.h
     minecraft/mod/Resource.h
     minecraft/mod/Resource.cpp
     minecraft/mod/ResourceFolderModel.h
@@ -910,7 +911,12 @@ SET(LAUNCHER_SOURCES
     ui/pages/instance/ShaderPackPage.h
     ui/pages/instance/ShaderPackPage.cpp
     ui/pages/instance/ModFolderPage.cpp
+    ui/pages/instance/ModFolderPageProfiles.cpp
     ui/pages/instance/ModFolderPage.h
+    ui/pages/instance/ProfileCheckStateDelegate.cpp
+    ui/pages/instance/ProfileCheckStateDelegate.h
+    ui/pages/instance/ProfileOverviewWidget.cpp
+    ui/pages/instance/ProfileOverviewWidget.h
     ui/pages/instance/NotesPage.cpp
     ui/pages/instance/NotesPage.h
     ui/pages/instance/LogPage.cpp

--- a/launcher/minecraft/launch/ScanModFolders.cpp
+++ b/launcher/minecraft/launch/ScanModFolders.cpp
@@ -64,17 +64,18 @@ bool applyLastActiveProfile(ModFolderModel* model,
             lastActiveIndex = 0;
         profileName = profileList.at(lastActiveIndex);
     }
-    if (profileName == QStringLiteral("All Mods")) {
-        profileName = QStringLiteral("Default");
+
+    QString profileKeyStr = ModProfileKeys::profileKey(prefix, profileName);
+    auto profileSetting = settings->getOrRegisterSetting(profileKeyStr, QStringList());
+    QStringList ids = profileSetting->get().toStringList();
+
+    // An absent profile key means the filesystem remains authoritative.
+    bool hasPersistedState = settings->containsValue(profileKeyStr);
+
+    if (!hasPersistedState) {
+        return false;
     }
 
-    auto profileSetting = settings->getOrRegisterSetting(ModProfileKeys::profileKey(prefix, profileName), QStringList());
-    QStringList ids = profileSetting->get().toStringList();
-    if (ids.isEmpty() && profileName == QStringLiteral("Default")) {
-        auto legacySetting = settings->getOrRegisterSetting(
-            ModProfileKeys::profileKey(prefix, QStringLiteral("All Mods")), QStringList());
-        ids = legacySetting->get().toStringList();
-    }
     QSet<QString> enabledModIds(ids.begin(), ids.end());
     model->applyEnabledIds(enabledModIds);
     if (outApplied)
@@ -85,6 +86,7 @@ bool applyLastActiveProfile(ModFolderModel* model,
 QSet<QString> applyForModel(ModFolderModel* model, SettingsObject* settings, const QString& prefix)
 {
     QSet<QString> enabledModIds;
+    bool haveExplicitConfig = false;
 
     auto defaultSelectedSetting = settings->getOrRegisterSetting(
         ModProfileKeys::overviewDefaultSelectedKey(prefix), true);
@@ -96,17 +98,15 @@ QSet<QString> applyForModel(ModFolderModel* model, SettingsObject* settings, con
         QStringList profileList = profileListSetting->get().toStringList();
         if (!profileList.isEmpty()) {
             QString defaultName = profileList.at(0);
-            if (defaultName == QStringLiteral("All Mods"))
-                defaultName = QStringLiteral("Default");
-            auto profileSetting = settings->getOrRegisterSetting(
-                ModProfileKeys::profileKey(prefix, defaultName), QStringList());
-            QStringList ids = profileSetting->get().toStringList();
-            if (ids.isEmpty()) {
-                auto legacySetting = settings->getOrRegisterSetting(
-                    ModProfileKeys::profileKey(prefix, QStringLiteral("All Mods")), QStringList());
-                ids = legacySetting->get().toStringList();
+            QString profileKeyStr = ModProfileKeys::profileKey(prefix, defaultName);
+            auto profileSetting = settings->getOrRegisterSetting(profileKeyStr, QStringList());
+
+            // An absent profile key means the filesystem remains authoritative.
+            if (settings->containsValue(profileKeyStr)) {
+                QStringList ids = profileSetting->get().toStringList();
+                enabledModIds = QSet<QString>(ids.begin(), ids.end());
+                haveExplicitConfig = true;
             }
-            enabledModIds = QSet<QString>(ids.begin(), ids.end());
         }
     } else {
         auto rtSetting = settings->getOrRegisterSetting(ModProfileKeys::runtimeProfilesKey(prefix), QStringList());
@@ -124,9 +124,12 @@ QSet<QString> applyForModel(ModFolderModel* model, SettingsObject* settings, con
             for (const QString& id : modIds)
                 enabledModIds.insert(id);
         }
+        haveExplicitConfig = true;
     }
 
-    model->applyEnabledIds(enabledModIds);
+    if (haveExplicitConfig) {
+        model->applyEnabledIds(enabledModIds);
+    }
     model->setLaunchSnapshot(enabledModIds);
     return enabledModIds;
 }

--- a/launcher/minecraft/launch/ScanModFolders.cpp
+++ b/launcher/minecraft/launch/ScanModFolders.cpp
@@ -39,6 +39,99 @@
 #include "launch/LaunchTask.h"
 #include "minecraft/MinecraftInstance.h"
 #include "minecraft/mod/ModFolderModel.h"
+#include "minecraft/mod/ModProfileKeys.h"
+#include "settings/SettingsObject.h"
+#include "settings/Setting.h"
+namespace {
+
+bool applyLastActiveProfile(ModFolderModel* model,
+                            SettingsObject* settings,
+                            const QString& prefix,
+                            QSet<QString>* outApplied = nullptr)
+{
+    auto profileListSetting = settings->getOrRegisterSetting(ModProfileKeys::profileListKey(prefix), QStringList());
+    QStringList profileList = profileListSetting->get().toStringList();
+    if (profileList.isEmpty()) {
+        return false;
+    }
+
+    auto nameSetting = settings->getOrRegisterSetting(ModProfileKeys::lastActiveProfileNameKey(prefix), QString());
+    QString profileName = nameSetting->get().toString();
+    if (profileName.isEmpty() || !profileList.contains(profileName)) {
+        auto indexSetting = settings->getOrRegisterSetting(ModProfileKeys::lastActiveIndexKey(prefix), 0);
+        int lastActiveIndex = indexSetting->get().toInt();
+        if (lastActiveIndex < 0 || lastActiveIndex >= profileList.size())
+            lastActiveIndex = 0;
+        profileName = profileList.at(lastActiveIndex);
+    }
+    if (profileName == QStringLiteral("All Mods")) {
+        profileName = QStringLiteral("Default");
+    }
+
+    auto profileSetting = settings->getOrRegisterSetting(ModProfileKeys::profileKey(prefix, profileName), QStringList());
+    QStringList ids = profileSetting->get().toStringList();
+    if (ids.isEmpty() && profileName == QStringLiteral("Default")) {
+        auto legacySetting = settings->getOrRegisterSetting(
+            ModProfileKeys::profileKey(prefix, QStringLiteral("All Mods")), QStringList());
+        ids = legacySetting->get().toStringList();
+    }
+    QSet<QString> enabledModIds(ids.begin(), ids.end());
+    model->applyEnabledIds(enabledModIds);
+    if (outApplied)
+        *outApplied = enabledModIds;
+    return true;
+}
+
+QSet<QString> applyForModel(ModFolderModel* model, SettingsObject* settings, const QString& prefix)
+{
+    QSet<QString> enabledModIds;
+
+    auto defaultSelectedSetting = settings->getOrRegisterSetting(
+        ModProfileKeys::overviewDefaultSelectedKey(prefix), true);
+    bool useDefault = defaultSelectedSetting->get().toBool();
+
+    if (useDefault) {
+        auto profileListSetting = settings->getOrRegisterSetting(
+            ModProfileKeys::profileListKey(prefix), QStringList());
+        QStringList profileList = profileListSetting->get().toStringList();
+        if (!profileList.isEmpty()) {
+            QString defaultName = profileList.at(0);
+            if (defaultName == QStringLiteral("All Mods"))
+                defaultName = QStringLiteral("Default");
+            auto profileSetting = settings->getOrRegisterSetting(
+                ModProfileKeys::profileKey(prefix, defaultName), QStringList());
+            QStringList ids = profileSetting->get().toStringList();
+            if (ids.isEmpty()) {
+                auto legacySetting = settings->getOrRegisterSetting(
+                    ModProfileKeys::profileKey(prefix, QStringLiteral("All Mods")), QStringList());
+                ids = legacySetting->get().toStringList();
+            }
+            enabledModIds = QSet<QString>(ids.begin(), ids.end());
+        }
+    } else {
+        auto rtSetting = settings->getOrRegisterSetting(ModProfileKeys::runtimeProfilesKey(prefix), QStringList());
+        QStringList selected = rtSetting->get().toStringList();
+        if (selected.isEmpty()) {
+            QSet<QString> fallback;
+            applyLastActiveProfile(model, settings, prefix, &fallback);
+            model->setLaunchSnapshot(fallback);
+            return fallback;
+        }
+        for (const QString& profileName : std::as_const(selected)) {
+            auto profileSetting = settings->getOrRegisterSetting(
+                ModProfileKeys::profileKey(prefix, profileName), QStringList());
+            const QStringList modIds = profileSetting->get().toStringList();
+            for (const QString& id : modIds)
+                enabledModIds.insert(id);
+        }
+    }
+
+    model->applyEnabledIds(enabledModIds);
+    model->setLaunchSnapshot(enabledModIds);
+    return enabledModIds;
+}
+
+}  // namespace
 
 void ScanModFolders::executeTask()
 {
@@ -46,18 +139,21 @@ void ScanModFolders::executeTask()
 
     auto loaders = m_inst->loaderModList();
     connect(loaders, &ModFolderModel::updateFinished, this, &ScanModFolders::modsDone, Qt::SingleShotConnection);
+    connect(loaders, &ModFolderModel::parseFinished, this, &ScanModFolders::onParseFinished);
     if (!loaders->update()) {
         m_modsDone = true;
     }
 
     auto cores = m_inst->coreModList();
     connect(cores, &ModFolderModel::updateFinished, this, &ScanModFolders::coreModsDone, Qt::SingleShotConnection);
+    connect(cores, &ModFolderModel::parseFinished, this, &ScanModFolders::onParseFinished);
     if (!cores->update()) {
         m_coreModsDone = true;
     }
 
     auto nils = m_inst->nilModList();
     connect(nils, &ModFolderModel::updateFinished, this, &ScanModFolders::nilModsDone, Qt::SingleShotConnection);
+    connect(nils, &ModFolderModel::parseFinished, this, &ScanModFolders::onParseFinished);
     if (!nils->update()) {
         m_nilModsDone = true;
     }
@@ -82,9 +178,46 @@ void ScanModFolders::nilModsDone()
     checkDone();
 }
 
+void ScanModFolders::onParseFinished()
+{
+    checkDone();
+}
 void ScanModFolders::checkDone()
 {
-    if (m_modsDone && m_coreModsDone && m_nilModsDone) {
-        emitSucceeded();
+    if (m_applyDone)
+        return;
+    if (!(m_modsDone && m_coreModsDone && m_nilModsDone))
+        return;
+    if (m_parent->instance()->loaderModList()->hasPendingParseTasks() ||
+        m_parent->instance()->coreModList()->hasPendingParseTasks() ||
+        m_parent->instance()->nilModList()->hasPendingParseTasks()) {
+        return;
+    }
+    m_applyDone = true;
+    applyRuntimeProfiles();
+    emitSucceeded();
+}
+void ScanModFolders::applyRuntimeProfiles()
+{
+    auto* mcInst = dynamic_cast<MinecraftInstance*>(m_parent->instance());
+    if (!mcInst)
+        return;
+    auto* settings = mcInst->settings();
+    applyForModel(mcInst->loaderModList(), settings, QStringLiteral("mods"));
+    applyForModel(mcInst->coreModList(),   settings, QStringLiteral("coremods"));
+    applyForModel(mcInst->nilModList(),    settings, QStringLiteral("nilmods"));
+    if (!m_restoreListenerConnected) {
+        m_restoreListenerConnected = true;
+        connect(mcInst, &BaseInstance::runningStatusChanged, this, [this, mcInst](bool running) {
+            if (running)
+                return;
+            auto* settings = mcInst->settings();
+            applyLastActiveProfile(mcInst->loaderModList(), settings, QStringLiteral("mods"));
+            applyLastActiveProfile(mcInst->coreModList(),   settings, QStringLiteral("coremods"));
+            applyLastActiveProfile(mcInst->nilModList(),    settings, QStringLiteral("nilmods"));
+            mcInst->loaderModList()->clearLaunchSnapshot();
+            mcInst->coreModList()->clearLaunchSnapshot();
+            mcInst->nilModList()->clearLaunchSnapshot();
+        });
     }
 }

--- a/launcher/minecraft/launch/ScanModFolders.h
+++ b/launcher/minecraft/launch/ScanModFolders.h
@@ -30,12 +30,16 @@ class ScanModFolders : public LaunchStep {
     void coreModsDone();
     void modsDone();
     void nilModsDone();
+    void onParseFinished();
 
    private:
     void checkDone();
+    void applyRuntimeProfiles();
 
    private:  // DATA
     bool m_modsDone = false;
     bool m_nilModsDone = false;
     bool m_coreModsDone = false;
+    bool m_restoreListenerConnected = false;
+    bool m_applyDone = false;
 };

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -136,31 +136,10 @@ QVariant ModFolderModel::data(const QModelIndex& index, int role) const
                 return QSize(32, 32);
             }
             break;
-        case Qt::ToolTipRole:
-            switch (column) {
-                case RequiredByColumn: {
-                    const auto list = requiredByList(at(row).mod_id());
-                    if (!list.isEmpty()) {
-                        return list.join(QLatin1Char('\n'));
-                    }
-                    break;
-                }
-                case RequiresColumn: {
-                    const auto list = requiresList(at(row).mod_id());
-                    if (!list.isEmpty()) {
-                        return list.join(QLatin1Char('\n'));
-                    }
-                    break;
-                }
-                default:
-                    break;
-            }
-            break;
         default:
             break;
     }
 
-    // map the columns to the base equivilents
     QModelIndex mappedIndex;
     switch (column) {
         case ActiveColumn:
@@ -297,6 +276,22 @@ Mod* findById(QSet<Mod*> mods, const QString& resourceId)
     auto found = std::ranges::find_if(mods, [resourceId](Mod* m) { return m->mod_id() == resourceId; });
     return found != mods.end() ? *found : nullptr;
 }
+QString normalizeForFuzzyModMatch(const QString& s)
+{
+    QString stripped;
+    for (const QChar& c : s) {
+        if (c.isLetterOrNumber()) {
+            stripped.append(c.toLower());
+        }
+    }
+    QList<QChar> chars(stripped.begin(), stripped.end());
+    std::sort(chars.begin(), chars.end());
+    QString sorted;
+    for (const QChar& c : chars) {
+        sorted.append(c);
+    }
+    return sorted;
+}
 }  // namespace
 
 void ModFolderModel::onParseFinished()
@@ -370,7 +365,6 @@ QSet<Mod*> collectMods(const QSet<Mod*>& mods, QHash<QString, QSet<Mod*>> relati
             }
         }
     }
-    // collect the affected mods until all of them are included in the list
     if (!needToCheck.isEmpty()) {
         affectedList += collectMods(needToCheck, relation, seen, shouldBeEnabled);
     }
@@ -399,7 +393,7 @@ QModelIndexList ModFolderModel::getAffectedMods(const QModelIndexList& indexes, 
             break;
         }
         case EnableAction::TOGGLE: {
-            return {};  // this function should not be called with TOGGLE
+            return {};
         }
     }
     for (auto* affected : affectedMods) {
@@ -515,14 +509,14 @@ QStringList reqToList(const QSet<Mod*>& l)
 }
 }  // namespace
 
-QStringList ModFolderModel::requiresList(const QString& id) const
+QStringList ModFolderModel::requiresList(const QString& id)
 {
-    return reqToList(m_requires.value(id));
+    return reqToList(m_requires[id]);
 }
 
-QStringList ModFolderModel::requiredByList(const QString& id) const
+QStringList ModFolderModel::requiredByList(const QString& id)
 {
-    return reqToList(m_requiredBy.value(id));
+    return reqToList(m_requiredBy[id]);
 }
 
 bool ModFolderModel::deleteResources(const QModelIndexList& indexes)
@@ -530,8 +524,6 @@ bool ModFolderModel::deleteResources(const QModelIndexList& indexes)
     auto deleteInvalid = [](QSet<Mod*>& mods) {
         for (auto it = mods.begin(); it != mods.end();) {
             auto* mod = *it;
-            // the QFileInfo::exists is used instead of mod->fileinfo().exists
-            // because the later somehow caches that the file exists
             if (!mod || !QFileInfo::exists(mod->fileinfo().absoluteFilePath())) {
                 it = mods.erase(it);
             } else {
@@ -552,4 +544,47 @@ bool ModFolderModel::deleteResources(const QModelIndexList& indexes)
         }
     }
     return rsp;
+}
+void ModFolderModel::applyEnabledIds(const QSet<QString>& enabledModIds)
+{
+    QSet<QString> normalizedEnabledModIds;
+    for (const QString& id : enabledModIds) {
+        normalizedEnabledModIds.insert(normalizeForFuzzyModMatch(id));
+    }
+    for (int i = 0; i < rowCount(); ++i) {
+        const Mod& mod = at(i);
+        bool shouldBeEnabled = enabledModIds.contains(mod.mod_id()) || enabledModIds.contains(mod.name()) ||
+                               normalizedEnabledModIds.contains(normalizeForFuzzyModMatch(mod.mod_id())) ||
+                               normalizedEnabledModIds.contains(normalizeForFuzzyModMatch(mod.name()));
+        if (mod.enabled() == shouldBeEnabled)
+            continue;
+        EnableAction action = shouldBeEnabled ? EnableAction::ENABLE : EnableAction::DISABLE;
+        auto& resource = m_resources[i];
+        auto oldId = resource->internalId();
+        if (!resource->enable(action)) {
+            qWarning() << "applyEnabledIds: could not"
+                       << (shouldBeEnabled ? "enable" : "disable")
+                       << resource->name();
+            continue;
+        }
+        auto newId = resource->internalId();
+        m_resourcesIndex.remove(oldId);
+        m_resourcesIndex[newId] = i;
+        emit dataChanged(index(i, 0), index(i, columnCount(QModelIndex()) - 1));
+    }
+}
+
+void ModFolderModel::setLaunchSnapshot(const QSet<QString>& enabledModIds)
+{
+    m_launchSnapshot = enabledModIds;
+}
+
+std::optional<QSet<QString>> ModFolderModel::launchSnapshot() const
+{
+    return m_launchSnapshot;
+}
+
+void ModFolderModel::clearLaunchSnapshot()
+{
+    m_launchSnapshot.reset();
 }

--- a/launcher/minecraft/mod/ModFolderModel.cpp
+++ b/launcher/minecraft/mod/ModFolderModel.cpp
@@ -140,6 +140,7 @@ QVariant ModFolderModel::data(const QModelIndex& index, int role) const
             break;
     }
 
+    // map the columns to the base equivilents
     QModelIndex mappedIndex;
     switch (column) {
         case ActiveColumn:
@@ -365,6 +366,7 @@ QSet<Mod*> collectMods(const QSet<Mod*>& mods, QHash<QString, QSet<Mod*>> relati
             }
         }
     }
+    // collect the affected mods until all of them are included in the list
     if (!needToCheck.isEmpty()) {
         affectedList += collectMods(needToCheck, relation, seen, shouldBeEnabled);
     }
@@ -393,7 +395,7 @@ QModelIndexList ModFolderModel::getAffectedMods(const QModelIndexList& indexes, 
             break;
         }
         case EnableAction::TOGGLE: {
-            return {};
+            return {};  // this function should not be called with TOGGLE
         }
     }
     for (auto* affected : affectedMods) {
@@ -524,6 +526,8 @@ bool ModFolderModel::deleteResources(const QModelIndexList& indexes)
     auto deleteInvalid = [](QSet<Mod*>& mods) {
         for (auto it = mods.begin(); it != mods.end();) {
             auto* mod = *it;
+            // the QFileInfo::exists is used instead of mod->fileinfo().exists
+            // because the later somehow caches that the file exists
             if (!mod || !QFileInfo::exists(mod->fileinfo().absoluteFilePath())) {
                 it = mods.erase(it);
             } else {

--- a/launcher/minecraft/mod/ModFolderModel.h
+++ b/launcher/minecraft/mod/ModFolderModel.h
@@ -53,6 +53,10 @@
 class BaseInstance;
 class QFileSystemWatcher;
 
+/**
+ * A legacy mod list.
+ * Backed by a folder.
+ */
 class ModFolderModel : public ResourceFolderModel {
     Q_OBJECT
    public:

--- a/launcher/minecraft/mod/ModFolderModel.h
+++ b/launcher/minecraft/mod/ModFolderModel.h
@@ -37,6 +37,8 @@
 
 #pragma once
 
+#include <optional>
+
 #include <QAbstractListModel>
 #include <QDir>
 #include <QHash>
@@ -51,10 +53,6 @@
 class BaseInstance;
 class QFileSystemWatcher;
 
-/**
- * A legacy mod list.
- * Backed by a folder.
- */
 class ModFolderModel : public ResourceFolderModel {
     Q_OBJECT
    public:
@@ -94,17 +92,24 @@ class ModFolderModel : public ResourceFolderModel {
 
     QModelIndexList getAffectedMods(const QModelIndexList& indexes, EnableAction action);
 
+    void applyEnabledIds(const QSet<QString>& enabledModIds);
+
+    void setLaunchSnapshot(const QSet<QString>& enabledModIds);
+    std::optional<QSet<QString>> launchSnapshot() const;
+    void clearLaunchSnapshot();
+
     RESOURCE_HELPERS(Mod)
 
    public:
-    QStringList requiresList(const QString& id) const;
-    QStringList requiredByList(const QString& id) const;
+    QStringList requiresList(const QString& id);
+    QStringList requiredByList(const QString& id);
 
    private slots:
     void onParseSucceeded(int ticket, const QString& resourceId) override;
     void onParseFinished();
 
    private:
+    std::optional<QSet<QString>> m_launchSnapshot;
     QHash<QString, QSet<Mod*>> m_requiredBy;
     QHash<QString, QSet<Mod*>> m_requires;
 };

--- a/launcher/minecraft/mod/ModProfileKeys.h
+++ b/launcher/minecraft/mod/ModProfileKeys.h
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QString>
+
+namespace ModProfileKeys {
+
+inline QString profileListKey(const QString& prefix)
+{
+    return QStringLiteral("ModProfileList_") + prefix;
+}
+
+inline QString profileKey(const QString& prefix, const QString& name)
+{
+    return prefix + QStringLiteral("/ModProfile_") + name;
+}
+
+inline QString runtimeProfilesKey(const QString& prefix)
+{
+    return QStringLiteral("ModRuntimeProfiles_") + prefix;
+}
+
+inline QString lastActiveIndexKey(const QString& prefix)
+{
+    return QStringLiteral("ModProfileLastActiveIndex_") + prefix;
+}
+
+inline QString lastActiveProfileNameKey(const QString& prefix)
+{
+    return QStringLiteral("ModProfileLastActiveName_") + prefix;
+}
+
+inline QString overviewDefaultSelectedKey(const QString& prefix)
+{
+    return QStringLiteral("ModProfileOverviewDefaultSelected_") + prefix;
+}
+
+}  // namespace ModProfileKeys

--- a/launcher/minecraft/mod/ModProfileKeys.h
+++ b/launcher/minecraft/mod/ModProfileKeys.h
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
  *  Prism Launcher - Minecraft Launcher
+ *  Copyright (C) 2026 Vivek Kushwaha <notvivekkushwaha@gmail.com>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -51,4 +52,4 @@ inline QString overviewDefaultSelectedKey(const QString& prefix)
     return QStringLiteral("ModProfileOverviewDefaultSelected_") + prefix;
 }
 
-}  // namespace ModProfileKeys
+}  

--- a/launcher/settings/SettingsObject.cpp
+++ b/launcher/settings/SettingsObject.cpp
@@ -217,6 +217,15 @@ bool SettingsObject::contains(const QString& id)
     return m_settings.contains(id);
 }
 
+bool SettingsObject::containsValue(const QString& id)
+{
+    auto setting = getSetting(id);
+    if (!setting)
+        return false;
+    // An invalid QVariant means the key is absent; a valid one may intentionally be empty.
+    return retrieveValue(*setting).isValid();
+}
+
 bool SettingsObject::reload()
 {
     for (auto setting : m_settings.values()) {

--- a/launcher/settings/SettingsObject.h
+++ b/launcher/settings/SettingsObject.h
@@ -165,6 +165,18 @@ class SettingsObject : public QObject {
     bool contains(const QString& id);
 
     /*!
+     * \brief Checks whether the setting has an explicitly persisted value in the backing store.
+     *
+     * Unlike contains(), which returns true for any registered setting regardless of whether a
+     * value was written, containsValue() returns true only when the backing store actually holds
+     * a value — distinguishing an absent key from a key present with an empty value.
+     *
+     * \param id The ID of the setting to check.
+     * \return True if the backing store has an explicit value for this setting.
+     */
+    bool containsValue(const QString& id);
+
+    /*!
      * \brief Reloads the settings and emit signals for changed settings
      * \return True if reloading was successful
      */

--- a/launcher/ui/pages/instance/ExternalResourcesPage.h
+++ b/launcher/ui/pages/instance/ExternalResourcesPage.h
@@ -29,7 +29,7 @@ class ExternalResourcesPage : public QMainWindow, public BasePage {
     virtual QString helpPage() const override = 0;
 
     virtual bool shouldDisplay() const override = 0;
-    QString extraHeaderInfoString();
+    virtual QString extraHeaderInfoString();
 
     void openedImpl() override;
     void closedImpl() override;

--- a/launcher/ui/pages/instance/ModFolderPage.cpp
+++ b/launcher/ui/pages/instance/ModFolderPage.cpp
@@ -37,6 +37,8 @@
  */
 
 #include "ModFolderPage.h"
+#include "ProfileCheckStateDelegate.h"
+#include "ProfileOverviewWidget.h"
 #include "minecraft/mod/Resource.h"
 #include "ui/dialogs/ExportToModListDialog.h"
 #include "ui/dialogs/InstallLoaderDialog.h"
@@ -46,9 +48,16 @@
 #include <QAction>
 #include <QEvent>
 #include <QKeyEvent>
+#include <QMouseEvent>
+#include <QHideEvent>
 #include <QMenu>
+#include <QShowEvent>
 #include <QMessageBox>
 #include <QSortFilterProxyModel>
+#include <QInputDialog>
+#include <QBoxLayout>
+#include <QGridLayout>
+#include <QStackedWidget>
 #include <algorithm>
 #include <memory>
 
@@ -67,13 +76,168 @@
 #include "tasks/Task.h"
 #include "ui/dialogs/ProgressDialog.h"
 
+ModFolderPage::~ModFolderPage()
+{
+    if (m_filterWindow) {
+        m_filterWindow->removeEventFilter(this);
+    }
+    if (ui && ui->treeView && ui->treeView->viewport()) {
+        ui->treeView->viewport()->removeEventFilter(this);
+    }
+}
+
+void ModFolderPage::repaintActiveColumn()
+{
+    if (ui && ui->treeView && ui->treeView->viewport())
+        ui->treeView->viewport()->update();
+}
+
+void ModFolderPage::refreshOverviewIfActive()
+{
+    if (m_actionProfileOverview && m_actionProfileOverview->isChecked())
+        refreshOverview();
+}
+
 ModFolderPage::ModFolderPage(MinecraftInstance* inst, ModFolderModel* model, QWidget* parent)
     : ExternalResourcesPage(inst, model, parent), m_model(model)
 {
+    disconnect(ui->treeView, &ModListView::activated, this, nullptr);
+    connect(ui->treeView, &ModListView::activated,
+            this, &ModFolderPage::onModItemActivated);
+
+    m_profileTabBar = new QTabBar(this);
+    m_profileTabBar->setExpanding(false);
+    m_profileTabBar->setDrawBase(false);
+    m_profileTabBar->setDocumentMode(false);
+    m_profileTabBar->setUsesScrollButtons(m_profileTabBar->count() > 1);
+    m_profileTabBar->setElideMode(Qt::ElideNone);
+    m_profileTabBar->setContextMenuPolicy(Qt::CustomContextMenu);
+    m_profileTabBar->setStyleSheet(
+        "QTabBar::tab {"
+        "  padding: 4px 12px;"
+        "  border: none;"
+        "  background: palette(button);"
+        "  color: palette(button-text);"
+        "  margin-right: 1px;"
+        "}"
+        "QTabBar::tab:first {"
+        "  font-weight: bold;"
+        "  margin-right: 8px;"
+        "}"
+        "QTabBar::tab:selected {"
+        "  background: palette(base);"
+        "  color: palette(text);"
+        "  border-bottom: 2px solid palette(highlight);"
+        "}"
+        "QTabBar::tab:hover:!selected {"
+        "  background: palette(alternate-base);"
+        "  color: palette(button-text);"
+        "}");
+    m_newTabButton = new QToolButton(this);
+    m_newTabButton->setText(QStringLiteral("+"));
+    m_newTabButton->setToolTip(tr("New Tab"));
+    m_newTabButton->setAutoRaise(true);
+    m_newTabButton->setFixedSize(24, 24);
+
+    if (ui->treeView->parentWidget() && ui->treeView->parentWidget()->layout()) {
+        QLayout* layout = ui->treeView->parentWidget()->layout();
+        if (auto* grid = qobject_cast<QGridLayout*>(layout)) {
+
+            m_tabRowContainer = new QWidget(this);
+            auto* tabRowLayout = new QHBoxLayout(m_tabRowContainer);
+            tabRowLayout->setContentsMargins(0, 0, 0, 0);
+            tabRowLayout->setSpacing(0);
+            tabRowLayout->addWidget(m_profileTabBar, 0);
+            tabRowLayout->addWidget(m_newTabButton,  0);
+            tabRowLayout->addStretch(1);
+            grid->addWidget(m_tabRowContainer, 0, 1, 1, 2);
+
+            grid->removeWidget(ui->treeView);
+            m_contentStack = new QStackedWidget(this);
+            m_contentStack->addWidget(ui->treeView);
+            m_overviewWidget = new ProfileOverviewWidget(this);
+            m_contentStack->addWidget(m_overviewWidget);
+            m_contentStack->setCurrentIndex(0);
+            grid->addWidget(m_contentStack, 1, 1, 1, 2);
+        }
+    }
+
+    auto* delegate = new ProfileCheckStateDelegate(
+        &m_profileStates, &m_currentProfile,
+        qobject_cast<QSortFilterProxyModel*>(m_filterModel),
+        m_model, this);
+    ui->treeView->setItemDelegateForColumn(ModFolderModel::ActiveColumn, delegate);
+    connect(delegate, &ProfileCheckStateDelegate::membershipToggled,
+            this, &ModFolderPage::onDelegateMembershipToggled);
+
+    ui->treeView->viewport()->installEventFilter(this);
+    m_profileTabBar->installEventFilter(this);
+    connect(m_profileTabBar, &QTabBar::currentChanged, this, [this](int index) {
+        if (m_applyingProfile) {
+            return;
+        }
+        ++m_profileSwitchGeneration;
+        applyProfileSwitch(index, m_profileSwitchGeneration);
+    });
+    connect(m_profileTabBar, &QTabBar::customContextMenuRequested,
+            this, &ModFolderPage::onTabContextMenuRequested);
+    connect(m_newTabButton, &QToolButton::clicked, this, [this] {
+        onTabNewToRight(m_profileTabBar->count() - 1);
+    });
+
+    connect(ui->filterEdit, &QLineEdit::textChanged, this, [this](const QString& text) {
+        if (m_overviewWidget)
+            m_overviewWidget->filterTextChanged(text);
+    });
+
     ui->actionDownloadItem->setText(tr("Download Mods"));
     ui->actionDownloadItem->setToolTip(tr("Download mods from online mod platforms"));
     ui->actionDownloadItem->setEnabled(true);
     ui->actionsToolbar->insertActionBefore(ui->actionAddItem, ui->actionDownloadItem);
+
+    ui->actionsToolbar->setIconSize(QSize(16, 16));
+    m_actionProfileOverview = new QAction(tr("Profile Overview"), this);
+    m_actionProfileOverview->setCheckable(true);
+    m_actionProfileOverview->setIcon(QIcon::fromTheme("loadermods"));
+    m_actionProfileOverview->setToolTip(
+        tr("Show the read-only launch composition overview.\n"
+           "Select which profiles are combined when launching the game."));
+    ui->actionsToolbar->insertActionBefore(ui->actionDownloadItem, m_actionProfileOverview);
+    ui->actionsToolbar->insertSeparator(ui->actionDownloadItem);
+    ui->actionsToolbar->setContextMenuPolicy(Qt::PreventContextMenu);
+
+    for (auto* barAction : ui->actionsToolbar->actions()) {
+        QWidget* wid = ui->actionsToolbar->widgetForAction(barAction);
+        if (auto* btn = qobject_cast<QToolButton*>(wid)) {
+            if (btn->text() == m_actionProfileOverview->text()) {
+                QObject::disconnect(ui->actionsToolbar, &QToolBar::iconSizeChanged,
+                                    btn, &QToolButton::setIconSize);
+                btn->setIconSize(QSize(16, 16));
+                btn->setStyleSheet("QToolButton { text-align: left; spacing: 4px; padding-left: 6px; }");
+                break;
+            }
+        }
+    }
+
+    if (m_actionProfileOverview && m_contentStack) {
+        connect(m_actionProfileOverview, &QAction::toggled, this, [this](bool checked) {
+            if (m_contentStack)
+                m_contentStack->setCurrentIndex(checked ? 1 : 0);
+            if (m_tabRowContainer)
+                m_tabRowContainer->setVisible(!checked);
+            if (ui && ui->frame)
+                ui->frame->setVisible(!checked);
+
+            if (ui && ui->actionsToolbar)
+                ui->actionsToolbar->setVisible(!checked);
+
+            if (m_overviewWidget)
+                m_overviewWidget->setOverviewActive(checked);
+
+            if (checked)
+                refreshOverview();
+        });
+    }
 
     connect(ui->actionDownloadItem, &QAction::triggered, this, &ModFolderPage::downloadMods);
 
@@ -110,6 +274,91 @@ ModFolderPage::ModFolderPage(MinecraftInstance* inst, ModFolderModel* model, QWi
     ui->actionsToolbar->insertActionAfter(ui->actionViewHomepage, ui->actionExportMetadata);
 
     ui->actionsToolbar->insertActionAfter(ui->actionViewFolder, ui->actionViewConfigs);
+
+    m_settingsPrefix = m_model->dir().dirName();
+    m_instance->settings()->getOrRegisterSetting(profileListKey(), QStringList() << "Default");
+    m_instance->settings()->getOrRegisterSetting(lastActiveIndexKey(), 0);
+    m_instance->settings()->getOrRegisterSetting(lastActiveNameKey(), QString());
+    m_instance->settings()->getOrRegisterSetting(runtimeProfilesKey(), QStringList());
+    m_instance->settings()->getOrRegisterSetting(overviewDefaultKey(), true);
+
+    QStringList profileList = m_instance->settings()->get(profileListKey()).toStringList();
+    if (profileList.isEmpty()) {
+        profileList.append("Default");
+    } else if (profileList.at(0) == "All Mods") {
+        profileList[0] = "Default";
+        QString oldKey = profileKey("All Mods");
+        QString newKey = profileKey("Default");
+        QStringList oldState = m_instance->settings()->get(oldKey).toStringList();
+        if (!oldState.isEmpty() && m_instance->settings()->get(newKey).toStringList().isEmpty()) {
+            m_instance->settings()->getOrRegisterSetting(newKey, QStringList());
+            m_instance->settings()->set(newKey, oldState);
+        }
+        m_instance->settings()->reset(oldKey);
+        m_instance->settings()->set(profileListKey(), profileList);
+    }
+    m_profileTabBar->blockSignals(true);
+    for (const QString& name : profileList) {
+        m_profileTabBar->addTab(name);
+        QString key = profileKey(name);
+        m_instance->settings()->getOrRegisterSetting(key, QStringList());
+        QStringList saved = m_instance->settings()->get(key).toStringList();
+        m_profileStates[name] = QSet<QString>(saved.begin(), saved.end());
+    }
+    m_profileTabBar->blockSignals(false);
+    m_profileTabBar->setUsesScrollButtons(m_profileTabBar->count() > 1);
+
+    int savedIndex = m_instance->settings()->get(lastActiveIndexKey()).toInt();
+    if (savedIndex < 0 || savedIndex >= m_profileTabBar->count()) {
+        savedIndex = 0;
+    }
+    QString savedName = m_instance->settings()->get(lastActiveNameKey()).toString();
+    if (savedName == "All Mods") {
+        savedName = "Default";
+        m_instance->settings()->set(lastActiveNameKey(), savedName);
+    }
+    if (!savedName.isEmpty()) {
+        for (int i = 0; i < m_profileTabBar->count(); ++i) {
+            if (m_profileTabBar->tabText(i) == savedName) {
+                savedIndex = i;
+                break;
+            }
+        }
+    }
+    m_profileTabBar->blockSignals(true);
+    m_profileTabBar->setCurrentIndex(savedIndex);
+    m_profileTabBar->blockSignals(false);
+
+    applyProfileSwitch(m_profileTabBar->currentIndex(), m_profileSwitchGeneration, /*isInitialLoad=*/true);
+
+    connect(m_instance, &BaseInstance::runningStatusChanged, this, [this](bool running) {
+        if (!running) {
+            refreshOverviewIfActive();
+            if (m_overviewWidget)
+                m_overviewWidget->setRunningLocked(false);
+        } else {
+            if (m_overviewWidget)
+                m_overviewWidget->setRunningLocked(true);
+            refreshOverviewIfActive();
+        }
+    });
+
+    connect(m_overviewWidget, &ProfileOverviewWidget::defaultSelected,
+            this, &ModFolderPage::onOverviewDefaultSelected);
+    connect(m_overviewWidget, &ProfileOverviewWidget::profileSelectionToggled,
+            this, &ModFolderPage::onOverviewProfileSelectionToggled);
+    connect(m_overviewWidget, &ProfileOverviewWidget::overviewExitRequested,
+            this, [this] {
+                if (m_actionProfileOverview)
+                    m_actionProfileOverview->setChecked(false);
+            });
+
+    connect(m_model, &ModFolderModel::updateFinished, this, [this] {
+        refreshOverviewIfActive();
+    });
+    connect(m_model, &ModFolderModel::dataChanged, this, [this] {
+        refreshOverviewIfActive();
+    });
 }
 
 bool ModFolderPage::shouldDisplay() const
@@ -182,6 +431,12 @@ void ModFolderPage::downloadMods()
 
 void ModFolderPage::downloadDialogFinished(int result)
 {
+    if (m_downloadFlowActive) {
+        return;
+    }
+    m_downloadFlowActive = true;
+    auto dialog = m_downloadDialog;
+    m_downloadDialog.clear();
     if (result != 0) {
         ConcurrentTask tasks(tr("Download Mods"), APPLICATION->settings()->get("NumberOfConcurrentDownloads").toInt());
         connect(&tasks, &Task::failed, this, [this](const QString& reason) {
@@ -194,8 +449,8 @@ void ModFolderPage::downloadDialogFinished(int result)
             }
         });
 
-        if (m_downloadDialog) {
-            for (auto& task : m_downloadDialog->getTasks()) {
+        if (dialog) {
+            for (auto& task : dialog->getTasks()) {
                 tasks.addTask(task);
             }
         } else {
@@ -206,11 +461,62 @@ void ModFolderPage::downloadDialogFinished(int result)
         loadDialog.setSkipButton(true, tr("Abort"));
         loadDialog.execWithTask(&tasks);
 
+        const QString capturedProfile = m_currentProfile;
+        const int capturedGeneration  = m_profileSwitchGeneration;
+
+        QSet<QString> knownModIds;
+        for (int i = 0; i < m_model->rowCount(); ++i)
+            knownModIds.insert(m_model->at(i).mod_id());
+
+        if (!capturedProfile.isEmpty()) {
+            auto parseConn = std::make_shared<QMetaObject::Connection>();
+            auto checkAndAddDelta = [this, capturedProfile, capturedGeneration,
+                                     knownModIds, parseConn]() -> bool {
+                if (capturedGeneration != m_profileSwitchGeneration ||
+                    capturedProfile != m_currentProfile) {
+                    if (*parseConn)
+                        disconnect(*parseConn);
+                    return true;
+                }
+                if (m_model->hasPendingParseTasks())
+                    return false;
+                if (*parseConn)
+                    disconnect(*parseConn);
+                QSet<QString> currentModIds;
+                for (int i = 0; i < m_model->rowCount(); ++i)
+                    currentModIds.insert(m_model->at(i).mod_id());
+                QSet<QString> newIds = currentModIds - knownModIds;
+                if (!newIds.isEmpty()) {
+                    bool profileStillExists = false;
+                    for (int i = 0; i < m_profileTabBar->count(); ++i) {
+                        if (m_profileTabBar->tabText(i) == capturedProfile) {
+                            profileStillExists = true;
+                            break;
+                        }
+                    }
+                    if (profileStillExists) {
+                        for (const QString& id : std::as_const(newIds))
+                            m_profileStates[capturedProfile].insert(id);
+                        persistProfileState(capturedProfile);
+                        repaintActiveColumn();
+                    }
+                }
+                return true;
+            };
+
+            *parseConn = connect(m_model, &ResourceFolderModel::parseFinished, this,
+                                 [checkAndAddDelta] { checkAndAddDelta(); });
+
+            connect(m_model, &ResourceFolderModel::updateFinished, this,
+                [checkAndAddDelta] { checkAndAddDelta(); },
+                Qt::SingleShotConnection);
+        }
         m_model->update();
     }
-    if (m_downloadDialog) {
-        m_downloadDialog->deleteLater();
+    if (dialog) {
+        dialog->deleteLater();
     }
+    m_downloadFlowActive = false;
 }
 
 void ModFolderPage::updateMods(bool includeDeps)
@@ -339,7 +645,11 @@ void ModFolderPage::exportModMetadata()
     auto selection = m_filterModel->mapSelectionToSource(ui->treeView->selectionModel()->selection()).indexes();
     auto selectedMods = m_model->selectedMods(selection);
     if (selectedMods.length() == 0) {
-        selectedMods = m_model->allMods();
+        for (auto* mod : m_model->allMods()) {
+            if (mod->enabled()) {
+                selectedMods.append(mod);
+            }
+        }
     }
 
     std::ranges::sort(selectedMods, [](const Mod* a, const Mod* b) { return a->name() < b->name(); });
@@ -389,7 +699,6 @@ bool NilModFolderPage::shouldDisplay() const
     return m_model->dir().exists();
 }
 
-// Helper function so this doesn't need to be duplicated 3 times
 inline bool ModFolderPage::handleNoModLoader()
 {
     int resp = QMessageBox::question(
@@ -397,11 +706,8 @@ inline bool ModFolderPage::handleNoModLoader()
         ModFolderPage::tr("You need to install a compatible mod loader before installing mods. Would you like to do so?"),
         QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
     if (resp == QMessageBox::Yes) {
-        // Should be safe
         auto* profile = this->m_instance->getPackProfile();
         InstallLoaderDialog dialog(profile, QString(), this);
-        // true if the user went through the install loader dialog
-        // false if the dialog got canceled/closed
         bool dialogAccepted = dialog.exec() != 0;
         this->m_container->refreshContainer();
 
@@ -415,7 +721,110 @@ inline bool ModFolderPage::handleNoModLoader()
         }
         return false;
     }
-    // Nothing happens the dialog is already closing
-    // returning true so the caller doesn't go and continue with opening it's dialog without a mod loader
     return true;
+}
+
+bool ModFolderPage::eventFilter(QObject* obj, QEvent* ev)
+{
+    if (!ui || !ui->treeView || !m_model) {
+        return ExternalResourcesPage::eventFilter(obj, ev);
+    }
+    if (obj == m_profileTabBar && ev->type() == QEvent::Wheel) {
+        return true;
+    }
+    if (ev->type() == QEvent::MouseButtonPress || ev->type() == QEvent::FocusIn) {
+        if (this->isVisible()) {
+            QWidget* widget = qobject_cast<QWidget*>(obj);
+            if (widget) {
+                if (!this->isAncestorOf(widget) && widget != this) {
+                    ui->treeView->clearSelection();
+                    ui->treeView->setCurrentIndex(QModelIndex());
+                }
+            }
+        }
+    }
+    if (obj == ui->treeView->viewport() && ev->type() == QEvent::MouseButtonPress) {
+        auto* me = static_cast<QMouseEvent*>(ev);
+        const QModelIndex idx = ui->treeView->indexAt(me->pos());
+        if (!idx.isValid()) {
+            ui->treeView->clearSelection();
+            ui->treeView->setCurrentIndex(QModelIndex());
+            return true;
+        }
+    }
+    return ExternalResourcesPage::eventFilter(obj, ev);
+}
+
+void ModFolderPage::mousePressEvent(QMouseEvent* event)
+{
+    if (ui->treeView) {
+        QPoint posInTreeView = ui->treeView->mapFrom(this, event->pos());
+        if (!ui->treeView->rect().contains(posInTreeView)) {
+            ui->treeView->clearSelection();
+            ui->treeView->setCurrentIndex(QModelIndex());
+        }
+    }
+    ExternalResourcesPage::mousePressEvent(event);
+}
+
+void ModFolderPage::showEvent(QShowEvent* event)
+{
+    ExternalResourcesPage::showEvent(event);
+    QWidget* w = window();
+    if (w && m_filterWindow != w) {
+        if (m_filterWindow) {
+            m_filterWindow->removeEventFilter(this);
+        }
+        m_filterWindow = w;
+        w->installEventFilter(this);
+    }
+}
+
+void ModFolderPage::hideEvent(QHideEvent* event)
+{
+    if (m_filterWindow) {
+        m_filterWindow->removeEventFilter(this);
+        m_filterWindow = nullptr;
+    }
+    ExternalResourcesPage::hideEvent(event);
+}
+
+void ModFolderPage::openedImpl()
+{
+    ExternalResourcesPage::openedImpl();
+
+    if (ui && ui->actionsToolbar) {
+        ui->actionsToolbar->setIconSize(QSize(16, 16));
+        for (auto* barAction : ui->actionsToolbar->actions()) {
+            barAction->setVisible(true);
+            if (QWidget* wid = ui->actionsToolbar->widgetForAction(barAction)) {
+                wid->setVisible(true);
+                if (auto* btn = qobject_cast<QToolButton*>(wid)) {
+                    if (btn->text() == m_actionProfileOverview->text()) {
+                        QObject::disconnect(ui->actionsToolbar, &QToolBar::iconSizeChanged,
+                                            btn, &QToolButton::setIconSize);
+                        btn->setIconSize(QSize(16, 16));
+                        btn->setStyleSheet("QToolButton { text-align: left; spacing: 4px; padding-left: 6px; }");
+                    }
+                }
+            }
+        }
+    }
+
+    const bool isOverview = m_actionProfileOverview && m_actionProfileOverview->isChecked();
+    if (ui && ui->actionsToolbar)
+        ui->actionsToolbar->setVisible(!isOverview);
+}
+
+void ModFolderPage::closedImpl()
+{
+    if (ui && ui->actionsToolbar) {
+        for (auto* barAction : ui->actionsToolbar->actions()) {
+            barAction->setVisible(true);
+            if (QWidget* wid = ui->actionsToolbar->widgetForAction(barAction))
+                wid->setVisible(true);
+        }
+    }
+
+    ExternalResourcesPage::closedImpl();
 }

--- a/launcher/ui/pages/instance/ModFolderPage.cpp
+++ b/launcher/ui/pages/instance/ModFolderPage.cpp
@@ -98,6 +98,36 @@ void ModFolderPage::refreshOverviewIfActive()
         refreshOverview();
 }
 
+QString ModFolderPage::extraHeaderInfoString()
+{
+    if (m_actionProfileOverview && m_actionProfileOverview->isChecked()) {
+        QStringList profileNames;
+        for (int i = 0; i < m_profileTabBar->count(); ++i)
+            profileNames.append(m_profileTabBar->tabText(i));
+
+        const bool overviewDefault = loadOverviewDefault();
+        const QStringList selected = loadRuntimeSelection();
+
+        QSet<QString> overviewIds;
+        if (overviewDefault) {
+            if (!profileNames.isEmpty())
+                overviewIds = m_profileStates.value(profileNames.at(0));
+        } else {
+            for (const QString& pname : selected)
+                overviewIds += m_profileStates.value(pname);
+        }
+
+        const int installedCount = m_model->size();
+        const int enabledCount   = static_cast<int>(overviewIds.size());
+
+        if (enabledCount != 0)
+            return tr(" (%1 installed, %2 enabled)").arg(installedCount).arg(enabledCount);
+        return tr(" (%1 installed)").arg(installedCount);
+    }
+
+    return ExternalResourcesPage::extraHeaderInfoString();
+}
+
 ModFolderPage::ModFolderPage(MinecraftInstance* inst, ModFolderModel* model, QWidget* parent)
     : ExternalResourcesPage(inst, model, parent), m_model(model)
 {
@@ -234,8 +264,12 @@ ModFolderPage::ModFolderPage(MinecraftInstance* inst, ModFolderModel* model, QWi
             if (m_overviewWidget)
                 m_overviewWidget->setOverviewActive(checked);
 
-            if (checked)
+            if (checked) {
                 refreshOverview();
+            } else {
+                if (updateExtraInfo)
+                    updateExtraInfo(id(), extraHeaderInfoString());
+            }
         });
     }
 
@@ -285,17 +319,6 @@ ModFolderPage::ModFolderPage(MinecraftInstance* inst, ModFolderModel* model, QWi
     QStringList profileList = m_instance->settings()->get(profileListKey()).toStringList();
     if (profileList.isEmpty()) {
         profileList.append("Default");
-    } else if (profileList.at(0) == "All Mods") {
-        profileList[0] = "Default";
-        QString oldKey = profileKey("All Mods");
-        QString newKey = profileKey("Default");
-        QStringList oldState = m_instance->settings()->get(oldKey).toStringList();
-        if (!oldState.isEmpty() && m_instance->settings()->get(newKey).toStringList().isEmpty()) {
-            m_instance->settings()->getOrRegisterSetting(newKey, QStringList());
-            m_instance->settings()->set(newKey, oldState);
-        }
-        m_instance->settings()->reset(oldKey);
-        m_instance->settings()->set(profileListKey(), profileList);
     }
     m_profileTabBar->blockSignals(true);
     for (const QString& name : profileList) {
@@ -313,10 +336,6 @@ ModFolderPage::ModFolderPage(MinecraftInstance* inst, ModFolderModel* model, QWi
         savedIndex = 0;
     }
     QString savedName = m_instance->settings()->get(lastActiveNameKey()).toString();
-    if (savedName == "All Mods") {
-        savedName = "Default";
-        m_instance->settings()->set(lastActiveNameKey(), savedName);
-    }
     if (!savedName.isEmpty()) {
         for (int i = 0; i < m_profileTabBar->count(); ++i) {
             if (m_profileTabBar->tabText(i) == savedName) {
@@ -356,6 +375,45 @@ ModFolderPage::ModFolderPage(MinecraftInstance* inst, ModFolderModel* model, QWi
     connect(m_model, &ModFolderModel::updateFinished, this, [this] {
         refreshOverviewIfActive();
     });
+    // mod_id() is only stable after all LocalModParseTask instances finish — until then it returns a filename-based fallback rather than the declared metadata ID.
+    // Seeding updates only the in-memory profile state; it does not modify settings or the filesystem.
+    {
+        auto seeded = std::make_shared<bool>(false);
+
+        auto doSeed = [this, seeded]() {
+            if (*seeded)
+                return;
+            if (m_model->rowCount() == 0 || m_model->hasPendingParseTasks())
+                return;
+            for (int i = 0; i < m_model->rowCount(); ++i) {
+                if (!m_model->at(i).isResolved())
+                    return;
+            }
+            *seeded = true;
+
+            auto* settings = m_instance->settings();
+            bool needsRepaint = false;
+            for (auto it = m_profileStates.begin(); it != m_profileStates.end(); ++it) {
+                const QString& name = it.key();
+                if (settings->containsValue(profileKey(name))) {
+                    continue;
+                }
+                QSet<QString> fromDisk;
+                for (int i = 0; i < m_model->rowCount(); ++i) {
+                    const Mod& mod = m_model->at(i);
+                    if (mod.enabled())
+                        fromDisk.insert(mod.mod_id());
+                }
+                it.value() = fromDisk;
+                needsRepaint = true;
+            }
+            if (needsRepaint)
+                repaintActiveColumn();
+        };
+
+        connect(m_model, &ModFolderModel::updateFinished,     this, doSeed, Qt::SingleShotConnection);
+        connect(m_model, &ResourceFolderModel::parseFinished, this, doSeed);
+    }
     connect(m_model, &ModFolderModel::dataChanged, this, [this] {
         refreshOverviewIfActive();
     });
@@ -699,6 +757,7 @@ bool NilModFolderPage::shouldDisplay() const
     return m_model->dir().exists();
 }
 
+// Helper function so this doesn't need to be duplicated 3 times
 inline bool ModFolderPage::handleNoModLoader()
 {
     int resp = QMessageBox::question(
@@ -706,8 +765,11 @@ inline bool ModFolderPage::handleNoModLoader()
         ModFolderPage::tr("You need to install a compatible mod loader before installing mods. Would you like to do so?"),
         QMessageBox::Yes | QMessageBox::No, QMessageBox::Yes);
     if (resp == QMessageBox::Yes) {
+        // Should be safe
         auto* profile = this->m_instance->getPackProfile();
         InstallLoaderDialog dialog(profile, QString(), this);
+        // true if the user went through the install loader dialog
+        // false if the dialog got canceled/closed
         bool dialogAccepted = dialog.exec() != 0;
         this->m_container->refreshContainer();
 
@@ -721,6 +783,8 @@ inline bool ModFolderPage::handleNoModLoader()
         }
         return false;
     }
+    // Nothing happens the dialog is already closing
+    // returning true so the caller doesn't go and continue with opening it's dialog without a mod loader
     return true;
 }
 

--- a/launcher/ui/pages/instance/ModFolderPage.h
+++ b/launcher/ui/pages/instance/ModFolderPage.h
@@ -38,9 +38,23 @@
 
 #pragma once
 
+#include <QMap>
 #include <QPointer>
+#include <QSet>
+#include <QStackedWidget>
+#include <QTabBar>
+#include <QToolButton>
 #include "ExternalResourcesPage.h"
+#include "minecraft/mod/ModProfileKeys.h"
 #include "ui/dialogs/ResourceDownloadDialog.h"
+
+class ProfileCheckStateDelegate;
+class ProfileOverviewWidget;
+
+struct ProfileOperation {
+    int     generation = 0;
+    QString profile;
+};
 
 class ModFolderPage : public ExternalResourcesPage {
     Q_OBJECT
@@ -49,7 +63,7 @@ class ModFolderPage : public ExternalResourcesPage {
 
    public:
     explicit ModFolderPage(MinecraftInstance* inst, ModFolderModel* model, QWidget* parent = nullptr);
-    virtual ~ModFolderPage() = default;
+    virtual ~ModFolderPage();
 
     void setFilter(const QString& filter) { m_fileSelectionFilter = filter; }
 
@@ -62,6 +76,8 @@ class ModFolderPage : public ExternalResourcesPage {
 
    public slots:
     void updateFrame(const QModelIndex& current, const QModelIndex& previous) override;
+    void enableItem() override;
+    void disableItem() override;
 
    private slots:
     void removeItems(const QItemSelection& selection) override;
@@ -72,10 +88,81 @@ class ModFolderPage : public ExternalResourcesPage {
     void deleteModMetadata();
     void exportModMetadata();
     void changeModVersion();
+    void onAddProfileClicked();
+    void onRemoveProfileClicked();
+
+    void onTabContextMenuRequested(const QPoint& pos);
+    void onTabNewToRight(int sourceIndex);
+    void onTabDuplicate(int sourceIndex);
+    void onTabRename(int tabIndex);
+    void onTabRemove(int tabIndex);
+    void onTabEnableAll(int tabIndex);
+    void onTabDisableAll(int tabIndex);
+
+    void onModItemActivated(const QModelIndex& proxyIndex);
+
+    void onDelegateMembershipToggled(const QString& modId, bool enabled);
+
+    void onOverviewDefaultSelected();
+    void onOverviewProfileSelectionToggled(const QString& profileName, bool selected);
+
+   private:
+    ProfileOperation beginOperation(const QString& profile);
+    bool isCurrentOperation(const ProfileOperation& op) const;
+
+    void toggleModMembership(const QString& modId, bool add);
+    void setAllModsInProfile(const QString& targetProfile, bool enableAll);
+    void persistProfileState(const QString& name);
+    void syncDisplayedProfileToFilesystem(const ProfileOperation& op);
+    bool confirmDependencyExpansion(const QModelIndexList& seedIndexes, EnableAction action, QSet<QString>& idsToChange);
+    void setCurrentProfile(const QString& name);
+    void refreshOverview();
+    void persistOverviewSelection(bool defaultSelected, const QStringList& selectedProfiles);
+
+    void repaintActiveColumn();
+    void refreshOverviewIfActive();
+
+    void applyProfileSwitch(int index, int generation, bool isInitialLoad = false);
+    void createProfile(const QString& name, const QSet<QString>& initialState, int insertAfterIndex = -1);
+    void saveProfileList();
+
+    QString profileListKey() const        { return ModProfileKeys::profileListKey(m_settingsPrefix); }
+    QString profileKey(const QString& n)  { return ModProfileKeys::profileKey(m_settingsPrefix, n); }
+    QString lastActiveIndexKey() const    { return ModProfileKeys::lastActiveIndexKey(m_settingsPrefix); }
+    QString lastActiveNameKey() const     { return ModProfileKeys::lastActiveProfileNameKey(m_settingsPrefix); }
+    QString runtimeProfilesKey() const    { return ModProfileKeys::runtimeProfilesKey(m_settingsPrefix); }
+    QString overviewDefaultKey() const    { return ModProfileKeys::overviewDefaultSelectedKey(m_settingsPrefix); }
+
+    QStringList loadRuntimeSelection() const;
+    void saveRuntimeSelection(const QStringList& selected);
+    bool loadOverviewDefault() const;
+
+    void openedImpl() override;
+    void closedImpl() override;
 
    protected:
-    ModFolderModel* m_model;
+    bool eventFilter(QObject* obj, QEvent* ev) override;
+    void mousePressEvent(QMouseEvent* event) override;
+    void showEvent(QShowEvent* event) override;
+    void hideEvent(QHideEvent* event) override;
+
+    ModFolderModel*   m_model;
     QPointer<ResourceDownload::ResourceDownloadDialog> m_downloadDialog;
+    QPointer<QWidget> m_filterWindow;
+    bool              m_downloadFlowActive = false;
+
+    QTabBar*           m_profileTabBar           = nullptr;
+    QToolButton*       m_newTabButton            = nullptr;
+    QWidget*           m_tabRowContainer         = nullptr;
+    QAction*           m_actionProfileOverview   = nullptr;
+    QStackedWidget*    m_contentStack            = nullptr;
+    ProfileOverviewWidget* m_overviewWidget      = nullptr;
+
+    QMap<QString, QSet<QString>> m_profileStates;
+    QString            m_currentProfile;
+    QString            m_settingsPrefix;
+    int                m_profileSwitchGeneration = 0;
+    bool               m_applyingProfile     = false;
 };
 
 class CoreModFolderPage : public ModFolderPage {

--- a/launcher/ui/pages/instance/ModFolderPage.h
+++ b/launcher/ui/pages/instance/ModFolderPage.h
@@ -146,6 +146,8 @@ class ModFolderPage : public ExternalResourcesPage {
     void showEvent(QShowEvent* event) override;
     void hideEvent(QHideEvent* event) override;
 
+    QString extraHeaderInfoString() override;
+
     ModFolderModel*   m_model;
     QPointer<ResourceDownload::ResourceDownloadDialog> m_downloadDialog;
     QPointer<QWidget> m_filterWindow;

--- a/launcher/ui/pages/instance/ModFolderPageProfiles.cpp
+++ b/launcher/ui/pages/instance/ModFolderPageProfiles.cpp
@@ -1,0 +1,651 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (c) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
+ *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
+ *  Copyright (c) 2023 Trial97 <alexandru.tripon97@gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * This file incorporates work covered by the following copyright and
+ * permission notice:
+ *
+ *      Copyright 2013-2021 MultiMC Contributors
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+#include "ModFolderPage.h"
+#include "ProfileCheckStateDelegate.h"
+#include "ProfileOverviewWidget.h"
+#include "minecraft/mod/Resource.h"
+#include "ui/dialogs/ExportToModListDialog.h"
+#include "ui/dialogs/InstallLoaderDialog.h"
+#include "ui_ExternalResourcesPage.h"
+
+#include <QAbstractItemModel>
+#include <QAction>
+#include <QEvent>
+#include <QKeyEvent>
+#include <QMouseEvent>
+#include <QHideEvent>
+#include <QMenu>
+#include <QShowEvent>
+#include <QMessageBox>
+#include <QSortFilterProxyModel>
+#include <QInputDialog>
+#include <QBoxLayout>
+#include <QGridLayout>
+#include <QStackedWidget>
+#include <algorithm>
+#include <memory>
+
+#include "Application.h"
+
+#include "ui/dialogs/CustomMessageBox.h"
+#include "ui/dialogs/ResourceDownloadDialog.h"
+#include "ui/dialogs/ResourceUpdateDialog.h"
+
+#include "minecraft/PackProfile.h"
+#include "minecraft/VersionFilterData.h"
+#include "minecraft/mod/Mod.h"
+#include "minecraft/mod/ModFolderModel.h"
+
+#include "tasks/ConcurrentTask.h"
+#include "tasks/Task.h"
+#include "ui/dialogs/ProgressDialog.h"
+
+void ModFolderPage::toggleModMembership(const QString& modId, bool add)
+{
+    if (m_currentProfile.isEmpty() || modId.isEmpty())
+        return;
+
+    int row = -1;
+    for (int i = 0; i < m_model->rowCount(); ++i) {
+        if (m_model->at(i).mod_id() == modId) {
+            row = i;
+            break;
+        }
+    }
+
+    QSet<QString> idsToChange{ modId };
+    if (row >= 0) {
+        EnableAction action = add ? EnableAction::ENABLE : EnableAction::DISABLE;
+        if (!confirmDependencyExpansion({ m_model->index(row, 0) }, action, idsToChange))
+            return;
+    }
+
+    for (const QString& id : std::as_const(idsToChange)) {
+        if (add)
+            m_profileStates[m_currentProfile].insert(id);
+        else
+            m_profileStates[m_currentProfile].remove(id);
+    }
+    persistProfileState(m_currentProfile);
+    repaintActiveColumn();
+    if (!m_instance->isRunning()) {
+        ++m_profileSwitchGeneration;
+        auto op = beginOperation(m_currentProfile);
+        syncDisplayedProfileToFilesystem(op);
+    }
+}
+
+void ModFolderPage::persistProfileState(const QString& name)
+{
+    if (name.isEmpty())
+        return;
+    const QSet<QString>& state = m_profileStates.value(name);
+    QString key = profileKey(name);
+    m_instance->settings()->getOrRegisterSetting(key, QStringList());
+    m_instance->settings()->set(key, QStringList(state.begin(), state.end()));
+}
+
+void ModFolderPage::setCurrentProfile(const QString& name)
+{
+    m_currentProfile = name;
+    m_profileTabBar->setProperty("currentProfileName", name);
+    m_instance->settings()->set(lastActiveNameKey(), name);
+    for (int i = 0; i < m_profileTabBar->count(); ++i) {
+        if (m_profileTabBar->tabText(i) == name) {
+            m_instance->settings()->set(lastActiveIndexKey(), i);
+            break;
+        }
+    }
+}
+
+ProfileOperation ModFolderPage::beginOperation(const QString& profile)
+{
+    ProfileOperation op;
+    op.generation = m_profileSwitchGeneration;
+    op.profile    = profile;
+    return op;
+}
+
+bool ModFolderPage::isCurrentOperation(const ProfileOperation& op) const
+{
+    return op.generation == m_profileSwitchGeneration && op.profile == m_currentProfile;
+}
+
+void ModFolderPage::syncDisplayedProfileToFilesystem(const ProfileOperation& op)
+{
+    if (m_instance->isRunning())
+        return;
+    if (m_currentProfile.isEmpty())
+        return;
+    QSet<QString> targetState = m_profileStates.value(m_currentProfile);
+    m_applyingProfile = true;
+    m_model->applyEnabledIds(targetState);
+    connect(m_model, &ResourceFolderModel::updateFinished, this,
+        [this, op] {
+            if (isCurrentOperation(op)) {
+                m_applyingProfile = false;
+            }
+        },
+        Qt::SingleShotConnection);
+    m_model->update();
+}
+
+bool ModFolderPage::confirmDependencyExpansion(const QModelIndexList& seedIndexes, EnableAction action, QSet<QString>& idsToChange)
+{
+    QModelIndexList affected = m_model->getAffectedMods(seedIndexes, action);
+    if (affected.isEmpty())
+        return true;
+
+    const bool enabling = (action == EnableAction::ENABLE);
+    QSet<QString> affectedIds;
+    QString details = enabling
+        ? tr("The following mods will be enabled:")
+        : tr("The following mods will be disabled:");
+    for (const auto& idx : affected) {
+        const Mod& m = m_model->at(idx.row());
+        affectedIds.insert(m.mod_id());
+        details += QString("\n- %1 (%2)").arg(m.name(), m.internalId());
+    }
+
+    const QString title = tr("Confirm toggle");
+    const QString noButton = tr("Only Toggle Selected");
+    const QString yesButton = tr("Toggle Required Mods");
+
+    QString message = tr("Toggling this mod will cause dependency changes to other mods in this profile.\n");
+    message += enabling
+        ? tr("%n mod(s) will be enabled\n", "", affected.size())
+        : tr("%n mod(s) will be disabled\n", "", affected.size());
+    message += tr("Do you want to automatically apply these related changes?\nIgnoring them may break the game.");
+
+    auto* box = CustomMessageBox::selectable(this, title, message, QMessageBox::Warning,
+                                             QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel, QMessageBox::No);
+    box->button(QMessageBox::No)->setText(noButton);
+    box->button(QMessageBox::Yes)->setText(yesButton);
+    box->setDetailedText(details);
+
+    const auto response = box->exec();
+
+    if (response == QMessageBox::Cancel)
+        return false;
+    if (response == QMessageBox::Yes)
+        idsToChange += affectedIds;
+    return true;
+}
+
+void ModFolderPage::setAllModsInProfile(const QString& targetProfile, bool enableAll)
+{
+    if (targetProfile.isEmpty())
+        return;
+    QSet<QString> newState;
+    if (enableAll) {
+        for (int i = 0; i < m_model->rowCount(); ++i)
+            newState.insert(m_model->at(i).mod_id());
+    }
+    m_profileStates[targetProfile] = newState;
+    persistProfileState(targetProfile);
+    repaintActiveColumn();
+    if (!m_instance->isRunning()) {
+        auto op = beginOperation(targetProfile);
+        syncDisplayedProfileToFilesystem(op);
+    }
+}
+
+void ModFolderPage::refreshOverview()
+{
+    if (!m_overviewWidget)
+        return;
+    QStringList profileNames;
+    for (int i = 0; i < m_profileTabBar->count(); ++i)
+        profileNames.append(m_profileTabBar->tabText(i));
+    bool overviewDefault = loadOverviewDefault();
+    QStringList selected = loadRuntimeSelection();
+    m_overviewWidget->refresh(m_model, m_profileStates, profileNames,
+                              overviewDefault, selected,
+                              m_instance->isRunning(),
+                              m_model->launchSnapshot());
+    if (ui && ui->filterEdit)
+        m_overviewWidget->filterTextChanged(ui->filterEdit->text());
+}
+
+bool ModFolderPage::loadOverviewDefault() const
+{
+    return m_instance->settings()->get(overviewDefaultKey()).toBool();
+}
+
+void ModFolderPage::persistOverviewSelection(bool defaultSelected, const QStringList& selectedProfiles)
+{
+    m_instance->settings()->set(overviewDefaultKey(), defaultSelected);
+    saveRuntimeSelection(selectedProfiles);
+}
+
+void ModFolderPage::onModItemActivated(const QModelIndex& proxyIndex)
+{
+    if (!proxyIndex.isValid())
+        return;
+    QModelIndex sourceIndex = m_filterModel->mapToSource(proxyIndex);
+    if (!sourceIndex.isValid())
+        return;
+    int row = sourceIndex.row();
+    if (row < 0 || row >= m_model->rowCount())
+        return;
+    const QString modId = m_model->at(row).mod_id();
+    if (modId.isEmpty())
+        return;
+    bool currentlyEnabled = m_profileStates.value(m_currentProfile).contains(modId);
+    toggleModMembership(modId, !currentlyEnabled);
+}
+
+void ModFolderPage::onDelegateMembershipToggled(const QString& modId, bool enabled)
+{
+    toggleModMembership(modId, enabled);
+}
+
+void ModFolderPage::enableItem()
+{
+    if (m_currentProfile.isEmpty())
+        return;
+    auto selection = m_filterModel->mapSelectionToSource(ui->treeView->selectionModel()->selection());
+    QModelIndexList seedIndexes;
+    QSet<QString> idsToChange;
+    for (const QModelIndex& idx : selection.indexes()) {
+        if (idx.column() != 0)
+            continue;
+        int row = idx.row();
+        if (row < 0 || row >= m_model->rowCount())
+            continue;
+        idsToChange.insert(m_model->at(row).mod_id());
+        seedIndexes << idx;
+    }
+    if (idsToChange.isEmpty())
+        return;
+
+    if (!confirmDependencyExpansion(seedIndexes, EnableAction::ENABLE, idsToChange))
+        return;
+
+    bool changed = false;
+    for (const QString& id : std::as_const(idsToChange)) {
+        if (!m_profileStates[m_currentProfile].contains(id)) {
+            m_profileStates[m_currentProfile].insert(id);
+            changed = true;
+        }
+    }
+    if (changed) {
+        persistProfileState(m_currentProfile);
+        repaintActiveColumn();
+        if (!m_instance->isRunning()) {
+            ++m_profileSwitchGeneration;
+            auto op = beginOperation(m_currentProfile);
+            syncDisplayedProfileToFilesystem(op);
+        }
+    }
+}
+
+void ModFolderPage::disableItem()
+{
+    if (m_currentProfile.isEmpty())
+        return;
+    auto selection = m_filterModel->mapSelectionToSource(ui->treeView->selectionModel()->selection());
+    QModelIndexList seedIndexes;
+    QSet<QString> idsToChange;
+    for (const QModelIndex& idx : selection.indexes()) {
+        if (idx.column() != 0)
+            continue;
+        int row = idx.row();
+        if (row < 0 || row >= m_model->rowCount())
+            continue;
+        idsToChange.insert(m_model->at(row).mod_id());
+        seedIndexes << idx;
+    }
+    if (idsToChange.isEmpty())
+        return;
+
+    if (!confirmDependencyExpansion(seedIndexes, EnableAction::DISABLE, idsToChange))
+        return;
+
+    bool changed = false;
+    for (const QString& id : std::as_const(idsToChange)) {
+        if (m_profileStates[m_currentProfile].contains(id)) {
+            m_profileStates[m_currentProfile].remove(id);
+            changed = true;
+        }
+    }
+    if (changed) {
+        persistProfileState(m_currentProfile);
+        repaintActiveColumn();
+        if (!m_instance->isRunning()) {
+            ++m_profileSwitchGeneration;
+            auto op = beginOperation(m_currentProfile);
+            syncDisplayedProfileToFilesystem(op);
+        }
+    }
+}
+
+void ModFolderPage::onOverviewDefaultSelected()
+{
+    persistOverviewSelection(true, QStringList());
+    refreshOverview();
+}
+
+void ModFolderPage::onOverviewProfileSelectionToggled(const QString& profileName, bool selected)
+{
+    QStringList current = loadRuntimeSelection();
+    if (selected) {
+        if (!current.contains(profileName))
+            current.append(profileName);
+        persistOverviewSelection(false, current);
+    } else {
+        current.removeAll(profileName);
+        if (current.isEmpty())
+            persistOverviewSelection(true, QStringList());
+        else
+            persistOverviewSelection(false, current);
+    }
+    refreshOverview();
+}
+
+void ModFolderPage::applyProfileSwitch(int index, int generation, bool isInitialLoad)
+{
+    if (!m_profileTabBar)
+        return;
+    if (isInitialLoad && m_instance->isRunning()) {
+        return;
+    }
+    if (index >= 0 && index < m_profileTabBar->count()) {
+        QString tabName = m_profileTabBar->tabText(index);
+        setCurrentProfile(tabName);
+
+        QSet<QString> enabledMods;
+        if (m_profileStates.contains(tabName)) {
+            enabledMods = m_profileStates[tabName];
+        } else {
+            QString key = profileKey(tabName);
+            m_instance->settings()->getOrRegisterSetting(key, QStringList());
+            QStringList saved = m_instance->settings()->get(key).toStringList();
+            enabledMods = QSet<QString>(saved.begin(), saved.end());
+            m_profileStates[tabName] = enabledMods;
+        }
+
+        if (!m_instance->isRunning()) {
+            int capturedGeneration = generation;
+            QString capturedProfile = tabName;
+            m_applyingProfile = true;
+            m_model->applyEnabledIds(enabledMods);
+            connect(m_model, &ResourceFolderModel::updateFinished, this,
+                [this, capturedGeneration, capturedProfile] {
+                    if (capturedGeneration != m_profileSwitchGeneration ||
+                        capturedProfile != m_currentProfile) {
+                        return;
+                    }
+                    m_applyingProfile = false;
+                },
+                Qt::SingleShotConnection);
+            m_model->update();
+        } else {
+            m_applyingProfile = false;
+            repaintActiveColumn();
+        }
+    } else {
+        m_currentProfile = QString();
+        m_profileTabBar->setProperty("currentProfileName", QString());
+        m_applyingProfile = false;
+        repaintActiveColumn();
+    }
+
+    refreshOverviewIfActive();
+}
+
+void ModFolderPage::onAddProfileClicked() {
+    bool ok;
+    QString name = QInputDialog::getText(this, tr("Add Profile"), tr("Profile Name:"),
+                                         QLineEdit::Normal, QString(), &ok);
+    if (ok && !name.isEmpty()) {
+        createProfile(name, QSet<QString>{});
+    }
+}
+
+void ModFolderPage::onRemoveProfileClicked() {
+    int index = m_profileTabBar->currentIndex();
+    if (index > 0) {
+        onTabRemove(index);
+    }
+}
+
+void ModFolderPage::createProfile(const QString& name, const QSet<QString>& initialState,
+                                   int insertAfterIndex)
+{
+    for (int i = 0; i < m_profileTabBar->count(); ++i) {
+        if (m_profileTabBar->tabText(i) == name) {
+            QMessageBox::warning(this, tr("Warning"),
+                                 tr("A profile with this name already exists."));
+            return;
+        }
+    }
+    m_profileStates[name] = initialState;
+    QString key = profileKey(name);
+    m_instance->settings()->getOrRegisterSetting(key, QStringList());
+    m_instance->settings()->set(key, QStringList(initialState.begin(), initialState.end()));
+    if (insertAfterIndex >= 0 && insertAfterIndex < m_profileTabBar->count()) {
+        m_profileTabBar->insertTab(insertAfterIndex + 1, name);
+    } else {
+        m_profileTabBar->addTab(name);
+    }
+    m_profileTabBar->setUsesScrollButtons(m_profileTabBar->count() > 1);
+    saveProfileList();
+    refreshOverviewIfActive();
+}
+
+void ModFolderPage::saveProfileList()
+{
+    QStringList profileList;
+    for (int i = 0; i < m_profileTabBar->count(); ++i) {
+        profileList.append(m_profileTabBar->tabText(i));
+    }
+    m_instance->settings()->set(profileListKey(), profileList);
+}
+
+void ModFolderPage::onTabContextMenuRequested(const QPoint& pos)
+{
+    int tabIndex = m_profileTabBar->tabAt(pos);
+    QMenu menu(this);
+    auto* newToRight = menu.addAction(tr("New Tab to Right"));
+    int insertAfter = tabIndex >= 0 ? tabIndex : m_profileTabBar->count() - 1;
+    connect(newToRight, &QAction::triggered, this, [this, insertAfter] {
+        onTabNewToRight(insertAfter);
+    });
+    if (tabIndex >= 0) {
+        auto* duplicate = menu.addAction(tr("Duplicate"));
+        connect(duplicate, &QAction::triggered, this, [this, tabIndex] {
+            onTabDuplicate(tabIndex);
+        });
+        if (tabIndex != 0) {
+            auto* rename = menu.addAction(tr("Rename"));
+            connect(rename, &QAction::triggered, this, [this, tabIndex] {
+                onTabRename(tabIndex);
+            });
+            auto* remove = menu.addAction(tr("Remove"));
+            connect(remove, &QAction::triggered, this, [this, tabIndex] {
+                onTabRemove(tabIndex);
+            });
+        }
+        menu.addSeparator();
+        auto* enableAll = menu.addAction(tr("Enable All"));
+        connect(enableAll, &QAction::triggered, this, [this, tabIndex] {
+            onTabEnableAll(tabIndex);
+        });
+        auto* disableAll = menu.addAction(tr("Disable All"));
+        connect(disableAll, &QAction::triggered, this, [this, tabIndex] {
+            onTabDisableAll(tabIndex);
+        });
+    }
+    menu.exec(m_profileTabBar->mapToGlobal(pos));
+}
+
+void ModFolderPage::onTabNewToRight(int sourceIndex)
+{
+    bool ok;
+    QString name = QInputDialog::getText(this, tr("New Profile"), tr("Profile Name:"),
+                                         QLineEdit::Normal, QString(), &ok);
+    if (ok && !name.isEmpty()) {
+        createProfile(name, QSet<QString>{}, sourceIndex);
+    }
+}
+
+void ModFolderPage::onTabDuplicate(int sourceIndex)
+{
+    if (m_applyingProfile) return;
+    QString sourceName = m_profileTabBar->tabText(sourceIndex);
+    QSet<QString> sourceState = m_profileStates.value(sourceName);
+    bool ok;
+    QString name = QInputDialog::getText(this, tr("Duplicate Profile"),
+                                          tr("New Profile Name:"), QLineEdit::Normal,
+                                          tr("Copy of %1").arg(sourceName), &ok);
+    if (ok && !name.isEmpty()) {
+        createProfile(name, sourceState, sourceIndex);
+    }
+}
+
+void ModFolderPage::onTabRename(int tabIndex)
+{
+    if (tabIndex == 0) return;
+    if (m_applyingProfile) return;
+    QString oldName = m_profileTabBar->tabText(tabIndex);
+    bool ok;
+    QString newName = QInputDialog::getText(this, tr("Rename Profile"),
+                                             tr("New Profile Name:"), QLineEdit::Normal,
+                                             oldName, &ok);
+    if (!ok || newName.isEmpty() || newName == oldName) return;
+    for (int i = 0; i < m_profileTabBar->count(); ++i) {
+        if (m_profileTabBar->tabText(i) == newName) {
+            QMessageBox::warning(this, tr("Warning"),
+                                 tr("A profile named \"%1\" already exists.").arg(newName));
+            return;
+        }
+    }
+    if (m_profileStates.contains(oldName)) {
+        m_profileStates[newName] = m_profileStates.take(oldName);
+    }
+    QString oldKey = profileKey(oldName);
+    QString newKey = profileKey(newName);
+    QStringList stateData = m_instance->settings()->get(oldKey).toStringList();
+    m_instance->settings()->reset(oldKey);
+    m_instance->settings()->getOrRegisterSetting(newKey, QStringList());
+    m_instance->settings()->set(newKey, stateData);
+    m_profileTabBar->setTabText(tabIndex, newName);
+    if (m_currentProfile == oldName) {
+        setCurrentProfile(newName);
+    }
+    QStringList rtSelected = loadRuntimeSelection();
+    int pos = rtSelected.indexOf(oldName);
+    if (pos >= 0) {
+        rtSelected[pos] = newName;
+        saveRuntimeSelection(rtSelected);
+    }
+    saveProfileList();
+    refreshOverviewIfActive();
+}
+
+void ModFolderPage::onTabRemove(int tabIndex)
+{
+    if (tabIndex == 0) return;
+    if (m_applyingProfile) return;
+    QString name = m_profileTabBar->tabText(tabIndex);
+    auto response = CustomMessageBox::selectable(
+                        this, tr("Remove Profile"),
+                        tr("Are you sure you want to remove the profile \"%1\"?\n"
+                           "This cannot be undone.").arg(name),
+                        QMessageBox::Warning,
+                        QMessageBox::Yes | QMessageBox::No, QMessageBox::No)->exec();
+    if (response != QMessageBox::Yes) return;
+    m_profileStates.remove(name);
+    m_instance->settings()->reset(profileKey(name));
+    QStringList runtimeSelected = loadRuntimeSelection();
+    if (runtimeSelected.removeAll(name) > 0) {
+        saveRuntimeSelection(runtimeSelected);
+    }
+    m_profileTabBar->removeTab(tabIndex);
+    m_profileTabBar->setUsesScrollButtons(m_profileTabBar->count() > 1);
+    if (m_currentProfile == name) {
+        ++m_profileSwitchGeneration;
+        applyProfileSwitch(0, m_profileSwitchGeneration);
+    }
+    saveProfileList();
+    refreshOverviewIfActive();
+}
+
+void ModFolderPage::onTabEnableAll(int tabIndex)
+{
+    if (m_applyingProfile) {
+        return;
+    }
+    QString targetProfile = m_profileTabBar->tabText(tabIndex);
+    ++m_profileSwitchGeneration;
+    if (m_profileTabBar->currentIndex() != tabIndex) {
+        m_profileTabBar->blockSignals(true);
+        m_profileTabBar->setCurrentIndex(tabIndex);
+        m_profileTabBar->blockSignals(false);
+    }
+    setCurrentProfile(targetProfile);
+    setAllModsInProfile(targetProfile, /*enableAll=*/true);
+}
+
+void ModFolderPage::onTabDisableAll(int tabIndex)
+{
+    if (m_applyingProfile) {
+        return;
+    }
+    QString targetProfile = m_profileTabBar->tabText(tabIndex);
+    ++m_profileSwitchGeneration;
+    if (m_profileTabBar->currentIndex() != tabIndex) {
+        m_profileTabBar->blockSignals(true);
+        m_profileTabBar->setCurrentIndex(tabIndex);
+        m_profileTabBar->blockSignals(false);
+    }
+    setCurrentProfile(targetProfile);
+    setAllModsInProfile(targetProfile, /*enableAll=*/false);
+}
+
+QStringList ModFolderPage::loadRuntimeSelection() const
+{
+    return m_instance->settings()->get(runtimeProfilesKey()).toStringList();
+}
+
+void ModFolderPage::saveRuntimeSelection(const QStringList& selected)
+{
+    m_instance->settings()->set(runtimeProfilesKey(), selected);
+}

--- a/launcher/ui/pages/instance/ModFolderPageProfiles.cpp
+++ b/launcher/ui/pages/instance/ModFolderPageProfiles.cpp
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
  *  Prism Launcher - Minecraft Launcher
- *  Copyright (c) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
- *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
- *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
- *  Copyright (c) 2023 Trial97 <alexandru.tripon97@gmail.com>
+ *  Copyright (C) 2026 Vivek Kushwaha <notvivekkushwaha@gmail.com>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -17,23 +14,6 @@
  *
  *  You should have received a copy of the GNU General Public License
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- *
- * This file incorporates work covered by the following copyright and
- * permission notice:
- *
- *      Copyright 2013-2021 MultiMC Contributors
- *
- *      Licensed under the Apache License, Version 2.0 (the "License");
- *      you may not use this file except in compliance with the License.
- *      You may obtain a copy of the License at
- *
- *          http://www.apache.org/licenses/LICENSE-2.0
- *
- *      Unless required by applicable law or agreed to in writing, software
- *      distributed under the License is distributed on an "AS IS" BASIS,
- *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *      See the License for the specific language governing permissions and
- *      limitations under the License.
  */
 
 #include "ModFolderPage.h"
@@ -241,6 +221,9 @@ void ModFolderPage::refreshOverview()
                               m_model->launchSnapshot());
     if (ui && ui->filterEdit)
         m_overviewWidget->filterTextChanged(ui->filterEdit->text());
+
+    if (updateExtraInfo)
+        updateExtraInfo(id(), extraHeaderInfoString());
 }
 
 bool ModFolderPage::loadOverviewDefault() const
@@ -402,20 +385,26 @@ void ModFolderPage::applyProfileSwitch(int index, int generation, bool isInitial
         }
 
         if (!m_instance->isRunning()) {
-            int capturedGeneration = generation;
-            QString capturedProfile = tabName;
-            m_applyingProfile = true;
-            m_model->applyEnabledIds(enabledMods);
-            connect(m_model, &ResourceFolderModel::updateFinished, this,
-                [this, capturedGeneration, capturedProfile] {
-                    if (capturedGeneration != m_profileSwitchGeneration ||
-                        capturedProfile != m_currentProfile) {
-                        return;
-                    }
-                    m_applyingProfile = false;
-                },
-                Qt::SingleShotConnection);
-            m_model->update();
+            // On initial load, an absent profile key means the filesystem state remains authoritative.
+            if (isInitialLoad && !m_instance->settings()->containsValue(profileKey(tabName))) {
+                m_applyingProfile = false;
+                repaintActiveColumn();
+            } else {
+                int capturedGeneration = generation;
+                QString capturedProfile = tabName;
+                m_applyingProfile = true;
+                m_model->applyEnabledIds(enabledMods);
+                connect(m_model, &ResourceFolderModel::updateFinished, this,
+                    [this, capturedGeneration, capturedProfile] {
+                        if (capturedGeneration != m_profileSwitchGeneration ||
+                            capturedProfile != m_currentProfile) {
+                            return;
+                        }
+                        m_applyingProfile = false;
+                    },
+                    Qt::SingleShotConnection);
+                m_model->update();
+            }
         } else {
             m_applyingProfile = false;
             repaintActiveColumn();

--- a/launcher/ui/pages/instance/ProfileCheckStateDelegate.cpp
+++ b/launcher/ui/pages/instance/ProfileCheckStateDelegate.cpp
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (c) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
+ *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
+ *  Copyright (c) 2023 Trial97 <alexandru.tripon97@gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * This file incorporates work covered by the following copyright and
+ * permission notice:
+ *
+ *      Copyright 2013-2021 MultiMC Contributors
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+#include "ProfileCheckStateDelegate.h"
+
+#include <QApplication>
+#include <QMouseEvent>
+#include <QPainter>
+#include <QSortFilterProxyModel>
+
+#include "minecraft/mod/ModFolderModel.h"
+
+ProfileCheckStateDelegate::ProfileCheckStateDelegate(
+    const QMap<QString, QSet<QString>>* profileStates,
+    const QString* currentProfile,
+    QSortFilterProxyModel* filterModel,
+    ModFolderModel* model,
+    QObject* parent)
+    : QStyledItemDelegate(parent)
+    , m_profileStates(profileStates)
+    , m_currentProfile(currentProfile)
+    , m_filterModel(filterModel)
+    , m_model(model)
+{}
+
+QString ProfileCheckStateDelegate::resolveModId(const QModelIndex& proxyIndex) const
+{
+    if (!proxyIndex.isValid())
+        return {};
+    QModelIndex sourceIndex = m_filterModel->mapToSource(proxyIndex);
+    if (!sourceIndex.isValid())
+        return {};
+    int row = sourceIndex.row();
+    if (row < 0 || row >= m_model->rowCount())
+        return {};
+    return m_model->at(row).mod_id();
+}
+
+void ProfileCheckStateDelegate::initStyleOption(QStyleOptionViewItem* option,
+                                               const QModelIndex& index) const
+{
+    QStyledItemDelegate::initStyleOption(option, index);
+    if (index.column() == ModFolderModel::ActiveColumn) {
+        const QString modId = resolveModId(index);
+        const bool checked = !m_currentProfile->isEmpty() &&
+                             m_profileStates->contains(*m_currentProfile) &&
+                             (*m_profileStates)[*m_currentProfile].contains(modId);
+        option->features |= QStyleOptionViewItem::HasCheckIndicator;
+        option->checkState = checked ? Qt::Checked : Qt::Unchecked;
+        if (checked) {
+            option->state |= QStyle::State_On;
+            option->state &= ~QStyle::State_Off;
+        } else {
+            option->state |= QStyle::State_Off;
+            option->state &= ~QStyle::State_On;
+        }
+    }
+}
+
+void ProfileCheckStateDelegate::paint(QPainter* painter,
+                                      const QStyleOptionViewItem& option,
+                                      const QModelIndex& index) const
+{
+    QStyledItemDelegate::paint(painter, option, index);
+}
+
+bool ProfileCheckStateDelegate::editorEvent(QEvent* event,
+                                            QAbstractItemModel* /*model*/,
+                                            const QStyleOptionViewItem& option,
+                                            const QModelIndex& index)
+{
+    if (index.column() != ModFolderModel::ActiveColumn)
+        return false;
+    if (m_currentProfile->isEmpty())
+        return false;
+
+    bool isClick = false;
+    if (event->type() == QEvent::MouseButtonRelease) {
+        auto* me = static_cast<QMouseEvent*>(event);
+        if (me->button() == Qt::LeftButton && option.rect.contains(me->pos()))
+            isClick = true;
+    } else if (event->type() == QEvent::KeyPress) {
+        auto* ke = static_cast<QKeyEvent*>(event);
+        if (ke->key() == Qt::Key_Space || ke->key() == Qt::Key_Return)
+            isClick = true;
+    }
+
+    if (!isClick)
+        return false;
+
+    const QString modId = resolveModId(index);
+    if (modId.isEmpty())
+        return false;
+
+    bool currentlyEnabled = (*m_profileStates)[*m_currentProfile].contains(modId);
+    emit membershipToggled(modId, !currentlyEnabled);
+    return true;
+}

--- a/launcher/ui/pages/instance/ProfileCheckStateDelegate.cpp
+++ b/launcher/ui/pages/instance/ProfileCheckStateDelegate.cpp
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
  *  Prism Launcher - Minecraft Launcher
- *  Copyright (c) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
- *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
- *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
- *  Copyright (c) 2023 Trial97 <alexandru.tripon97@gmail.com>
+ *  Copyright (C) 2026 Vivek Kushwaha <notvivekkushwaha@gmail.com>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -17,23 +14,6 @@
  *
  *  You should have received a copy of the GNU General Public License
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- *
- * This file incorporates work covered by the following copyright and
- * permission notice:
- *
- *      Copyright 2013-2021 MultiMC Contributors
- *
- *      Licensed under the Apache License, Version 2.0 (the "License");
- *      you may not use this file except in compliance with the License.
- *      You may obtain a copy of the License at
- *
- *          http://www.apache.org/licenses/LICENSE-2.0
- *
- *      Unless required by applicable law or agreed to in writing, software
- *      distributed under the License is distributed on an "AS IS" BASIS,
- *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *      See the License for the specific language governing permissions and
- *      limitations under the License.
  */
 
 #include "ProfileCheckStateDelegate.h"

--- a/launcher/ui/pages/instance/ProfileCheckStateDelegate.h
+++ b/launcher/ui/pages/instance/ProfileCheckStateDelegate.h
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (c) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
+ *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
+ *  Copyright (c) 2023 Trial97 <alexandru.tripon97@gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * This file incorporates work covered by the following copyright and
+ * permission notice:
+ *
+ *      Copyright 2013-2021 MultiMC Contributors
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+#pragma once
+
+#include <QStyledItemDelegate>
+#include <QSet>
+#include <QString>
+#include <QMap>
+
+class ModFolderModel;
+class QSortFilterProxyModel;
+
+class ProfileCheckStateDelegate : public QStyledItemDelegate {
+    Q_OBJECT
+   public:
+    explicit ProfileCheckStateDelegate(
+        const QMap<QString, QSet<QString>>* profileStates,
+        const QString* currentProfile,
+        QSortFilterProxyModel* filterModel,
+        ModFolderModel* model,
+        QObject* parent = nullptr);
+
+    void paint(QPainter* painter,
+               const QStyleOptionViewItem& option,
+               const QModelIndex& index) const override;
+
+    void initStyleOption(QStyleOptionViewItem* option,
+                         const QModelIndex& index) const override;
+
+    bool editorEvent(QEvent* event,
+                     QAbstractItemModel* model,
+                     const QStyleOptionViewItem& option,
+                     const QModelIndex& index) override;
+
+   signals:
+    void membershipToggled(const QString& modId, bool enabled);
+
+   private:
+    QString resolveModId(const QModelIndex& proxyIndex) const;
+
+    const QMap<QString, QSet<QString>>* m_profileStates;
+    const QString* m_currentProfile;
+    QSortFilterProxyModel* m_filterModel;
+    ModFolderModel* m_model;
+};

--- a/launcher/ui/pages/instance/ProfileCheckStateDelegate.h
+++ b/launcher/ui/pages/instance/ProfileCheckStateDelegate.h
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
  *  Prism Launcher - Minecraft Launcher
- *  Copyright (c) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
- *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
- *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
- *  Copyright (c) 2023 Trial97 <alexandru.tripon97@gmail.com>
+ *  Copyright (C) 2026 Vivek Kushwaha <notvivekkushwaha@gmail.com>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -17,23 +14,6 @@
  *
  *  You should have received a copy of the GNU General Public License
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- *
- * This file incorporates work covered by the following copyright and
- * permission notice:
- *
- *      Copyright 2013-2021 MultiMC Contributors
- *
- *      Licensed under the Apache License, Version 2.0 (the "License");
- *      you may not use this file except in compliance with the License.
- *      You may obtain a copy of the License at
- *
- *          http://www.apache.org/licenses/LICENSE-2.0
- *
- *      Unless required by applicable law or agreed to in writing, software
- *      distributed under the License is distributed on an "AS IS" BASIS,
- *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *      See the License for the specific language governing permissions and
- *      limitations under the License.
  */
 
 #pragma once

--- a/launcher/ui/pages/instance/ProfileOverviewWidget.cpp
+++ b/launcher/ui/pages/instance/ProfileOverviewWidget.cpp
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
  *  Prism Launcher - Minecraft Launcher
- *  Copyright (c) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
- *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
- *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
- *  Copyright (c) 2023 Trial97 <alexandru.tripon97@gmail.com>
+ *  Copyright (C) 2026 Vivek Kushwaha <notvivekkushwaha@gmail.com>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -17,23 +14,6 @@
  *
  *  You should have received a copy of the GNU General Public License
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- *
- * This file incorporates work covered by the following copyright and
- * permission notice:
- *
- *      Copyright 2013-2021 MultiMC Contributors
- *
- *      Licensed under the Apache License, Version 2.0 (the "License");
- *      you may not use this file except in compliance with the License.
- *      You may obtain a copy of the License at
- *
- *          http://www.apache.org/licenses/LICENSE-2.0
- *
- *      Unless required by applicable law or agreed to in writing, software
- *      distributed under the License is distributed on an "AS IS" BASIS,
- *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *      See the License for the specific language governing permissions and
- *      limitations under the License.
  */
 
 #include "ProfileOverviewWidget.h"
@@ -548,6 +528,7 @@ void ProfileOverviewWidget::refresh(ModFolderModel* model,
                     sources.append(pname);
             }
         }
+        sources.sort(Qt::CaseInsensitive);
 
         int row = m_table->rowCount();
         m_table->insertRow(row);

--- a/launcher/ui/pages/instance/ProfileOverviewWidget.cpp
+++ b/launcher/ui/pages/instance/ProfileOverviewWidget.cpp
@@ -1,0 +1,621 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (c) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
+ *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
+ *  Copyright (c) 2023 Trial97 <alexandru.tripon97@gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * This file incorporates work covered by the following copyright and
+ * permission notice:
+ *
+ *      Copyright 2013-2021 MultiMC Contributors
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+#include "ProfileOverviewWidget.h"
+
+#include <QFrame>
+#include <QHeaderView>
+#include <QLabel>
+#include <QPainter>
+#include <QPushButton>
+#include <QStyle>
+#include <QTableWidget>
+#include <QTableWidgetItem>
+#include <QVBoxLayout>
+
+#include "minecraft/mod/ModFolderModel.h"
+
+FlowLayout::FlowLayout(QWidget* parent, int margin, int hSpacing, int vSpacing)
+    : QLayout(parent), m_hSpace(hSpacing), m_vSpace(vSpacing)
+{
+    setContentsMargins(margin, margin, margin, margin);
+}
+
+FlowLayout::~FlowLayout()
+{
+    QLayoutItem* item;
+    while ((item = takeAt(0)))
+        delete item;
+}
+
+void FlowLayout::addItem(QLayoutItem* item)
+{
+    m_itemList.append(item);
+}
+
+int FlowLayout::horizontalSpacing() const
+{
+    return m_hSpace >= 0 ? m_hSpace : 4;
+}
+
+int FlowLayout::verticalSpacing() const
+{
+    return m_vSpace >= 0 ? m_vSpace : 4;
+}
+
+int FlowLayout::count() const
+{
+    return m_itemList.size();
+}
+
+QLayoutItem* FlowLayout::itemAt(int index) const
+{
+    return m_itemList.value(index);
+}
+
+QLayoutItem* FlowLayout::takeAt(int index)
+{
+    if (index >= 0 && index < m_itemList.size())
+        return m_itemList.takeAt(index);
+    return nullptr;
+}
+
+Qt::Orientations FlowLayout::expandingDirections() const
+{
+    return {};
+}
+
+bool FlowLayout::hasHeightForWidth() const
+{
+    return true;
+}
+
+int FlowLayout::heightForWidth(int width) const
+{
+    return doLayout(QRect(0, 0, width, 0), true);
+}
+
+void FlowLayout::setGeometry(const QRect& rect)
+{
+    QLayout::setGeometry(rect);
+    doLayout(rect, false);
+}
+
+QSize FlowLayout::sizeHint() const
+{
+    return minimumSize();
+}
+
+QSize FlowLayout::minimumSize() const
+{
+    QSize size;
+    for (const QLayoutItem* item : m_itemList)
+        size = size.expandedTo(item->minimumSize());
+    int left, top, right, bottom;
+    getContentsMargins(&left, &top, &right, &bottom);
+    return size + QSize(left + right, top + bottom);
+}
+
+int FlowLayout::doLayout(const QRect& rect, bool testOnly) const
+{
+    int left, top, right, bottom;
+    getContentsMargins(&left, &top, &right, &bottom);
+    QRect effectiveRect = rect.adjusted(+left, +top, -right, -bottom);
+    int x = effectiveRect.x();
+    int y = effectiveRect.y();
+    int lineHeight = 0;
+
+    for (QLayoutItem* item : m_itemList) {
+        QWidget* wid = item->widget();
+        if (wid && wid->isHidden())
+            continue;
+
+        int spaceX = horizontalSpacing();
+        int spaceY = verticalSpacing();
+        int itemWidth = item->sizeHint().width();
+        int itemHeight = item->sizeHint().height();
+
+        int nextX = x + itemWidth + spaceX;
+        if (nextX - spaceX > effectiveRect.right() && lineHeight > 0) {
+            x = effectiveRect.x();
+            y = y + lineHeight + spaceY;
+            nextX = x + itemWidth + spaceX;
+            lineHeight = 0;
+        }
+
+        if (!testOnly)
+            item->setGeometry(QRect(QPoint(x, y), item->sizeHint()));
+
+        x = nextX;
+        lineHeight = qMax(lineHeight, itemHeight);
+    }
+    return y + lineHeight - rect.y() + bottom;
+}
+
+OverviewItemDelegate::OverviewItemDelegate(QObject* parent)
+    : QStyledItemDelegate(parent)
+{}
+
+void OverviewItemDelegate::initStyleOption(QStyleOptionViewItem* option,
+                                          const QModelIndex& index) const
+{
+    QStyledItemDelegate::initStyleOption(option, index);
+    if (index.column() == 2 || index.column() == 3) {
+        option->text.clear();
+        option->icon = QIcon();
+    }
+}
+
+void OverviewItemDelegate::paint(QPainter* painter,
+                                const QStyleOptionViewItem& option,
+                                const QModelIndex& index) const
+{
+    painter->save();
+    painter->setRenderHint(QPainter::Antialiasing, true);
+
+    const bool isDark = option.palette.color(QPalette::Base).lightness() < 128;
+
+    if (index.column() == 0) {
+        QStyleOptionViewItem opt = option;
+        opt.features |= QStyleOptionViewItem::HasCheckIndicator;
+        opt.checkState = index.data(Qt::CheckStateRole).value<Qt::CheckState>();
+        opt.state |= QStyle::State_Enabled;
+        if (opt.checkState == Qt::Checked) {
+            opt.state |= QStyle::State_On;
+            opt.state &= ~QStyle::State_Off;
+        } else {
+            opt.state |= QStyle::State_Off;
+            opt.state &= ~QStyle::State_On;
+        }
+        QStyledItemDelegate::paint(painter, opt, index);
+        painter->restore();
+        return;
+    }
+
+    if (index.column() == 2) {
+        QStyledItemDelegate::paint(painter, option, index);
+
+        QString statusText = index.data(Qt::DisplayRole).toString();
+        if (!statusText.isEmpty()) {
+            QColor bg, border, text;
+            if (statusText == tr("Enabled")) {
+                bg = isDark ? QColor(35, 75, 45) : QColor(225, 248, 230);
+                border = isDark ? QColor(55, 130, 75) : QColor(140, 210, 155);
+                text = isDark ? QColor(145, 235, 165) : QColor(20, 115, 45);
+            } else if (statusText == tr("Disabled")) {
+                bg = isDark ? QColor(50, 50, 50) : QColor(235, 235, 235);
+                border = isDark ? QColor(90, 90, 90) : QColor(190, 190, 190);
+                text = isDark ? QColor(170, 170, 170) : QColor(90, 90, 90);
+            } else {
+                bg = isDark ? QColor(80, 55, 15) : QColor(255, 244, 215);
+                border = isDark ? QColor(160, 110, 30) : QColor(235, 180, 70);
+                text = isDark ? QColor(255, 205, 100) : QColor(150, 85, 0);
+            }
+
+            QFont font = option.font;
+            font.setPointSize(qMax(font.pointSize() - 1, 8));
+            QFontMetrics fm(font);
+            int textWidth = fm.horizontalAdvance(statusText);
+            int chipWidth = textWidth + 16;
+            int chipHeight = 20;
+            int chipX = option.rect.left() + 4;
+            int chipY = option.rect.top() + (option.rect.height() - chipHeight) / 2;
+            QRect chipRect(chipX, chipY, chipWidth, chipHeight);
+
+            painter->setPen(QPen(border, 1));
+            painter->setBrush(bg);
+            painter->drawRoundedRect(chipRect, 4, 4);
+
+            painter->setFont(font);
+            painter->setPen(text);
+            painter->drawText(chipRect, Qt::AlignCenter, statusText);
+        }
+        painter->restore();
+        return;
+    }
+
+    if (index.column() == 3) {
+        QStyledItemDelegate::paint(painter, option, index);
+
+        QStringList sources = index.data(Qt::UserRole).toStringList();
+        if (sources.isEmpty()) {
+            QFont font = option.font;
+            painter->setFont(font);
+            painter->setPen(option.palette.color(QPalette::PlaceholderText));
+            painter->drawText(option.rect.adjusted(6, 0, -6, 0), Qt::AlignVCenter | Qt::AlignLeft, QStringLiteral("—"));
+        } else {
+            QFont font = option.font;
+            font.setPointSize(qMax(font.pointSize() - 1, 8));
+            painter->setFont(font);
+            QFontMetrics fm(font);
+
+            QColor chipBg = option.palette.color(QPalette::Button);
+            QColor chipBorder = isDark ? QColor(80, 80, 80) : QColor(190, 190, 190);
+            QColor chipText = option.palette.color(QPalette::ButtonText);
+
+            int startX = option.rect.left() + 4;
+            int startY = option.rect.top() + 3;
+            int curX = startX;
+            int curY = startY;
+            int chipHeight = 20;
+            int hSpacing = 5;
+            int vSpacing = 3;
+            int rightLimit = option.rect.right() - 4;
+
+            for (const QString& name : sources) {
+                int textWidth = fm.horizontalAdvance(name);
+                int chipWidth = textWidth + 14;
+
+                if (curX + chipWidth > rightLimit && curX > startX) {
+                    curX = startX;
+                    curY += chipHeight + vSpacing;
+                }
+
+                int actualWidth = qMin(chipWidth, rightLimit - curX);
+                if (actualWidth < 10)
+                    break;
+
+                QRect chipRect(curX, curY, actualWidth, chipHeight);
+                painter->setPen(QPen(chipBorder, 1));
+                painter->setBrush(chipBg);
+                painter->drawRoundedRect(chipRect, 4, 4);
+
+                painter->setPen(chipText);
+                painter->drawText(chipRect, Qt::AlignCenter, fm.elidedText(name, Qt::ElideRight, chipRect.width() - 6));
+
+                curX += chipWidth + hSpacing;
+            }
+        }
+        painter->restore();
+        return;
+    }
+
+    painter->restore();
+    QStyledItemDelegate::paint(painter, option, index);
+}
+
+QSize OverviewItemDelegate::sizeHint(const QStyleOptionViewItem& option,
+                                    const QModelIndex& index) const
+{
+    if (index.column() == 0) {
+        return QSize(36, 26);
+    }
+    if (index.column() == 2) {
+        QString statusText = index.data(Qt::DisplayRole).toString();
+        QFont font = option.font;
+        font.setPointSize(qMax(font.pointSize() - 1, 8));
+        QFontMetrics fm(font);
+        return QSize(fm.horizontalAdvance(statusText) + 24, 26);
+    }
+    if (index.column() == 3) {
+        QStringList sources = index.data(Qt::UserRole).toStringList();
+        if (sources.isEmpty())
+            return QSize(40, 26);
+
+        QFont font = option.font;
+        font.setPointSize(qMax(font.pointSize() - 1, 8));
+        QFontMetrics fm(font);
+
+        int colWidth = option.rect.width();
+        if (const auto* view = qobject_cast<const QTableView*>(option.widget)) {
+            int w = view->columnWidth(index.column());
+            if (w > 0)
+                colWidth = w;
+        }
+
+        int availableWidth = colWidth > 20 ? (colWidth - 8) : 200;
+        int startX = 0;
+        int curX = startX;
+        int numLines = 1;
+        int hSpacing = 5;
+
+        for (const QString& name : sources) {
+            int chipWidth = fm.horizontalAdvance(name) + 14;
+            if (curX + chipWidth > availableWidth && curX > startX) {
+                curX = startX;
+                numLines++;
+            }
+            curX += chipWidth + hSpacing;
+        }
+
+        int height = numLines * 20 + (numLines - 1) * 3 + 6;
+        return QSize(availableWidth, qMax(height, 26));
+    }
+    return QStyledItemDelegate::sizeHint(option, index);
+}
+
+ProfileOverviewWidget::ProfileOverviewWidget(QWidget* parent)
+    : QWidget(parent)
+{
+    auto* mainLayout = new QVBoxLayout(this);
+    mainLayout->setContentsMargins(0, 2, 0, 0);
+    mainLayout->setSpacing(4);
+
+    auto* headerRow = new QWidget(this);
+    auto* headerLayout = new QHBoxLayout(headerRow);
+    headerLayout->setContentsMargins(0, 0, 0, 0);
+    headerLayout->setSpacing(8);
+
+    m_selectionRow = new QWidget(headerRow);
+    m_selectionLayout = new FlowLayout(m_selectionRow, 0, 4, 4);
+
+    m_defaultButton = new QPushButton(tr("Default"), m_selectionRow);
+    m_defaultButton->setCheckable(true);
+    QFont defFont = m_defaultButton->font();
+    defFont.setBold(true);
+    m_defaultButton->setFont(defFont);
+    m_defaultButton->setToolTip(tr("Use Default's mod set exclusively at launch."));
+    connect(m_defaultButton, &QPushButton::clicked, this, [this](bool) {
+        emit defaultSelected();
+    });
+    m_selectionLayout->addWidget(m_defaultButton);
+
+    m_separator = new QFrame(m_selectionRow);
+    m_separator->setFrameShape(QFrame::VLine);
+    m_separator->setFrameShadow(QFrame::Sunken);
+    m_separator->setFixedSize(2, 22);
+    m_selectionLayout->addWidget(m_separator);
+
+    headerLayout->addWidget(m_selectionRow, 1);
+
+    m_overviewExitButton = new QPushButton(tr("Profile Overview"), headerRow);
+    m_overviewExitButton->setCheckable(true);
+    m_overviewExitButton->setChecked(true);
+    m_overviewExitButton->setIcon(QIcon::fromTheme("loadermods"));
+    m_overviewExitButton->setIconSize(QSize(16, 16));
+    m_overviewExitButton->setToolTip(
+        tr("Show the read-only launch composition overview.\n"
+           "Select which profiles are combined when launching the game."));
+    connect(m_overviewExitButton, &QPushButton::clicked, this, &ProfileOverviewWidget::overviewExitRequested);
+    headerLayout->addWidget(m_overviewExitButton, 0, Qt::AlignTop | Qt::AlignRight);
+
+    mainLayout->addWidget(headerRow);
+
+    m_statusLabel = new QLabel(this);
+    m_statusLabel->setContentsMargins(4, 0, 4, 0);
+    m_statusLabel->setWordWrap(true);
+    m_statusLabel->setVisible(false);
+    mainLayout->addWidget(m_statusLabel);
+
+    m_table = new QTableWidget(this);
+    m_table->setColumnCount(4);
+    m_table->setHorizontalHeaderLabels({ tr("Enabled at Launch"), tr("Mod"), tr("Status"), tr("Source Profiles") });
+    m_table->setItemDelegate(new OverviewItemDelegate(this));
+    m_table->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+    m_table->horizontalHeader()->setSectionResizeMode(1, QHeaderView::Stretch);
+    m_table->horizontalHeader()->setSectionResizeMode(2, QHeaderView::ResizeToContents);
+    m_table->horizontalHeader()->setSectionResizeMode(3, QHeaderView::Stretch);
+    m_table->verticalHeader()->setVisible(false);
+    m_table->verticalHeader()->setDefaultSectionSize(26);
+    m_table->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    m_table->setSelectionBehavior(QAbstractItemView::SelectRows);
+    m_table->setAlternatingRowColors(true);
+    connect(m_table->horizontalHeader(), &QHeaderView::sectionResized, m_table, &QTableWidget::resizeRowsToContents);
+    connect(m_table->horizontalHeader(), &QHeaderView::geometriesChanged, m_table, &QTableWidget::resizeRowsToContents);
+    mainLayout->addWidget(m_table, 1);
+}
+
+void ProfileOverviewWidget::buildSelectionRow(const QStringList& profileNames,
+                                              bool overviewDefault,
+                                              const QStringList& selectedProfiles,
+                                              bool isRunning)
+{
+    for (auto* btn : m_profileButtons) {
+        m_selectionLayout->removeWidget(btn);
+        delete btn;
+    }
+    m_profileButtons.clear();
+
+    m_defaultButton->setChecked(overviewDefault);
+    m_defaultButton->setEnabled(!isRunning);
+
+    for (int i = 1; i < profileNames.size(); ++i) {
+        const QString& name = profileNames.at(i);
+        auto* btn = new QPushButton(name, m_selectionRow);
+        btn->setCheckable(true);
+        btn->setChecked(!overviewDefault && selectedProfiles.contains(name));
+        btn->setEnabled(!isRunning);
+        if (isRunning)
+            btn->setToolTip(tr("Cannot change launch selection while Minecraft is running."));
+        else
+            btn->setToolTip(tr("Toggle this profile in the launch composition."));
+        connect(btn, &QPushButton::clicked, this, [this, name](bool checked) {
+            emit profileSelectionToggled(name, checked);
+        });
+        m_selectionLayout->addWidget(btn);
+        m_profileButtons.append(btn);
+    }
+    m_selectionRow->updateGeometry();
+}
+
+void ProfileOverviewWidget::setRunningLocked(bool running)
+{
+    m_defaultButton->setEnabled(!running);
+    for (auto* btn : m_profileButtons)
+        btn->setEnabled(!running);
+    if (running) {
+        m_statusLabel->setText(tr("Minecraft is running — launch composition is locked."));
+        m_statusLabel->setVisible(true);
+    } else {
+        m_statusLabel->clear();
+        m_statusLabel->setVisible(false);
+    }
+}
+
+void ProfileOverviewWidget::refresh(ModFolderModel* model,
+                                    const QMap<QString, QSet<QString>>& profileStates,
+                                    const QStringList& profileNames,
+                                    bool overviewDefault,
+                                    const QStringList& selectedProfiles,
+                                    bool isRunning,
+                                    const std::optional<QSet<QString>>& launchSnapshot)
+{
+    buildSelectionRow(profileNames, overviewDefault, selectedProfiles, isRunning);
+
+    if (m_overviewExitButton)
+        m_overviewExitButton->setChecked(true);
+
+    if (isRunning) {
+        m_statusLabel->setText(tr("Minecraft is running — launch composition is locked."));
+        m_statusLabel->setVisible(true);
+    } else {
+        m_statusLabel->clear();
+        m_statusLabel->setVisible(false);
+    }
+
+    QSet<QString> nextLaunchIds;
+    if (overviewDefault) {
+        if (!profileNames.isEmpty())
+            nextLaunchIds = profileStates.value(profileNames.at(0));
+    } else {
+        for (const QString& pname : selectedProfiles)
+            nextLaunchIds += profileStates.value(pname);
+    }
+
+    QMap<QString, QString> modIdToName;
+    for (int i = 0; i < model->rowCount(); ++i) {
+        const auto& mod = model->at(i);
+        modIdToName[mod.mod_id()] = mod.name();
+    }
+
+    QSet<QString> displayIds = nextLaunchIds;
+    if (isRunning && launchSnapshot.has_value())
+        displayIds += launchSnapshot.value();
+
+    m_table->setRowCount(0);
+    m_table->setSortingEnabled(false);
+
+    for (const QString& modId : std::as_const(displayIds)) {
+        const bool inNextLaunch = nextLaunchIds.contains(modId);
+        const bool inSnapshot   = isRunning && launchSnapshot.has_value() && launchSnapshot->contains(modId);
+        const bool launchEnabled = isRunning ? inSnapshot : inNextLaunch;
+
+        QString statusText;
+        if (isRunning && launchSnapshot.has_value()) {
+            bool nextLaunchEnabled = inNextLaunch;
+            if (inSnapshot == nextLaunchEnabled)
+                statusText = inSnapshot ? tr("Enabled") : tr("Disabled");
+            else if (inSnapshot && !nextLaunchEnabled)
+                statusText = tr("Override · Disabled next launch");
+            else
+                statusText = tr("Override · Enabled next launch");
+        } else {
+            statusText = inNextLaunch ? tr("Enabled") : tr("Disabled");
+        }
+
+        QStringList sources;
+        if (overviewDefault) {
+            if (!profileNames.isEmpty() && profileStates.value(profileNames.at(0)).contains(modId))
+                sources.append(profileNames.at(0));
+        } else {
+            for (const QString& pname : selectedProfiles) {
+                if (profileStates.value(pname).contains(modId))
+                    sources.append(pname);
+            }
+        }
+
+        int row = m_table->rowCount();
+        m_table->insertRow(row);
+
+        auto* checkItem = new QTableWidgetItem();
+        checkItem->setCheckState(launchEnabled ? Qt::Checked : Qt::Unchecked);
+        checkItem->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
+        m_table->setItem(row, 0, checkItem);
+
+        QString displayName = modIdToName.value(modId, modId);
+        auto* nameItem = new QTableWidgetItem(displayName);
+        nameItem->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
+        m_table->setItem(row, 1, nameItem);
+
+        auto* statusItem = new QTableWidgetItem(statusText);
+        statusItem->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
+        m_table->setItem(row, 2, statusItem);
+
+        auto* sourceItem = new QTableWidgetItem();
+        sourceItem->setData(Qt::UserRole, sources);
+        sourceItem->setData(Qt::DisplayRole, sources.join(QStringLiteral(", ")));
+        sourceItem->setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
+        m_table->setItem(row, 3, sourceItem);
+    }
+
+    m_table->setSortingEnabled(true);
+    m_table->sortByColumn(1, Qt::AscendingOrder);
+    m_table->resizeRowsToContents();
+}
+
+void ProfileOverviewWidget::filterTextChanged(const QString& filter)
+{
+    if (!m_table)
+        return;
+    for (int row = 0; row < m_table->rowCount(); ++row) {
+        if (filter.isEmpty()) {
+            m_table->setRowHidden(row, false);
+            continue;
+        }
+        auto* nameItem = m_table->item(row, 1);
+        auto* statusItem = m_table->item(row, 2);
+        auto* sourceItem = m_table->item(row, 3);
+        bool match = (nameItem && nameItem->text().contains(filter, Qt::CaseInsensitive)) ||
+                     (statusItem && statusItem->text().contains(filter, Qt::CaseInsensitive)) ||
+                     (sourceItem && sourceItem->text().contains(filter, Qt::CaseInsensitive));
+        m_table->setRowHidden(row, !match);
+    }
+    m_table->resizeRowsToContents();
+}
+
+void ProfileOverviewWidget::showEvent(QShowEvent* event)
+{
+    QWidget::showEvent(event);
+    if (m_overviewExitButton)
+        m_overviewExitButton->setChecked(true);
+    if (m_table)
+        m_table->resizeRowsToContents();
+}
+
+void ProfileOverviewWidget::resizeEvent(QResizeEvent* event)
+{
+    QWidget::resizeEvent(event);
+    if (m_table)
+        m_table->resizeRowsToContents();
+}
+
+void ProfileOverviewWidget::setOverviewActive(bool active)
+{
+    if (m_overviewExitButton)
+        m_overviewExitButton->setChecked(active);
+}

--- a/launcher/ui/pages/instance/ProfileOverviewWidget.h
+++ b/launcher/ui/pages/instance/ProfileOverviewWidget.h
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ *  Prism Launcher - Minecraft Launcher
+ *  Copyright (c) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
+ *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
+ *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
+ *  Copyright (c) 2023 Trial97 <alexandru.tripon97@gmail.com>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, version 3.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * This file incorporates work covered by the following copyright and
+ * permission notice:
+ *
+ *      Copyright 2013-2021 MultiMC Contributors
+ *
+ *      Licensed under the Apache License, Version 2.0 (the "License");
+ *      you may not use this file except in compliance with the License.
+ *      You may obtain a copy of the License at
+ *
+ *          http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *      Unless required by applicable law or agreed to in writing, software
+ *      distributed under the License is distributed on an "AS IS" BASIS,
+ *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *      See the License for the specific language governing permissions and
+ *      limitations under the License.
+ */
+
+#pragma once
+
+#include <QWidget>
+#include <QSet>
+#include <QString>
+#include <QMap>
+#include <QStringList>
+#include <QLayout>
+#include <QStyledItemDelegate>
+#include <optional>
+
+class ModFolderModel;
+class QTableWidget;
+class QLabel;
+class QPushButton;
+class QFrame;
+
+class FlowLayout : public QLayout {
+   public:
+    explicit FlowLayout(QWidget* parent, int margin = 0, int hSpacing = 6, int vSpacing = 6);
+    ~FlowLayout() override;
+
+    void addItem(QLayoutItem* item) override;
+    int horizontalSpacing() const;
+    int verticalSpacing() const;
+    Qt::Orientations expandingDirections() const override;
+    bool hasHeightForWidth() const override;
+    int heightForWidth(int) const override;
+    int count() const override;
+    QLayoutItem* itemAt(int index) const override;
+    QSize minimumSize() const override;
+    void setGeometry(const QRect& rect) override;
+    QSize sizeHint() const override;
+    QLayoutItem* takeAt(int index) override;
+
+   private:
+    int doLayout(const QRect& rect, bool testOnly) const;
+
+    QList<QLayoutItem*> m_itemList;
+    int m_hSpace;
+    int m_vSpace;
+};
+
+class OverviewItemDelegate : public QStyledItemDelegate {
+    Q_OBJECT
+   public:
+    explicit OverviewItemDelegate(QObject* parent = nullptr);
+
+    void initStyleOption(QStyleOptionViewItem* option,
+                         const QModelIndex& index) const override;
+
+    void paint(QPainter* painter,
+               const QStyleOptionViewItem& option,
+               const QModelIndex& index) const override;
+
+    QSize sizeHint(const QStyleOptionViewItem& option,
+                   const QModelIndex& index) const override;
+};
+
+class ProfileOverviewWidget : public QWidget {
+    Q_OBJECT
+   public:
+    explicit ProfileOverviewWidget(QWidget* parent = nullptr);
+
+    void refresh(ModFolderModel* model,
+                 const QMap<QString, QSet<QString>>& profileStates,
+                 const QStringList& profileNames,
+                 bool overviewDefault,
+                 const QStringList& selectedProfiles,
+                 bool isRunning,
+                 const std::optional<QSet<QString>>& launchSnapshot);
+
+    void setRunningLocked(bool running);
+
+    void filterTextChanged(const QString& filter);
+
+    void setOverviewActive(bool active);
+
+   protected:
+    void showEvent(QShowEvent* event) override;
+    void resizeEvent(QResizeEvent* event) override;
+
+   signals:
+    void defaultSelected();
+    void profileSelectionToggled(const QString& profileName, bool selected);
+    void overviewExitRequested();
+
+   private:
+    void buildSelectionRow(const QStringList& profileNames,
+                           bool overviewDefault,
+                           const QStringList& selectedProfiles,
+                           bool isRunning);
+
+    QWidget*      m_selectionRow       = nullptr;
+    FlowLayout*   m_selectionLayout    = nullptr;
+    QPushButton*  m_defaultButton      = nullptr;
+    QFrame*       m_separator          = nullptr;
+    QPushButton*  m_overviewExitButton = nullptr;
+    QList<QPushButton*> m_profileButtons;
+
+    QTableWidget* m_table       = nullptr;
+    QLabel*       m_statusLabel = nullptr;
+};

--- a/launcher/ui/pages/instance/ProfileOverviewWidget.h
+++ b/launcher/ui/pages/instance/ProfileOverviewWidget.h
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 /*
  *  Prism Launcher - Minecraft Launcher
- *  Copyright (c) 2022 Jamie Mansfield <jmansfield@cadixdev.org>
- *  Copyright (C) 2022 Sefa Eyeoglu <contact@scrumplex.net>
- *  Copyright (C) 2022 TheKodeToad <TheKodeToad@proton.me>
- *  Copyright (c) 2023 Trial97 <alexandru.tripon97@gmail.com>
+ *  Copyright (C) 2026 Vivek Kushwaha <notvivekkushwaha@gmail.com>
  *
  *  This program is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -17,23 +14,6 @@
  *
  *  You should have received a copy of the GNU General Public License
  *  along with this program.  If not, see <https://www.gnu.org/licenses/>.
- *
- * This file incorporates work covered by the following copyright and
- * permission notice:
- *
- *      Copyright 2013-2021 MultiMC Contributors
- *
- *      Licensed under the Apache License, Version 2.0 (the "License");
- *      you may not use this file except in compliance with the License.
- *      You may obtain a copy of the License at
- *
- *          http://www.apache.org/licenses/LICENSE-2.0
- *
- *      Unless required by applicable law or agreed to in writing, software
- *      distributed under the License is distributed on an "AS IS" BASIS,
- *      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *      See the License for the specific language governing permissions and
- *      limitations under the License.
  */
 
 #pragma once


### PR DESCRIPTION
I added a feature in Mod Page where user can create multiple mod profiles ( example : Optimization , Shaders , or Building ) . Profiles can be created, duplicated, renamed, removed, and switched from the tab bar, with each profile remembering its own enabled mods. Export list now exports currently selected mod profile.
Closes #154 
supersedes #5719 

This PR also fixes a different issue by allowing user to clear current selection of a mod by clicking anywhere outside the mod list, when there is no space left in mod list .
Closes #5117 

**What's New :**

- Mods Page now has a **Default** tab, which behaves like existing Mods tab.
- New **Profile Overview** button which is a read-only representation of what will be loaded on next launch.
- It supports **multiple profile selection**, with resulting mod set composed as union of selected profiles.
- Default and user-created profile selection are mutually exclusive.
- Improved profile state synchronization and persistence across profile switching and mod updates.
- Profile edits can still be made while Minecraft is running, with the Overview representing the resulting state for the next launch.

**Screenshots**

**Multiple profile tabs**

<img width="535" height="612" alt="image" src="https://github.com/user-attachments/assets/6cb71ca7-90fa-40c0-b7b7-34f368b30fb2" />



**Profile Overview Panel**

<img width="446" height="510" alt="image" src="https://github.com/user-attachments/assets/3f98e432-99ca-476a-a790-dce5687fe459" />

AI assistance was used during development, and the relevant commits are marked with:
Assisted-by: Claude:sonnet-5