### PR TITLE
fix(screenshots): join imgur deletehashes as repeated params

### DIFF
--- a/launcher/screenshots/ImgurAlbumCreation.cpp
+++ b/launcher/screenshots/ImgurAlbumCreation.cpp
@@ -67,7 +67,7 @@ QNetworkReply* ImgurAlbumCreation::getReply(QNetworkRequest& request)
     for (auto shot : m_screenshots) {
         hashes.append(shot->m_imgurDeleteHash);
     }
-    const QByteArray data = "deletehashes=" + hashes.join(',').toUtf8() + "&title=Minecraft%20Screenshots&privacy=hidden";
+    const QByteArray data = "deletehashes=" + hashes.join("&deletehashes=").toUtf8() + "&title=Minecraft%20Screenshots&privacy=hidden";
     return m_network->post(request, data);
 }
 


### PR DESCRIPTION
found when working on https://github.com/PrismLauncher/PrismLauncher/pull/6020
Imgur doc link https://apidocs.imgur.com/#8f89bd41-28a1-4624-9393-95e12cec509a
so the concatenation with ',' doesn't work for some reason I needed to join them as separate `deletehashes` as mentioned in the API documentation.
I do not know when the update happened and imgur stopped accepting comma separated lists but I know this impacts all prism versions as the line was from MultiMC era.