### PR TITLE
 feat: add configurable world tools to instance toolbar 

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -891,6 +891,8 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
 
         m_settings->registerSetting("Env", "{}");
 
+        m_settings->registerSetting("WorldTools", "{}");
+
         // Custom Microsoft Authentication Client ID
         m_settings->registerSetting("MSAClientIDOverride", "");
 

--- a/launcher/Commandline.cpp
+++ b/launcher/Commandline.cpp
@@ -116,7 +116,7 @@ QString expandVariables(const QString& input, const QProcessEnvironment& dict)
                     const auto res = dict.value(result.mid(startIdx, i - 1 - startIdx), "");
                     if (!res.isEmpty()) {
                         result.replace(startIdx - 2, i - startIdx + 2, res);
-                        i = startIdx - 2 + res.length();
+                        i = startIdx - 2 + static_cast<int>(res.length());
                     }
                     state = State::Base;
                 }
@@ -126,7 +126,7 @@ QString expandVariables(const QString& input, const QProcessEnvironment& dict)
                     const auto res = dict.value(result.mid(startIdx, i - startIdx - 1), "");
                     if (!res.isEmpty()) {
                         result.replace(startIdx - 1, i - startIdx, res);
-                        i = startIdx - 1 + res.length();
+                        i = startIdx - 1 + static_cast<int>(res.length());
                     }
                     state = State::Base;
                 }

--- a/launcher/Commandline.cpp
+++ b/launcher/Commandline.cpp
@@ -150,4 +150,15 @@ QStringList process(const QString& cmd, const QProcessEnvironment& dict)
     return splited;
 }
 
+QString quoteForSplitCommand(const QString& input)
+{
+    if (!input.contains(' ')) {
+        return input;
+    }
+
+    QString escaped = input;
+    escaped.replace("\"", R"(""")");
+    return "\"" + escaped + "\"";
+}
+
 }  // namespace Commandline

--- a/launcher/Commandline.h
+++ b/launcher/Commandline.h
@@ -51,4 +51,11 @@ QString expandVariables(const QString& input, const QProcessEnvironment& dict);
  */
 QStringList process(const QString& cmd, const QProcessEnvironment& dict = {});
 
+/**
+ * @brief quote a single argument so that QProcess::splitCommand() parses it back out unchanged
+ * @param input the argument to quote
+ * @return the quoted argument, or the input unchanged if quoting isn't necessary
+ */
+QString quoteForSplitCommand(const QString& input);
+
 }  // namespace Commandline

--- a/launcher/ui/pages/global/ExternalToolsPage.cpp
+++ b/launcher/ui/pages/global/ExternalToolsPage.cpp
@@ -50,47 +50,47 @@
 #include "settings/SettingsObject.h"
 #include "tools/BaseProfiler.h"
 
-ExternalToolsPage::ExternalToolsPage(QWidget* parent) : QWidget(parent), ui(new Ui::ExternalToolsPage)
+ExternalToolsPage::ExternalToolsPage(QWidget* parent) : QWidget(parent), m_ui(new Ui::ExternalToolsPage)
 {
-    ui->setupUi(this);
+    m_ui->setupUi(this);
 
-    ui->jsonEditorTextBox->setClearButtonEnabled(true);
+    m_ui->jsonEditorTextBox->setClearButtonEnabled(true);
 
-    ui->jvisualvmLink->setOpenExternalLinks(true);
-    ui->jprofilerLink->setOpenExternalLinks(true);
+    m_ui->jvisualvmLink->setOpenExternalLinks(true);
+    m_ui->jprofilerLink->setOpenExternalLinks(true);
 
-    ui->worldToolTree->header()->setStretchLastSection(false);
-    ui->worldToolTree->header()->setSectionResizeMode(0, QHeaderView::Interactive);
-    ui->worldToolTree->header()->setSectionResizeMode(1, QHeaderView::Stretch);
-    ui->worldToolTree->header()->setSectionResizeMode(2, QHeaderView::Interactive);
-    ui->worldToolTree->header()->resizeSection(0, 150);
-    ui->worldToolTree->header()->resizeSection(2, 36);
+    m_ui->worldToolTree->header()->setStretchLastSection(false);
+    m_ui->worldToolTree->header()->setSectionResizeMode(0, QHeaderView::Interactive);
+    m_ui->worldToolTree->header()->setSectionResizeMode(1, QHeaderView::Stretch);
+    m_ui->worldToolTree->header()->setSectionResizeMode(2, QHeaderView::Interactive);
+    m_ui->worldToolTree->header()->resizeSection(0, 150);
+    m_ui->worldToolTree->header()->resizeSection(2, 36);
     loadSettings();
 }
 
 ExternalToolsPage::~ExternalToolsPage()
 {
-    delete ui;
+    delete m_ui;
 }
 
 void ExternalToolsPage::loadSettings()
 {
-    auto s = APPLICATION->settings();
-    ui->jprofilerPathEdit->setText(s->get("JProfilerPath").toString());
-    ui->jvisualvmPathEdit->setText(s->get("JVisualVMPath").toString());
+    auto* s = APPLICATION->settings();
+    m_ui->jprofilerPathEdit->setText(s->get("JProfilerPath").toString());
+    m_ui->jvisualvmPathEdit->setText(s->get("JVisualVMPath").toString());
 
     // Editors
-    ui->jsonEditorTextBox->setText(s->get("JsonEditor").toString());
+    m_ui->jsonEditorTextBox->setText(s->get("JsonEditor").toString());
 
     // World Tools
-    ui->worldToolTree->clear();
+    m_ui->worldToolTree->clear();
     const QVariantMap tools = Json::toMap(APPLICATION->settings()->get("WorldTools").toString());
     for (auto it = tools.constBegin(); it != tools.constEnd(); ++it) {
-        auto* item = new QTreeWidgetItem(ui->worldToolTree);
+        auto* item = new QTreeWidgetItem(m_ui->worldToolTree);
         item->setText(0, it.key());
         item->setText(1, it.value().toString());
         item->setFlags(item->flags() | Qt::ItemIsEditable);
-        ui->worldToolTree->addTopLevelItem(item);
+        m_ui->worldToolTree->addTopLevelItem(item);
         setupWorldToolBrowseBtn(item);
     }
 }
@@ -118,17 +118,17 @@ void ExternalToolsPage::setupWorldToolBrowseBtn(QTreeWidgetItem* item)
             }
         }
     });
-    ui->worldToolTree->setItemWidget(item, 2, btn);
+    m_ui->worldToolTree->setItemWidget(item, 2, btn);
 }
 void ExternalToolsPage::applySettings()
 {
-    auto s = APPLICATION->settings();
+    auto* s = APPLICATION->settings();
 
-    s->set("JProfilerPath", ui->jprofilerPathEdit->text());
-    s->set("JVisualVMPath", ui->jvisualvmPathEdit->text());
+    s->set("JProfilerPath", m_ui->jprofilerPathEdit->text());
+    s->set("JVisualVMPath", m_ui->jvisualvmPathEdit->text());
 
     // Editors
-    QString jsonEditor = ui->jsonEditorTextBox->text();
+    QString jsonEditor = m_ui->jsonEditorTextBox->text();
     if (!jsonEditor.isEmpty() && (!QFileInfo(jsonEditor).exists() || !QFileInfo(jsonEditor).isExecutable())) {
         QString found = QStandardPaths::findExecutable(jsonEditor);
         if (!found.isEmpty()) {
@@ -139,8 +139,8 @@ void ExternalToolsPage::applySettings()
 
     // World Tools
     QVariantMap tools;
-    auto* item = ui->worldToolTree->topLevelItem(0);
-    for (int i = 1; item != nullptr; item = ui->worldToolTree->topLevelItem(i++)) {
+    auto* item = m_ui->worldToolTree->topLevelItem(0);
+    for (int i = 1; item != nullptr; item = m_ui->worldToolTree->topLevelItem(i++)) {
         const QString name = item->text(0).trimmed();
         const QString command = item->text(1).trimmed();
         if (!name.isEmpty() && !command.isEmpty()) {
@@ -152,27 +152,27 @@ void ExternalToolsPage::applySettings()
 
 void ExternalToolsPage::on_jprofilerPathBtn_clicked()
 {
-    QString raw_dir = ui->jprofilerPathEdit->text();
+    QString rawDir = m_ui->jprofilerPathEdit->text();
     QString error;
     do {
-        raw_dir = QFileDialog::getExistingDirectory(this, tr("JProfiler Folder"), raw_dir);
-        if (raw_dir.isEmpty()) {
+        rawDir = QFileDialog::getExistingDirectory(this, tr("JProfiler Folder"), rawDir);
+        if (rawDir.isEmpty()) {
             break;
         }
-        QString cooked_dir = FS::NormalizePath(raw_dir);
-        if (!APPLICATION->profilers()["jprofiler"]->check(cooked_dir, &error)) {
+        QString cookedDir = FS::NormalizePath(rawDir);
+        if (!APPLICATION->profilers()["jprofiler"]->check(cookedDir, &error)) {
             QMessageBox::critical(this, tr("Error"), tr("Error while checking JProfiler install:\n%1").arg(error));
             continue;
-        } else {
-            ui->jprofilerPathEdit->setText(cooked_dir);
-            break;
         }
-    } while (1);
+        m_ui->jprofilerPathEdit->setText(cookedDir);
+        break;
+
+    } while (true);
 }
 void ExternalToolsPage::on_jprofilerCheckBtn_clicked()
 {
     QString error;
-    if (!APPLICATION->profilers()["jprofiler"]->check(ui->jprofilerPathEdit->text(), &error)) {
+    if (!APPLICATION->profilers()["jprofiler"]->check(m_ui->jprofilerPathEdit->text(), &error)) {
         QMessageBox::critical(this, tr("Error"), tr("Error while checking JProfiler install:\n%1").arg(error));
     } else {
         QMessageBox::information(this, tr("OK"), tr("JProfiler setup seems to be OK"));
@@ -181,27 +181,27 @@ void ExternalToolsPage::on_jprofilerCheckBtn_clicked()
 
 void ExternalToolsPage::on_jvisualvmPathBtn_clicked()
 {
-    QString raw_dir = ui->jvisualvmPathEdit->text();
+    QString rawDir = m_ui->jvisualvmPathEdit->text();
     QString error;
     do {
-        raw_dir = QFileDialog::getOpenFileName(this, tr("VisualVM Executable"), raw_dir);
-        if (raw_dir.isEmpty()) {
+        rawDir = QFileDialog::getOpenFileName(this, tr("VisualVM Executable"), rawDir);
+        if (rawDir.isEmpty()) {
             break;
         }
-        QString cooked_dir = FS::NormalizePath(raw_dir);
-        if (!APPLICATION->profilers()["jvisualvm"]->check(cooked_dir, &error)) {
+        QString cookedDir = FS::NormalizePath(rawDir);
+        if (!APPLICATION->profilers()["jvisualvm"]->check(cookedDir, &error)) {
             QMessageBox::critical(this, tr("Error"), tr("Error while checking VisualVM install:\n%1").arg(error));
             continue;
-        } else {
-            ui->jvisualvmPathEdit->setText(cooked_dir);
-            break;
         }
-    } while (1);
+        m_ui->jvisualvmPathEdit->setText(cookedDir);
+        break;
+
+    } while (true);
 }
 void ExternalToolsPage::on_jvisualvmCheckBtn_clicked()
 {
     QString error;
-    if (!APPLICATION->profilers()["jvisualvm"]->check(ui->jvisualvmPathEdit->text(), &error)) {
+    if (!APPLICATION->profilers()["jvisualvm"]->check(m_ui->jvisualvmPathEdit->text(), &error)) {
         QMessageBox::critical(this, tr("Error"), tr("Error while checking VisualVM install:\n%1").arg(error));
     } else {
         QMessageBox::information(this, tr("OK"), tr("VisualVM setup seems to be OK"));
@@ -210,40 +210,40 @@ void ExternalToolsPage::on_jvisualvmCheckBtn_clicked()
 
 void ExternalToolsPage::on_worldToolAddBtn_clicked()
 {
-    auto* item = new QTreeWidgetItem(ui->worldToolTree);
+    auto* item = new QTreeWidgetItem(m_ui->worldToolTree);
     item->setFlags(item->flags() | Qt::ItemIsEditable);
-    ui->worldToolTree->addTopLevelItem(item);
+    m_ui->worldToolTree->addTopLevelItem(item);
     setupWorldToolBrowseBtn(item);
-    ui->worldToolTree->setCurrentItem(item);
-    ui->worldToolTree->editItem(item, 0);
+    m_ui->worldToolTree->setCurrentItem(item);
+    m_ui->worldToolTree->editItem(item, 0);
 }
 
 void ExternalToolsPage::on_worldToolRemoveBtn_clicked()
 {
-    for (QTreeWidgetItem* item : ui->worldToolTree->selectedItems()) {
-        ui->worldToolTree->takeTopLevelItem(ui->worldToolTree->indexOfTopLevelItem(item));
+    for (QTreeWidgetItem* item : m_ui->worldToolTree->selectedItems()) {
+        m_ui->worldToolTree->takeTopLevelItem(m_ui->worldToolTree->indexOfTopLevelItem(item));
     }
 }
 
 void ExternalToolsPage::on_jsonEditorBrowseBtn_clicked()
 {
-    QString raw_file = QFileDialog::getOpenFileName(this, tr("Text Editor"),
-                                                    ui->jsonEditorTextBox->text().isEmpty()
+    QString rawFile = QFileDialog::getOpenFileName(this, tr("Text Editor"),
+                                                   m_ui->jsonEditorTextBox->text().isEmpty()
 #if defined(Q_OS_LINUX)
-                                                        ? QString("/usr/bin")
+                                                       ? QString("/usr/bin")
 #else
-                                                        ? QStandardPaths::standardLocations(QStandardPaths::ApplicationsLocation).first()
+                                                       ? QStandardPaths::standardLocations(QStandardPaths::ApplicationsLocation).first()
 #endif
-                                                        : ui->jsonEditorTextBox->text());
+                                                       : m_ui->jsonEditorTextBox->text());
 
-    if (raw_file.isEmpty()) {
+    if (rawFile.isEmpty()) {
         return;
     }
-    QString cooked_file = FS::NormalizePath(raw_file);
+    QString cookedFile = FS::NormalizePath(rawFile);
 
     // it has to exist and be an executable
-    if (QFileInfo(cooked_file).exists() && QFileInfo(cooked_file).isExecutable()) {
-        ui->jsonEditorTextBox->setText(cooked_file);
+    if (QFileInfo(cookedFile).exists() && QFileInfo(cookedFile).isExecutable()) {
+        m_ui->jsonEditorTextBox->setText(cookedFile);
     } else {
         QMessageBox::warning(this, tr("Invalid"), tr("The file chosen does not seem to be an executable"));
     }
@@ -257,5 +257,5 @@ bool ExternalToolsPage::apply()
 
 void ExternalToolsPage::retranslate()
 {
-    ui->retranslateUi(this);
+    m_ui->retranslateUi(this);
 }

--- a/launcher/ui/pages/global/ExternalToolsPage.cpp
+++ b/launcher/ui/pages/global/ExternalToolsPage.cpp
@@ -109,7 +109,7 @@ void ExternalToolsPage::setupWorldToolBrowseBtn(QTreeWidgetItem* item)
         if (!filePath.isEmpty()) {
             QFileInfo fileInfo(filePath);
             if (!fileInfo.isExecutable()) {
-                QMessageBox::warning(this, tr("Invalid"), tr("The selected file is not executable"));
+                QMessageBox::warning(this, tr("Invalid command"), tr("The selected file is not executable"));
                 return;
             }
             item->setText(1, Commandline::quoteForSplitCommand(filePath) + " ${WORLD_PATH}");

--- a/launcher/ui/pages/global/ExternalToolsPage.cpp
+++ b/launcher/ui/pages/global/ExternalToolsPage.cpp
@@ -37,12 +37,16 @@
 #include "ui_ExternalToolsPage.h"
 
 #include <QFileDialog>
+#include <QFileInfo>
 #include <QMessageBox>
 #include <QStandardPaths>
 #include <QTabBar>
 
 #include <FileSystem.h>
+#include <QTreeWidgetItem>
 #include "Application.h"
+#include "Commandline.h"
+#include "Json.h"
 #include "settings/SettingsObject.h"
 #include "tools/BaseProfiler.h"
 
@@ -54,6 +58,13 @@ ExternalToolsPage::ExternalToolsPage(QWidget* parent) : QWidget(parent), ui(new 
 
     ui->jvisualvmLink->setOpenExternalLinks(true);
     ui->jprofilerLink->setOpenExternalLinks(true);
+
+    ui->worldToolTree->header()->setStretchLastSection(false);
+    ui->worldToolTree->header()->setSectionResizeMode(0, QHeaderView::Interactive);
+    ui->worldToolTree->header()->setSectionResizeMode(1, QHeaderView::Stretch);
+    ui->worldToolTree->header()->setSectionResizeMode(2, QHeaderView::Interactive);
+    ui->worldToolTree->header()->resizeSection(0, 150);
+    ui->worldToolTree->header()->resizeSection(2, 36);
     loadSettings();
 }
 
@@ -70,6 +81,44 @@ void ExternalToolsPage::loadSettings()
 
     // Editors
     ui->jsonEditorTextBox->setText(s->get("JsonEditor").toString());
+
+    // World Tools
+    ui->worldToolTree->clear();
+    const QVariantMap tools = Json::toMap(APPLICATION->settings()->get("WorldTools").toString());
+    for (auto it = tools.constBegin(); it != tools.constEnd(); ++it) {
+        auto* item = new QTreeWidgetItem(ui->worldToolTree);
+        item->setText(0, it.key());
+        item->setText(1, it.value().toString());
+        item->setFlags(item->flags() | Qt::ItemIsEditable);
+        ui->worldToolTree->addTopLevelItem(item);
+        setupWorldToolBrowseBtn(item);
+    }
+}
+
+void ExternalToolsPage::setupWorldToolBrowseBtn(QTreeWidgetItem* item)
+{
+    auto* btn = new QPushButton("...");
+    btn->setFixedWidth(30);
+    connect(btn, &QPushButton::clicked, this, [this, item]() {
+#ifdef Q_OS_WIN
+        const QString filter = tr("Executables (*.exe *.bat);;All Files (*)");
+#else
+        const QString filter = tr("All Files (*)");
+#endif
+        const QString filePath = QFileDialog::getOpenFileName(this, tr("Select Executable"), QString(), filter);
+        if (!filePath.isEmpty()) {
+            QFileInfo fileInfo(filePath);
+            if (!fileInfo.isExecutable()) {
+                QMessageBox::warning(this, tr("Invalid"), tr("The selected file is not executable"));
+                return;
+            }
+            item->setText(1, Commandline::quoteForSplitCommand(filePath) + " ${WORLD_PATH}");
+            if (item->text(0).trimmed().isEmpty()) {
+                item->setText(0, fileInfo.baseName());
+            }
+        }
+    });
+    ui->worldToolTree->setItemWidget(item, 2, btn);
 }
 void ExternalToolsPage::applySettings()
 {
@@ -87,6 +136,18 @@ void ExternalToolsPage::applySettings()
         }
     }
     s->set("JsonEditor", jsonEditor);
+
+    // World Tools
+    QVariantMap tools;
+    auto* item = ui->worldToolTree->topLevelItem(0);
+    for (int i = 1; item != nullptr; item = ui->worldToolTree->topLevelItem(i++)) {
+        const QString name = item->text(0).trimmed();
+        const QString command = item->text(1).trimmed();
+        if (!name.isEmpty() && !command.isEmpty()) {
+            tools.insert(name, command);
+        }
+    }
+    APPLICATION->settings()->set("WorldTools", Json::fromMap(tools));
 }
 
 void ExternalToolsPage::on_jprofilerPathBtn_clicked()
@@ -144,6 +205,23 @@ void ExternalToolsPage::on_jvisualvmCheckBtn_clicked()
         QMessageBox::critical(this, tr("Error"), tr("Error while checking VisualVM install:\n%1").arg(error));
     } else {
         QMessageBox::information(this, tr("OK"), tr("VisualVM setup seems to be OK"));
+    }
+}
+
+void ExternalToolsPage::on_worldToolAddBtn_clicked()
+{
+    auto* item = new QTreeWidgetItem(ui->worldToolTree);
+    item->setFlags(item->flags() | Qt::ItemIsEditable);
+    ui->worldToolTree->addTopLevelItem(item);
+    setupWorldToolBrowseBtn(item);
+    ui->worldToolTree->setCurrentItem(item);
+    ui->worldToolTree->editItem(item, 0);
+}
+
+void ExternalToolsPage::on_worldToolRemoveBtn_clicked()
+{
+    for (QTreeWidgetItem* item : ui->worldToolTree->selectedItems()) {
+        ui->worldToolTree->takeTopLevelItem(ui->worldToolTree->indexOfTopLevelItem(item));
     }
 }
 

--- a/launcher/ui/pages/global/ExternalToolsPage.h
+++ b/launcher/ui/pages/global/ExternalToolsPage.h
@@ -39,6 +39,8 @@
 
 #include "ui/pages/BasePage.h"
 
+class QTreeWidgetItem;
+
 namespace Ui {
 class ExternalToolsPage;
 }
@@ -67,6 +69,7 @@ class ExternalToolsPage : public QWidget, public BasePage {
    private:
     void loadSettings();
     void applySettings();
+    void setupWorldToolBrowseBtn(QTreeWidgetItem* item);
 
    private:
     Ui::ExternalToolsPage* ui;
@@ -77,4 +80,6 @@ class ExternalToolsPage : public QWidget, public BasePage {
     void on_jvisualvmPathBtn_clicked();
     void on_jvisualvmCheckBtn_clicked();
     void on_jsonEditorBrowseBtn_clicked();
+    void on_worldToolAddBtn_clicked();
+    void on_worldToolRemoveBtn_clicked();
 };

--- a/launcher/ui/pages/global/ExternalToolsPage.h
+++ b/launcher/ui/pages/global/ExternalToolsPage.h
@@ -50,7 +50,7 @@ class ExternalToolsPage : public QWidget, public BasePage {
 
    public:
     explicit ExternalToolsPage(QWidget* parent = 0);
-    ~ExternalToolsPage();
+    ~ExternalToolsPage() override;
 
     QString displayName() const override { return tr("Tools"); }
     QIcon icon() const override
@@ -63,7 +63,7 @@ class ExternalToolsPage : public QWidget, public BasePage {
     }
     QString id() const override { return "external-tools"; }
     QString helpPage() const override { return "Tools"; }
-    virtual bool apply() override;
+    bool apply() override;
     void retranslate() override;
 
    private:
@@ -72,7 +72,7 @@ class ExternalToolsPage : public QWidget, public BasePage {
     void setupWorldToolBrowseBtn(QTreeWidgetItem* item);
 
    private:
-    Ui::ExternalToolsPage* ui;
+    Ui::ExternalToolsPage* m_ui;
 
    private slots:
     void on_jprofilerPathBtn_clicked();

--- a/launcher/ui/pages/global/ExternalToolsPage.ui
+++ b/launcher/ui/pages/global/ExternalToolsPage.ui
@@ -33,8 +33,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>669</width>
-        <height>819</height>
+        <width>657</width>
+        <height>867</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -228,6 +228,99 @@
             <property name="text">
              <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://visualvm.github.io/&quot;&gt;VisualVM Website&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="worldToolsBox">
+         <property name="title">
+          <string>World Tools</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_5">
+          <item>
+           <widget class="QLabel" name="worldToolsHint">
+            <property name="text">
+             <string>Custom tools launchable on worlds from the instance Worlds menu. Command supports the ${WORLD_PATH} placeholder.</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_7">
+            <item>
+             <widget class="QPushButton" name="worldToolAddBtn">
+              <property name="text">
+               <string>&amp;Add</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="worldToolRemoveBtn">
+              <property name="text">
+               <string>&amp;Remove</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QTreeWidget" name="worldToolTree">
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>120</height>
+             </size>
+            </property>
+            <property name="alternatingRowColors">
+             <bool>true</bool>
+            </property>
+            <property name="selectionMode">
+             <enum>QAbstractItemView::ExtendedSelection</enum>
+            </property>
+            <property name="rootIsDecorated">
+             <bool>false</bool>
+            </property>
+            <property name="itemsExpandable">
+             <bool>false</bool>
+            </property>
+            <property name="animated">
+             <bool>true</bool>
+            </property>
+            <property name="expandsOnDoubleClick">
+             <bool>false</bool>
+            </property>
+            <column>
+             <property name="text">
+              <string>Name</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string>Command</string>
+             </property>
+            </column>
+            <column>
+             <property name="text">
+              <string notr="true"/>
+             </property>
+            </column>
            </widget>
           </item>
          </layout>

--- a/launcher/ui/pages/instance/WorldListPage.cpp
+++ b/launcher/ui/pages/instance/WorldListPage.cpp
@@ -36,6 +36,7 @@
  */
 
 #include "WorldListPage.h"
+#include "AssertHelpers.h"
 #include "Commandline.h"
 #include "minecraft/WorldList.h"
 #include "settings/SettingsObject.h"
@@ -348,7 +349,7 @@ void WorldListPage::populateWorldToolsMenu()
         connect(settingsAction, &QAction::triggered, this, [] { APPLICATION->ShowGlobalSettings(nullptr, "external-tools"); });
     } else {
         for (auto it = tools.constBegin(); it != tools.constEnd(); ++it) {
-            if (it.key().isEmpty()) {
+            if (ASSERT_NEVER(it.key().isEmpty())) {
                 continue;
             }
             auto* action = m_worldToolsMenu->addAction(it.key());

--- a/launcher/ui/pages/instance/WorldListPage.cpp
+++ b/launcher/ui/pages/instance/WorldListPage.cpp
@@ -36,19 +36,23 @@
  */
 
 #include "WorldListPage.h"
+#include "Commandline.h"
 #include "minecraft/WorldList.h"
+#include "settings/SettingsObject.h"
 #include "ui/dialogs/CustomMessageBox.h"
 #include "ui/dialogs/ProgressDialog.h"
 #include "ui_WorldListPage.h"
 
 #include <ui/widgets/PageContainer.h>
 #include <QClipboard>
+#include <QCursor>
 #include <QDialogButtonBox>
 #include <QEvent>
 #include <QInputDialog>
 #include <QKeyEvent>
 #include <QMenu>
 #include <QMessageBox>
+#include <QProcess>
 #include <QPushButton>
 #include <QSortFilterProxyModel>
 #include <QTreeView>
@@ -57,6 +61,7 @@
 #include "FileSystem.h"
 
 #include "DesktopServices.h"
+#include "Json.h"
 #include "ui/GuiUtil.h"
 
 #include "Application.h"
@@ -87,7 +92,7 @@ class WorldListProxyModel : public QSortFilterProxyModel {
 };
 
 WorldListPage::WorldListPage(MinecraftInstance* inst, WorldList* worlds, QWidget* parent)
-    : QMainWindow(parent), m_inst(inst), ui(new Ui::WorldListPage), m_worlds(worlds)
+    : QMainWindow(parent), m_inst(inst), ui(new Ui::WorldListPage), m_worlds(worlds), m_worldToolsMenu(new QMenu(this))
 {
     ui->setupUi(this);
 
@@ -115,6 +120,15 @@ WorldListPage::WorldListPage(MinecraftInstance* inst, WorldList* worlds, QWidget
     head->setSectionResizeMode(4, QHeaderView::ResizeToContents);
 
     connect(ui->worldTreeView->selectionModel(), &QItemSelectionModel::currentChanged, this, &WorldListPage::worldChanged);
+
+    ui->actionWorldTools->setMenu(m_worldToolsMenu);
+    connect(ui->actionWorldTools, &QAction::triggered, this, [this] {
+        if (getSelectedWorld().isValid() && !m_worldToolsMenu->isEmpty()) {
+            m_worldToolsMenu->popup(QCursor::pos());
+        }
+    });
+    connect(APPLICATION->settings()->getSetting("WorldTools").get(), &Setting::SettingChanged, this, [this] { populateWorldToolsMenu(); });
+
     worldChanged(QModelIndex(), QModelIndex());
 }
 
@@ -130,6 +144,8 @@ void WorldListPage::openedImpl()
     m_wide_bar_setting = APPLICATION->settings()->getOrRegisterSetting(setting_name);
 
     ui->toolBar->setVisibilityState(QByteArray::fromBase64(m_wide_bar_setting->get().toString().toUtf8()));
+
+    populateWorldToolsMenu();
 }
 
 void WorldListPage::closedImpl()
@@ -151,7 +167,6 @@ void WorldListPage::ShowContextMenu(const QPoint& pos)
     menu->exec(ui->worldTreeView->mapToGlobal(pos));
     delete menu;
 }
-
 QMenu* WorldListPage::createPopupMenu()
 {
     QMenu* filteredMenu = QMainWindow::createPopupMenu();
@@ -278,7 +293,7 @@ void WorldListPage::on_actionData_Packs_triggered()
     dialog->setAttribute(Qt::WA_DeleteOnClose);
 
     connect(dialog, &QDialog::finished, this,
-            [dialog]() { APPLICATION->settings()->set("DataPackDownloadGeometry", dialog->saveGeometry().toBase64()); });
+            [dialog] { APPLICATION->settings()->set("DataPackDownloadGeometry", dialog->saveGeometry().toBase64()); });
 
     dialog->open();
 }
@@ -314,6 +329,63 @@ void WorldListPage::on_actionCopy_Seed_triggered()
     APPLICATION->clipboard()->setText(QString::number(seed));
 }
 
+void WorldListPage::populateWorldToolsMenu()
+{
+    m_worldToolsMenu->clear();
+    const QVariantMap tools = Json::toMap(APPLICATION->settings()->get("WorldTools").toString());
+
+    if (tools.isEmpty()) {
+        auto* noToolsAction = m_worldToolsMenu->addAction(tr("No Tools Added"));
+        noToolsAction->setEnabled(false);
+        m_worldToolsMenu->addSeparator();
+        auto* settingsAction = m_worldToolsMenu->addAction(tr("Open Settings"));
+        connect(settingsAction, &QAction::triggered, this, [] { APPLICATION->ShowGlobalSettings(nullptr, "external-tools"); });
+    } else {
+        for (auto it = tools.constBegin(); it != tools.constEnd(); ++it) {
+            if (it.key().isEmpty()) {
+                continue;
+            }
+            auto* action = m_worldToolsMenu->addAction(it.key());
+            connect(action, &QAction::triggered, this,
+                    [this, name = it.key(), command = it.value().toString()] { launchWorldTool(name, command); });
+        }
+    }
+
+    ui->actionWorldTools->setEnabled(getSelectedWorld().isValid());
+}
+
+void WorldListPage::launchWorldTool(const QString& name, const QString& command)
+{
+    const QModelIndex index = getSelectedWorld();
+    if (!index.isValid()) {
+        return;
+    }
+
+    if (!worldSafetyNagQuestion(name)) {
+        return;
+    }
+
+    const auto folderPath = m_worlds->data(index, WorldList::FolderRole).toString();
+    QProcessEnvironment vars;
+    vars.insert("WORLD_PATH", folderPath);
+
+    auto args = Commandline::process(command, vars);
+    if (args.isEmpty()) {
+        QMessageBox::warning(this->parentWidget(), tr("Invalid command"), tr("The tool command is empty."));
+        return;
+    }
+
+    const auto program = args.takeFirst();
+    auto* process = new QProcess(this);
+    process->setWorkingDirectory(folderPath);
+    process->start(program, args);
+    if (!process->waitForStarted()) {
+        QMessageBox::warning(this->parentWidget(), tr("Tool failed to start!"),
+                             tr("The tool could not be started.\nError: %1").arg(process->errorString()));
+        process->deleteLater();
+    }
+}
+
 void WorldListPage::worldChanged([[maybe_unused]] const QModelIndex& current, [[maybe_unused]] const QModelIndex& previous)
 {
     QModelIndex index = getSelectedWorld();
@@ -323,6 +395,7 @@ void WorldListPage::worldChanged([[maybe_unused]] const QModelIndex& current, [[
     ui->actionCopy->setEnabled(enable);
     ui->actionRename->setEnabled(enable);
     ui->actionData_Packs->setEnabled(enable);
+    ui->actionWorldTools->setEnabled(enable);
     bool hasIcon = !index.data(WorldList::IconFileRole).isNull();
     ui->actionReset_Icon->setEnabled(enable && hasIcon);
 

--- a/launcher/ui/pages/instance/WorldListPage.cpp
+++ b/launcher/ui/pages/instance/WorldListPage.cpp
@@ -57,6 +57,7 @@
 #include <QSortFilterProxyModel>
 #include <QTreeView>
 #include <Qt>
+#include <memory>
 
 #include "FileSystem.h"
 
@@ -67,18 +68,19 @@
 #include "Application.h"
 #include "DataPackPage.h"
 
+namespace {
 class WorldListProxyModel : public QSortFilterProxyModel {
     Q_OBJECT
 
    public:
-    WorldListProxyModel(QObject* parent) : QSortFilterProxyModel(parent) {}
+    explicit WorldListProxyModel(QObject* parent) : QSortFilterProxyModel(parent) {}
 
-    virtual QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override
     {
         QModelIndex sourceIndex = mapToSource(index);
 
         if (index.column() == 0 && role == Qt::DecorationRole) {
-            WorldList* worlds = qobject_cast<WorldList*>(sourceModel());
+            auto* worlds = qobject_cast<WorldList*>(sourceModel());
             auto iconFile = worlds->data(sourceIndex, WorldList::IconFileRole).toString();
             if (iconFile.isNull()) {
                 // NOTE: Minecraft uses the same placeholder for servers AND worlds
@@ -90,39 +92,40 @@ class WorldListProxyModel : public QSortFilterProxyModel {
         return sourceIndex.data(role);
     }
 };
+}  // namespace
 
 WorldListPage::WorldListPage(MinecraftInstance* inst, WorldList* worlds, QWidget* parent)
-    : QMainWindow(parent), m_inst(inst), ui(new Ui::WorldListPage), m_worlds(worlds), m_worldToolsMenu(new QMenu(this))
+    : QMainWindow(parent), m_inst(inst), m_ui(new Ui::WorldListPage), m_worlds(worlds), m_worldToolsMenu(new QMenu(this))
 {
-    ui->setupUi(this);
+    m_ui->setupUi(this);
 
-    ui->toolBar->insertSpacer(ui->actionRefresh);
+    m_ui->toolBar->insertSpacer(m_ui->actionRefresh);
 
-    WorldListProxyModel* proxy = new WorldListProxyModel(this);
+    auto* proxy = new WorldListProxyModel(this);
     proxy->setSortCaseSensitivity(Qt::CaseInsensitive);
     proxy->setSourceModel(m_worlds);
     proxy->setSortRole(Qt::UserRole);
-    ui->worldTreeView->setSortingEnabled(true);
-    ui->worldTreeView->setModel(proxy);
-    ui->worldTreeView->installEventFilter(this);
-    ui->worldTreeView->setContextMenuPolicy(Qt::CustomContextMenu);
-    ui->worldTreeView->setIconSize(QSize(64, 64));
-    connect(ui->worldTreeView, &QTreeView::customContextMenuRequested, this, &WorldListPage::ShowContextMenu);
-    connect(ui->worldTreeView, &QAbstractItemView::activated, this, [this] {
-        if (ui->actionJoin->isEnabled()) {
+    m_ui->worldTreeView->setSortingEnabled(true);
+    m_ui->worldTreeView->setModel(proxy);
+    m_ui->worldTreeView->installEventFilter(this);
+    m_ui->worldTreeView->setContextMenuPolicy(Qt::CustomContextMenu);
+    m_ui->worldTreeView->setIconSize(QSize(64, 64));
+    connect(m_ui->worldTreeView, &QTreeView::customContextMenuRequested, this, &WorldListPage::ShowContextMenu);
+    connect(m_ui->worldTreeView, &QAbstractItemView::activated, this, [this] {
+        if (m_ui->actionJoin->isEnabled()) {
             on_actionJoin_triggered();
         }
     });
 
-    auto head = ui->worldTreeView->header();
+    auto* head = m_ui->worldTreeView->header();
     head->setSectionResizeMode(0, QHeaderView::Stretch);
     head->setSectionResizeMode(1, QHeaderView::ResizeToContents);
     head->setSectionResizeMode(4, QHeaderView::ResizeToContents);
 
-    connect(ui->worldTreeView->selectionModel(), &QItemSelectionModel::currentChanged, this, &WorldListPage::worldChanged);
+    connect(m_ui->worldTreeView->selectionModel(), &QItemSelectionModel::currentChanged, this, &WorldListPage::worldChanged);
 
-    ui->actionWorldTools->setMenu(m_worldToolsMenu);
-    connect(ui->actionWorldTools, &QAction::triggered, this, [this] {
+    m_ui->actionWorldTools->setMenu(m_worldToolsMenu);
+    connect(m_ui->actionWorldTools, &QAction::triggered, this, [this] {
         if (getSelectedWorld().isValid() && !m_worldToolsMenu->isEmpty()) {
             m_worldToolsMenu->popup(QCursor::pos());
         }
@@ -136,14 +139,14 @@ void WorldListPage::openedImpl()
 {
     m_worlds->startWatching();
 
-    if (!m_inst || !m_inst->traits().contains("feature:is_quick_play_singleplayer")) {
-        ui->toolBar->removeAction(ui->actionJoin);
+    if ((m_inst == nullptr) || !m_inst->traits().contains("feature:is_quick_play_singleplayer")) {
+        m_ui->toolBar->removeAction(m_ui->actionJoin);
     }
 
-    const auto setting_name = QString("WideBarVisibility_%1").arg(id());
-    m_wide_bar_setting = APPLICATION->settings()->getOrRegisterSetting(setting_name);
+    const auto settingName = QString("WideBarVisibility_%1").arg(id());
+    m_wideBarSetting = APPLICATION->settings()->getOrRegisterSetting(settingName);
 
-    ui->toolBar->setVisibilityState(QByteArray::fromBase64(m_wide_bar_setting->get().toString().toUtf8()));
+    m_ui->toolBar->setVisibilityState(QByteArray::fromBase64(m_wideBarSetting->get().toString().toUtf8()));
 
     populateWorldToolsMenu();
 }
@@ -152,25 +155,25 @@ void WorldListPage::closedImpl()
 {
     m_worlds->stopWatching();
 
-    m_wide_bar_setting->set(QString::fromUtf8(ui->toolBar->getVisibilityState().toBase64()));
+    m_wideBarSetting->set(QString::fromUtf8(m_ui->toolBar->getVisibilityState().toBase64()));
 }
 
 WorldListPage::~WorldListPage()
 {
     m_worlds->stopWatching();
-    delete ui;
+    delete m_ui;
 }
 
 void WorldListPage::ShowContextMenu(const QPoint& pos)
 {
-    auto menu = ui->toolBar->createContextMenu(this, tr("Context menu"));
-    menu->exec(ui->worldTreeView->mapToGlobal(pos));
+    auto* menu = m_ui->toolBar->createContextMenu(this, tr("Context menu"));
+    menu->exec(m_ui->worldTreeView->mapToGlobal(pos));
     delete menu;
 }
 QMenu* WorldListPage::createPopupMenu()
 {
     QMenu* filteredMenu = QMainWindow::createPopupMenu();
-    filteredMenu->removeAction(ui->toolBar->toggleViewAction());
+    filteredMenu->removeAction(m_ui->toolBar->toggleViewAction());
     return filteredMenu;
 }
 
@@ -181,16 +184,16 @@ bool WorldListPage::shouldDisplay() const
 
 void WorldListPage::retranslate()
 {
-    ui->retranslateUi(this);
+    m_ui->retranslateUi(this);
 }
 
-bool WorldListPage::worldListFilter(QKeyEvent* keyEvent)
+bool WorldListPage::worldListFilter(QKeyEvent* ev)
 {
-    if (keyEvent->key() == Qt::Key_Delete) {
+    if (ev->key() == Qt::Key_Delete) {
         on_actionRemove_triggered();
         return true;
     }
-    return QWidget::eventFilter(ui->worldTreeView, keyEvent);
+    return QWidget::eventFilter(m_ui->worldTreeView, ev);
 }
 
 bool WorldListPage::eventFilter(QObject* obj, QEvent* ev)
@@ -198,9 +201,10 @@ bool WorldListPage::eventFilter(QObject* obj, QEvent* ev)
     if (ev->type() != QEvent::KeyPress) {
         return QWidget::eventFilter(obj, ev);
     }
-    QKeyEvent* keyEvent = static_cast<QKeyEvent*>(ev);
-    if (obj == ui->worldTreeView)
+    auto* keyEvent = static_cast<QKeyEvent*>(ev);
+    if (obj == m_ui->worldTreeView) {
         return worldListFilter(keyEvent);
+    }
     return QWidget::eventFilter(obj, ev);
 }
 
@@ -251,13 +255,14 @@ void WorldListPage::on_actionData_Packs_triggered()
         return;
     }
 
-    if (!worldSafetyNagQuestion(tr("Manage Data Packs")))
+    if (!worldSafetyNagQuestion(tr("Manage Data Packs"))) {
         return;
+    }
 
     const QString fullPath = m_worlds->data(index, WorldList::FolderRole).toString();
     const QString folder = FS::PathCombine(fullPath, "datapacks");
 
-    auto dialog = new QDialog(this);
+    auto* dialog = new QDialog(this);
     dialog->setWindowTitle(tr("Data packs for %1").arg(m_worlds->data(index, WorldList::NameRole).toString()));
     dialog->setWindowModality(Qt::WindowModal);
 
@@ -268,22 +273,22 @@ void WorldListPage::on_actionData_Packs_triggered()
     GenericPageProvider provider(dialog->windowTitle());
 
     bool isIndexed = !APPLICATION->settings()->get("ModMetadataDisabled").toBool();
-    m_datapackModel.reset(new DataPackFolderModel(folder, m_inst, isIndexed, true));
+    m_datapackModel = std::make_unique<DataPackFolderModel>(folder, m_inst, isIndexed, true);
 
     provider.addPageCreator([this] { return new DataPackPage(m_inst, m_datapackModel.get(), this); });
 
-    auto layout = new QVBoxLayout(dialog);
+    auto* layout = new QVBoxLayout(dialog);
 
-    auto focusStealer = new QPushButton(dialog);
+    auto* focusStealer = new QPushButton(dialog);
     layout->addWidget(focusStealer);
     focusStealer->setDefault(true);
     focusStealer->hide();
 
-    auto pageContainer = new PageContainer(&provider, {}, dialog);
+    auto* pageContainer = new PageContainer(&provider, {}, dialog);
     pageContainer->hidePageList();
     layout->addWidget(pageContainer);
 
-    auto buttonBox = new QDialogButtonBox(QDialogButtonBox::Close | QDialogButtonBox::Help);
+    auto* buttonBox = new QDialogButtonBox(QDialogButtonBox::Close | QDialogButtonBox::Help);
     connect(buttonBox, &QDialogButtonBox::rejected, dialog, &QDialog::reject);
     connect(buttonBox, &QDialogButtonBox::helpRequested, pageContainer, &PageContainer::help);
     layout->addWidget(buttonBox);
@@ -302,19 +307,20 @@ void WorldListPage::on_actionReset_Icon_triggered()
 {
     auto proxiedIndex = getSelectedWorld();
 
-    if (!proxiedIndex.isValid())
+    if (!proxiedIndex.isValid()) {
         return;
+    }
 
     if (m_worlds->resetIcon(proxiedIndex.row())) {
-        ui->actionReset_Icon->setEnabled(false);
+        m_ui->actionReset_Icon->setEnabled(false);
     }
 }
 
 QModelIndex WorldListPage::getSelectedWorld()
 {
-    auto index = ui->worldTreeView->selectionModel()->currentIndex();
+    auto index = m_ui->worldTreeView->selectionModel()->currentIndex();
 
-    auto proxy = (QSortFilterProxyModel*)ui->worldTreeView->model();
+    auto* proxy = dynamic_cast<QSortFilterProxyModel*>(m_ui->worldTreeView->model());
     return proxy->mapToSource(index);
 }
 
@@ -351,7 +357,7 @@ void WorldListPage::populateWorldToolsMenu()
         }
     }
 
-    ui->actionWorldTools->setEnabled(getSelectedWorld().isValid());
+    m_ui->actionWorldTools->setEnabled(getSelectedWorld().isValid());
 }
 
 void WorldListPage::launchWorldTool(const QString& name, const QString& command)
@@ -390,20 +396,20 @@ void WorldListPage::worldChanged([[maybe_unused]] const QModelIndex& current, [[
 {
     QModelIndex index = getSelectedWorld();
     bool enable = index.isValid();
-    ui->actionCopy_Seed->setEnabled(enable);
-    ui->actionRemove->setEnabled(enable);
-    ui->actionCopy->setEnabled(enable);
-    ui->actionRename->setEnabled(enable);
-    ui->actionData_Packs->setEnabled(enable);
-    ui->actionWorldTools->setEnabled(enable);
+    m_ui->actionCopy_Seed->setEnabled(enable);
+    m_ui->actionRemove->setEnabled(enable);
+    m_ui->actionCopy->setEnabled(enable);
+    m_ui->actionRename->setEnabled(enable);
+    m_ui->actionData_Packs->setEnabled(enable);
+    m_ui->actionWorldTools->setEnabled(enable);
     bool hasIcon = !index.data(WorldList::IconFileRole).isNull();
-    ui->actionReset_Icon->setEnabled(enable && hasIcon);
+    m_ui->actionReset_Icon->setEnabled(enable && hasIcon);
 
-    auto supportsJoin = m_inst && m_inst->traits().contains("feature:is_quick_play_singleplayer");
-    ui->actionJoin->setEnabled(enable && supportsJoin);
+    auto supportsJoin = (m_inst != nullptr) && m_inst->traits().contains("feature:is_quick_play_singleplayer");
+    m_ui->actionJoin->setEnabled(enable && supportsJoin);
 
     if (!supportsJoin) {
-        ui->toolBar->removeAction(ui->actionJoin);
+        m_ui->toolBar->removeAction(m_ui->actionJoin);
     }
 }
 
@@ -416,7 +422,7 @@ void WorldListPage::on_actionAdd_triggered()
     }
 
     m_worlds->stopWatching();
-    for (auto filename : list) {
+    for (const auto& filename : list) {
         auto task = m_worlds->createInstallWorldTask(QFileInfo(filename));
         if (!task) {
             continue;
@@ -427,7 +433,7 @@ void WorldListPage::on_actionAdd_triggered()
     m_worlds->startWatching();
 }
 
-bool WorldListPage::isWorldSafe(QModelIndex)
+bool WorldListPage::isWorldSafe(QModelIndex /*unused*/)
 {
     return !m_inst->isRunning();
 }
@@ -485,11 +491,12 @@ void WorldListPage::on_actionRename_triggered()
         return;
     }
 
-    if (!worldSafetyNagQuestion(tr("Rename World")))
+    if (!worldSafetyNagQuestion(tr("Rename World"))) {
         return;
+    }
 
     auto worldVariant = m_worlds->data(index, WorldList::ObjectRole);
-    auto world = (World*)worldVariant.value<void*>();
+    auto* world = static_cast<World*>(worldVariant.value<void*>());
 
     bool ok = false;
     QString name = QInputDialog::getText(this, tr("World name"), tr("Enter a new world name."), QLineEdit::Normal, world->name(), &ok);
@@ -511,7 +518,7 @@ void WorldListPage::on_actionJoin_triggered()
         return;
     }
     auto worldVariant = m_worlds->data(index, WorldList::ObjectRole);
-    auto world = (World*)worldVariant.value<void*>();
+    auto* world = static_cast<World*>(worldVariant.value<void*>());
     APPLICATION->launch(m_inst, LaunchMode::Normal, std::make_shared<MinecraftTarget>(MinecraftTarget::parse(world->folderName(), true)));
 }
 

--- a/launcher/ui/pages/instance/WorldListPage.h
+++ b/launcher/ui/pages/instance/WorldListPage.h
@@ -42,6 +42,7 @@
 
 #include "settings/Setting.h"
 
+class QMenu;
 class WorldList;
 namespace Ui {
 class WorldListPage;
@@ -76,10 +77,13 @@ class WorldListPage : public QMainWindow, public BasePage {
     QModelIndex getSelectedWorld();
     bool isWorldSafe(QModelIndex index);
     bool worldSafetyNagQuestion(const QString& actionType);
+    void populateWorldToolsMenu();
+    void launchWorldTool(const QString& name, const QString& command);
 
    private:
     Ui::WorldListPage* ui;
     WorldList* m_worlds;
+    QMenu* m_worldToolsMenu = nullptr;
 
     std::shared_ptr<Setting> m_wide_bar_setting = nullptr;
     std::unique_ptr<DataPackFolderModel> m_datapackModel;

--- a/launcher/ui/pages/instance/WorldListPage.h
+++ b/launcher/ui/pages/instance/WorldListPage.h
@@ -52,18 +52,18 @@ class WorldListPage : public QMainWindow, public BasePage {
     Q_OBJECT
 
    public:
-    explicit WorldListPage(MinecraftInstance* inst, WorldList* worlds, QWidget* parent = 0);
-    virtual ~WorldListPage();
+    explicit WorldListPage(MinecraftInstance* inst, WorldList* worlds, QWidget* parent = nullptr);
+    ~WorldListPage() override;
 
-    virtual QString displayName() const override { return tr("Worlds"); }
-    virtual QIcon icon() const override { return QIcon::fromTheme("worlds"); }
-    virtual QString id() const override { return "worlds"; }
-    virtual QString helpPage() const override { return "Worlds"; }
-    virtual bool shouldDisplay() const override;
+    QString displayName() const override { return tr("Worlds"); }
+    QIcon icon() const override { return QIcon::fromTheme("worlds"); }
+    QString id() const override { return "worlds"; }
+    QString helpPage() const override { return "Worlds"; }
+    bool shouldDisplay() const override;
     void retranslate() override;
 
-    virtual void openedImpl() override;
-    virtual void closedImpl() override;
+    void openedImpl() override;
+    void closedImpl() override;
 
    protected:
     bool eventFilter(QObject* obj, QEvent* ev) override;
@@ -81,11 +81,11 @@ class WorldListPage : public QMainWindow, public BasePage {
     void launchWorldTool(const QString& name, const QString& command);
 
    private:
-    Ui::WorldListPage* ui;
+    Ui::WorldListPage* m_ui;
     WorldList* m_worlds;
     QMenu* m_worldToolsMenu = nullptr;
 
-    std::shared_ptr<Setting> m_wide_bar_setting = nullptr;
+    std::shared_ptr<Setting> m_wideBarSetting = nullptr;
     std::unique_ptr<DataPackFolderModel> m_datapackModel;
 
    private slots:

--- a/launcher/ui/pages/instance/WorldListPage.ui
+++ b/launcher/ui/pages/instance/WorldListPage.ui
@@ -41,6 +41,9 @@
       <property name="alternatingRowColors">
        <bool>true</bool>
       </property>
+      <property name="verticalScrollMode">
+       <enum>QAbstractItemView::ScrollPerPixel</enum>
+      </property>
       <property name="rootIsDecorated">
        <bool>false</bool>
       </property>
@@ -52,9 +55,6 @@
       </property>
       <property name="allColumnsShowFocus">
        <bool>true</bool>
-      </property>
-      <property name="verticalScrollMode">
-       <enum>QAbstractItemView::ScrollPerPixel</enum>
       </property>
       <attribute name="headerStretchLastSection">
        <bool>false</bool>
@@ -87,8 +87,9 @@
    <addaction name="actionJoin"/>
    <addaction name="actionRename"/>
    <addaction name="actionCopy"/>
-    <addaction name="actionRemove"/>
-    <addaction name="actionData_Packs"/>
+   <addaction name="actionRemove"/>
+   <addaction name="actionData_Packs"/>
+   <addaction name="actionWorldTools"/>
    <addaction name="actionReset_Icon"/>
    <addaction name="separator"/>
    <addaction name="actionCopy_Seed"/>
@@ -141,6 +142,14 @@
    </property>
    <property name="toolTip">
     <string>Remove world icon to make the game re-generate it on next load.</string>
+   </property>
+  </action>
+  <action name="actionWorldTools">
+   <property name="text">
+    <string>Tools</string>
+   </property>
+   <property name="toolTip">
+    <string>Run an external tool on the selected world.</string>
    </property>
   </action>
   <action name="actionData_Packs">

--- a/launcher/ui/widgets/WideBar.cpp
+++ b/launcher/ui/widgets/WideBar.cpp
@@ -4,6 +4,8 @@
 #include <QCryptographicHash>
 #include <QToolButton>
 
+#include <algorithm>
+
 class ActionButton : public QToolButton {
     Q_OBJECT
    public:
@@ -33,6 +35,7 @@ class ActionButton : public QToolButton {
             setPopupMode(QToolButton::MenuButtonPopup);
         }
         if (!m_use_default_action) {
+            setMenu(m_action->menu());
             setChecked(m_action->isChecked());
             setCheckable(m_action->isCheckable());
             setText(m_action->text());
@@ -89,7 +92,7 @@ void WideBar::addSeparator()
 
 auto WideBar::getMatching(QAction* act) -> QList<BarEntry>::iterator
 {
-    auto iter = std::find_if(m_entries.begin(), m_entries.end(), [act](BarEntry const& entry) { return entry.menu_action == act; });
+    auto iter = std::ranges::find_if(m_entries, [act](const BarEntry& entry) { return entry.menu_action == act; });
 
     return iter;
 }
@@ -202,7 +205,7 @@ static void copyAction(QAction* from, QAction* to)
     to->setToolTip(from->toolTip());
 }
 
-void WideBar::showVisibilityMenu(QPoint const& position)
+void WideBar::showVisibilityMenu(const QPoint& position)
 {
     if (!m_bar_menu) {
         m_bar_menu = std::make_unique<QMenu>(this);
@@ -254,7 +257,7 @@ QByteArray WideBar::getVisibilityState() const
 {
     QByteArray state;
 
-    for (auto const& entry : m_entries) {
+    for (const auto& entry : m_entries) {
         if (entry.type != BarEntry::Type::Action)
             continue;
 
@@ -295,7 +298,7 @@ void WideBar::setVisibilityState(QByteArray&& state)
 QByteArray WideBar::getHash() const
 {
     QCryptographicHash hash(QCryptographicHash::Sha1);
-    for (auto const& entry : m_entries) {
+    for (const auto& entry : m_entries) {
         if (entry.type != BarEntry::Type::Action)
             continue;
         hash.addData(entry.menu_action->text().toLatin1());
@@ -304,9 +307,9 @@ QByteArray WideBar::getHash() const
     return hash.result().toBase64();
 }
 
-bool WideBar::checkHash(QByteArray const& old_hash) const
+bool WideBar::checkHash(const QByteArray& oldHash) const
 {
-    return old_hash == getHash();
+    return oldHash == getHash();
 }
 
 void WideBar::removeAction(QAction* action)


### PR DESCRIPTION
blocked by #6022

With the removal of mceditor rise the general world tools
surely there is an issue that can be closed with this but to lazy

Similar to Env vars I save the tools in the config, ... sue me

edit:
fixes #973
fixes #739