### PR TITLE
Fix: Preserve auto-join server address for quickplay (Fixes #5991)

### DIFF
--- a/launcher/launch/steps/LookupServerAddress.cpp
+++ b/launcher/launch/steps/LookupServerAddress.cpp
@@ -86,6 +86,7 @@ void LookupServerAddress::resolve(const QString& address, quint16 port)
 {
     m_output->address = address;
     m_output->port = port;
+    m_output->originalAddress = address + ':' + QString::number(port);
 
     m_dnsLookup->deleteLater();
     emitSucceeded();

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -248,6 +248,7 @@ void MinecraftInstance::loadSpecificSettings()
     // Join server on launch, this does not have a global override
     m_settings->registerSetting("JoinServerOnLaunch", false);
     m_settings->registerSetting("JoinServerOnLaunchAddress", "");
+    m_settings->registerSetting("JoinServerOnLaunchPreResolveSrv", false);
     m_settings->registerSetting("JoinWorldOnLaunch", "");
 
     // Use account for instance, this does not have a global override
@@ -765,7 +766,7 @@ QStringList MinecraftInstance::processMinecraftArgs(AuthSessionPtr session, Mine
     if (targetToJoin) {
         if (!targetToJoin->address.isEmpty()) {
             if (profile->hasTrait("feature:is_quick_play_multiplayer")) {
-                args << "--quickPlayMultiplayer" << targetToJoin->address + ':' + QString::number(targetToJoin->port);
+                args << "--quickPlayMultiplayer" << targetToJoin->originalAddress;
             } else {
                 args << "--server" << targetToJoin->address;
                 args << "--port" << QString::number(targetToJoin->port);
@@ -821,6 +822,7 @@ QString MinecraftInstance::createLaunchScript(AuthSessionPtr session, MinecraftT
         if (!targetToJoin->address.isEmpty()) {
             launchScript += "serverAddress " + targetToJoin->address + "\n";
             launchScript += "serverPort " + QString::number(targetToJoin->port) + "\n";
+            launchScript += "serverOriginalAddress " + targetToJoin->originalAddress + "\n";
         } else if (!targetToJoin->world.isEmpty()) {
             launchScript += "worldName " + targetToJoin->world + "\n";
         }
@@ -1165,7 +1167,8 @@ LaunchTask* MinecraftInstance::createLaunchTask(AuthSessionPtr session, Minecraf
         }
     }
 
-    if (targetToJoin && targetToJoin->port == 25565) {
+    if (targetToJoin && !targetToJoin->address.isEmpty() && targetToJoin->port == 25565 &&
+        settings()->get("JoinServerOnLaunchPreResolveSrv").toBool()) {
         // Resolve server address to join on launch
         auto step = makeShared<LookupServerAddress>(pptr);
         step->setLookupAddress(targetToJoin->address);

--- a/launcher/minecraft/launch/MinecraftTarget.cpp
+++ b/launcher/minecraft/launch/MinecraftTarget.cpp
@@ -61,5 +61,5 @@ MinecraftTarget MinecraftTarget::parse(const QString& fullAddress, bool useWorld
         }
     }
 
-    return MinecraftTarget{ realAddress, realPort };
+    return MinecraftTarget{ fullAddress, realAddress, realPort };
 }

--- a/launcher/minecraft/launch/MinecraftTarget.h
+++ b/launcher/minecraft/launch/MinecraftTarget.h
@@ -20,6 +20,7 @@
 #include <QString>
 
 struct MinecraftTarget {
+    QString originalAddress;
     QString address;
     quint16 port;
 

--- a/launcher/ui/widgets/MinecraftSettingsWidget.cpp
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.cpp
@@ -99,6 +99,7 @@ MinecraftSettingsWidget::MinecraftSettingsWidget(MinecraftInstance* instance, QW
 
         connect(m_ui->openGlobalSettingsButton, &QCommandLinkButton::clicked, this, &MinecraftSettingsWidget::openGlobalSettings);
         connect(m_ui->serverJoinAddressButton, &QAbstractButton::toggled, m_ui->serverJoinAddress, &QWidget::setEnabled);
+        connect(m_ui->serverJoinAddressButton, &QAbstractButton::toggled, m_ui->serverJoinPreResolveSrv, &QWidget::setEnabled);
         connect(m_ui->worldJoinButton, &QAbstractButton::toggled, m_ui->worldsCb, &QWidget::setEnabled);
 
         connect(m_ui->globalDataPacksGroupBox, &QGroupBox::toggled, this, [this](bool value) {
@@ -257,6 +258,8 @@ void MinecraftSettingsWidget::loadSettings()
         }
 
         m_ui->serverJoinGroupBox->setChecked(settings->get("JoinServerOnLaunch").toBool());
+        m_ui->serverJoinPreResolveSrv->setChecked(settings->get("JoinServerOnLaunchPreResolveSrv").toBool());
+        m_ui->serverJoinPreResolveSrv->setEnabled(m_ui->serverJoinAddressButton->isChecked());
 
         m_ui->instanceAccountGroupBox->setChecked(settings->get("UseAccountForInstance").toBool());
         updateAccountsMenu(*settings);
@@ -460,6 +463,7 @@ void MinecraftSettingsWidget::saveSettings()
         // Join server on launch
         bool joinServerOnLaunch = m_ui->serverJoinGroupBox->isChecked();
         settings->set("JoinServerOnLaunch", joinServerOnLaunch);
+        settings->set("JoinServerOnLaunchPreResolveSrv", m_ui->serverJoinPreResolveSrv->isChecked());
         if (joinServerOnLaunch) {
             if (m_ui->serverJoinAddressButton->isChecked() || !m_quickPlaySingleplayer) {
                 settings->set("JoinServerOnLaunchAddress", m_ui->serverJoinAddress->text());

--- a/launcher/ui/widgets/MinecraftSettingsWidget.ui
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.ui
@@ -473,6 +473,16 @@ It is most likely you will need to change the path - please refer to the mod's w
                 </property>
                </spacer>
               </item>
+              <item row="2" column="0" colspan="2">
+               <widget class="QCheckBox" name="serverJoinPreResolveSrv">
+                <property name="toolTip">
+                 <string>Resolve Minecraft SRV records before launch. This may change the server address visible to Minecraft and mods.</string>
+                </property>
+                <property name="text">
+                 <string>Pre-resolve SRV records</string>
+                </property>
+               </widget>
+              </item>
              </layout>
             </widget>
            </item>

--- a/libraries/launcher/org/prismlauncher/launcher/impl/AbstractLauncher.java
+++ b/libraries/launcher/org/prismlauncher/launcher/impl/AbstractLauncher.java
@@ -70,7 +70,7 @@ public abstract class AbstractLauncher implements Launcher {
     // secondary parameters
     protected final int width, height;
     protected final boolean maximize;
-    protected final String serverAddress, serverPort, worldName;
+    protected final String serverAddress, serverPort, serverOriginalAddress, worldName;
 
     protected final String mainClassName;
 
@@ -80,6 +80,7 @@ public abstract class AbstractLauncher implements Launcher {
 
         serverAddress = params.getString("serverAddress", null);
         serverPort = params.getString("serverPort", null);
+        serverOriginalAddress = params.getString("serverOriginalAddress", null);
         worldName = params.getString("worldName", null);
 
         String windowParams = params.getString("windowParams", null);

--- a/libraries/launcher/org/prismlauncher/launcher/impl/StandardLauncher.java
+++ b/libraries/launcher/org/prismlauncher/launcher/impl/StandardLauncher.java
@@ -85,7 +85,7 @@ public final class StandardLauncher extends AbstractLauncher {
             if (quickPlayMultiplayerSupported) {
                 // as of 23w14a
                 gameArgs.add("--quickPlayMultiplayer");
-                gameArgs.add(serverAddress + ':' + serverPort);
+                gameArgs.add(serverOriginalAddress != null ? serverOriginalAddress : serverAddress + ':' + serverPort);
             } else {
                 gameArgs.add("--server");
                 gameArgs.add(serverAddress);


### PR DESCRIPTION
Fixes #5991 

# Summary
When configuring the server auto-join functionality of an instance, a new checkbox is available (default: disabled) that allows the user to specifically **opt-in** to SRV resolution prior to game launch. _(Minecraft instances prior to 1.3.0 do not have native SRV resolution support, but all subsequent versions do. This checkbox provides the option to retain backwards-compatible resolution behavior.)_

If the checkbox is left disabled, it will retain the literal input to the auto-join server field as a new field in MinecraftTarget, which will be used by the launch script to assemble the `--quickPlayMultiplayer` argument instead of the manually-assembled server/port combination from the SRV resolution.

# Testing
Built changes and ran a manual smoke test using the `demo.aurbi.host` instance & server I provided in issue #5991 for easier repro.
- Prism launches
- Instance settings opens/closes, retains new checkbox value as expected
- Configured auto-join with SRV resolution OFF: Launched & auto-joined server with reported correct `demo.aurbi.host` reported. (previously: incorrect `demo.linode.sys.aurbi.host:25565`)
- Configured auto-join with SRV resolution ON: Launched & auto-joined server with "incorrect" `demo.linode.sys.aurbi.host:25565` reported. (no change from prior to fix, obviously)

**AI use disclosure:** I used GPT-5.5 in pi to orient myself in the project and quickly find the touch-points for the UI, the SRV resolution, and the argument construction processes. I otherwise planned and wrote the changes (minimal that they are) myself. Issue and PR text are hand-written.