### PR TITLE
Fix some atl install bugs

### DIFF
--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
@@ -79,16 +79,16 @@ Meta::Version::Ptr getComponentVersion(const QString& uid, const QString& versio
 namespace ATLauncher {
 
 PackInstallTask::PackInstallTask(UserInteractionSupport* support, QString packName, QString version, InstallMode installMode)
-    : m_support(support), m_install_mode(installMode), m_pack_name(packName), m_version_name(std::move(version))
+    : m_support(support), m_installMode(installMode), m_packName(packName), m_versionName(std::move(version))
 {
     static const QRegularExpression s_regex("[^A-Za-z0-9]");
-    m_pack_safe_name = packName.replace(s_regex, "");
+    m_packSafeName = packName.replace(s_regex, "");
 }
 
 bool PackInstallTask::abort()
 {
-    if (abortable) {
-        return jobPtr->abort();
+    if (m_abortable) {
+        return m_jobPtr->abort();
     }
     return false;
 }
@@ -98,7 +98,7 @@ void PackInstallTask::executeTask()
     qDebug() << "PackInstallTask::executeTask:" << QThread::currentThreadId();
     NetJob::Ptr netJob{ new NetJob("ATLauncher::VersionFetch", APPLICATION->network()) };
     auto searchUrl =
-        QString(BuildConfig.ATL_DOWNLOAD_SERVER_URL + "packs/%1/versions/%2/Configs.json").arg(m_pack_safe_name).arg(m_version_name);
+        QString(BuildConfig.ATL_DOWNLOAD_SERVER_URL + "packs/%1/versions/%2/Configs.json").arg(m_packSafeName).arg(m_versionName);
 
     auto [action, response] = Net::ApiRequest::makeByteArray(QUrl(searchUrl));
     netJob->addNetAction(action);
@@ -107,8 +107,8 @@ void PackInstallTask::executeTask()
     connect(netJob.get(), &NetJob::failed, this, &PackInstallTask::onDownloadFailed);
     connect(netJob.get(), &NetJob::aborted, this, &PackInstallTask::onDownloadAborted);
 
-    jobPtr = netJob;
-    jobPtr->start();
+    m_jobPtr = netJob;
+    m_jobPtr->start();
 }
 
 void PackInstallTask::onDownloadSucceeded(QByteArray* responsePtr)
@@ -117,7 +117,7 @@ void PackInstallTask::onDownloadSucceeded(QByteArray* responsePtr)
 
     // NOTE(TheKodeToad): moving the response out to avoid it from being destroyed by jobPtr.reset()
     QByteArray response = std::move(*responsePtr);
-    jobPtr.reset();
+    m_jobPtr.reset();
 
     QJsonParseError parseError{};
     QJsonDocument doc = QJsonDocument::fromJson(response, &parseError);
@@ -141,7 +141,7 @@ void PackInstallTask::onDownloadSucceeded(QByteArray* responsePtr)
     QString message;
     bool resetDirectory = false;
 
-    switch (m_install_mode) {
+    switch (m_installMode) {
         case InstallMode::Reinstall:
         case InstallMode::Update:
             message = m_version.messages.update;
@@ -168,7 +168,7 @@ void PackInstallTask::onDownloadSucceeded(QByteArray* responsePtr)
         emitFailed(tr("Failed to get local metadata index for '%1' v%2").arg("net.minecraft", m_version.minecraft));
         return;
     }
-    minecraftVersion = ver;
+    m_minecraftVersion = ver;
 
     if (resetDirectory) {
         deleteExistingFiles();
@@ -184,13 +184,13 @@ void PackInstallTask::onDownloadSucceeded(QByteArray* responsePtr)
 void PackInstallTask::onDownloadFailed(QString reason)
 {
     qDebug() << "PackInstallTask::onDownloadFailed:" << QThread::currentThreadId();
-    jobPtr.reset();
+    m_jobPtr.reset();
     emitFailed(std::move(reason));
 }
 
 void PackInstallTask::onDownloadAborted()
 {
-    jobPtr.reset();
+    m_jobPtr.reset();
     emitAborted();
 }
 
@@ -200,18 +200,18 @@ void PackInstallTask::deleteExistingFiles()
 
     // Setup defaults, as per https://wiki.atlauncher.com/pack-admin/xml/delete
     VersionDeletes deletes;
-    deletes.folders.append(VersionDelete{ "root", "mods%s%" });
-    deletes.folders.append(VersionDelete{ "root", "configs%s%" });
-    deletes.folders.append(VersionDelete{ "root", "bin%s%" });
+    deletes.folders.append(VersionDelete{ .base = "root", .target = "mods%s%" });
+    deletes.folders.append(VersionDelete{ .base = "root", .target = "configs%s%" });
+    deletes.folders.append(VersionDelete{ .base = "root", .target = "bin%s%" });
 
     // Setup defaults, as per https://wiki.atlauncher.com/pack-admin/xml/keep
     VersionKeeps keeps;
-    keeps.files.append(VersionKeep{ "root", "mods%s%PortalGunSounds.pak" });
-    keeps.folders.append(VersionKeep{ "root", "mods%s%rei_minimap%s%" });
-    keeps.folders.append(VersionKeep{ "root", "mods%s%VoxelMods%s%" });
-    keeps.files.append(VersionKeep{ "root", "config%s%NEI.cfg" });
-    keeps.files.append(VersionKeep{ "root", "options.txt" });
-    keeps.files.append(VersionKeep{ "root", "servers.dat" });
+    keeps.files.append(VersionKeep{ .base = "root", .target = "mods%s%PortalGunSounds.pak" });
+    keeps.folders.append(VersionKeep{ .base = "root", .target = "mods%s%rei_minimap%s%" });
+    keeps.folders.append(VersionKeep{ .base = "root", .target = "mods%s%VoxelMods%s%" });
+    keeps.files.append(VersionKeep{ .base = "root", .target = "config%s%NEI.cfg" });
+    keeps.files.append(VersionKeep{ .base = "root", .target = "options.txt" });
+    keeps.files.append(VersionKeep{ .base = "root", .target = "servers.dat" });
 
     // Merge with version deletes and keeps
     for (const auto& item : m_version.deletes.files) {
@@ -374,7 +374,7 @@ QString PackInstallTask::getVersionForLoader(const QString& uid)
                 // not all mod loaders depend on a given Minecraft version, so we won't do this
                 // filtering for those loaders.
                 if (m_version.loader.type != "fabric") {
-                    auto iter = std::find_if(reqs.begin(), reqs.end(), [](const Meta::Require& req) { return req.uid == "net.minecraft"; });
+                    auto iter = std::ranges::find_if(reqs, [](const Meta::Require& req) { return req.uid == "net.minecraft"; });
                     if (iter == reqs.end()) {
                         continue;
                     }
@@ -456,8 +456,8 @@ bool PackInstallTask::createLibrariesComponent(const QString& instanceRoot, Pack
     }
 
     QList<GradleSpecifier> exempt;
-    for (const auto& componentUid : componentsToInstall.keys()) {
-        auto componentVersion = componentsToInstall.value(componentUid);
+    for (const auto& componentUid : m_componentsToInstall.keys()) {
+        auto componentVersion = m_componentsToInstall.value(componentUid);
         if (componentVersion->data()) {
             for (const auto& library : componentVersion->data()->libraries) {
                 GradleSpecifier lib(library->rawName());
@@ -466,8 +466,8 @@ bool PackInstallTask::createLibrariesComponent(const QString& instanceRoot, Pack
         }
     }
 
-    if (minecraftVersion->data()) {
-        for (const auto& library : minecraftVersion->data()->libraries) {
+    if (m_minecraftVersion->data()) {
+        for (const auto& library : m_minecraftVersion->data()->libraries) {
             GradleSpecifier lib(library->rawName());
             exempt.append(lib);
         }
@@ -483,7 +483,7 @@ bool PackInstallTask::createLibrariesComponent(const QString& instanceRoot, Pack
     auto patchFileName = FS::PathCombine(patchDir, targetId + ".json");
 
     auto f = std::make_shared<VersionFile>();
-    f->name = m_pack_name + " " + m_version_name + " (libraries)";
+    f->name = m_packName + " " + m_versionName + " (libraries)";
 
     const static QMap<QString, QString> s_liteLoaderMap = {
         { "61179803bcd5fb7790789b790908663d", "1.12-SNAPSHOT" },   { "1420785ecbfed5aff4a586c5c9dd97eb", "1.12.2-SNAPSHOT" },
@@ -508,7 +508,7 @@ bool PackInstallTask::createLibrariesComponent(const QString& instanceRoot, Pack
         if (s_liteLoaderMap.contains(lib.md5)) {
             auto ver = getComponentVersion("com.mumfrey.liteloader", s_liteLoaderMap.value(lib.md5));
             if (ver) {
-                componentsToInstall.insert("com.mumfrey.liteloader", ver);
+                m_componentsToInstall.insert("com.mumfrey.liteloader", ver);
                 continue;
             }
         }
@@ -603,8 +603,8 @@ bool PackInstallTask::createPackComponent(const QString& instanceRoot, PackProfi
 
     QStringList mainClasses;
     QStringList tweakers;
-    for (const auto& componentUid : componentsToInstall.keys()) {
-        auto componentVersion = componentsToInstall.value(componentUid);
+    for (const auto& componentUid : m_componentsToInstall.keys()) {
+        auto componentVersion = m_componentsToInstall.value(componentUid);
 
         if (componentVersion->data()) {
             if (componentVersion->data()->mainClass != QString("")) {
@@ -615,7 +615,7 @@ bool PackInstallTask::createPackComponent(const QString& instanceRoot, PackProfi
     }
 
     auto f = std::make_shared<VersionFile>();
-    f->name = m_pack_name + " " + m_version_name;
+    f->name = m_packName + " " + m_versionName;
     if (!mainClass.isEmpty() && !mainClasses.contains(mainClass)) {
         f->mainClass = mainClass;
     }
@@ -655,10 +655,10 @@ void PackInstallTask::installConfigs()
 {
     qDebug() << "PackInstallTask::installConfigs:" << QThread::currentThreadId();
     setStatus(tr("Downloading configs..."));
-    jobPtr.reset(new NetJob(tr("Config download"), APPLICATION->network()));
+    m_jobPtr.reset(new NetJob(tr("Config download"), APPLICATION->network()));
 
-    auto path = QString("Configs/%1/%2.zip").arg(m_pack_safe_name).arg(m_version_name);
-    auto url = QString(BuildConfig.ATL_DOWNLOAD_SERVER_URL + "packs/%1/versions/%2/Configs.zip").arg(m_pack_safe_name).arg(m_version_name);
+    auto path = QString("Configs/%1/%2.zip").arg(m_packSafeName).arg(m_versionName);
+    auto url = QString(BuildConfig.ATL_DOWNLOAD_SERVER_URL + "packs/%1/versions/%2/Configs.zip").arg(m_packSafeName).arg(m_versionName);
     auto entry = APPLICATION->metacache()->resolveEntry("ATLauncherPacks", path);
     entry->setStale(true);
 
@@ -666,31 +666,31 @@ void PackInstallTask::installConfigs()
     if (!m_version.configs.sha1.isEmpty()) {
         dl->addValidator(new Net::ChecksumValidator(QCryptographicHash::Sha1, m_version.configs.sha1));
     }
-    jobPtr->addNetAction(dl);
-    archivePath = entry->getFullPath();
+    m_jobPtr->addNetAction(dl);
+    m_archivePath = entry->getFullPath();
 
-    connect(jobPtr.get(), &NetJob::succeeded, this, [this]() {
-        abortable = false;
-        jobPtr.reset();
+    connect(m_jobPtr.get(), &NetJob::succeeded, this, [this]() {
+        m_abortable = false;
+        m_jobPtr.reset();
         extractConfigs();
     });
-    connect(jobPtr.get(), &NetJob::failed, this, [this](QString reason) {
-        abortable = false;
-        jobPtr.reset();
+    connect(m_jobPtr.get(), &NetJob::failed, this, [this](QString reason) {
+        m_abortable = false;
+        m_jobPtr.reset();
         emitFailed(std::move(reason));
     });
-    connect(jobPtr.get(), &NetJob::progress, this, [this](qint64 current, qint64 total) {
-        abortable = true;
+    connect(m_jobPtr.get(), &NetJob::progress, this, [this](qint64 current, qint64 total) {
+        m_abortable = true;
         setProgress(current, total);
     });
-    connect(jobPtr.get(), &NetJob::stepProgress, this, &PackInstallTask::propagateStepProgress);
-    connect(jobPtr.get(), &NetJob::aborted, this, [this] {
-        abortable = false;
-        jobPtr.reset();
+    connect(m_jobPtr.get(), &NetJob::stepProgress, this, &PackInstallTask::propagateStepProgress);
+    connect(m_jobPtr.get(), &NetJob::aborted, this, [this] {
+        m_abortable = false;
+        m_jobPtr.reset();
         emitAborted();
     });
 
-    jobPtr->start();
+    m_jobPtr->start();
 }
 
 void PackInstallTask::extractConfigs()
@@ -699,7 +699,7 @@ void PackInstallTask::extractConfigs()
     setStatus(tr("Extracting configs..."));
 
     QDir extractDir(m_stagingPath);
-    m_extractFuture = QtConcurrent::run(QThreadPool::globalInstance(), QOverload<QString, QString>::of(MMCZip::extractDir), archivePath,
+    m_extractFuture = QtConcurrent::run(QThreadPool::globalInstance(), QOverload<QString, QString>::of(MMCZip::extractDir), m_archivePath,
                                         extractDir.absolutePath() + "/minecraft");
     connect(&m_extractFutureWatcher, &QFutureWatcher<QStringList>::finished, this, [this]() { downloadMods(); });
     connect(&m_extractFutureWatcher, &QFutureWatcher<QStringList>::canceled, this, [this]() { emitAborted(); });
@@ -731,8 +731,8 @@ void PackInstallTask::downloadMods()
 
     setStatus(tr("Downloading mods..."));
 
-    jarmods.clear();
-    jobPtr.reset(new NetJob(tr("Mod download"), APPLICATION->network()));
+    m_jarmods.clear();
+    m_jobPtr.reset(new NetJob(tr("Mod download"), APPLICATION->network()));
 
     QList<VersionMod> blockedMods;
     for (const auto& mod : m_version.mods) {
@@ -769,23 +769,23 @@ void PackInstallTask::downloadMods()
         if (mod.type == ModType::Extract || mod.type == ModType::TexturePackExtract || mod.type == ModType::ResourcePackExtract) {
             auto entry = APPLICATION->metacache()->resolveEntry("ATLauncherPacks", cacheName);
             entry->setStale(true);
-            modsToExtract.insert(entry->getFullPath(), mod);
+            m_modsToExtract.insert(entry->getFullPath(), mod);
 
             auto dl = Net::ApiRequest::makeCached(url, entry);
             if (!mod.md5.isEmpty()) {
                 dl->addValidator(new Net::ChecksumValidator(QCryptographicHash::Md5, mod.md5));
             }
-            jobPtr->addNetAction(dl);
+            m_jobPtr->addNetAction(dl);
         } else if (mod.type == ModType::Decomp) {
             auto entry = APPLICATION->metacache()->resolveEntry("ATLauncherPacks", cacheName);
             entry->setStale(true);
-            modsToDecomp.insert(entry->getFullPath(), mod);
+            m_modsToDecomp.insert(entry->getFullPath(), mod);
 
             auto dl = Net::ApiRequest::makeCached(url, entry);
             if (!mod.md5.isEmpty()) {
                 dl->addValidator(new Net::ChecksumValidator(QCryptographicHash::Md5, mod.md5));
             }
-            jobPtr->addNetAction(dl);
+            m_jobPtr->addNetAction(dl);
         } else {
             auto relpath = getDirForModType(mod.type, mod.type_raw);
             if (relpath == Q_NULLPTR) {
@@ -799,29 +799,29 @@ void PackInstallTask::downloadMods()
             if (!mod.md5.isEmpty()) {
                 dl->addValidator(new Net::ChecksumValidator(QCryptographicHash::Md5, mod.md5));
             }
-            jobPtr->addNetAction(dl);
+            m_jobPtr->addNetAction(dl);
 
             auto path = FS::PathCombine(m_stagingPath, "minecraft", relpath, mod.file);
 
             if (mod.type == ModType::Forge) {
                 auto ver = getComponentVersion("net.minecraftforge", mod.version);
                 if (ver) {
-                    componentsToInstall.insert("net.minecraftforge", ver);
+                    m_componentsToInstall.insert("net.minecraftforge", ver);
                     continue;
                 }
 
                 qDebug() << "Jarmod: " + path;
-                jarmods.push_back(path);
+                m_jarmods.push_back(path);
             }
 
             if (mod.type == ModType::Jar) {
                 qDebug() << "Jarmod: " + path;
-                jarmods.push_back(path);
+                m_jarmods.push_back(path);
             }
 
             // Download after Forge handling, to avoid downloading Forge twice.
             qDebug() << "Will download" << url << "to" << path;
-            modsToCopy[entry->getFullPath()] = path;
+            m_modsToCopy[entry->getFullPath()] = path;
         }
     }
     if (!blockedMods.isEmpty()) {
@@ -861,9 +861,9 @@ void PackInstallTask::downloadMods()
                 }
                 const auto& mod = *modIter;
                 if (mod.type == ModType::Extract || mod.type == ModType::TexturePackExtract || mod.type == ModType::ResourcePackExtract) {
-                    modsToExtract.insert(blocked.localPath, mod);
+                    m_modsToExtract.insert(blocked.localPath, mod);
                 } else if (mod.type == ModType::Decomp) {
-                    modsToDecomp.insert(blocked.localPath, mod);
+                    m_modsToDecomp.insert(blocked.localPath, mod);
                 } else {
                     auto relpath = getDirForModType(mod.type, mod.type_raw);
                     if (relpath == Q_NULLPTR) {
@@ -875,20 +875,20 @@ void PackInstallTask::downloadMods()
                     if (mod.type == ModType::Forge) {
                         auto ver = getComponentVersion("net.minecraftforge", mod.version);
                         if (ver) {
-                            componentsToInstall.insert("net.minecraftforge", ver);
+                            m_componentsToInstall.insert("net.minecraftforge", ver);
                             continue;
                         }
 
                         qDebug() << "Jarmod: " + path;
-                        jarmods.push_back(path);
+                        m_jarmods.push_back(path);
                     }
 
                     if (mod.type == ModType::Jar) {
                         qDebug() << "Jarmod: " + path;
-                        jarmods.push_back(path);
+                        m_jarmods.push_back(path);
                     }
 
-                    modsToCopy[blocked.localPath] = path;
+                    m_modsToCopy[blocked.localPath] = path;
                 }
             }
         } else {
@@ -897,29 +897,29 @@ void PackInstallTask::downloadMods()
         }
     }
 
-    connect(jobPtr.get(), &NetJob::succeeded, this, &PackInstallTask::onModsDownloaded);
-    connect(jobPtr.get(), &NetJob::progress, this, [this](qint64 current, qint64 total) {
+    connect(m_jobPtr.get(), &NetJob::succeeded, this, &PackInstallTask::onModsDownloaded);
+    connect(m_jobPtr.get(), &NetJob::progress, this, [this](qint64 current, qint64 total) {
         setDetails(tr("%1 out of %2 complete").arg(current).arg(total));
-        abortable = true;
+        m_abortable = true;
         setProgress(current, total);
     });
-    connect(jobPtr.get(), &NetJob::stepProgress, this, &PackInstallTask::propagateStepProgress);
-    connect(jobPtr.get(), &NetJob::aborted, this, &PackInstallTask::emitAborted);
-    connect(jobPtr.get(), &NetJob::failed, this, &PackInstallTask::emitFailed);
+    connect(m_jobPtr.get(), &NetJob::stepProgress, this, &PackInstallTask::propagateStepProgress);
+    connect(m_jobPtr.get(), &NetJob::aborted, this, &PackInstallTask::emitAborted);
+    connect(m_jobPtr.get(), &NetJob::failed, this, &PackInstallTask::emitFailed);
 
-    jobPtr->start();
+    m_jobPtr->start();
 }
 
 void PackInstallTask::onModsDownloaded()
 {
-    abortable = false;
+    m_abortable = false;
 
     qDebug() << "PackInstallTask::onModsDownloaded:" << QThread::currentThreadId();
-    jobPtr.reset();
+    m_jobPtr.reset();
 
-    if (!modsToExtract.empty() || !modsToDecomp.empty() || !modsToCopy.empty()) {
-        m_modExtractFuture =
-            QtConcurrent::run(QThreadPool::globalInstance(), &PackInstallTask::extractMods, this, modsToExtract, modsToDecomp, modsToCopy);
+    if (!m_modsToExtract.empty() || !m_modsToDecomp.empty() || !m_modsToCopy.empty()) {
+        m_modExtractFuture = QtConcurrent::run(QThreadPool::globalInstance(), &PackInstallTask::extractMods, this, m_modsToExtract,
+                                               m_modsToDecomp, m_modsToCopy);
         connect(&m_modExtractFutureWatcher, &QFutureWatcher<QStringList>::finished, this, &PackInstallTask::onModsExtracted);
         connect(&m_modExtractFutureWatcher, &QFutureWatcher<QStringList>::canceled, this, &PackInstallTask::emitAborted);
         m_modExtractFutureWatcher.setFuture(m_modExtractFuture);
@@ -1071,12 +1071,12 @@ void PackInstallTask::install()
             return;
         }
 
-        for (const auto& componentUid : componentsToInstall.keys()) {
-            auto version = componentsToInstall.value(componentUid);
+        for (const auto& componentUid : m_componentsToInstall.keys()) {
+            auto version = m_componentsToInstall.value(componentUid);
             components->setComponentVersion(componentUid, version->version());
         }
 
-        components->installJarMods(jarmods);
+        components->installJarMods(m_jarmods);
 
         // Use a component to fill in the rest of the data
         // todo: use more detection
@@ -1089,9 +1089,9 @@ void PackInstallTask::install()
 
         m_instance->setName(name());
         m_instance->setIconKey(m_instIcon);
-        m_instance->setManagedPack("atlauncher", m_pack_safe_name, m_pack_name, m_version_name, m_version_name);
+        m_instance->setManagedPack("atlauncher", m_packSafeName, m_packName, m_versionName, m_versionName);
 
-        jarmods.clear();
+        m_jarmods.clear();
     }
     downloadFiles(m_instance.get());
 }

--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
@@ -1027,14 +1027,15 @@ void PackInstallTask::install()
     setStatus(tr("Installing modpack"));
 
     auto instanceConfigPath = FS::PathCombine(m_stagingPath, "instance.cfg");
-    MinecraftInstance instance(m_globalSettings, std::make_unique<INISettingsObject>(instanceConfigPath), m_stagingPath);
+    m_instance =
+        std::make_unique<MinecraftInstance>(m_globalSettings, std::make_unique<INISettingsObject>(instanceConfigPath), m_stagingPath);
     {
-        SettingsObject::Lock lock(instance.settings());
-        auto* components = instance.getPackProfile();
+        SettingsObject::Lock lock(m_instance->settings());
+        auto* components = m_instance->getPackProfile();
         components->buildingFromScratch();
 
         // Use a component to add libraries BEFORE Minecraft
-        if (!createLibrariesComponent(instance.instanceRoot(), components)) {
+        if (!createLibrariesComponent(m_instance->instanceRoot(), components)) {
             emitFailed(tr("Failed to create libraries component"));
             return;
         }
@@ -1078,20 +1079,20 @@ void PackInstallTask::install()
 
         // Use a component to fill in the rest of the data
         // todo: use more detection
-        if (!createPackComponent(instance.instanceRoot(), components)) {
+        if (!createPackComponent(m_instance->instanceRoot(), components)) {
             emitFailed(tr("Failed to create pack component"));
             return;
         }
 
         components->saveNow();
 
-        instance.setName(name());
-        instance.setIconKey(m_instIcon);
-        instance.setManagedPack("atlauncher", m_pack_safe_name, m_pack_name, m_version_name, m_version_name);
+        m_instance->setName(name());
+        m_instance->setIconKey(m_instIcon);
+        m_instance->setManagedPack("atlauncher", m_pack_safe_name, m_pack_name, m_version_name, m_version_name);
 
         jarmods.clear();
     }
-    downloadFiles(&instance);
+    downloadFiles(m_instance.get());
 }
 
 }  // namespace ATLauncher

--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.cpp
@@ -66,7 +66,8 @@ bool isPathTraversal(const QString& basePath, const QString& entryName)
     auto safeName = FS::RemoveInvalidPathChars(entryName);
     auto fullPath = FS::PathCombine(basePath, safeName);
     auto baseUrl = QUrl::fromLocalFile(basePath);
-    return !baseUrl.isParentOf(QUrl::fromLocalFile(fullPath));
+    auto fullUrl = QUrl::fromLocalFile(fullPath);
+    return !(baseUrl == fullUrl || baseUrl.isParentOf(fullUrl));
 }
 
 Meta::Version::Ptr getComponentVersion(const QString& uid, const QString& version)

--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.h
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.h
@@ -145,6 +145,8 @@ class PackInstallTask : public InstanceTask {
 
     QFuture<bool> m_modExtractFuture;
     QFutureWatcher<bool> m_modExtractFutureWatcher;
+
+    std::unique_ptr<MinecraftInstance> m_instance;
 };
 
 }  // namespace ATLauncher

--- a/launcher/modplatform/atlauncher/ATLPackInstallTask.h
+++ b/launcher/modplatform/atlauncher/ATLPackInstallTask.h
@@ -121,24 +121,24 @@ class PackInstallTask : public InstanceTask {
    private:
     UserInteractionSupport* m_support;
 
-    bool abortable = false;
+    bool m_abortable = false;
 
-    NetJob::Ptr jobPtr;
+    NetJob::Ptr m_jobPtr;
 
-    InstallMode m_install_mode;
-    QString m_pack_name;
-    QString m_pack_safe_name;
-    QString m_version_name;
+    InstallMode m_installMode;
+    QString m_packName;
+    QString m_packSafeName;
+    QString m_versionName;
     PackVersion m_version;
 
-    QMap<QString, VersionMod> modsToExtract;
-    QMap<QString, VersionMod> modsToDecomp;
-    QMap<QString, QString> modsToCopy;
+    QMap<QString, VersionMod> m_modsToExtract;
+    QMap<QString, VersionMod> m_modsToDecomp;
+    QMap<QString, QString> m_modsToCopy;
 
-    QString archivePath;
-    QStringList jarmods;
-    Meta::Version::Ptr minecraftVersion;
-    QMap<QString, Meta::Version::Ptr> componentsToInstall;
+    QString m_archivePath;
+    QStringList m_jarmods;
+    Meta::Version::Ptr m_minecraftVersion;
+    QMap<QString, Meta::Version::Ptr> m_componentsToInstall;
 
     QFuture<std::optional<QStringList>> m_extractFuture;
     QFutureWatcher<std::optional<QStringList>> m_extractFutureWatcher;


### PR DESCRIPTION
- one a use after free(first commit)
  - to test install a pack that needs to download game files(easily replicated on new portable) 
- a false parse traversal(second)
  - install Skyblock2( will fail because it thinks the minecraft root is outside minceraft root)
- clang-tidy(third)
  - just basic var renames
  - a ranges replace
  - some fancy struct init 

if we have another 11.x version this would need to be backported