### PR TITLE
fix(net): force outgoing HTTP(S) requests over IPv4

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -45,6 +45,7 @@
 
 #include "DataMigrationTask.h"
 #include "java/JavaInstallList.h"
+#include "net/NetworkAccessManager.h"
 #include "net/PasteUpload.h"
 #include "tasks/Task.h"
 #include "tools/GenericProfiler.h"
@@ -932,7 +933,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
 
     // initialize network access and proxy setup
     {
-        m_network.reset(new QNetworkAccessManager());
+        m_network.reset(new Net::NetworkAccessManager());
         QString proxyTypeStr = settings()->get("ProxyType").toString();
         QString addr = settings()->get("ProxyAddr").toString();
         int port = settings()->get("ProxyPort").value<qint16>();

--- a/launcher/CMakeLists.txt
+++ b/launcher/CMakeLists.txt
@@ -128,6 +128,8 @@ set(NET_SOURCES
     net/NetJob.cpp
     net/NetJob.h
     net/NetUtils.h
+    net/NetworkAccessManager.cpp
+    net/NetworkAccessManager.h
     net/PasteUpload.cpp
     net/PasteUpload.h
     net/Sink.h
@@ -644,6 +646,8 @@ set(PRISMUPDATER_SOURCES
     net/NetJob.cpp
     net/NetJob.h
     net/NetUtils.h
+    net/NetworkAccessManager.cpp
+    net/NetworkAccessManager.h
     net/Sink.h
     net/Validator.h
     net/HeaderProxy.h

--- a/launcher/net/NetworkAccessManager.cpp
+++ b/launcher/net/NetworkAccessManager.cpp
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ * Prism Launcher - Minecraft Launcher
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "NetworkAccessManager.h"
+
+#include <QDateTime>
+#include <QHostInfo>
+#include <QUrl>
+
+namespace Net {
+
+namespace {
+constexpr qint64 dnsCacheTtlSecs = 300;
+}
+
+QHostAddress NetworkAccessManager::resolveIPv4(const QString& hostName)
+{
+    const qint64 now = QDateTime::currentSecsSinceEpoch();
+
+    auto it = m_dnsCache.find(hostName);
+    if (it != m_dnsCache.end()) {
+        if (it->expiresAt > now)
+            return it->address;
+        m_dnsCache.erase(it);
+    }
+
+    const QHostInfo info = QHostInfo::fromName(hostName);
+    for (const auto& addr : info.addresses()) {
+        if (addr.protocol() == QAbstractSocket::IPv4Protocol) {
+            m_dnsCache.insert(hostName, { addr, now + dnsCacheTtlSecs });
+            return addr;
+        }
+    }
+    // no IPv4 address available for this host; caller falls back to default behavior
+    return {};
+}
+
+QNetworkReply* NetworkAccessManager::createRequest(Operation op, const QNetworkRequest& originalReq, QIODevice* outgoingData)
+{
+    QUrl url = originalReq.url();
+    const QString scheme = url.scheme();
+    const QString host = url.host();
+
+    // Only rewrite plain hostnames on http(s); leave literal IPs and other schemes untouched.
+    if ((scheme == QLatin1String("http") || scheme == QLatin1String("https")) && !host.isEmpty() && QHostAddress(host).isNull()) {
+        const QHostAddress ipv4 = resolveIPv4(host);
+        if (!ipv4.isNull()) {
+            QNetworkRequest req = originalReq;
+            url.setHost(ipv4.toString());
+            req.setUrl(url);
+            req.setRawHeader("Host", host.toUtf8());
+            req.setPeerVerifyName(host);
+            // HTTP/2 sends ":authority" from the request URL (the IP literal here), ignoring
+            // the raw Host header above, which servers doing name-based routing reject. Force
+            // HTTP/1.1 so the Host header override actually takes effect.
+            req.setAttribute(QNetworkRequest::Http2AllowedAttribute, false);
+            return QNetworkAccessManager::createRequest(op, req, outgoingData);
+        }
+    }
+
+    return QNetworkAccessManager::createRequest(op, originalReq, outgoingData);
+}
+
+}  // namespace Net

--- a/launcher/net/NetworkAccessManager.h
+++ b/launcher/net/NetworkAccessManager.h
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ * Prism Launcher - Minecraft Launcher
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QHash>
+#include <QHostAddress>
+#include <QNetworkAccessManager>
+
+namespace Net {
+
+/// QNetworkAccessManager that forces outgoing HTTP(S) requests over IPv4.
+///
+/// Qt has no public API to restrict QNetworkAccessManager to a single network
+/// layer protocol. Some dual-stack networks silently fail IPv6 connections to
+/// Xbox Live and libraries.minecraft.net, so we resolve the request's hostname
+/// ourselves and connect to its IPv4 address directly, while keeping the
+/// original hostname for the HTTP Host header and TLS SNI/certificate
+/// validation (via QNetworkRequest::setPeerVerifyName).
+class NetworkAccessManager : public QNetworkAccessManager {
+    Q_OBJECT
+   public:
+    using QNetworkAccessManager::QNetworkAccessManager;
+
+   protected:
+    QNetworkReply* createRequest(Operation op, const QNetworkRequest& originalReq, QIODevice* outgoingData) override;
+
+   private:
+    QHostAddress resolveIPv4(const QString& hostName);
+
+    struct CacheEntry {
+        QHostAddress address;
+        qint64 expiresAt;
+    };
+    QHash<QString, CacheEntry> m_dnsCache;
+};
+
+}  // namespace Net

--- a/launcher/updater/prismupdater/PrismUpdater.cpp
+++ b/launcher/updater/prismupdater/PrismUpdater.cpp
@@ -22,6 +22,7 @@
 
 #include "PrismUpdater.h"
 #include "BuildConfig.h"
+#include "net/NetworkAccessManager.h"
 #include "ui/dialogs/ProgressDialog.h"
 
 #include <cstdlib>
@@ -278,7 +279,7 @@ PrismUpdaterApp::PrismUpdaterApp(int& argc, char** argv) : QApplication(argc, ar
     }
 
     {  // network
-        m_network = std::make_unique<QNetworkAccessManager>();
+        m_network = std::make_unique<Net::NetworkAccessManager>();
         qDebug() << "Detecting proxy settings...";
         QNetworkProxy proxy = QNetworkProxy::applicationProxy();
         m_network->setProxy(proxy);


### PR DESCRIPTION
🛠️ **Attention**: ~Work-in-progress!~ CLOSED
🤖 **Disclaimer**: AI Assisted work

Issue is caused by misconfigured `mss-clamp6` setting in my router firewall.

## What is this?

This PR resolves a long standing issue affecting people having both IPv4 and IPv6 enabled in their network. The following symptoms are,
1. Launcher can't finish the login flow via Xbox Live. The last step times out.
1. Launcher can't pull resources from `api.minecraftservices.com` site. Requests time out similarly.
Note: Microsoft's own Minecraft Launcher suffers from the same timeouts as well.

I decided to go after this solution since it prevents me to play Minecraft on my Mac. I asked Claude Code to investigate and propose a fix.
I ask you to test it and give feedback.

## Status

The first round tested on macOS 26 (MacMini M4 Pro) and Debian Forky (Radxa Orion O6N).

- [x] Smoke tests (Mac and Linux)
- [ ] Refactor the PR based on your feedback
- [ ] Test on Windows computer (please someone do a favor)
- [ ] opt-in setting (optional)
- [ ] Finalize PR

## Technical Details
- Add `Net::NetworkAccessManager` type, a `QNetworkAccessManager` subclass that resolves request hostnames to their IPv4 address and connects directly to it, while preserving the original `Host`header and TLS SNI/certificate validation via `setPeerVerifyName`.
- HTTP/2 is disabled per-request since its ":authority" pseudo-header would otherwise leak the IP literal instead of the original hostname.
- Wire it into both the launcher and `PrismUpdater`.
