### PR TITLE
fix shortcut world launch

### DIFF
--- a/launcher/ui/dialogs/CreateShortcutDialog.cpp
+++ b/launcher/ui/dialogs/CreateShortcutDialog.cpp
@@ -37,6 +37,7 @@
 
 #include <QLayout>
 #include <QPushButton>
+#include <QSortFilterProxyModel>
 
 #include "BuildConfig.h"
 #include "CreateShortcutDialog.h"
@@ -55,6 +56,27 @@
 #include "minecraft/WorldList.h"
 #include "minecraft/auth/AccountList.h"
 
+// Model for join-on-launch world selection
+class WorldSelectionProxyModel : public QSortFilterProxyModel {
+    Q_OBJECT
+
+   public:
+    WorldSelectionProxyModel(QObject* parent) : QSortFilterProxyModel(parent) {}
+
+    virtual QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const
+    {
+        // World metadata parsing logic
+        if (index.column() == 0 && role == Qt::DisplayRole) {
+            auto* worlds = qobject_cast<WorldList*>(sourceModel());
+            auto* world = static_cast<World*>(worlds->data(mapToSource(index), WorldList::ObjectRole).value<void*>());
+            return tr("%1 [%2] - Last Played: %3")
+                .arg(world->name(), world->gameType().toTranslatedString(), world->lastPlayed().toString(Qt::ISODate));
+        }
+
+        return QSortFilterProxyModel::data(index, role);
+    }
+};
+
 CreateShortcutDialog::CreateShortcutDialog(MinecraftInstance* instance, QWidget* parent)
     : QDialog(parent), ui(new Ui::CreateShortcutDialog), m_instance(instance)
 {
@@ -63,17 +85,6 @@ CreateShortcutDialog::CreateShortcutDialog(MinecraftInstance* instance, QWidget*
     InstIconKey = instance->iconKey();
     ui->iconButton->setIcon(APPLICATION->icons()->getIcon(InstIconKey));
     ui->instNameTextBox->setPlaceholderText(instance->name());
-
-    m_QuickJoinSupported = instance && instance->traits().contains("feature:is_quick_play_singleplayer");
-    auto worldList = instance->worldList();
-    worldList->update();
-    if (!m_QuickJoinSupported || worldList->empty()) {
-        ui->worldTarget->hide();
-        ui->worldSelectionBox->hide();
-        ui->serverTarget->setChecked(true);
-        ui->serverTarget->hide();
-        ui->serverLabel->show();
-    }
 
     // Populate save targets
     if (!DesktopServices::isFlatpak()) {
@@ -88,14 +99,19 @@ CreateShortcutDialog::CreateShortcutDialog(MinecraftInstance* instance, QWidget*
     }
     ui->saveTargetSelectionBox->addItem(tr("Other..."), QVariant::fromValue(ShortcutTarget::Other));
 
-    // Populate worlds
-    if (m_QuickJoinSupported) {
-        for (const auto& world : worldList->allWorlds()) {
-            // Entry name: World Name [Game Mode] - Last Played: DateTime
-            QString entry_name = tr("%1 [%2] - Last Played: %3")
-                                     .arg(world.name(), world.gameType().toTranslatedString(), world.lastPlayed().toString(Qt::ISODate));
-            ui->worldSelectionBox->addItem(entry_name, world.name());
-        }
+    // Populate worlds asynchronously
+    m_quickJoinSupported = instance && instance->traits().contains("feature:is_quick_play_singleplayer");
+    m_worldList = instance->worldList();
+    connect(m_worldList, &QAbstractItemModel::modelReset, this, &CreateShortcutDialog::updateWorldTargetVisibility);
+    connect(m_worldList, &QAbstractItemModel::rowsInserted, this, &CreateShortcutDialog::updateWorldTargetVisibility);
+    connect(m_worldList, &QAbstractItemModel::rowsRemoved, this, &CreateShortcutDialog::updateWorldTargetVisibility);
+    // Also does the initial scan, same as update() would.
+    m_worldList->startWatching();
+
+    if (m_quickJoinSupported) {
+        m_worldProxyModel = new WorldSelectionProxyModel(this);
+        m_worldProxyModel->setSourceModel(m_worldList);
+        ui->worldSelectionBox->setModel(m_worldProxyModel);
     }
 
     // Populate accounts
@@ -121,6 +137,7 @@ CreateShortcutDialog::CreateShortcutDialog(MinecraftInstance* instance, QWidget*
 
 CreateShortcutDialog::~CreateShortcutDialog()
 {
+    m_worldList->stopWatching();
     delete ui;
 }
 
@@ -189,6 +206,17 @@ void CreateShortcutDialog::stateChanged()
     }
 }
 
+void CreateShortcutDialog::updateWorldTargetVisibility()
+{
+    bool hasWorlds = m_quickJoinSupported && m_worldList->rowCount() > 0;
+    ui->worldTarget->setVisible(hasWorlds);
+    ui->worldSelectionBox->setVisible(hasWorlds);
+    ui->serverTarget->setVisible(hasWorlds);
+    ui->serverLabel->setVisible(!hasWorlds);
+    if (!hasWorlds)
+        ui->serverTarget->setChecked(true);
+}
+
 // Real work
 void CreateShortcutDialog::createShortcut()
 {
@@ -197,7 +225,9 @@ void CreateShortcutDialog::createShortcut()
     if (ui->targetCheckbox->isChecked()) {
         if (ui->worldTarget->isChecked()) {
             targetString = tr("world");
-            extraArgs = { "--world", ui->worldSelectionBox->currentData().toString() };
+            auto sourceIndex = m_worldProxyModel->mapToSource(m_worldProxyModel->index(ui->worldSelectionBox->currentIndex(), 0));
+            auto* world = static_cast<World*>(m_worldList->data(sourceIndex, WorldList::ObjectRole).value<void*>());
+            extraArgs = { "--world", world->folderName() };
         } else if (ui->serverTarget->isChecked()) {
             targetString = tr("server");
             extraArgs = { "--server", ui->serverAddressBox->text() };
@@ -219,3 +249,5 @@ void CreateShortcutDialog::createShortcut()
     else
         ShortcutUtils::createInstanceShortcutInOther(args);
 }
+
+#include "CreateShortcutDialog.moc"

--- a/launcher/ui/dialogs/CreateShortcutDialog.cpp
+++ b/launcher/ui/dialogs/CreateShortcutDialog.cpp
@@ -39,7 +39,6 @@
 #include <QPushButton>
 #include <QSortFilterProxyModel>
 
-#include "BuildConfig.h"
 #include "CreateShortcutDialog.h"
 #include "ui_CreateShortcutDialog.h"
 
@@ -48,7 +47,6 @@
 #include "BaseInstance.h"
 #include "DesktopServices.h"
 #include "FileSystem.h"
-#include "InstanceList.h"
 #include "icons/IconList.h"
 
 #include "minecraft/MinecraftInstance.h"
@@ -61,9 +59,9 @@ class WorldSelectionProxyModel : public QSortFilterProxyModel {
     Q_OBJECT
 
    public:
-    WorldSelectionProxyModel(QObject* parent) : QSortFilterProxyModel(parent) {}
+    explicit WorldSelectionProxyModel(QObject* parent) : QSortFilterProxyModel(parent) {}
 
-    virtual QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override
     {
         // World metadata parsing logic
         if (index.column() == 0 && role == Qt::DisplayRole) {

--- a/launcher/ui/dialogs/CreateShortcutDialog.h
+++ b/launcher/ui/dialogs/CreateShortcutDialog.h
@@ -30,7 +30,7 @@ class CreateShortcutDialog : public QDialog {
 
    public:
     explicit CreateShortcutDialog(MinecraftInstance* instance, QWidget* parent = nullptr);
-    ~CreateShortcutDialog();
+    ~CreateShortcutDialog() override;
 
     void createShortcut();
 

--- a/launcher/ui/dialogs/CreateShortcutDialog.h
+++ b/launcher/ui/dialogs/CreateShortcutDialog.h
@@ -18,6 +18,8 @@
 #include <QDialog>
 
 class MinecraftInstance;
+class WorldList;
+class QSortFilterProxyModel;
 
 namespace Ui {
 class CreateShortcutDialog;
@@ -51,8 +53,11 @@ class CreateShortcutDialog : public QDialog {
     Ui::CreateShortcutDialog* ui;
     QString InstIconKey;
     MinecraftInstance* m_instance;
-    bool m_QuickJoinSupported = false;
+    bool m_quickJoinSupported = false;
+    WorldList* m_worldList = nullptr;
+    QSortFilterProxyModel* m_worldProxyModel = nullptr;
 
     // Functions
     void stateChanged();
+    void updateWorldTargetVisibility();
 };


### PR DESCRIPTION
Closes #6032 

* World list now correctly loads asynchronously
* --world arg now correctly points to directory name

AI Dislcaimer: Claude Sonnet 5 used for code generation. All generated code have been manually reviewed by Yundi Xu.

<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!

If you used AI assistance for your contribution, please make sure you are aware of our restrictions: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#restrictions-on-generative-ai-usage-ai-policy
-->
