### PR TITLE
 feat(launch): add pre-load command 

### DIFF
--- a/launcher/Application.cpp
+++ b/launcher/Application.cpp
@@ -797,6 +797,7 @@ Application::Application(int& argc, char** argv) : QApplication(argc, argv)
         m_settings->registerSetting("WrapperCommand", "");
 
         // Custom Commands
+        m_settings->registerSetting({ "PreLoadCommand", "PreLoadCmd" }, "");
         m_settings->registerSetting({ "PreLaunchCommand", "PreLaunchCmd" }, "");
         m_settings->registerSetting({ "PostExitCommand", "PostExitCmd" }, "");
 

--- a/launcher/BaseInstance.cpp
+++ b/launcher/BaseInstance.cpp
@@ -108,6 +108,7 @@ BaseInstance::BaseInstance(SettingsObject* globalSettings, std::unique_ptr<Setti
 
     // Custom Commands
     auto commandSetting = m_settings->registerSetting({ "OverrideCommands", "OverrideLaunchCmd" }, false);
+    m_settings->registerOverride(globalSettings->getSetting("PreLoadCommand"), commandSetting);
     m_settings->registerOverride(globalSettings->getSetting("PreLaunchCommand"), commandSetting);
     m_settings->registerOverride(globalSettings->getSetting("WrapperCommand"), commandSetting);
     m_settings->registerOverride(globalSettings->getSetting("PostExitCommand"), commandSetting);
@@ -137,6 +138,11 @@ BaseInstance::BaseInstance(SettingsObject* globalSettings, std::unique_ptr<Setti
 QString BaseInstance::getPreLaunchCommand()
 {
     return settings()->get("PreLaunchCommand").toString();
+}
+
+QString BaseInstance::getPreLoadCommand()
+{
+    return settings()->get("PreLoadCommand").toString();
 }
 
 QString BaseInstance::getWrapperCommand()

--- a/launcher/BaseInstance.h
+++ b/launcher/BaseInstance.h
@@ -154,6 +154,7 @@ class BaseInstance : public QObject {
     QString notes() const;
     void setNotes(const QString& val);
 
+    QString getPreLoadCommand();
     QString getPreLaunchCommand();
     QString getPostExitCommand();
     QString getWrapperCommand();

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -50,8 +50,8 @@
 #include "launch/LaunchTask.h"
 #include "launch/TaskStepWrapper.h"
 #include "launch/steps/CheckJava.h"
-#include "launch/steps/LookupServerAddress.h"
 #include "launch/steps/LaunchCommand.h"
+#include "launch/steps/LookupServerAddress.h"
 #include "launch/steps/QuitAfterGameStop.h"
 #include "launch/steps/TextPrint.h"
 
@@ -1174,6 +1174,13 @@ LaunchTask* MinecraftInstance::createLaunchTask(AuthSessionPtr session, Minecraf
         process->appendStep(step);
     }
 
+    // run pre-load command if that's needed, before the metadata is loaded
+    if (!getPreLoadCommand().isEmpty()) {
+        auto step = makeShared<LaunchCommand>(pptr, getPreLoadCommand(), tr("Pre-Load"));
+        step->setWorkingDirectory(gameRoot());
+        process->appendStep(step);
+    }
+
     // load meta
     {
         auto mode = session->launchMode != LaunchMode::Offline ? Net::Mode::Online : Net::Mode::Offline;
@@ -1189,7 +1196,7 @@ LaunchTask* MinecraftInstance::createLaunchTask(AuthSessionPtr session, Minecraf
     }
 
     // run pre-launch command if that's needed
-    if (getPreLaunchCommand().size()) {
+    if (!getPreLaunchCommand().isEmpty()) {
         auto step = makeShared<LaunchCommand>(pptr, getPreLaunchCommand(), tr("Pre-Launch"));
         step->setWorkingDirectory(gameRoot());
         process->appendStep(step);
@@ -1245,7 +1252,7 @@ LaunchTask* MinecraftInstance::createLaunchTask(AuthSessionPtr session, Minecraf
     }
 
     // run post-exit command if that's needed
-    if (getPostExitCommand().size()) {
+    if (!getPostExitCommand().isEmpty()) {
         auto step = makeShared<LaunchCommand>(pptr, getPostExitCommand(), tr("Post-Launch"));
         step->setWorkingDirectory(gameRoot());
         process->appendStep(step);

--- a/launcher/ui/widgets/CustomCommands.cpp
+++ b/launcher/ui/widgets/CustomCommands.cpp
@@ -47,12 +47,18 @@ CustomCommands::CustomCommands(QWidget* parent) : QWidget(parent), ui(new Ui::Cu
     connect(ui->overrideCheckBox, &QCheckBox::toggled, ui->customCommandsWidget, &QWidget::setEnabled);
 }
 
-void CustomCommands::initialize(bool checkable, bool checked, const QString& prelaunch, const QString& wrapper, const QString& postexit)
+void CustomCommands::initialize(bool checkable,
+                                bool checked,
+                                const QString& preLoad,
+                                const QString& prelaunch,
+                                const QString& wrapper,
+                                const QString& postexit)
 {
     ui->overrideCheckBox->setVisible(checkable);
     if (checkable) {
         ui->overrideCheckBox->setChecked(checked);
     }
+    ui->preLoadCmdTextBox->setText(preLoad);
     ui->preLaunchCmdTextBox->setText(prelaunch);
     ui->wrapperCmdTextBox->setText(wrapper);
     ui->postExitCmdTextBox->setText(postexit);
@@ -66,6 +72,11 @@ void CustomCommands::retranslate()
 bool CustomCommands::checked() const
 {
     return ui->overrideCheckBox->isChecked();
+}
+
+QString CustomCommands::preLoadCommand() const
+{
+    return ui->preLoadCmdTextBox->text();
 }
 
 QString CustomCommands::prelaunchCommand() const

--- a/launcher/ui/widgets/CustomCommands.h
+++ b/launcher/ui/widgets/CustomCommands.h
@@ -47,10 +47,16 @@ class CustomCommands : public QWidget {
    public:
     explicit CustomCommands(QWidget* parent = 0);
     virtual ~CustomCommands();
-    void initialize(bool checkable, bool checked, const QString& prelaunch, const QString& wrapper, const QString& postexit);
+    void initialize(bool checkable,
+                    bool checked,
+                    const QString& preLoad,
+                    const QString& prelaunch,
+                    const QString& wrapper,
+                    const QString& postexit);
 
     void retranslate();
     bool checked() const;
+    QString preLoadCommand() const;
     QString prelaunchCommand() const;
     QString wrapperCommand() const;
     QString postexitCommand() const;

--- a/launcher/ui/widgets/CustomCommands.ui
+++ b/launcher/ui/widgets/CustomCommands.ui
@@ -48,52 +48,7 @@
       <property name="rightMargin">
        <number>0</number>
       </property>
-      <item row="0" column="0">
-       <widget class="QLabel" name="labelPreLaunchCmd">
-        <property name="text">
-         <string>&amp;Pre-launch Command</string>
-        </property>
-        <property name="buddy">
-         <cstring>preLaunchCmdTextBox</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <spacer name="verticalSpacer_2">
-        <property name="orientation">
-         <enum>Qt::Vertical</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Fixed</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>0</width>
-          <height>6</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLineEdit" name="preLaunchCmdTextBox"/>
-      </item>
-      <item row="4" column="0">
-       <widget class="QLineEdit" name="wrapperCmdTextBox"/>
-      </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="labelPostExitCmd">
-        <property name="text">
-         <string>P&amp;ost-exit Command</string>
-        </property>
-        <property name="buddy">
-         <cstring>postExitCmdTextBox</cstring>
-        </property>
-       </widget>
-      </item>
       <item row="7" column="0">
-       <widget class="QLineEdit" name="postExitCmdTextBox"/>
-      </item>
-      <item row="3" column="0">
        <widget class="QLabel" name="labelWrapperCmd">
         <property name="text">
          <string>&amp;Wrapper Command</string>
@@ -103,13 +58,87 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item row="4" column="0">
+       <widget class="QLineEdit" name="preLaunchCmdTextBox"/>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="labelPreLoadCmd">
+        <property name="text">
+         <string>&amp;Pre-load Command</string>
+        </property>
+        <property name="buddy">
+         <cstring>preLoadCmdTextBox</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="6" column="0">
        <spacer name="verticalSpacer_3">
         <property name="orientation">
-         <enum>Qt::Vertical</enum>
+         <enum>Qt::Orientation::Vertical</enum>
         </property>
         <property name="sizeType">
-         <enum>QSizePolicy::Fixed</enum>
+         <enum>QSizePolicy::Policy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>0</width>
+          <height>6</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="11" column="0">
+       <widget class="QLineEdit" name="postExitCmdTextBox"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLineEdit" name="preLoadCmdTextBox"/>
+      </item>
+      <item row="9" column="0">
+       <spacer name="verticalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Orientation::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Policy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>0</width>
+          <height>6</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="8" column="0">
+       <widget class="QLineEdit" name="wrapperCmdTextBox"/>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="labelPreLaunchCmd">
+        <property name="text">
+         <string>&amp;Pre-launch Command</string>
+        </property>
+        <property name="buddy">
+         <cstring>preLaunchCmdTextBox</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="0">
+       <widget class="QLabel" name="labelPostExitCmd">
+        <property name="text">
+         <string>P&amp;ost-exit Command</string>
+        </property>
+        <property name="buddy">
+         <cstring>postExitCmdTextBox</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <spacer name="verticalSpacer_4">
+        <property name="orientation">
+         <enum>Qt::Orientation::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Policy::Fixed</enum>
         </property>
         <property name="sizeHint" stdset="0">
          <size>
@@ -125,23 +154,23 @@
    <item>
     <widget class="QLabel" name="labelCustomCmdsDescription">
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pre-launch command runs before the instance launches and post-exit command runs after it exits.&lt;/p&gt;&lt;p&gt;Both will be run in the launcher's working folder with extra environment variables:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;$INST_NAME - Name of the instance&lt;/li&gt;&lt;li&gt;$INST_ID - ID of the instance (its folder name)&lt;/li&gt;&lt;li&gt;$INST_DIR - absolute path of the instance&lt;/li&gt;&lt;li&gt;$INST_MC_DIR - absolute path of Minecraft&lt;/li&gt;&lt;li&gt;$INST_JAVA - Java binary used for launch&lt;/li&gt;&lt;li&gt;$INST_JAVA_ARGS - command-line parameters used for launch (warning: will not work correctly if arguments contain spaces)&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Wrapper command allows launching using an extra wrapper program (like 'optirun' on Linux)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pre-load command runs before the instance's metadata is loaded, pre-launch command runs before the instance launches and post-exit command runs after it exits.&lt;/p&gt;&lt;p&gt;All will be run in the launcher's working folder with extra environment variables:&lt;/p&gt;&lt;ul&gt;&lt;li&gt;$INST_NAME - Name of the instance&lt;/li&gt;&lt;li&gt;$INST_ID - ID of the instance (its folder name)&lt;/li&gt;&lt;li&gt;$INST_DIR - absolute path of the instance&lt;/li&gt;&lt;li&gt;$INST_MC_DIR - absolute path of Minecraft&lt;/li&gt;&lt;li&gt;$INST_JAVA - Java binary used for launch&lt;/li&gt;&lt;li&gt;$INST_JAVA_ARGS - command-line parameters used for launch (warning: will not work correctly if arguments contain spaces)&lt;/li&gt;&lt;/ul&gt;&lt;p&gt;Wrapper command allows launching using an extra wrapper program (like 'optirun' on Linux)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+      <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
      </property>
      <property name="wordWrap">
       <bool>true</bool>
      </property>
      <property name="textInteractionFlags">
-      <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+      <set>Qt::TextInteractionFlag::LinksAccessibleByMouse|Qt::TextInteractionFlag::TextSelectableByMouse</set>
      </property>
     </widget>
    </item>
    <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>

--- a/launcher/ui/widgets/MinecraftSettingsWidget.cpp
+++ b/launcher/ui/widgets/MinecraftSettingsWidget.cpp
@@ -198,8 +198,8 @@ void MinecraftSettingsWidget::loadSettings()
 
     // Custom commands
     m_ui->customCommands->initialize(m_instance != nullptr, m_instance == nullptr || settings->get("OverrideCommands").toBool(),
-                                     settings->get("PreLaunchCommand").toString(), settings->get("WrapperCommand").toString(),
-                                     settings->get("PostExitCommand").toString());
+                                     settings->get("PreLoadCommand").toString(), settings->get("PreLaunchCommand").toString(),
+                                     settings->get("WrapperCommand").toString(), settings->get("PostExitCommand").toString());
 
     // Environment variables
     m_ui->environmentVariables->initialize(m_instance != nullptr, m_instance == nullptr || settings->get("OverrideEnv").toBool(),
@@ -382,10 +382,12 @@ void MinecraftSettingsWidget::saveSettings()
         settings->set("OverrideCommands", custcmd);
 
     if (custcmd) {
+        settings->set("PreLoadCommand", m_ui->customCommands->preLoadCommand());
         settings->set("PreLaunchCommand", m_ui->customCommands->prelaunchCommand());
         settings->set("WrapperCommand", m_ui->customCommands->wrapperCommand());
         settings->set("PostExitCommand", m_ui->customCommands->postexitCommand());
     } else {
+        settings->reset("PreLoadCommand");
         settings->reset("PreLaunchCommand");
         settings->reset("WrapperCommand");
         settings->reset("PostExitCommand");


### PR DESCRIPTION
blocked by #6037
mentioned in #3944
this runs before meta loading so this can help users to run a script that changes the Minecraft version before the meta is loaded