### PR TITLE
ResourceFolderModel: move resource resolving tasks to separate thread (properly)

### DIFF
--- a/launcher/java/JavaChecker.cpp
+++ b/launcher/java/JavaChecker.cpp
@@ -36,12 +36,12 @@
 #include "JavaChecker.h"
 
 #include <QDebug>
-#include <QFile>
 #include <QMap>
 #include <QProcess>
 #include <utility>
 
 #include "Commandline.h"
+#include "FileSystem.h"
 #include "java/JavaUtils.h"
 
 JavaChecker::JavaChecker(QString path, QString args, int minMem, int maxMem, int permGen, int id)

--- a/launcher/minecraft/mod/ResourceFolderModel.cpp
+++ b/launcher/minecraft/mod/ResourceFolderModel.cpp
@@ -51,7 +51,8 @@ ResourceFolderModel::ResourceFolderModel(const QDir& dir, MinecraftInstance* ins
 
 ResourceFolderModel::~ResourceFolderModel()
 {
-    while (!QThreadPool::globalInstance()->waitForDone(100)) {
+    m_resourceResolverThread.quit();
+    while (!m_resourceResolverThread.wait(100)) {
         QCoreApplication::processEvents();
     }
 }
@@ -383,6 +384,8 @@ void ResourceFolderModel::resolveResource(Resource::Ptr res)
         return;
     }
 
+    task->moveToThread(&m_resourceResolverThread);
+
     int ticket = m_nextResolutionTicket.fetch_add(1);
 
     res->setResolving(true, ticket);
@@ -405,7 +408,8 @@ void ResourceFolderModel::resolveResource(Resource::Ptr res)
     m_resourceResolver.addTask(task);
 
     if (!m_resourceResolverRunning) {
-        QThreadPool::globalInstance()->start(&m_resourceResolver);
+        m_resourceResolverThread.start();
+        m_resourceResolver.start();
         m_resourceResolverRunning = true;
     }
 }

--- a/launcher/minecraft/mod/ResourceFolderModel.h
+++ b/launcher/minecraft/mod/ResourceFolderModel.h
@@ -1,18 +1,13 @@
 #pragma once
 
-#include <QAbstractListModel>
-#include <QAction>
 #include <QDir>
 #include <QFileSystemWatcher>
 #include <QHeaderView>
-#include <QMutex>
-#include <QSet>
 #include <QSortFilterProxyModel>
+#include <QThread>
 #include <QTreeView>
 
 #include "Resource.h"
-
-#include "BaseInstance.h"
 
 #include "tasks/ConcurrentTask.h"
 #include "tasks/Task.h"

--- a/launcher/minecraft/mod/ResourceFolderModel.h
+++ b/launcher/minecraft/mod/ResourceFolderModel.h
@@ -268,6 +268,7 @@ class ResourceFolderModel : public QAbstractListModel {
     // Runs off-thread
     ConcurrentTask m_resourceResolver;
     bool m_resourceResolverRunning = false;
+    QThread m_resourceResolverThread{this};
 
     QMap<int, Task::Ptr> m_activeParseTasks;
     std::atomic<int> m_nextResolutionTicket = 0;


### PR DESCRIPTION
The `QThreadPool` approach didn't work because `ConcurrentTask::executeTask` uses queued connections, which will handle the signal based on the object's (`ConcurrentTask`'s) thread affinity (which is Main Thread until moved):
https://github.com/PrismLauncher/PrismLauncher/blob/24124e5b4f1c9e646f003361ad201465c08b9bc7/launcher/tasks/ConcurrentTask.cpp#L64-L68

`ConcurrentTask::executeNextSubTask` also uses a queued connection to start the task:
https://github.com/PrismLauncher/PrismLauncher/blob/24124e5b4f1c9e646f003361ad201465c08b9bc7/launcher/tasks/ConcurrentTask.cpp#L171