### PR TITLE
Update Modrinth api

### DIFF
--- a/launcher/modplatform/ModIndex.h
+++ b/launcher/modplatform/ModIndex.h
@@ -102,6 +102,53 @@ struct SideType : EnumWrapper<SideType, SideTypeValue> {
     using Base::Base; /* inherit ctor */
 };
 
+enum class DisclosureTypeValue : std::uint8_t {
+    Unknown,
+    AIContent,
+    AIContentCode,
+    AIContentAssets,
+    AIContentText,
+    AIContentFunctionality,
+    Advertisements,
+    EpilepsyTriggers,
+    SystemInteractions,
+    Telemetry,
+    TelemetryOptIn,
+    TelemetryOptOut,
+    TelemetryAlwaysActive,
+    DerivativeWork,
+    PaidFeatures,
+    Archived,
+};
+struct DisclosureType : EnumWrapper<DisclosureType, DisclosureTypeValue> {
+    static constexpr auto invalid() { return Unknown; };
+
+    static constexpr auto mapping()
+    {
+        return std::array{
+            std::pair{ AIContent, "ai_content" },
+            std::pair{ AIContentCode, "ai_content_code" },
+            std::pair{ AIContentAssets, "ai_content_assets" },
+            std::pair{ AIContentText, "ai_content_text" },
+            std::pair{ AIContentFunctionality, "ai_content_functionality" },
+            std::pair{ Advertisements, "advertisements" },
+            std::pair{ EpilepsyTriggers, "epilepsy_triggers" },
+            std::pair{ SystemInteractions, "system_interactions" },
+            std::pair{ Telemetry, "telemetry" },
+            std::pair{ TelemetryOptIn, "telemetry_opt_in" },
+            std::pair{ TelemetryOptOut, "telemetry_opt_out" },
+            std::pair{ TelemetryAlwaysActive, "telemetry_always_active" },
+            std::pair{ DerivativeWork, "derivative_work" },
+            std::pair{ PaidFeatures, "paid_features" },
+            std::pair{ Archived, "archived" },
+        };
+    };
+
+    using enum DisclosureTypeValue;
+    using Base = EnumWrapper<DisclosureType, DisclosureTypeValue>;
+    using Base::Base; /* inherit ctor */
+};
+
 namespace ProviderCapabilities {
 const char* name(ResourceProvider);
 QString readableName(ResourceProvider);

--- a/launcher/modplatform/ResourceAPI.h
+++ b/launcher/modplatform/ResourceAPI.h
@@ -83,6 +83,7 @@ class ResourceAPI {
         std::optional<ModPlatform::SideType> side;
         std::optional<QStringList> categoryIds;
         bool openSource{};
+        std::vector<ModPlatform::DisclosureType> excludeDisclosureTypes;
     };
 
     struct VersionSearchArgs {

--- a/launcher/modplatform/modrinth/ModrinthAPI.h
+++ b/launcher/modplatform/modrinth/ModrinthAPI.h
@@ -118,7 +118,7 @@ class ModrinthAPI final : public ResourceAPI {
    private:
     static QString resourceTypeParameter(ModPlatform::ResourceType type);
 
-    QString createFacets(const SearchArgs& args) const
+    static QString createFacets(const SearchArgs& args)
     {
         QStringList facetsList;
 
@@ -200,7 +200,7 @@ class ModrinthAPI final : public ResourceAPI {
             .arg(BuildConfig.MODRINTH_PROD_URL, args.pack->addonId.toString(), getArguments.isEmpty() ? "" : "?", getArguments.join('&'));
     };
 
-    QString getGameVersionsArray(const std::vector<Version>& mcVersions) const
+    static QString getGameVersionsArray(const std::vector<Version>& mcVersions)
     {
         QString s;
         for (const auto& ver : mcVersions) {

--- a/launcher/modplatform/modrinth/ModrinthAPI.h
+++ b/launcher/modplatform/modrinth/ModrinthAPI.h
@@ -137,6 +137,11 @@ class ModrinthAPI final : public ResourceAPI {
         if (args.categoryIds.has_value() && !args.categoryIds->empty()) {
             facetsList.append(QString("[%1]").arg(getCategoriesFilters(args.categoryIds.value())));
         }
+        if (!args.excludeDisclosureTypes.empty()) {
+            for (const auto& d : args.excludeDisclosureTypes) {
+                facetsList.append(QString("[\"disclosure_types!=%1\"]").arg(d.toString()));
+            }
+        }
         if (args.openSource) {
             facetsList.append("[\"open_source:true\"]");
         }

--- a/launcher/modplatform/modrinth/ModrinthAPI.h
+++ b/launcher/modplatform/modrinth/ModrinthAPI.h
@@ -83,11 +83,15 @@ class ModrinthAPI final : public ResourceAPI {
     {
         switch (side.value()) {
             case ModPlatform::SideType::ClientSide:
-                return { R"("client_side:required","client_side:optional"],["server_side:optional","server_side:unsupported")" };
+                return {
+                    R"("environment:client_only","environment:client_only_server_optional","environment:singleplayer_only","environment:client_or_server","environment:client_or_server_prefers_both")"
+                };
             case ModPlatform::SideTypeValue::ServerSide:
-                return { R"("server_side:required","server_side:optional"],["client_side:optional","client_side:unsupported")" };
+                return {
+                    R"("environment:server_only","environment:server_only_client_optional","environment:dedicated_server_only","environment:client_or_server","environment:client_or_server_prefers_both")"
+                };
             case ModPlatform::SideTypeValue::UniversalSide:
-                return { R"("client_side:required"],["server_side:required")" };
+                return { R"("environment:client_and_server","client_or_server_prefers_both")" };
             case ModPlatform::SideTypeValue::NoSide:
             // fallthrough
             default:

--- a/launcher/ui/pages/modplatform/ModModel.cpp
+++ b/launcher/ui/pages/modplatform/ModModel.cpp
@@ -52,15 +52,18 @@ ResourceAPI::SearchArgs ModModel::createSearchArguments()
 
     auto sort = getCurrentSortingMethodByIndex();
 
-    return { .type = ModPlatform::ResourceType::Mod,
-             .offset = m_next_search_offset,
-             .search = m_search_term,
-             .sorting = sort,
-             .loaders = loaders,
-             .versions = versions,
-             .side = side,
-             .categoryIds = categories,
-             .openSource = m_filter->openSource };
+    return {
+        .type = ModPlatform::ResourceType::Mod,
+        .offset = m_next_search_offset,
+        .search = m_search_term,
+        .sorting = sort,
+        .loaders = loaders,
+        .versions = versions,
+        .side = side,
+        .categoryIds = categories,
+        .openSource = m_filter->openSource,
+        .excludeDisclosureTypes = m_filter->excludeDisclosureTypes,
+    };
 }
 
 ResourceAPI::VersionSearchArgs ModModel::createVersionsArguments(const QModelIndex& index)

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
@@ -38,7 +38,6 @@
 
 #include "Application.h"
 #include "BuildConfig.h"
-#include "Json.h"
 #include "modplatform/ModIndex.h"
 #include "modplatform/modrinth/ModrinthAPI.h"
 #include "net/NetJob.h"
@@ -48,22 +47,42 @@
 
 #include <QMessageBox>
 #include <memory>
+#include <utility>
 
+namespace {
+auto sortFromIndex(int index) -> QString
+{
+    switch (index) {
+        default:
+        case 0:
+            return "relevance";
+        case 1:
+            return "downloads";
+        case 2:
+            return "follows";
+        case 3:
+            return "newest";
+        case 4:
+            return "updated";
+    }
+}
+}  // namespace
 namespace Modrinth {
 
 ModpackListModel::ModpackListModel(ModrinthPage* parent) : QAbstractListModel(parent), m_parent(parent) {}
 
-auto ModpackListModel::debugName() const -> QString
+auto ModpackListModel::debugName() -> QString
 {
-    return m_parent->debugName();
+    return ModrinthPage::debugName();
 }
 
 /******** Make data requests ********/
 
 void ModpackListModel::fetchMore(const QModelIndex& parent)
 {
-    if (parent.isValid())
+    if (parent.isValid()) {
         return;
+    }
     if (m_nextSearchOffset == 0) {
         qWarning() << "fetchMore with 0 offset is wrong...";
         return;
@@ -90,11 +109,12 @@ auto ModpackListModel::data(const QModelIndex& index, int role) const -> QVarian
             return pack->description;
         }
         case Qt::DecorationRole: {
-            if (m_logoMap.contains(pack->logoName))
+            if (m_logoMap.contains(pack->logoName)) {
                 return m_logoMap.value(pack->logoName);
+            }
 
             QIcon icon = QIcon::fromTheme("screenshot-placeholder");
-            ((ModpackListModel*)this)->requestLogo(pack->logoName, pack->logoUrl);
+            const_cast<ModpackListModel*>(this)->requestLogo(pack->logoName, pack->logoUrl);
             return icon;
         }
         case Qt::UserRole: {
@@ -121,8 +141,9 @@ auto ModpackListModel::data(const QModelIndex& index, int role) const -> QVarian
 bool ModpackListModel::setData(const QModelIndex& index, const QVariant& value, [[maybe_unused]] int role)
 {
     int pos = index.row();
-    if (pos >= m_modpacks.size() || pos < 0 || !index.isValid())
+    if (pos >= m_modpacks.size() || pos < 0 || !index.isValid()) {
         return false;
+    }
 
     m_modpacks[pos] = value.value<ModPlatform::IndexedPack::Ptr>();
 
@@ -131,8 +152,9 @@ bool ModpackListModel::setData(const QModelIndex& index, const QVariant& value, 
 
 void ModpackListModel::performPaginatedSearch()
 {
-    if (hasActiveSearchJob())
+    if (hasActiveSearchJob()) {
         return;
+    }
 
     // Modrinth ids are not limited to numbers and can be any length
     if (m_searchState != ResetRequested && m_currentSearchTerm.startsWith("#")) {
@@ -140,7 +162,7 @@ void ModpackListModel::performPaginatedSearch()
         if (!projectId.isEmpty()) {
             ResourceAPI::Callback<ModPlatform::IndexedPack::Ptr> callbacks;
 
-            callbacks.onFail = [this](QString reason, int networkErrorCode) {
+            callbacks.onFail = [this](const QString& reason, int networkErrorCode) {
                 if (networkErrorCode == 404) {
                     m_searchState = ResetRequested;
                 }
@@ -153,7 +175,7 @@ void ModpackListModel::performPaginatedSearch()
             };
             auto project = std::make_shared<ModPlatform::IndexedPack>();
             project->addonId = projectId;
-            if (auto job = ModrinthAPI::get().getProjectInfo({ project }, std::move(callbacks), false); job) {
+            if (auto job = ModrinthAPI::get().getProjectInfo({ project }, callbacks, false); job) {
                 m_jobPtr = job;
                 m_jobPtr->start();
             }
@@ -166,7 +188,7 @@ void ModpackListModel::performPaginatedSearch()
     ResourceAPI::Callback<QList<ModPlatform::IndexedPack::Ptr>> callbacks{};
 
     callbacks.onSucceed = [this](auto& doc) { searchRequestFinished(doc); };
-    callbacks.onFail = [this](QString reason, int networkErrorCode) { searchRequestFailed(reason, networkErrorCode); };
+    callbacks.onFail = [this](const QString& reason, int networkErrorCode) { searchRequestFailed(reason, networkErrorCode); };
     callbacks.onAbort = [this] {
         qCritical() << "Search task aborted by an unknown reason!";
         searchRequestFailed("Aborted", 0);
@@ -185,7 +207,7 @@ void ModpackListModel::performPaginatedSearch()
             .openSource = m_filter->openSource,
             .excludeDisclosureTypes = m_filter->excludeDisclosureTypes,
         },
-        std::move(callbacks));
+        callbacks);
 
     m_jobPtr = netJob;
     m_jobPtr->start();
@@ -208,61 +230,45 @@ void ModpackListModel::refresh()
     performPaginatedSearch();
 }
 
-static auto sortFromIndex(int index) -> QString
-{
-    switch (index) {
-        default:
-        case 0:
-            return "relevance";
-        case 1:
-            return "downloads";
-        case 2:
-            return "follows";
-        case 3:
-            return "newest";
-        case 4:
-            return "updated";
-    }
-}
-
 void ModpackListModel::searchWithTerm(const QString& term,
                                       const int sort,
                                       std::shared_ptr<ModFilterWidget::Filter> filter,
                                       bool filterChanged)
 {
-    if (sort > 5 || sort < 0)
+    if (sort > 5 || sort < 0) {
         return;
+    }
 
-    auto sort_str = sortFromIndex(sort);
+    auto sortStr = sortFromIndex(sort);
 
-    if (m_currentSearchTerm == term && m_currentSearchTerm.isNull() == term.isNull() && m_currentSort == sort_str && !filterChanged) {
+    if (m_currentSearchTerm == term && m_currentSearchTerm.isNull() == term.isNull() && m_currentSort == sortStr && !filterChanged) {
         return;
     }
 
     m_currentSearchTerm = term;
-    m_currentSort = sort_str;
-    m_filter = filter;
+    m_currentSort = sortStr;
+    m_filter = std::move(filter);
 
     refresh();
 }
 
-void ModpackListModel::getLogo(const QString& logo, const QString& logoUrl, LogoCallback callback)
+void ModpackListModel::getLogo(const QString& logo, const QString& logoUrl, const LogoCallback& callback)
 {
     if (m_logoMap.contains(logo)) {
-        callback(APPLICATION->metacache()->resolveEntry(m_parent->metaEntryBase(), QString("logos/%1").arg(logo))->getFullPath());
+        callback(APPLICATION->metacache()->resolveEntry(ModrinthPage::metaEntryBase(), QString("logos/%1").arg(logo))->getFullPath());
     } else {
         requestLogo(logo, logoUrl);
     }
 }
 
-void ModpackListModel::requestLogo(QString logo, QString url)
+void ModpackListModel::requestLogo(const QString& logo, const QString& url)
 {
     if (m_loadingLogos.contains(logo) || m_failedLogos.contains(logo) || url.isEmpty()) {
         return;
     }
 
-    MetaEntryPtr entry = APPLICATION->metacache()->resolveEntry(m_parent->metaEntryBase(), QString("logos/%1").arg(logo));
-    auto job = new NetJob(QString("%1 Icon Download %2").arg(m_parent->debugName()).arg(logo), APPLICATION->network());
+    MetaEntryPtr entry = APPLICATION->metacache()->resolveEntry(ModrinthPage::metaEntryBase(), QString("logos/%1").arg(logo));
+    auto* job = new NetJob(QString("%1 Icon Download %2").arg(ModrinthPage::debugName()).arg(logo), APPLICATION->network());
     job->setAskRetry(false);
     job->addNetAction(Net::ApiRequest::makeCached(QUrl(url), entry));
 
@@ -286,7 +292,7 @@ void ModpackListModel::requestLogo(QString logo, QString url)
 
 /******** Request callbacks ********/
 
-void ModpackListModel::logoLoaded(QString logo, QIcon out)
+void ModpackListModel::logoLoaded(const QString& logo, const QIcon& out)
 {
     m_loadingLogos.removeAll(logo);
     m_logoMap.insert(logo, out);
@@ -297,7 +303,7 @@ void ModpackListModel::logoLoaded(QString logo, QIcon out)
     }
 }
 
-void ModpackListModel::logoFailed(QString logo)
+void ModpackListModel::logoFailed(const QString& logo)
 {
     m_failedLogos.append(logo);
     m_loadingLogos.removeAll(logo);
@@ -307,18 +313,19 @@ void ModpackListModel::searchRequestFinished(QList<ModPlatform::IndexedPack::Ptr
 {
     m_jobPtr.reset();
 
-    if (newList.size() < m_modpacks_per_page) {
+    if (newList.size() < m_modpacksPerPage) {
         m_searchState = Finished;
     } else {
-        m_nextSearchOffset += m_modpacks_per_page;
+        m_nextSearchOffset += m_modpacksPerPage;
         m_searchState = CanPossiblyFetchMore;
     }
 
     // When you have a Qt build with assertions turned on, proceeding here will abort the application
-    if (newList.size() == 0)
+    if (newList.size() == 0) {
         return;
+    }
 
-    beginInsertRows(QModelIndex(), m_modpacks.size(), m_modpacks.size() + newList.size() - 1);
+    beginInsertRows(QModelIndex(), static_cast<int>(m_modpacks.size()), static_cast<int>(m_modpacks.size() + newList.size() - 1));
     m_modpacks.append(newList);
     endInsertRows();
 }
@@ -327,12 +334,12 @@ void ModpackListModel::searchRequestForOneSucceeded(ModPlatform::IndexedPack::Pt
 {
     m_jobPtr.reset();
 
-    beginInsertRows(QModelIndex(), m_modpacks.size(), m_modpacks.size() + 1);
+    beginInsertRows(QModelIndex(), static_cast<int>(m_modpacks.size()), static_cast<int>(m_modpacks.size() + 1));
     m_modpacks.append(pack);
     endInsertRows();
 }
 
-void ModpackListModel::searchRequestFailed(const QString& reason, int networkErrorCode)
+void ModpackListModel::searchRequestFailed(const QString& /*reason*/, int networkErrorCode)
 {
     if (networkErrorCode == -1) {
         // Unknown error in network stack

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModel.cpp
@@ -172,9 +172,20 @@ void ModpackListModel::performPaginatedSearch()
         searchRequestFailed("Aborted", 0);
     };
 
-    auto netJob = ModrinthAPI::get().searchProjects({ .type=ModPlatform::ResourceType::Modpack, .offset=m_nextSearchOffset, .search=m_currentSearchTerm, .sorting=sort, .loaders=m_filter->loaders,
-                                       .versions=m_filter->versions, .side=ModPlatform::SideType::NoSide, .categoryIds=m_filter->categoryIds, .openSource=m_filter->openSource },
-                                     std::move(callbacks));
+    auto netJob = ModrinthAPI::get().searchProjects(
+        {
+            .type = ModPlatform::ResourceType::Modpack,
+            .offset = m_nextSearchOffset,
+            .search = m_currentSearchTerm,
+            .sorting = sort,
+            .loaders = m_filter->loaders,
+            .versions = m_filter->versions,
+            .side = ModPlatform::SideType::NoSide,
+            .categoryIds = m_filter->categoryIds,
+            .openSource = m_filter->openSource,
+            .excludeDisclosureTypes = m_filter->excludeDisclosureTypes,
+        },
+        std::move(callbacks));
 
     m_jobPtr = netJob;
     m_jobPtr->start();

--- a/launcher/ui/pages/modplatform/modrinth/ModrinthModel.h
+++ b/launcher/ui/pages/modplatform/modrinth/ModrinthModel.h
@@ -53,20 +53,20 @@ class ModpackListModel : public QAbstractListModel {
     Q_OBJECT
 
    public:
-    ModpackListModel(ModrinthPage* parent);
+    explicit ModpackListModel(ModrinthPage* parent);
     ~ModpackListModel() override = default;
 
-    inline auto rowCount(const QModelIndex& parent) const -> int override { return parent.isValid() ? 0 : m_modpacks.size(); };
-    inline auto columnCount(const QModelIndex& parent) const -> int override { return parent.isValid() ? 0 : 1; };
-    inline auto flags(const QModelIndex& index) const -> Qt::ItemFlags override { return QAbstractListModel::flags(index); };
+    auto rowCount(const QModelIndex& parent) const -> int override { return parent.isValid() ? 0 : static_cast<int>(m_modpacks.size()); };
+    auto columnCount(const QModelIndex& parent) const -> int override { return parent.isValid() ? 0 : 1; };
+    auto flags(const QModelIndex& index) const -> Qt::ItemFlags override { return QAbstractListModel::flags(index); };
 
-    auto debugName() const -> QString;
+    static auto debugName() -> QString;
 
     /* Retrieve information from the model at a given index with the given role */
     auto data(const QModelIndex& index, int role) const -> QVariant override;
     bool setData(const QModelIndex& index, const QVariant& value, int role) override;
 
-    inline void setActiveJob(NetJob::Ptr ptr) { m_jobPtr = ptr; }
+    void setActiveJob(NetJob::Ptr ptr) { m_jobPtr = ptr; }
 
     /* Ask the API for more information */
     void fetchMore(const QModelIndex& parent) override;
@@ -76,27 +76,27 @@ class ModpackListModel : public QAbstractListModel {
     bool hasActiveSearchJob() const { return m_jobPtr && m_jobPtr->isRunning(); }
     Task::Ptr activeSearchJob() { return hasActiveSearchJob() ? m_jobPtr : nullptr; }
 
-    void getLogo(const QString& logo, const QString& logoUrl, LogoCallback callback);
+    void getLogo(const QString& logo, const QString& logoUrl, const LogoCallback& callback);
 
-    inline auto canFetchMore(const QModelIndex& parent) const -> bool override
+    auto canFetchMore(const QModelIndex& parent) const -> bool override
     {
         return parent.isValid() ? false : m_searchState == CanPossiblyFetchMore;
     };
 
    public slots:
-    void searchRequestFinished(QList<ModPlatform::IndexedPack::Ptr>& doc_all);
+    void searchRequestFinished(QList<ModPlatform::IndexedPack::Ptr>& newList);
     void searchRequestFailed(const QString& reason, int networkErrorCode);
     void searchRequestForOneSucceeded(ModPlatform::IndexedPack::Ptr);
 
    protected slots:
 
-    void logoFailed(QString logo);
-    void logoLoaded(QString logo, QIcon out);
+    void logoFailed(const QString& logo);
+    void logoLoaded(const QString& logo, const QIcon& out);
 
     void performPaginatedSearch();
 
    protected:
-    void requestLogo(QString file, QString url);
+    void requestLogo(const QString& logo, const QString& url);
 
     inline auto getMineVersions() const -> std::vector<Version>;
 
@@ -114,13 +114,13 @@ class ModpackListModel : public QAbstractListModel {
     QString m_currentSort;
     std::shared_ptr<ModFilterWidget::Filter> m_filter;
     int m_nextSearchOffset = 0;
-    enum SearchState { None, CanPossiblyFetchMore, ResetRequested, Finished } m_searchState = None;
+    enum SearchState : std::uint8_t { None, CanPossiblyFetchMore, ResetRequested, Finished } m_searchState = None;
 
     Task::Ptr m_jobPtr;
 
     std::shared_ptr<QByteArray> m_allResponse = std::make_shared<QByteArray>();
-    QByteArray m_specific_response;
+    QByteArray m_specificResponse;
 
-    int m_modpacks_per_page = 20;
+    int m_modpacksPerPage = 20;
 };
 }  // namespace Modrinth

--- a/launcher/ui/widgets/ModFilterWidget.cpp
+++ b/launcher/ui/widgets/ModFilterWidget.cpp
@@ -134,6 +134,7 @@ ModFilterWidget::ModFilterWidget(MinecraftInstance* instance, bool extended)
         ui->versions->hide();
         ui->showAllVersions->hide();
         ui->environmentGroup->hide();
+        ui->disclosureGroup->hide();
         ui->openSource->hide();
     }
 
@@ -172,6 +173,22 @@ ModFilterWidget::ModFilterWidget(MinecraftInstance* instance, bool extended)
     connect(ui->betaCb, &QCheckBox::stateChanged, this, &ModFilterWidget::onReleaseFilterChanged);
     connect(ui->alphaCb, &QCheckBox::stateChanged, this, &ModFilterWidget::onReleaseFilterChanged);
     connect(ui->unknownCb, &QCheckBox::stateChanged, this, &ModFilterWidget::onReleaseFilterChanged);
+
+    connect(ui->aiContent, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
+    connect(ui->aiContentCode, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
+    connect(ui->aiContentAssets, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
+    connect(ui->aiContentText, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
+    connect(ui->aiContentFunctionality, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
+    connect(ui->advertisements, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
+    connect(ui->epilepsyTriggers, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
+    connect(ui->systemInteractions, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
+    connect(ui->telemetry, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
+    connect(ui->telemetryOptIn, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
+    connect(ui->telemetryOptOut, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
+    connect(ui->telemetryAlwaysActive, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
+    connect(ui->derivativeWork, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
+    connect(ui->paidFeatures, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
+    connect(ui->archived, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
 
     setHidden(true);
     loadVersionList();
@@ -400,6 +417,39 @@ void ModFilterWidget::onReleaseFilterChanged()
     m_filter->releases = releases;
     if (m_filter_changed)
         emit filterChanged();
+}
+
+void ModFilterWidget::onDisclosureFilterChanged()
+{
+    std::vector<ModPlatform::DisclosureType> exclude;
+
+    auto collect = [&](QCheckBox* checkbox, ModPlatform::DisclosureType type) {
+        if (checkbox->checkState() == Qt::Checked) {
+            exclude.push_back(type);
+        }
+    };
+
+    collect(ui->aiContent, ModPlatform::DisclosureType::AIContent);
+    collect(ui->aiContentCode, ModPlatform::DisclosureType::AIContentCode);
+    collect(ui->aiContentAssets, ModPlatform::DisclosureType::AIContentAssets);
+    collect(ui->aiContentText, ModPlatform::DisclosureType::AIContentText);
+    collect(ui->aiContentFunctionality, ModPlatform::DisclosureType::AIContentFunctionality);
+    collect(ui->advertisements, ModPlatform::DisclosureType::Advertisements);
+    collect(ui->epilepsyTriggers, ModPlatform::DisclosureType::EpilepsyTriggers);
+    collect(ui->systemInteractions, ModPlatform::DisclosureType::SystemInteractions);
+    collect(ui->telemetry, ModPlatform::DisclosureType::Telemetry);
+    collect(ui->telemetryOptIn, ModPlatform::DisclosureType::TelemetryOptIn);
+    collect(ui->telemetryOptOut, ModPlatform::DisclosureType::TelemetryOptOut);
+    collect(ui->telemetryAlwaysActive, ModPlatform::DisclosureType::TelemetryAlwaysActive);
+    collect(ui->derivativeWork, ModPlatform::DisclosureType::DerivativeWork);
+    collect(ui->paidFeatures, ModPlatform::DisclosureType::PaidFeatures);
+    collect(ui->archived, ModPlatform::DisclosureType::Archived);
+
+    m_filter_changed = exclude != m_filter->excludeDisclosureTypes;
+    m_filter->excludeDisclosureTypes = exclude;
+    if (m_filter_changed) {
+        emit filterChanged();
+    }
 }
 
 void ModFilterWidget::onShowMoreClicked()

--- a/launcher/ui/widgets/ModFilterWidget.cpp
+++ b/launcher/ui/widgets/ModFilterWidget.cpp
@@ -49,10 +49,7 @@
 #include "Application.h"
 #include "minecraft/PackProfile.h"
 
-ModFilterWidget* ModFilterWidget::create(MinecraftInstance* instance, bool extended)
-{
-    return new ModFilterWidget(instance, extended);
-}
+namespace {
 
 class VersionBasicModel : public QIdentityProxyModel {
     Q_OBJECT
@@ -60,12 +57,14 @@ class VersionBasicModel : public QIdentityProxyModel {
    public:
     explicit VersionBasicModel(QObject* parent = nullptr) : QIdentityProxyModel(parent) {}
 
-    virtual QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override
+    QVariant data(const QModelIndex& index, int role = Qt::DisplayRole) const override
     {
-        if (role == Qt::DisplayRole)
+        if (role == Qt::DisplayRole) {
             return QIdentityProxyModel::data(index, BaseVersionList::VersionIdRole);
-        if (role == Qt::UserRole)
+        }
+        if (role == Qt::UserRole) {
             return QIdentityProxyModel::data(index, BaseVersionList::VersionIdRole);
+        }
         return {};
     }
 };
@@ -74,7 +73,7 @@ class AllVersionProxyModel : public QSortFilterProxyModel {
     Q_OBJECT
 
    public:
-    AllVersionProxyModel(QObject* parent = nullptr) : QSortFilterProxyModel(parent) {}
+    explicit AllVersionProxyModel(QObject* parent = nullptr) : QSortFilterProxyModel(parent) {}
 
     int rowCount(const QModelIndex& parent = QModelIndex()) const override { return QSortFilterProxyModel::rowCount(parent) + 1; }
 
@@ -107,88 +106,93 @@ class AllVersionProxyModel : public QSortFilterProxyModel {
     }
 };
 
-ModFilterWidget::ModFilterWidget(MinecraftInstance* instance, bool extended)
-    : QTabWidget(), ui(new Ui::ModFilterWidget), m_instance(instance), m_filter(new Filter())
+}  // namespace
+ModFilterWidget* ModFilterWidget::create(MinecraftInstance* instance, bool extended)
 {
-    ui->setupUi(this);
+    return new ModFilterWidget(instance, extended);
+}
 
-    m_versions_proxy = new VersionProxyModel(this);
-    m_versions_proxy->setFilter(BaseVersionList::TypeRole, Filters::equals("release"));
+ModFilterWidget::ModFilterWidget(MinecraftInstance* instance, bool extended)
+    : m_ui(new Ui::ModFilterWidget), m_instance(instance), m_filter(new Filter()), m_versionsProxy(new VersionProxyModel(this))
+{
+    m_ui->setupUi(this);
+
+    m_versionsProxy->setFilter(BaseVersionList::TypeRole, Filters::equals("release"));
 
     QAbstractProxyModel* proxy = new VersionBasicModel(this);
-    proxy->setSourceModel(m_versions_proxy);
+    proxy->setSourceModel(m_versionsProxy);
 
     if (extended) {
         if (!m_instance) {
-            ui->environmentGroup->hide();
+            m_ui->environmentGroup->hide();
         }
-        ui->versions->setSourceModel(proxy);
-        ui->versions->setSeparator(", ");
-        ui->versions->setDefaultText(tr("All Versions"));
-        ui->version->hide();
+        m_ui->versions->setSourceModel(proxy);
+        m_ui->versions->setSeparator(", ");
+        m_ui->versions->setDefaultText(tr("All Versions"));
+        m_ui->version->hide();
     } else {
-        auto allVersions = new AllVersionProxyModel(this);
+        auto* allVersions = new AllVersionProxyModel(this);
         allVersions->setSourceModel(proxy);
         proxy = allVersions;
-        ui->version->setModel(proxy);
-        ui->versions->hide();
-        ui->showAllVersions->hide();
-        ui->environmentGroup->hide();
-        ui->disclosureGroup->hide();
-        ui->openSource->hide();
+        m_ui->version->setModel(proxy);
+        m_ui->versions->hide();
+        m_ui->showAllVersions->hide();
+        m_ui->environmentGroup->hide();
+        m_ui->disclosureGroup->hide();
+        m_ui->openSource->hide();
     }
 
-    connect(ui->showAllVersions, &QCheckBox::stateChanged, this, &ModFilterWidget::onShowAllVersionsChanged);
-    connect(ui->versions, &QComboBox::currentIndexChanged, this, &ModFilterWidget::onVersionFilterChanged);
-    connect(ui->versions, &CheckComboBox::checkedItemsChanged, this, [this] { onVersionFilterChanged(0); });
-    connect(ui->version, &QComboBox::currentTextChanged, this, &ModFilterWidget::onVersionFilterTextChanged);
+    connect(m_ui->showAllVersions, &QCheckBox::stateChanged, this, &ModFilterWidget::onShowAllVersionsChanged);
+    connect(m_ui->versions, &QComboBox::currentIndexChanged, this, &ModFilterWidget::onVersionFilterChanged);
+    connect(m_ui->versions, &CheckComboBox::checkedItemsChanged, this, [this] { onVersionFilterChanged(0); });
+    connect(m_ui->version, &QComboBox::currentTextChanged, this, &ModFilterWidget::onVersionFilterTextChanged);
 
-    connect(ui->neoForge, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
-    connect(ui->forge, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
-    connect(ui->fabric, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
-    connect(ui->quilt, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
-    connect(ui->liteLoader, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
-    connect(ui->babric, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
-    connect(ui->btaBabric, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
-    connect(ui->legacyFabric, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
-    connect(ui->ornithe, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
-    connect(ui->rift, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
+    connect(m_ui->neoForge, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
+    connect(m_ui->forge, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
+    connect(m_ui->fabric, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
+    connect(m_ui->quilt, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
+    connect(m_ui->liteLoader, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
+    connect(m_ui->babric, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
+    connect(m_ui->btaBabric, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
+    connect(m_ui->legacyFabric, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
+    connect(m_ui->ornithe, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
+    connect(m_ui->rift, &QCheckBox::stateChanged, this, &ModFilterWidget::onLoadersFilterChanged);
 
-    connect(ui->showMoreButton, &QPushButton::clicked, this, &ModFilterWidget::onShowMoreClicked);
+    connect(m_ui->showMoreButton, &QPushButton::clicked, this, &ModFilterWidget::onShowMoreClicked);
 
     if (!extended) {
-        ui->showMoreButton->setVisible(false);
-        ui->extendedModLoadersWidget->setVisible(false);
+        m_ui->showMoreButton->setVisible(false);
+        m_ui->extendedModLoadersWidget->setVisible(false);
     }
 
     if (extended) {
-        connect(ui->clientSide, &QCheckBox::stateChanged, this, &ModFilterWidget::onSideFilterChanged);
-        connect(ui->serverSide, &QCheckBox::stateChanged, this, &ModFilterWidget::onSideFilterChanged);
+        connect(m_ui->clientSide, &QCheckBox::stateChanged, this, &ModFilterWidget::onSideFilterChanged);
+        connect(m_ui->serverSide, &QCheckBox::stateChanged, this, &ModFilterWidget::onSideFilterChanged);
     }
 
-    connect(ui->hideInstalled, &QCheckBox::stateChanged, this, &ModFilterWidget::onHideInstalledFilterChanged);
-    connect(ui->openSource, &QCheckBox::stateChanged, this, &ModFilterWidget::onOpenSourceFilterChanged);
+    connect(m_ui->hideInstalled, &QCheckBox::stateChanged, this, &ModFilterWidget::onHideInstalledFilterChanged);
+    connect(m_ui->openSource, &QCheckBox::stateChanged, this, &ModFilterWidget::onOpenSourceFilterChanged);
 
-    connect(ui->releaseCb, &QCheckBox::stateChanged, this, &ModFilterWidget::onReleaseFilterChanged);
-    connect(ui->betaCb, &QCheckBox::stateChanged, this, &ModFilterWidget::onReleaseFilterChanged);
-    connect(ui->alphaCb, &QCheckBox::stateChanged, this, &ModFilterWidget::onReleaseFilterChanged);
-    connect(ui->unknownCb, &QCheckBox::stateChanged, this, &ModFilterWidget::onReleaseFilterChanged);
+    connect(m_ui->releaseCb, &QCheckBox::stateChanged, this, &ModFilterWidget::onReleaseFilterChanged);
+    connect(m_ui->betaCb, &QCheckBox::stateChanged, this, &ModFilterWidget::onReleaseFilterChanged);
+    connect(m_ui->alphaCb, &QCheckBox::stateChanged, this, &ModFilterWidget::onReleaseFilterChanged);
+    connect(m_ui->unknownCb, &QCheckBox::stateChanged, this, &ModFilterWidget::onReleaseFilterChanged);
 
-    connect(ui->aiContent, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
-    connect(ui->aiContentCode, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
-    connect(ui->aiContentAssets, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
-    connect(ui->aiContentText, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
-    connect(ui->aiContentFunctionality, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
-    connect(ui->advertisements, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
-    connect(ui->epilepsyTriggers, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
-    connect(ui->systemInteractions, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
-    connect(ui->telemetry, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
-    connect(ui->telemetryOptIn, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
-    connect(ui->telemetryOptOut, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
-    connect(ui->telemetryAlwaysActive, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
-    connect(ui->derivativeWork, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
-    connect(ui->paidFeatures, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
-    connect(ui->archived, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
+    connect(m_ui->aiContent, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
+    connect(m_ui->aiContentCode, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
+    connect(m_ui->aiContentAssets, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
+    connect(m_ui->aiContentText, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
+    connect(m_ui->aiContentFunctionality, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
+    connect(m_ui->advertisements, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
+    connect(m_ui->epilepsyTriggers, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
+    connect(m_ui->systemInteractions, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
+    connect(m_ui->telemetry, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
+    connect(m_ui->telemetryOptIn, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
+    connect(m_ui->telemetryOptOut, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
+    connect(m_ui->telemetryAlwaysActive, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
+    connect(m_ui->derivativeWork, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
+    connect(m_ui->paidFeatures, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
+    connect(m_ui->archived, &QCheckBox::stateChanged, this, &ModFilterWidget::onDisclosureFilterChanged);
 
     setHidden(true);
     loadVersionList();
@@ -197,43 +201,45 @@ ModFilterWidget::ModFilterWidget(MinecraftInstance* instance, bool extended)
 
 auto ModFilterWidget::getFilter() -> std::shared_ptr<Filter>
 {
-    m_filter_changed = false;
+    m_filterChanged = false;
     return m_filter;
 }
 
 ModFilterWidget::~ModFilterWidget()
 {
-    delete ui;
+    delete m_ui;
 }
 
 void ModFilterWidget::loadVersionList()
 {
-    m_version_list = APPLICATION->metadataIndex()->get("net.minecraft");
-    if (!m_version_list->isLoaded()) {
-        QEventLoop load_version_list_loop;
+    m_versionList = APPLICATION->metadataIndex()->get("net.minecraft");
+    if (!m_versionList->isLoaded()) {
+        QEventLoop loadVersionListLoop;
 
-        QTimer time_limit_for_list_load;
-        time_limit_for_list_load.setTimerType(Qt::TimerType::CoarseTimer);
-        time_limit_for_list_load.setSingleShot(true);
-        time_limit_for_list_load.callOnTimeout(&load_version_list_loop, &QEventLoop::quit);
-        time_limit_for_list_load.start(4000);
+        QTimer timeLimitForListLoad;
+        timeLimitForListLoad.setTimerType(Qt::TimerType::CoarseTimer);
+        timeLimitForListLoad.setSingleShot(true);
+        timeLimitForListLoad.callOnTimeout(&loadVersionListLoop, &QEventLoop::quit);
+        timeLimitForListLoad.start(4000);
 
-        auto task = m_version_list->getLoadTask();
+        auto task = m_versionList->getLoadTask();
 
         connect(task.get(), &Task::failed, this, [this] {
-            ui->versions->setEnabled(false);
-            ui->showAllVersions->setEnabled(false);
+            m_ui->versions->setEnabled(false);
+            m_ui->showAllVersions->setEnabled(false);
         });
-        connect(task.get(), &Task::finished, &load_version_list_loop, &QEventLoop::quit);
+        connect(task.get(), &Task::finished, &loadVersionListLoop, &QEventLoop::quit);
 
-        if (!task->isRunning())
+        if (!task->isRunning()) {
             task->start();
+        }
 
-        load_version_list_loop.exec();
-        if (time_limit_for_list_load.isActive())
-            time_limit_for_list_load.stop();
+        loadVersionListLoop.exec();
+        if (timeLimitForListLoad.isActive()) {
+            timeLimitForListLoad.stop();
+        }
     }
-    m_versions_proxy->setSourceModel(m_version_list.get());
+    m_versionsProxy->setSourceModel(m_versionList.get());
 }
 
 void ModFilterWidget::prepareBasicFilter()
@@ -244,121 +250,137 @@ void ModFilterWidget::prepareBasicFilter()
         m_filter->side = ModPlatform::SideType::NoSide;  // or "both"
         ModPlatform::ModLoaderTypes loaders;
         if (m_instance->settings()->get("OverrideModDownloadLoaders").toBool()) {
-            for (auto loader : Json::toStringList(m_instance->settings()->get("ModDownloadLoaders").toString())) {
+            for (const auto& loader : Json::toStringList(m_instance->settings()->get("ModDownloadLoaders").toString())) {
                 loaders |= ModPlatform::getModLoaderFromString(loader);
             }
         } else {
             loaders = m_instance->getPackProfile()->getSupportedModLoaders().value_or(ModPlatform::ModLoaderTypes(0));
         }
-        ui->neoForge->setChecked(loaders & ModPlatform::NeoForge);
-        ui->forge->setChecked(loaders & ModPlatform::Forge);
-        ui->fabric->setChecked(loaders & ModPlatform::Fabric);
-        ui->quilt->setChecked(loaders & ModPlatform::Quilt);
-        ui->liteLoader->setChecked(loaders & ModPlatform::LiteLoader);
-        ui->babric->setChecked(loaders & ModPlatform::Babric);
-        ui->btaBabric->setChecked(loaders & ModPlatform::BTA);
-        ui->legacyFabric->setChecked(loaders & ModPlatform::LegacyFabric);
-        ui->ornithe->setChecked(loaders & ModPlatform::Ornithe);
-        ui->rift->setChecked(loaders & ModPlatform::Rift);
+        m_ui->neoForge->setChecked(loaders.testAnyFlag(ModPlatform::NeoForge));
+        m_ui->forge->setChecked(loaders.testAnyFlag(ModPlatform::Forge));
+        m_ui->fabric->setChecked(loaders.testAnyFlag(ModPlatform::Fabric));
+        m_ui->quilt->setChecked(loaders.testAnyFlag(ModPlatform::Quilt));
+        m_ui->liteLoader->setChecked(loaders.testAnyFlag(ModPlatform::LiteLoader));
+        m_ui->babric->setChecked(loaders.testAnyFlag(ModPlatform::Babric));
+        m_ui->btaBabric->setChecked(loaders.testAnyFlag(ModPlatform::BTA));
+        m_ui->legacyFabric->setChecked(loaders.testAnyFlag(ModPlatform::LegacyFabric));
+        m_ui->ornithe->setChecked(loaders.testAnyFlag(ModPlatform::Ornithe));
+        m_ui->rift->setChecked(loaders.testAnyFlag(ModPlatform::Rift));
         m_filter->loaders = loaders;
         auto def = m_instance->getPackProfile()->getComponentVersion("net.minecraft");
         m_filter->versions.emplace_back(def);
-        ui->versions->setCheckedItems({ def });
-        ui->version->setCurrentIndex(ui->version->findText(def));
+        m_ui->versions->setCheckedItems({ def });
+        m_ui->version->setCurrentIndex(m_ui->version->findText(def));
     } else {
-        ui->hideInstalled->hide();
+        m_ui->hideInstalled->hide();
     }
 }
 
 void ModFilterWidget::onShowAllVersionsChanged()
 {
-    if (ui->showAllVersions->isChecked())
-        m_versions_proxy->clearFilters();
-    else
-        m_versions_proxy->setFilter(BaseVersionList::TypeRole, Filters::equals("release"));
+    if (m_ui->showAllVersions->isChecked()) {
+        m_versionsProxy->clearFilters();
+    } else {
+        m_versionsProxy->setFilter(BaseVersionList::TypeRole, Filters::equals("release"));
+    }
 }
 
-void ModFilterWidget::onVersionFilterChanged(int)
+void ModFilterWidget::onVersionFilterChanged(int /*unused*/)
 {
-    auto versions = ui->versions->checkedItems();
+    auto versions = m_ui->versions->checkedItems();
     versions.sort();
-    std::vector<Version> current_list;
+    std::vector<Version> currentList;
 
-    for (const QString& version : versions)
-        current_list.emplace_back(version);
+    for (const auto& version : versions) {
+        currentList.emplace_back(version);
+    }
 
-    m_filter_changed = m_filter->versions.size() != current_list.size() ||
-                       !std::equal(m_filter->versions.begin(), m_filter->versions.end(), current_list.begin(), current_list.end());
-    m_filter->versions = current_list;
-    if (m_filter_changed)
+    m_filterChanged = m_filter->versions.size() != currentList.size() ||
+                      !std::equal(m_filter->versions.begin(), m_filter->versions.end(), currentList.begin(), currentList.end());
+    m_filter->versions = currentList;
+    if (m_filterChanged) {
         emit filterChanged();
+    }
 }
 
 void ModFilterWidget::onLoadersFilterChanged()
 {
     ModPlatform::ModLoaderTypes loaders;
-    if (ui->neoForge->isChecked())
+    if (m_ui->neoForge->isChecked()) {
         loaders |= ModPlatform::NeoForge;
-    if (ui->forge->isChecked())
+    }
+    if (m_ui->forge->isChecked()) {
         loaders |= ModPlatform::Forge;
-    if (ui->fabric->isChecked())
+    }
+    if (m_ui->fabric->isChecked()) {
         loaders |= ModPlatform::Fabric;
-    if (ui->quilt->isChecked())
+    }
+    if (m_ui->quilt->isChecked()) {
         loaders |= ModPlatform::Quilt;
-    if (ui->liteLoader->isChecked())
+    }
+    if (m_ui->liteLoader->isChecked()) {
         loaders |= ModPlatform::LiteLoader;
-    if (ui->babric->isChecked())
+    }
+    if (m_ui->babric->isChecked()) {
         loaders |= ModPlatform::Babric;
-    if (ui->btaBabric->isChecked())
+    }
+    if (m_ui->btaBabric->isChecked()) {
         loaders |= ModPlatform::BTA;
-    if (ui->legacyFabric->isChecked())
+    }
+    if (m_ui->legacyFabric->isChecked()) {
         loaders |= ModPlatform::LegacyFabric;
-    if (ui->ornithe->isChecked())
+    }
+    if (m_ui->ornithe->isChecked()) {
         loaders |= ModPlatform::Ornithe;
-    if (ui->rift->isChecked())
+    }
+    if (m_ui->rift->isChecked()) {
         loaders |= ModPlatform::Rift;
-    m_filter_changed = loaders != m_filter->loaders;
+    }
+    m_filterChanged = loaders != m_filter->loaders;
     m_filter->loaders = loaders;
-    if (m_filter_changed)
+    if (m_filterChanged) {
         emit filterChanged();
+    }
 }
 
 void ModFilterWidget::onSideFilterChanged()
 {
     ModPlatform::SideType side;
 
-    if (ui->clientSide->isChecked() && !ui->serverSide->isChecked()) {
+    if (m_ui->clientSide->isChecked() && !m_ui->serverSide->isChecked()) {
         side = ModPlatform::SideType::ClientSide;
-    } else if (!ui->clientSide->isChecked() && ui->serverSide->isChecked()) {
+    } else if (!m_ui->clientSide->isChecked() && m_ui->serverSide->isChecked()) {
         side = ModPlatform::SideType::ServerSide;
-    } else if (ui->clientSide->isChecked() && ui->serverSide->isChecked()) {
+    } else if (m_ui->clientSide->isChecked() && m_ui->serverSide->isChecked()) {
         side = ModPlatform::SideType::UniversalSide;
     } else {
         side = ModPlatform::SideType::NoSide;
     }
 
-    m_filter_changed = side != m_filter->side;
+    m_filterChanged = side != m_filter->side;
     m_filter->side = side;
-    if (m_filter_changed)
+    if (m_filterChanged) {
         emit filterChanged();
+    }
 }
 
 void ModFilterWidget::onHideInstalledFilterChanged()
 {
-    auto hide = ui->hideInstalled->isChecked();
-    m_filter_changed = hide != m_filter->hideInstalled;
+    auto hide = m_ui->hideInstalled->isChecked();
+    m_filterChanged = hide != m_filter->hideInstalled;
     m_filter->hideInstalled = hide;
-    if (m_filter_changed)
+    if (m_filterChanged) {
         emit filterChanged();
+    }
 }
 
 void ModFilterWidget::onVersionFilterTextChanged(const QString& version)
 {
     m_filter->versions.clear();
-    if (ui->version->currentData(Qt::UserRole) != "all") {
+    if (m_ui->version->currentData(Qt::UserRole) != "all") {
         m_filter->versions.emplace_back(version);
     }
-    m_filter_changed = true;
+    m_filterChanged = true;
     emit filterChanged();
 }
 
@@ -366,14 +388,14 @@ void ModFilterWidget::setCategories(const QList<ModPlatform::Category>& categori
 {
     m_categories = categories;
 
-    delete ui->categoryGroup->layout();
-    auto layout = new QVBoxLayout(ui->categoryGroup);
+    delete m_ui->categoryGroup->layout();
+    auto* layout = new QVBoxLayout(m_ui->categoryGroup);
 
     for (const auto& category : categories) {
         auto name = category.name;
         name.replace("-", " ");
         name.replace("&", "&&");
-        auto checkbox = new QCheckBox(name);
+        auto* checkbox = new QCheckBox(name);
         auto font = checkbox->font();
         font.setCapitalization(QFont::Capitalize);
         checkbox->setFont(font);
@@ -382,12 +404,13 @@ void ModFilterWidget::setCategories(const QList<ModPlatform::Category>& categori
 
         const QString id = category.id;
         connect(checkbox, &QCheckBox::toggled, this, [this, id](bool checked) {
-            if (checked)
+            if (checked) {
                 m_filter->categoryIds.append(id);
-            else
+            } else {
                 m_filter->categoryIds.removeOne(id);
+            }
 
-            m_filter_changed = true;
+            m_filterChanged = true;
             emit filterChanged();
         });
     }
@@ -395,28 +418,34 @@ void ModFilterWidget::setCategories(const QList<ModPlatform::Category>& categori
 
 void ModFilterWidget::onOpenSourceFilterChanged()
 {
-    auto open = ui->openSource->isChecked();
-    m_filter_changed = open != m_filter->openSource;
+    auto open = m_ui->openSource->isChecked();
+    m_filterChanged = open != m_filter->openSource;
     m_filter->openSource = open;
-    if (m_filter_changed)
+    if (m_filterChanged) {
         emit filterChanged();
+    }
 }
 
 void ModFilterWidget::onReleaseFilterChanged()
 {
     std::vector<ModPlatform::IndexedVersionType> releases;
-    if (ui->releaseCb->isChecked())
-        releases.push_back(ModPlatform::IndexedVersionType::Release);
-    if (ui->betaCb->isChecked())
-        releases.push_back(ModPlatform::IndexedVersionType::Beta);
-    if (ui->alphaCb->isChecked())
-        releases.push_back(ModPlatform::IndexedVersionType::Alpha);
-    if (ui->unknownCb->isChecked())
-        releases.push_back(ModPlatform::IndexedVersionType::Unknown);
-    m_filter_changed = releases != m_filter->releases;
+    if (m_ui->releaseCb->isChecked()) {
+        releases.emplace_back(ModPlatform::IndexedVersionType::Release);
+    }
+    if (m_ui->betaCb->isChecked()) {
+        releases.emplace_back(ModPlatform::IndexedVersionType::Beta);
+    }
+    if (m_ui->alphaCb->isChecked()) {
+        releases.emplace_back(ModPlatform::IndexedVersionType::Alpha);
+    }
+    if (m_ui->unknownCb->isChecked()) {
+        releases.emplace_back(ModPlatform::IndexedVersionType::Unknown);
+    }
+    m_filterChanged = releases != m_filter->releases;
     m_filter->releases = releases;
-    if (m_filter_changed)
+    if (m_filterChanged) {
         emit filterChanged();
+    }
 }
 
 void ModFilterWidget::onDisclosureFilterChanged()
@@ -429,33 +458,33 @@ void ModFilterWidget::onDisclosureFilterChanged()
         }
     };
 
-    collect(ui->aiContent, ModPlatform::DisclosureType::AIContent);
-    collect(ui->aiContentCode, ModPlatform::DisclosureType::AIContentCode);
-    collect(ui->aiContentAssets, ModPlatform::DisclosureType::AIContentAssets);
-    collect(ui->aiContentText, ModPlatform::DisclosureType::AIContentText);
-    collect(ui->aiContentFunctionality, ModPlatform::DisclosureType::AIContentFunctionality);
-    collect(ui->advertisements, ModPlatform::DisclosureType::Advertisements);
-    collect(ui->epilepsyTriggers, ModPlatform::DisclosureType::EpilepsyTriggers);
-    collect(ui->systemInteractions, ModPlatform::DisclosureType::SystemInteractions);
-    collect(ui->telemetry, ModPlatform::DisclosureType::Telemetry);
-    collect(ui->telemetryOptIn, ModPlatform::DisclosureType::TelemetryOptIn);
-    collect(ui->telemetryOptOut, ModPlatform::DisclosureType::TelemetryOptOut);
-    collect(ui->telemetryAlwaysActive, ModPlatform::DisclosureType::TelemetryAlwaysActive);
-    collect(ui->derivativeWork, ModPlatform::DisclosureType::DerivativeWork);
-    collect(ui->paidFeatures, ModPlatform::DisclosureType::PaidFeatures);
-    collect(ui->archived, ModPlatform::DisclosureType::Archived);
+    collect(m_ui->aiContent, ModPlatform::DisclosureType::AIContent);
+    collect(m_ui->aiContentCode, ModPlatform::DisclosureType::AIContentCode);
+    collect(m_ui->aiContentAssets, ModPlatform::DisclosureType::AIContentAssets);
+    collect(m_ui->aiContentText, ModPlatform::DisclosureType::AIContentText);
+    collect(m_ui->aiContentFunctionality, ModPlatform::DisclosureType::AIContentFunctionality);
+    collect(m_ui->advertisements, ModPlatform::DisclosureType::Advertisements);
+    collect(m_ui->epilepsyTriggers, ModPlatform::DisclosureType::EpilepsyTriggers);
+    collect(m_ui->systemInteractions, ModPlatform::DisclosureType::SystemInteractions);
+    collect(m_ui->telemetry, ModPlatform::DisclosureType::Telemetry);
+    collect(m_ui->telemetryOptIn, ModPlatform::DisclosureType::TelemetryOptIn);
+    collect(m_ui->telemetryOptOut, ModPlatform::DisclosureType::TelemetryOptOut);
+    collect(m_ui->telemetryAlwaysActive, ModPlatform::DisclosureType::TelemetryAlwaysActive);
+    collect(m_ui->derivativeWork, ModPlatform::DisclosureType::DerivativeWork);
+    collect(m_ui->paidFeatures, ModPlatform::DisclosureType::PaidFeatures);
+    collect(m_ui->archived, ModPlatform::DisclosureType::Archived);
 
-    m_filter_changed = exclude != m_filter->excludeDisclosureTypes;
+    m_filterChanged = exclude != m_filter->excludeDisclosureTypes;
     m_filter->excludeDisclosureTypes = exclude;
-    if (m_filter_changed) {
+    if (m_filterChanged) {
         emit filterChanged();
     }
 }
 
 void ModFilterWidget::onShowMoreClicked()
 {
-    ui->extendedModLoadersWidget->setVisible(true);
-    ui->showMoreButton->setVisible(false);
+    m_ui->extendedModLoadersWidget->setVisible(true);
+    m_ui->showMoreButton->setVisible(false);
 }
 
 #include "ModFilterWidget.moc"

--- a/launcher/ui/widgets/ModFilterWidget.h
+++ b/launcher/ui/widgets/ModFilterWidget.h
@@ -39,6 +39,7 @@
 #include <QList>
 #include <QListWidgetItem>
 #include <QTabWidget>
+#include <algorithm>
 
 #include "Version.h"
 
@@ -75,29 +76,31 @@ class ModFilterWidget : public QTabWidget {
         }
         bool operator!=(const Filter& other) const { return !(*this == other); }
 
-        bool checkMcVersions(QStringList value)
+        bool checkMcVersions(const QStringList& value)
         {
-            for (auto mcVersion : versions)
-                if (value.contains(mcVersion.toString()))
+            for (const auto& mcVersion : versions) {
+                if (value.contains(mcVersion.toString())) {
                     return true;
+                }
+            }
 
             return versions.empty();
         }
 
         bool checkModpackFilters(const ModPlatform::IndexedVersion& v)
         {
-            return ((!loaders || !v.loaders || loaders & v.loaders) &&  // loaders
-                    (releases.empty() ||                                // releases
-                     std::find(releases.cbegin(), releases.cend(), v.versionType) != releases.cend()) &&
+            return ((!loaders || !v.loaders || loaders.testAnyFlags(v.loaders)) &&  // loaders
+                    (releases.empty() ||                                            // releases
+                     std::ranges::find(releases, v.versionType) != releases.cend()) &&
                     checkMcVersions({ v.mcVersion }));  // gameVersion}
         }
     };
 
     static ModFilterWidget* create(MinecraftInstance* instance, bool extended);
-    virtual ~ModFilterWidget();
+    ~ModFilterWidget() override;
 
     auto getFilter() -> std::shared_ptr<Filter>;
-    auto changed() const -> bool { return m_filter_changed; }
+    auto changed() const -> bool { return m_filterChanged; }
 
    signals:
     void filterChanged();
@@ -124,14 +127,14 @@ class ModFilterWidget : public QTabWidget {
     void onDisclosureFilterChanged();
 
    private:
-    Ui::ModFilterWidget* ui;
+    Ui::ModFilterWidget* m_ui;
 
     MinecraftInstance* m_instance = nullptr;
     std::shared_ptr<Filter> m_filter;
-    bool m_filter_changed = false;
+    bool m_filterChanged = false;
 
-    Meta::VersionList::Ptr m_version_list;
-    VersionProxyModel* m_versions_proxy = nullptr;
+    Meta::VersionList::Ptr m_versionList;
+    VersionProxyModel* m_versionsProxy = nullptr;
 
     QList<ModPlatform::Category> m_categories;
 };

--- a/launcher/ui/widgets/ModFilterWidget.h
+++ b/launcher/ui/widgets/ModFilterWidget.h
@@ -65,11 +65,13 @@ class ModFilterWidget : public QTabWidget {
         bool hideInstalled;
         QStringList categoryIds;
         bool openSource;
+        std::vector<ModPlatform::DisclosureType> excludeDisclosureTypes;
 
         bool operator==(const Filter& other) const
         {
             return hideInstalled == other.hideInstalled && side == other.side && loaders == other.loaders && versions == other.versions &&
-                   releases == other.releases && categoryIds == other.categoryIds && openSource == other.openSource;
+                   releases == other.releases && categoryIds == other.categoryIds && openSource == other.openSource &&
+                   excludeDisclosureTypes == other.excludeDisclosureTypes;
         }
         bool operator!=(const Filter& other) const { return !(*this == other); }
 
@@ -119,6 +121,7 @@ class ModFilterWidget : public QTabWidget {
     void onOpenSourceFilterChanged();
     void onReleaseFilterChanged();
     void onShowMoreClicked();
+    void onDisclosureFilterChanged();
 
    private:
     Ui::ModFilterWidget* ui;

--- a/launcher/ui/widgets/ModFilterWidget.ui
+++ b/launcher/ui/widgets/ModFilterWidget.ui
@@ -53,7 +53,7 @@
       </size>
      </property>
      <property name="sizeAdjustPolicy">
-      <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
+      <enum>QAbstractScrollArea::SizeAdjustPolicy::AdjustToContentsOnFirstShow</enum>
      </property>
      <property name="widgetResizable">
       <bool>true</bool>
@@ -62,9 +62,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>0</y>
+        <y>-636</y>
         <width>294</width>
-        <height>817</height>
+        <height>1234</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -303,9 +303,123 @@
         </widget>
        </item>
        <item>
+        <widget class="QGroupBox" name="disclosureGroup">
+         <property name="title">
+          <string>Advanced exclusions</string>
+         </property>
+         <layout class="QVBoxLayout" name="disclosureLayout">
+          <item>
+           <widget class="QCheckBox" name="aiContent">
+            <property name="text">
+             <string>AI content</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="aiContentCode">
+            <property name="text">
+             <string>AI content (code)</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="aiContentAssets">
+            <property name="text">
+             <string>AI content (assets)</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="aiContentText">
+            <property name="text">
+             <string>AI content (text)</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="aiContentFunctionality">
+            <property name="text">
+             <string>AI content (functionality)</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="advertisements">
+            <property name="text">
+             <string>Advertisements</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="epilepsyTriggers">
+            <property name="text">
+             <string>Epilepsy triggers</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="systemInteractions">
+            <property name="text">
+             <string>System interactions</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="telemetry">
+            <property name="text">
+             <string>Telemetry</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="telemetryOptIn">
+            <property name="text">
+             <string>Telemetry (opt-in)</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="telemetryOptOut">
+            <property name="text">
+             <string>Telemetry (opt-out)</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="telemetryAlwaysActive">
+            <property name="text">
+             <string>Telemetry (always active)</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="derivativeWork">
+            <property name="text">
+             <string>Derivative work</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="paidFeatures">
+            <property name="text">
+             <string>Paid features</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="archived">
+            <property name="text">
+             <string>Archived</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <spacer name="verticalSpacer">
          <property name="orientation">
-          <enum>Qt::Vertical</enum>
+          <enum>Qt::Orientation::Vertical</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>


### PR DESCRIPTION
https://discord.com/channels/1031648380885147709/1031823065937629267/1546312755034853457
also removed deprecated client/server facets in favor of env(hope I mapped that correctly)
the filter should apply for now only on mods and modpacks as the filterwidget is only available there.
I will say the tristate may be a bit weird for this but just to make sure it is all taken into consideration:
- off: no facet
- partial: we check if the facet is not present
- on: we check if the facet is present