### PR TITLE
fix: only pass the demo applet parameter when launching the demo

### DIFF
--- a/libraries/launcher/legacy/org/prismlauncher/legacy/LegacyFrame.java
+++ b/libraries/launcher/legacy/org/prismlauncher/legacy/LegacyFrame.java
@@ -132,8 +132,12 @@ final class LegacyFrame extends JFrame {
         launcher.setParameter("sessionid", session);
         launcher.setParameter("stand-alone", true); // Show the quit button. This often doesn't seem to work.
         launcher.setParameter("haspaid", true); // Some old versions need this for world saves to work.
-        launcher.setParameter("demo", demo);
         launcher.setParameter("fullscreen", false);
+
+        // The first versions with demo support (12w16a to 12w18a) enable it whenever this parameter is present,
+        // ignoring its value, so it must be left unset entirely for a normal launch.
+        if (demo)
+            launcher.setParameter("demo", true);
 
         add(launcher);
 


### PR DESCRIPTION
Fixes #759
Fixes #4223

## Problem

12w16a to 12w18a, the first versions with demo support, always run in demo mode, even on accounts that own the game.

Their applet checks only whether the `demo` parameter is present, not what it is set to. From `MinecraftApplet.init()` in the 12w17a client:

```
267: getParameter("demo")
273: ifnull  284         // only skipped when the parameter is absent
280: iconst_1
281: Minecraft.a(Z)      // setDemo(true)
```

`LegacyFrame.start` always called `launcher.setParameter("demo", demo)`. The boolean overload stores the literal string `"false"`, which `Launcher.getParameter` then returns as non-null, so a normal launch of those versions was read as a demo launch.

1.2.5 and older never read a `demo` parameter, and later versions compare its value, which is why only this window of snapshots is affected.

## Change

Set the parameter only when the demo was actually requested. An absent parameter means "not a demo" in every version that reads it, so no other version changes behaviour, and deliberate demo launches still pass it.
