### PR TITLE
fix(modrinth): detect datapacks from project_type and loaders

### DIFF
--- a/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
@@ -23,6 +23,7 @@
 
 #include "Json.h"
 #include "modplatform/ModIndex.h"
+#include "modplatform/ResourceType.h"
 
 namespace {
 bool shouldDownloadOnSide(const QString& side)
@@ -42,6 +43,10 @@ void Modrinth::loadIndexedPack(ModPlatform::IndexedPack& pack, QJsonObject& obj)
     pack.provider = ModPlatform::ResourceProvider::MODRINTH;
     pack.name = Json::requireString(obj, "title");
     pack.resourceType = ModrinthAPI::getResourceType(obj["project_type"].toString());
+    if ((obj.contains("loaders") && obj.value("loaders").toArray({}).contains("datapack")) ||
+        (obj.contains("all_project_types") && obj.value("all_project_types").toArray({}).contains("datapack"))) {
+        pack.resourceType = ModPlatform::ResourceType::DataPack;
+    }
 
     pack.slug = obj["slug"].toString("");
     if (!pack.slug.isEmpty()) {

--- a/launcher/ui/dialogs/ResourceDownloadDialog.cpp
+++ b/launcher/ui/dialogs/ResourceDownloadDialog.cpp
@@ -256,26 +256,30 @@ void ResourceDownloadDialog::addResource(const ModPlatform::IndexedPack::Ptr& pa
     auto* model = getBaseModel();
     auto* instance = dynamic_cast<MinecraftInstance*>(m_instance);
     if (instance) {
+        ResourceFolderModel* targetModel = nullptr;
         switch (pack->resourceType) {
             case ModPlatform::ResourceType::Mod:
-                model = instance->loaderModList();
+                targetModel = instance->loaderModList();
                 break;
             case ModPlatform::ResourceType::ResourcePack:
-                model = instance->resourcePackList();
+                targetModel = instance->resourcePackList();
                 break;
             case ModPlatform::ResourceType::ShaderPack:
-                model = instance->shaderPackList();
+                targetModel = instance->shaderPackList();
                 break;
             case ModPlatform::ResourceType::DataPack:
-                model = instance->dataPackList();
+                targetModel = instance->dataPackList();
                 break;
                 // case ModPlatform::ResourceType::World:
-                // model = instance->worldList();
+                // targetModel = instance->worldList();
             case ModPlatform::ResourceType::TexturePack:
-                model = instance->texturePackList();
+                targetModel = instance->texturePackList();
                 break;
             default:
                 break;
+        }
+        if (targetModel != nullptr && targetModel->id() != model->id()) {
+            model = targetModel;
         }
     }
     selectedPage()->addResourceToPage(pack, ver, model, std::move(downloadReason), std::move(dependentOn));
@@ -371,7 +375,7 @@ ResourceDownloadDialog* ResourceDownloadDialog::createMod(QWidget* parent,
     QList<BasePage*> pages;
 
     // need to load all resources for dependency task
-    auto* mInstance = dynamic_cast<MinecraftInstance*>(instance);
+    auto* mInstance = instance;
     if (mInstance) {
         for (auto* model : mInstance->resourceLists()) {
             if (model) {


### PR DESCRIPTION
fixes 2 things:
- first the Modrinth datapack detection( the resourceType is mod and has loaders or for search all_project_types as a list and inside there is "datapack" as a string)
- fix installing the datapack in world (before all  the packs were downloaded globally)

this affects only nightly