### PR TITLE
fix: filter resource pack, shader pack versions by instance MC version

### DIFF
--- a/launcher/ui/pages/modplatform/ResourcePackModel.cpp
+++ b/launcher/ui/pages/modplatform/ResourcePackModel.cpp
@@ -7,6 +7,9 @@
 #include <QMessageBox>
 #include <utility>
 
+#include "minecraft/MinecraftInstance.h"
+#include "minecraft/PackProfile.h"
+
 namespace ResourceDownload {
 
 ResourcePackResourceModel::ResourcePackResourceModel(const BaseInstance& base_inst,
@@ -37,13 +40,33 @@ ResourceAPI::SearchArgs ResourcePackResourceModel::createSearchArguments()
 ResourceAPI::VersionSearchArgs ResourcePackResourceModel::createVersionsArguments(const QModelIndex& entry)
 {
     auto pack = m_packs[entry.row()];
-    return { .pack = pack, .mcVersions = {}, .loaders = {}, .resourceType = ModPlatform::ResourceType::ResourcePack };
+
+    std::optional<std::vector<Version>> versions{};
+    auto* profile = static_cast<const MinecraftInstance&>(m_base_instance).getPackProfile();
+    if (auto mcVersion = profile->getComponentVersion("net.minecraft"); !mcVersion.isEmpty()) {
+        versions = std::vector<Version>{ Version(mcVersion) };
+    }
+
+    return { .pack = pack, .mcVersions = versions, .loaders = {}, .resourceType = ModPlatform::ResourceType::ResourcePack };
 }
 
 ResourceAPI::ProjectInfoArgs ResourcePackResourceModel::createInfoArguments(const QModelIndex& entry)
 {
     auto pack = m_packs[entry.row()];
     return { .pack = pack };
+}
+
+bool ResourcePackResourceModel::checkVersionFilters(const ModPlatform::IndexedVersion& v)
+{
+    if (optedOut(v)) {
+        return false;
+    }
+
+    auto* profile = static_cast<const MinecraftInstance&>(m_base_instance).getPackProfile();
+    auto mcVersion = profile->getComponentVersion("net.minecraft");
+
+    // Fall back to accepting the version if either side has no version info to compare against.
+    return mcVersion.isEmpty() || v.mcVersion.isEmpty() || v.mcVersion.contains(mcVersion);
 }
 
 void ResourcePackResourceModel::searchWithTerm(const QString& term, unsigned int sort)

--- a/launcher/ui/pages/modplatform/ResourcePackModel.h
+++ b/launcher/ui/pages/modplatform/ResourcePackModel.h
@@ -32,6 +32,9 @@ class ResourcePackResourceModel : public ResourceModel {
     ResourceAPI::ProjectInfoArgs createInfoArguments(const QModelIndex&) override;
 
    protected:
+    bool checkVersionFilters(const ModPlatform::IndexedVersion&) override;
+
+   protected:
     const BaseInstance& m_base_instance;
 
    private:

--- a/launcher/ui/pages/modplatform/ShaderPackModel.cpp
+++ b/launcher/ui/pages/modplatform/ShaderPackModel.cpp
@@ -7,6 +7,9 @@
 #include <QMessageBox>
 #include <utility>
 
+#include "minecraft/MinecraftInstance.h"
+#include "minecraft/PackProfile.h"
+
 namespace ResourceDownload {
 
 ShaderPackResourceModel::ShaderPackResourceModel(const BaseInstance& baseInst,
@@ -37,13 +40,33 @@ ResourceAPI::SearchArgs ShaderPackResourceModel::createSearchArguments()
 ResourceAPI::VersionSearchArgs ShaderPackResourceModel::createVersionsArguments(const QModelIndex& entry)
 {
     auto pack = m_packs[entry.row()];
-    return { .pack = pack, .mcVersions = {}, .loaders = {}, .resourceType = ModPlatform::ResourceType::ShaderPack };
+
+    std::optional<std::vector<Version>> versions{};
+    auto* profile = static_cast<const MinecraftInstance&>(m_baseInstance).getPackProfile();
+    if (auto mcVersion = profile->getComponentVersion("net.minecraft"); !mcVersion.isEmpty()) {
+        versions = std::vector<Version>{ Version(mcVersion) };
+    }
+
+    return { .pack = pack, .mcVersions = versions, .loaders = {}, .resourceType = ModPlatform::ResourceType::ShaderPack };
 }
 
 ResourceAPI::ProjectInfoArgs ShaderPackResourceModel::createInfoArguments(const QModelIndex& entry)
 {
     auto pack = m_packs[entry.row()];
     return { .pack = pack };
+}
+
+bool ShaderPackResourceModel::checkVersionFilters(const ModPlatform::IndexedVersion& v)
+{
+    if (optedOut(v)) {
+        return false;
+    }
+
+    auto* profile = static_cast<const MinecraftInstance&>(m_baseInstance).getPackProfile();
+    auto mcVersion = profile->getComponentVersion("net.minecraft");
+
+    // Fall back to accepting the version if either side has no version info to compare against.
+    return mcVersion.isEmpty() || v.mcVersion.isEmpty() || v.mcVersion.contains(mcVersion);
 }
 
 void ShaderPackResourceModel::searchWithTerm(const QString& term, unsigned int sort)

--- a/launcher/ui/pages/modplatform/ShaderPackModel.h
+++ b/launcher/ui/pages/modplatform/ShaderPackModel.h
@@ -32,6 +32,9 @@ class ShaderPackResourceModel : public ResourceModel {
     ResourceAPI::ProjectInfoArgs createInfoArguments(const QModelIndex&) override;
 
    protected:
+    bool checkVersionFilters(const ModPlatform::IndexedVersion&) override;
+
+   protected:
     const BaseInstance& m_baseInstance;
 
    private:

--- a/launcher/ui/pages/modplatform/TexturePackModel.h
+++ b/launcher/ui/pages/modplatform/TexturePackModel.h
@@ -21,6 +21,12 @@ class TexturePackResourceModel : public ResourcePackResourceModel {
     ResourceAPI::VersionSearchArgs createVersionsArguments(const QModelIndex&) override;
 
    protected:
+    // Texture packs (pre-1.6) are matched by pack-format compatibility rather than an exact
+    // Minecraft version, which is already handled by restricting the searched/requested
+    // versions to s_availableVersions above, so fall back to the base (opt-out only) check here.
+    bool checkVersionFilters(const ModPlatform::IndexedVersion& v) override { return ResourceModel::checkVersionFilters(v); }
+
+   protected:
     Meta::VersionList::Ptr m_version_list;
     Task::Ptr m_task;
 };


### PR DESCRIPTION
## Summary
Resource pack and shader pack downloads were picking whichever version
the API returned first (usually just the newest upload), ignoring the
instance's Minecraft version. Mods already filtered by MC version
correctly — resource/shader packs never had that logic wired in.

This adds the same MC-version filtering that mods already use, so the
version picked matches the instance.

## Test plan
- Built and ran the launcher locally
- Confirmed downloading a resource pack from Modrinth on an older
  instance now picks a version matching that instance's MC version,
  instead of always the latest
