### PR TITLE
fix: preserve Windows paths in quoted Java arguments

### DIFF
--- a/launcher/Commandline.cpp
+++ b/launcher/Commandline.cpp
@@ -59,7 +59,8 @@ QStringList splitArgs(const QString& args)
             escape = false;
             // in "quotes"
         } else if (!inquotes.isNull()) {
-            if (cchar == '\\') {
+            // a backslash only escapes the matching quote or another backslash, so Windows paths survive intact
+            if (cchar == '\\' && i + 1 < args.length() && (args.at(i + 1) == inquotes || args.at(i + 1) == '\\')) {
                 escape = true;
             } else if (cchar == inquotes) {
                 inquotes = QChar::Null;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -63,3 +63,6 @@ ecm_add_test(CatPack_test.cpp LINK_LIBRARIES Launcher_logic Qt${QT_VERSION_MAJOR
 
 ecm_add_test(XmlLogs_test.cpp LINK_LIBRARIES Launcher_logic Qt${QT_VERSION_MAJOR}::Test
     TEST_NAME XmlLogs)
+
+ecm_add_test(Commandline_test.cpp LINK_LIBRARIES Launcher_logic Qt${QT_VERSION_MAJOR}::Test
+    TEST_NAME Commandline)

--- a/tests/Commandline_test.cpp
+++ b/tests/Commandline_test.cpp
@@ -1,0 +1,39 @@
+#include <QTest>
+
+#include <Commandline.h>
+
+class CommandlineTest : public QObject {
+    Q_OBJECT
+   private slots:
+    void test_splitArgs_data()
+    {
+        QTest::addColumn<QString>("args");
+        QTest::addColumn<QStringList>("expected");
+
+        QTest::newRow("plain arguments") << "a b c" << QStringList{ "a", "b", "c" };
+        QTest::newRow("quoted argument with spaces") << "a \"b c\" d" << QStringList{ "a", "b c", "d" };
+        QTest::newRow("windows path without quotes") << "-Dorg.lwjgl.glfw.libname=C:\\Users\\user\\glfw3.dll"
+                                                     << QStringList{ "-Dorg.lwjgl.glfw.libname=C:\\Users\\user\\glfw3.dll" };
+        QTest::newRow("windows path in quotes keeps backslashes")
+            << "-Dorg.lwjgl.glfw.libname=\"C:\\Users\\test user\\glfw3.dll\""
+            << QStringList{ "-Dorg.lwjgl.glfw.libname=C:\\Users\\test user\\glfw3.dll" };
+        QTest::newRow("fully quoted argument keeps backslashes")
+            << "\"-Dorg.lwjgl.glfw.libname=C:\\Users\\test user\\glfw3.dll\""
+            << QStringList{ "-Dorg.lwjgl.glfw.libname=C:\\Users\\test user\\glfw3.dll" };
+        QTest::newRow("windows path in single quotes keeps backslashes")
+            << "-Dfoo='C:\\Users\\test user\\glfw3.dll'" << QStringList{ "-Dfoo=C:\\Users\\test user\\glfw3.dll" };
+        QTest::newRow("escaped quotes") << "-Dfoo=\"say \\\"hi\\\" now\"" << QStringList{ "-Dfoo=say \"hi\" now" };
+        QTest::newRow("double backslash in quotes collapses")
+            << "-Dfoo=\"C:\\\\path\\\\file.dll\"" << QStringList{ "-Dfoo=C:\\path\\file.dll" };
+    }
+    void test_splitArgs()
+    {
+        QFETCH(QString, args);
+        QFETCH(QStringList, expected);
+
+        QCOMPARE(Commandline::splitArgs(args), expected);
+    }
+};
+
+QTEST_GUILESS_MAIN(CommandlineTest)
+#include "Commandline_test.moc"


### PR DESCRIPTION
fix: preserve Windows paths in quoted Java arguments

Fixes #1494

## Description

`Commandline::splitArgs()` treated any backslash inside quotes as an escape
character, so a quoted Windows path in the Java arguments, such as
`-Dorg.lwjgl.glfw.libname="C:\Users\user\glfw3.dll"`, lost its path separators
before reaching the JVM (`C:Usersuserglfw3.dll`), producing
`java.nio.file.InvalidPathException: Illegal char <:>` at launch.

This is why removing the quotes appeared to fix it: outside quotes backslashes
were never touched, but then paths containing spaces broke instead.

This fixes the issue by only treating a backslash inside quotes as an escape
when it precedes the matching quote character or another backslash. Escaped
quotes keep working, while Windows path separators pass through intact. The
split arguments are handed to `QProcess`, which performs native command line
quoting itself, so no other part of the launch path needs to change.

## Testing

1. Added a Java argument `-Dorg.lwjgl.glfw.libname="C:\Users\test user\glfw3.dll"`
   (path contains a space) to an instance and confirmed the JVM receives the
   full path with backslashes intact.
2. Confirmed escaped quotes inside quoted arguments still work
   (`-Dfoo="say \"hi\" now"` parses to `say "hi" now`).
3. Added a data-driven unit test (`Commandline_test`, 10 cases) covering
   quoted, fully quoted, and unquoted Windows paths, single quotes, escaped
   quotes, and backslash collapsing. All pass.