### PR TITLE
 feat(packwiz): track provider-less resources

### DIFF
--- a/launcher/minecraft/mod/Resource.cpp
+++ b/launcher/minecraft/mod/Resource.cpp
@@ -99,7 +99,7 @@ void removeThePrefix(QString& string)
 auto Resource::provider() const -> QString
 {
     if (metadata()) {
-        return ModPlatform::ProviderCapabilities::readableName(metadata()->provider);
+        return metadata()->provider.readableName();
     }
 
     return QObject::tr("Unknown");
@@ -108,7 +108,7 @@ auto Resource::provider() const -> QString
 auto Resource::homepage() const -> QString
 {
     if (metadata()) {
-        return ModPlatform::getMetaURL(metadata()->provider, metadata()->project_id);
+        return metadata()->provider.getMetaURL(metadata()->project_id);
     }
 
     return {};

--- a/launcher/minecraft/mod/tasks/ResourceFolderLoadTask.cpp
+++ b/launcher/minecraft/mod/tasks/ResourceFolderLoadTask.cpp
@@ -92,6 +92,7 @@ void ResourceFolderLoadTask::executeTask()
             } else {
                 m_result->resources[resource->internalId()].reset(resource);
                 m_result->resources[resource->internalId()]->setStatus(ResourceStatus::NoMetadata);
+                createNoProviderMetadata(resource);
             }
         } else {
             QString choppedId = resource->internalId().chopped(9);
@@ -108,6 +109,7 @@ void ResourceFolderLoadTask::executeTask()
             } else {
                 m_result->resources[resource->internalId()].reset(resource);
                 m_result->resources[resource->internalId()]->setStatus(ResourceStatus::NoMetadata);
+                createNoProviderMetadata(resource);
             }
         }
     }
@@ -151,4 +153,21 @@ void ResourceFolderLoadTask::getFromMetadata()
         resource->setStatus(ResourceStatus::NotInstalled);
         m_result->resources[resource->internalId()].reset(resource);
     }
+}
+
+bool ResourceFolderLoadTask::createNoProviderMetadata(Resource* resource)
+{
+    if (!m_is_indexed) {
+        return false;
+    }
+
+    if (resource->type() == ResourceType::FOLDER || resource->type() == ResourceType::UNKNOWN) {
+        return false;
+    }
+
+    auto mod = Packwiz::V1::createNoProviderModFormat(resource->name(), resource->fileinfo().fileName());
+    Metadata::update(m_index_dir, mod);
+    resource->setMetadata(mod);
+
+    return true;
 }

--- a/launcher/minecraft/mod/tasks/ResourceFolderLoadTask.h
+++ b/launcher/minecraft/mod/tasks/ResourceFolderLoadTask.h
@@ -72,6 +72,8 @@ class ResourceFolderLoadTask : public Task {
    private:
     void getFromMetadata();
 
+    bool createNoProviderMetadata(Resource* resource);
+
    private:
     QDir m_resource_dir, m_index_dir;
     bool m_is_indexed;

--- a/launcher/modplatform/EnsureMetadataTask.cpp
+++ b/launcher/modplatform/EnsureMetadataTask.cpp
@@ -105,7 +105,8 @@ void EnsureMetadataTask::executeTask()
         }
 
         // They already have the right metadata :o
-        if (resource->status() != ResourceStatus::NoMetadata && resource->metadata() && resource->metadata()->provider == m_provider) {
+        if (resource->status() != ResourceStatus::NoMetadata && resource->metadata() && resource->metadata()->provider == m_provider &&
+            resource->metadata()->provider.isValid()) {
             qDebug() << "Resource" << resource->name() << "already has metadata!";
             emitReady(resource);
             continue;

--- a/launcher/modplatform/EnsureMetadataTask.cpp
+++ b/launcher/modplatform/EnsureMetadataTask.cpp
@@ -9,6 +9,7 @@
 #include "QObjectPtr.h"
 #include "minecraft/mod/tasks/LocalResourceUpdateTask.h"
 
+#include "modplatform/ModIndex.h"
 #include "modplatform/flame/FlameAPI.h"
 #include "modplatform/flame/FlameModIndex.h"
 #include "modplatform/helpers/HashUtils.h"
@@ -118,13 +119,16 @@ void EnsureMetadataTask::executeTask()
 
     Task::Ptr versionTask;
 
-    switch (m_provider) {
+    switch (m_provider.value()) {
         case (ModPlatform::ResourceProvider::MODRINTH):
             versionTask = modrinthVersionsTask();
             break;
         case (ModPlatform::ResourceProvider::FLAME):
             versionTask = flameVersionsTask();
             break;
+        default:
+            emitFailed("Unknown provider");
+            return;
     }
 
     auto invalidadeLeftover = [this] {
@@ -139,13 +143,16 @@ void EnsureMetadataTask::executeTask()
     connect(versionTask.get(), &Task::finished, this, [this, invalidadeLeftover] {
         Task::Ptr projectTask;
 
-        switch (m_provider) {
+        switch (m_provider.value()) {
             case (ModPlatform::ResourceProvider::MODRINTH):
                 projectTask = modrinthProjectsTask();
                 break;
             case (ModPlatform::ResourceProvider::FLAME):
                 projectTask = flameProjectsTask();
                 break;
+            default:
+                emitFailed("Unknown provider");
+                return;
         }
 
         if (!projectTask) {
@@ -167,10 +174,10 @@ void EnsureMetadataTask::executeTask()
     });
 
     if (m_resources.size() > 1) {
-        setStatus(tr("Requesting metadata information from %1...").arg(ModPlatform::ProviderCapabilities::readableName(m_provider)));
+        setStatus(tr("Requesting metadata information from %1...").arg(m_provider.readableName()));
     } else if (!m_resources.empty()) {
-        setStatus(tr("Requesting metadata information from %1 for '%2'...")
-                      .arg(ModPlatform::ProviderCapabilities::readableName(m_provider), m_resources.begin().value()->name()));
+        setStatus(
+            tr("Requesting metadata information from %1 for '%2'...").arg(m_provider.readableName(), m_resources.begin().value()->name()));
     }
 
     m_currentTask = versionTask;
@@ -225,7 +232,7 @@ void EnsureMetadataTask::emitFail(Resource* resource, QString key, RemoveFromLis
 
 Task::Ptr EnsureMetadataTask::modrinthVersionsTask()
 {
-    auto hashType = ModPlatform::ProviderCapabilities::hashType(ModPlatform::ResourceProvider::MODRINTH).first();
+    auto hashType = ModPlatform::ResourceProvider(ModPlatform::ResourceProvider::MODRINTH).hashType().first();
 
     auto [verTask, response] = ModrinthAPI::currentVersions(m_resources.keys(), hashType);
 
@@ -508,7 +515,7 @@ void EnsureMetadataTask::updateMetadata(ModPlatform::IndexedPack& pack, ModPlatf
 
         connect(task.get(), &Task::finished, this, [this, &pack, resource] { updateMetadataCallback(pack, resource); });
 
-        m_updateMetadataTasks[ModPlatform::ProviderCapabilities::name(pack.provider) + pack.addonId.toString()] = task;
+        m_updateMetadataTasks[pack.provider.toString() + pack.addonId.toString()] = task;
         task->start();
     } catch (Json::JsonException& e) {
         qDebug() << e.cause();

--- a/launcher/modplatform/ModIndex.cpp
+++ b/launcher/modplatform/ModIndex.cpp
@@ -44,46 +44,6 @@ QList<ModLoaderType> modLoaderTypesToList(ModLoaderTypes flags)
     return flagList;
 }
 
-const char* ProviderCapabilities::name(ResourceProvider p)
-{
-    switch (p) {
-        case ResourceProvider::MODRINTH:
-            return "modrinth";
-        case ResourceProvider::FLAME:
-            return "curseforge";
-    }
-    return {};
-}
-
-QString ProviderCapabilities::readableName(ResourceProvider p)
-{
-    switch (p) {
-        case ResourceProvider::MODRINTH:
-            return "Modrinth";
-        case ResourceProvider::FLAME:
-            return "CurseForge";
-    }
-    return {};
-}
-
-QStringList ProviderCapabilities::hashType(ResourceProvider p)
-{
-    switch (p) {
-        case ResourceProvider::MODRINTH:
-            return { "sha512", "sha1" };
-        case ResourceProvider::FLAME:
-            // Try newer formats first, fall back to old format
-            return { "sha1", "md5", "murmur2" };
-    }
-    return {};
-}
-
-QString getMetaURL(ResourceProvider provider, QVariant projectID)
-{
-    return ((provider == ModPlatform::ResourceProvider::FLAME) ? "https://www.curseforge.com/projects/" : "https://modrinth.com/mod/") +
-           projectID.toString();
-}
-
 auto getModLoaderAsString(ModLoaderType type) -> const QString
 {
     switch (type) {

--- a/launcher/modplatform/ModIndex.h
+++ b/launcher/modplatform/ModIndex.h
@@ -57,7 +57,62 @@ using enum ModLoaderType;
 Q_DECLARE_FLAGS(ModLoaderTypes, ModLoaderType)
 QList<ModLoaderType> modLoaderTypesToList(ModLoaderTypes flags);
 
-enum class ResourceProvider : std::uint8_t { MODRINTH, FLAME };
+enum class ResourceProviderValue : std::uint8_t { MODRINTH, FLAME, UNKNOWN };
+struct ResourceProvider : EnumWrapper<ResourceProvider, ResourceProviderValue> {
+    static constexpr auto invalid() { return UNKNOWN; };
+
+    static constexpr auto mapping()
+    {
+        return std::array{
+            std::pair{ MODRINTH, "modrinth" },
+            std::pair{ FLAME, "curseforge" },
+        };
+    }
+
+    QString readableName() const
+    {
+        switch (value()) {
+            case MODRINTH:
+                return "Modrinth";
+            case FLAME:
+                return "CurseForge";
+            case ResourceProviderValue::UNKNOWN:
+                break;
+        }
+        return "Unknown";
+    }
+
+    QStringList hashType() const
+    {
+        switch (value()) {
+            case ResourceProvider::MODRINTH:
+                return { "sha512", "sha1" };
+            case ResourceProvider::FLAME:
+                // Try newer formats first, fall back to old format
+                return { "sha1", "md5", "murmur2" };
+            case ResourceProviderValue::UNKNOWN:
+                break;
+        }
+        return {};
+    }
+
+    QString getMetaURL(const QVariant& projectID) const
+    {
+        switch (value()) {
+            case ResourceProvider::MODRINTH:
+                return "https://modrinth.com/mod/" + projectID.toString();
+            case ResourceProvider::FLAME:
+                return "https://www.curseforge.com/projects/" + projectID.toString();
+            case ResourceProviderValue::UNKNOWN:
+                break;
+        }
+        return {};
+    }
+
+    using enum ResourceProviderValue;
+    using Base = EnumWrapper<ResourceProvider, ResourceProviderValue>;
+    using Base::Base;
+};
 
 enum class DependencyTypeValue : std::uint8_t { REQUIRED, OPTIONAL, INCOMPATIBLE, EMBEDDED, TOOL, INCLUDE, UNKNOWN };
 struct DependencyType : EnumWrapper<DependencyType, DependencyTypeValue> {
@@ -148,12 +203,6 @@ struct DisclosureType : EnumWrapper<DisclosureType, DisclosureTypeValue> {
     using Base = EnumWrapper<DisclosureType, DisclosureTypeValue>;
     using Base::Base; /* inherit ctor */
 };
-
-namespace ProviderCapabilities {
-const char* name(ResourceProvider);
-QString readableName(ResourceProvider);
-QStringList hashType(ResourceProvider);
-}  // namespace ProviderCapabilities
 
 struct ModpackAuthor {
     QString name;
@@ -298,8 +347,6 @@ inline auto getOverrideDeps() -> QList<OverrideDep>
         { .quilt = "lwVhp9o5", .fabric = "Ha28R6CL", .slug = "KotlinLibraries", .provider = ModPlatform::ResourceProvider::MODRINTH }
     };
 }
-
-QString getMetaURL(ResourceProvider provider, QVariant projectID);
 
 auto getModLoaderAsString(ModLoaderType type) -> const QString;
 auto getModLoaderFromString(QString type) -> ModLoaderType;

--- a/launcher/modplatform/flame/FlameModIndex.cpp
+++ b/launcher/modplatform/flame/FlameModIndex.cpp
@@ -173,7 +173,7 @@ auto FlameMod::loadIndexedPackVersion(QJsonObject& obj, bool loadChangelog) -> M
     auto hashList = obj["hashes"].toArray();
     for (auto h : hashList) {
         auto hashEntry = h.toObject();
-        auto hashTypes = ModPlatform::ProviderCapabilities::hashType(ModPlatform::ResourceProvider::FLAME);
+        auto hashTypes = ModPlatform::ResourceProvider(ModPlatform::ResourceProvider::FLAME).hashType();
         auto hashAlgo = enumToString(hashEntry["algo"].toInt(1));
         if (hashTypes.contains(hashAlgo)) {
             file.hash = Json::requireString(hashEntry, "value");

--- a/launcher/modplatform/flame/FlamePackExportTask.cpp
+++ b/launcher/modplatform/flame/FlamePackExportTask.cpp
@@ -422,10 +422,12 @@ QByteArray FlamePackExportTask::generateHTML()
     QString content = "";
     for (auto mod : resolvedFiles) {
         if (mod.isMod) {
-            content += QString(TEMPLATE)
-                           .replace("{name}", mod.name.toHtmlEscaped())
-                           .replace("{url}", ModPlatform::getMetaURL(ModPlatform::ResourceProvider::FLAME, mod.addonId).toHtmlEscaped())
-                           .replace("{authors}", !mod.authors.isEmpty() ? QString(" (by %1)").arg(mod.authors).toHtmlEscaped() : "");
+            content +=
+                QString(TEMPLATE)
+                    .replace("{name}", mod.name.toHtmlEscaped())
+                    .replace("{url}",
+                             ModPlatform::ResourceProvider(ModPlatform::ResourceProvider::FLAME).getMetaURL(mod.addonId).toHtmlEscaped())
+                    .replace("{authors}", !mod.authors.isEmpty() ? QString(" (by %1)").arg(mod.authors).toHtmlEscaped() : "");
         }
     }
     content = "<ul>" + content + "</ul>";

--- a/launcher/modplatform/helpers/HashUtils.cpp
+++ b/launcher/modplatform/helpers/HashUtils.cpp
@@ -11,10 +11,9 @@ namespace Hashing {
 
 Hasher::Ptr createHasher(QString file_path, ModPlatform::ResourceProvider provider)
 {
-    switch (provider) {
+    switch (provider.value()) {
         case ModPlatform::ResourceProvider::MODRINTH:
-            return makeShared<Hasher>(file_path,
-                                      ModPlatform::ProviderCapabilities::hashType(ModPlatform::ResourceProvider::MODRINTH).first());
+            return makeShared<Hasher>(file_path, ModPlatform::ResourceProvider(ModPlatform::ResourceProvider::MODRINTH).hashType().first());
         case ModPlatform::ResourceProvider::FLAME:
             return makeShared<Hasher>(file_path, Algorithm::Murmur2);
         default:

--- a/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
+++ b/launcher/modplatform/modrinth/ModrinthCheckUpdate.cpp
@@ -18,7 +18,7 @@ ModrinthCheckUpdate::ModrinthCheckUpdate(QList<Resource*>& resources,
                                          QList<ModPlatform::ModLoaderType> loadersList,
                                          ResourceFolderModel* resourceModel)
     : CheckUpdateTask(resources, mcVersions, std::move(loadersList), resourceModel)
-    , m_hashType(ModPlatform::ProviderCapabilities::hashType(ModPlatform::ResourceProvider::MODRINTH).first())
+    , m_hashType(ModPlatform::ResourceProvider(ModPlatform::ResourceProvider::MODRINTH).hashType().first())
 {
     if (!m_loadersList.isEmpty()) {  // this is for mods so append all the other posible loaders to the initial list
         m_initialSize = m_loadersList.length();

--- a/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
+++ b/launcher/modplatform/modrinth/ModrinthPackIndex.cpp
@@ -230,7 +230,7 @@ ModPlatform::IndexedVersion Modrinth::loadIndexedPackVersion(QJsonObject& obj,
             file.hash = Json::requireString(hashList, preferredHashType);
             file.hashType = preferredHashType;
         } else {
-            auto hashTypes = ModPlatform::ProviderCapabilities::hashType(ModPlatform::ResourceProvider::MODRINTH);
+            auto hashTypes = ModPlatform::ResourceProvider(ModPlatform::ResourceProvider::MODRINTH).hashType();
             for (auto& hashType : hashTypes) {
                 if (hashList.contains(hashType)) {
                     file.hash = Json::requireString(hashList, hashType);

--- a/launcher/modplatform/packwiz/Packwiz.cpp
+++ b/launcher/modplatform/packwiz/Packwiz.cpp
@@ -21,6 +21,7 @@
 
 #include <QDebug>
 #include <QDir>
+#include <QFileInfo>
 #include <QObject>
 #include <algorithm>
 #include <compare>
@@ -143,6 +144,23 @@ auto V1::createModFormat([[maybe_unused]] const QDir& index_dir,
     return mod;
 }
 
+auto V1::createNoProviderModFormat(const QString& name, const QString& filename) -> Mod
+{
+    Mod mod;
+
+    mod.name = name;
+
+    auto realFilename = filename;
+    if (realFilename.endsWith(".disabled")) {
+        realFilename.chop(9);
+    }
+
+    mod.filename = realFilename;
+    mod.slug = QFileInfo(realFilename).completeBaseName();
+
+    return mod;
+}
+
 void V1::updateModIndex(const QDir& index_dir, Mod& mod)
 {
     if (!mod.isValid()) {
@@ -229,15 +247,16 @@ void V1::updateModIndex(const QDir& index_dir, Mod& mod)
                                 { "x-prismlauncher-mc-versions", mcVersions },
                                 { "x-prismlauncher-release-type", mod.releaseType.toString().toStdString() },
                                 { "x-prismlauncher-version-number", mod.version_number.toStdString() },
-                                { "x-prismlauncher-dependencies", deps },
-                                { "download",
-                                  toml::table{
-                                      { "mode", mod.mode.toStdString() },
-                                      { "url", mod.url.toString().toStdString() },
-                                      { "hash-format", mod.hash_format.toStdString() },
-                                      { "hash", mod.hash.toStdString() },
-                                  } },
-                                { "update", toml::table{ { mod.provider.toString().toStdString(), update } } } };
+                                { "x-prismlauncher-dependencies", deps } };
+
+        if (mod.provider.isValid()) {
+            tbl.emplace("download", toml::table{ { "mode", mod.mode.toStdString() },
+                                                 { "url", mod.url.toString().toStdString() },
+                                                 { "hash-format", mod.hash_format.toStdString() },
+                                                 { "hash", mod.hash.toStdString() } });
+            tbl.emplace("update", toml::table{ { mod.provider.toString().toStdString(), update } });
+        }
+
         std::stringstream ss;
         ss << tbl;
         in_stream << QString::fromStdString(ss.str());
@@ -327,38 +346,31 @@ auto V1::getIndexForMod(const QDir& index_dir, QString slug) -> Mod
 
     {  // [download] info
         auto download_table = table["download"].as_table();
-        if (!download_table) {
-            qCritical() << QString("No [download] section found on mod metadata!");
-            return {};
+        if (download_table) {
+            mod.mode = stringEntry(*download_table, "mode");
+            mod.url = stringEntry(*download_table, "url");
+            mod.hash_format = stringEntry(*download_table, "hash-format");
+            mod.hash = stringEntry(*download_table, "hash");
         }
-
-        mod.mode = stringEntry(*download_table, "mode");
-        mod.url = stringEntry(*download_table, "url");
-        mod.hash_format = stringEntry(*download_table, "hash-format");
-        mod.hash = stringEntry(*download_table, "hash");
     }
 
     {  // [update] info
         using Provider = ModPlatform::ResourceProvider;
 
         auto update_table = table["update"];
-        if (!update_table || !update_table.is_table()) {
-            qCritical() << QString("No [update] section found on mod metadata!");
-            return {};
-        }
-
-        toml::table* mod_provider_table = nullptr;
-        if ((mod_provider_table = update_table[Provider(Provider::FLAME).toString().toStdString()].as_table()) != nullptr) {
-            mod.provider = Provider::FLAME;
-            mod.file_id = intEntry(*mod_provider_table, "file-id");
-            mod.project_id = intEntry(*mod_provider_table, "project-id");
-        } else if ((mod_provider_table = update_table[Provider(Provider::MODRINTH).toString().toStdString()].as_table())) {
-            mod.provider = Provider::MODRINTH;
-            mod.mod_id() = stringEntry(*mod_provider_table, "mod-id");
-            mod.version() = stringEntry(*mod_provider_table, "version");
-        } else {
-            qCritical() << QString("No mod provider on mod metadata!");
-            return {};
+        if (update_table && update_table.is_table()) {
+            toml::table* mod_provider_table = nullptr;
+            if ((mod_provider_table = update_table[Provider(Provider::FLAME).toString().toStdString()].as_table()) != nullptr) {
+                mod.provider = Provider::FLAME;
+                mod.file_id = intEntry(*mod_provider_table, "file-id");
+                mod.project_id = intEntry(*mod_provider_table, "project-id");
+            } else if ((mod_provider_table = update_table[Provider(Provider::MODRINTH).toString().toStdString()].as_table())) {
+                mod.provider = Provider::MODRINTH;
+                mod.mod_id() = stringEntry(*mod_provider_table, "mod-id");
+                mod.version() = stringEntry(*mod_provider_table, "version");
+            } else {
+                qWarning() << QString("No supported mod provider found on mod metadata!");
+            }
         }
     }
     {  // dependencies

--- a/launcher/modplatform/packwiz/Packwiz.cpp
+++ b/launcher/modplatform/packwiz/Packwiz.cpp
@@ -171,7 +171,7 @@ void V1::updateModIndex(const QDir& index_dir, Mod& mod)
     }
 
     toml::table update;
-    switch (mod.provider) {
+    switch (mod.provider.value()) {
         case (ModPlatform::ResourceProvider::FLAME):
             if (mod.file_id.toInt() == 0 || mod.project_id.toInt() == 0) {
                 qCritical() << QString("Did not write file %1 because missing information!").arg(normalized_fname);
@@ -191,6 +191,8 @@ void V1::updateModIndex(const QDir& index_dir, Mod& mod)
                 { "mod-id", mod.mod_id().toString().toStdString() },
                 { "version", mod.version().toString().toStdString() },
             };
+            break;
+        case ModPlatform::ResourceProviderValue::UNKNOWN:
             break;
     }
 
@@ -235,7 +237,7 @@ void V1::updateModIndex(const QDir& index_dir, Mod& mod)
                                       { "hash-format", mod.hash_format.toStdString() },
                                       { "hash", mod.hash.toStdString() },
                                   } },
-                                { "update", toml::table{ { ModPlatform::ProviderCapabilities::name(mod.provider), update } } } };
+                                { "update", toml::table{ { mod.provider.toString().toStdString(), update } } } };
         std::stringstream ss;
         ss << tbl;
         in_stream << QString::fromStdString(ss.str());
@@ -346,11 +348,11 @@ auto V1::getIndexForMod(const QDir& index_dir, QString slug) -> Mod
         }
 
         toml::table* mod_provider_table = nullptr;
-        if ((mod_provider_table = update_table[ModPlatform::ProviderCapabilities::name(Provider::FLAME)].as_table())) {
+        if ((mod_provider_table = update_table[Provider(Provider::FLAME).toString().toStdString()].as_table()) != nullptr) {
             mod.provider = Provider::FLAME;
             mod.file_id = intEntry(*mod_provider_table, "file-id");
             mod.project_id = intEntry(*mod_provider_table, "project-id");
-        } else if ((mod_provider_table = update_table[ModPlatform::ProviderCapabilities::name(Provider::MODRINTH)].as_table())) {
+        } else if ((mod_provider_table = update_table[Provider(Provider::MODRINTH).toString().toStdString()].as_table())) {
             mod.provider = Provider::MODRINTH;
             mod.mod_id() = stringEntry(*mod_provider_table, "mod-id");
             mod.version() = stringEntry(*mod_provider_table, "version");

--- a/launcher/modplatform/packwiz/Packwiz.h
+++ b/launcher/modplatform/packwiz/Packwiz.h
@@ -57,13 +57,15 @@ class V1 {
 
        public:
         // This is a totally heuristic, but should work for now.
-        auto isValid() const -> bool { return !slug.isEmpty() && !project_id.isNull(); }
+        auto isValid() const -> bool { return !slug.isEmpty() && !filename.isEmpty(); }
 
         // Different providers can use different names for the same thing
         // Modrinth-specific
         auto mod_id() -> QVariant& { return project_id; }
         auto version() -> QVariant& { return file_id; }
     };
+
+    static auto createNoProviderModFormat(const QString& name, const QString& filename) -> Mod;
 
     /* Generates the object representing the information in a mod.pw.toml file via
      * its common representation in the launcher, when downloading mods.

--- a/launcher/ui/dialogs/ChooseProviderDialog.cpp
+++ b/launcher/ui/dialogs/ChooseProviderDialog.cpp
@@ -67,17 +67,17 @@ void ChooseProviderDialog::confirmAll()
 
 auto ChooseProviderDialog::getSelectedProvider() const -> ModPlatform::ResourceProvider
 {
-    return ModPlatform::ResourceProvider(m_providers.checkedId());
+    return { static_cast<ModPlatform::ResourceProviderValue>(m_providers.checkedId()) };
 }
 
 void ChooseProviderDialog::addProviders()
 {
-    int btn_index = 0;
-    QRadioButton* btn;
+    QRadioButton* btn = nullptr;
 
-    for (auto& provider : { ModPlatform::ResourceProvider::MODRINTH, ModPlatform::ResourceProvider::FLAME }) {
-        btn = new QRadioButton(ModPlatform::ProviderCapabilities::readableName(provider), this);
-        m_providers.addButton(btn, btn_index++);
+    for (const auto& provider : { ModPlatform::ResourceProvider(ModPlatform::ResourceProvider::MODRINTH),
+                                  ModPlatform::ResourceProvider(ModPlatform::ResourceProvider::FLAME) }) {
+        btn = new QRadioButton(provider.readableName(), this);
+        m_providers.addButton(btn, static_cast<int>(provider.value()));
         ui->providersLayout->addWidget(btn);
     }
 }

--- a/launcher/ui/dialogs/ChooseProviderDialog.h
+++ b/launcher/ui/dialogs/ChooseProviderDialog.h
@@ -2,14 +2,10 @@
 
 #include <QButtonGroup>
 #include <QDialog>
-#include <cstdint>
+#include "modplatform/ModIndex.h"
 
 namespace Ui {
 class ChooseProviderDialog;
-}
-
-namespace ModPlatform {
-enum class ResourceProvider : std::uint8_t;
 }
 
 class Mod;

--- a/launcher/ui/dialogs/ResourceDownloadDialog.cpp
+++ b/launcher/ui/dialogs/ResourceDownloadDialog.cpp
@@ -212,7 +212,7 @@ void ResourceDownloadDialog::confirm()
         auto extraInfo = dependencyExtraInfo.value(task->getPack()->addonId.toString());
         confirmDialog->appendResource({ .name = task->getName(),
                                         .filename = task->getFilename(),
-                                        .provider = ModPlatform::ProviderCapabilities::name(task->getProvider()),
+                                        .provider = task->getProvider().toString(),
                                         .required_by = extraInfo.requiredByNames,
                                         .version_type = task->getVersion().versionType.toString(),
                                         .enabled = !extraInfo.maybeInstalled });
@@ -335,12 +335,14 @@ void ResourceDownloadDialog::selectedPageChanged(BasePage* previous, BasePage* s
 
 void ResourceDownloadDialog::setResourceMetadata(const std::shared_ptr<Metadata::ModStruct>& meta)
 {
-    switch (meta->provider) {
+    switch (meta->provider.value()) {
         case ModPlatform::ResourceProvider::MODRINTH:
             selectPage(Modrinth::id());
             break;
         case ModPlatform::ResourceProvider::FLAME:
             selectPage(Flame::id());
+            break;
+        case ModPlatform::ResourceProviderValue::UNKNOWN:
             break;
     }
 

--- a/launcher/ui/dialogs/ResourceUpdateDialog.cpp
+++ b/launcher/ui/dialogs/ResourceUpdateDialog.cpp
@@ -36,11 +36,13 @@ std::vector<Version> mcVersions(MinecraftInstance* inst)
 }
 ModPlatform::ResourceProvider next(ModPlatform::ResourceProvider p)
 {
-    switch (p) {
+    switch (p.value()) {
         case ModPlatform::ResourceProvider::MODRINTH:
             return ModPlatform::ResourceProvider::FLAME;
         case ModPlatform::ResourceProvider::FLAME:
             return ModPlatform::ResourceProvider::MODRINTH;
+        case ModPlatform::ResourceProviderValue::UNKNOWN:
+            break;
     }
 
     return ModPlatform::ResourceProvider::FLAME;
@@ -307,12 +309,14 @@ auto ResourceUpdateDialog::ensureMetadata() -> bool
 
     // adds resource to list based on provider
     auto addToTmp = [&modrinthTmp, &flameTmp](Resource* resource, ModPlatform::ResourceProvider p) {
-        switch (p) {
+        switch (p.value()) {
             case ModPlatform::ResourceProvider::MODRINTH:
                 modrinthTmp.push_back(resource);
                 break;
             case ModPlatform::ResourceProvider::FLAME:
                 flameTmp.push_back(resource);
+                break;
+            case ModPlatform::ResourceProviderValue::UNKNOWN:
                 break;
         }
     };
@@ -416,12 +420,14 @@ void ResourceUpdateDialog::onMetadataEnsured(Resource* resource)
         return;
     }
 
-    switch (resource->metadata()->provider) {
+    switch (resource->metadata()->provider.value()) {
         case ModPlatform::ResourceProvider::MODRINTH:
             m_modrinthToUpdate.push_back(resource);
             break;
         case ModPlatform::ResourceProvider::FLAME:
             m_flameToUpdate.push_back(resource);
+            break;
+        case ModPlatform::ResourceProviderValue::UNKNOWN:
             break;
     }
 }
@@ -462,7 +468,7 @@ void ResourceUpdateDialog::appendResource(const CheckUpdateTask::Update& info, Q
     itemTop->setExpanded(true);
 
     auto* providerItem = new QTreeWidgetItem(itemTop);
-    QString providerName = ModPlatform::ProviderCapabilities::readableName(info.provider);
+    QString providerName = info.provider.readableName();
     providerItem->setText(0, tr("Provider: %1").arg(providerName));
     providerItem->setData(0, Qt::UserRole, providerName);
 

--- a/launcher/ui/dialogs/ResourceUpdateDialog.cpp
+++ b/launcher/ui/dialogs/ResourceUpdateDialog.cpp
@@ -323,7 +323,12 @@ auto ResourceUpdateDialog::ensureMetadata() -> bool
 
     // ask the user on what provider to seach for the mod first
     for (auto* candidate : m_candidates) {
-        if (candidate->status() != ResourceStatus::NoMetadata) {
+        if (candidate->metadata() && candidate->metadata()->provider.value() == ModPlatform::ResourceProviderValue::UNKNOWN) {
+            m_rematchSlugs[candidate] = candidate->metadata()->slug;
+        }
+
+        if (candidate->status() != ResourceStatus::NoMetadata &&
+            (candidate->metadata() && candidate->metadata()->provider.value() != ModPlatform::ResourceProviderValue::UNKNOWN)) {
             onMetadataEnsured(candidate);
             continue;
         }
@@ -418,6 +423,14 @@ void ResourceUpdateDialog::onMetadataEnsured(Resource* resource)
     // When the mod is a folder, for instance
     if (!resource->metadata()) {
         return;
+    }
+
+    // remove old file
+    if (m_rematchSlugs.contains(resource)) {
+        auto oldSlug = m_rematchSlugs.take(resource);
+        if (oldSlug != resource->metadata()->slug) {
+            Metadata::remove(indexDir(), oldSlug);
+        }
     }
 
     switch (resource->metadata()->provider.value()) {

--- a/launcher/ui/dialogs/ResourceUpdateDialog.h
+++ b/launcher/ui/dialogs/ResourceUpdateDialog.h
@@ -55,6 +55,7 @@ class ResourceUpdateDialog final : public ReviewMessageBox {
     QList<Resource*> m_flameToUpdate;
 
     ConcurrentTask::Ptr m_secondTryMetadata;
+    QHash<Resource*, QString> m_rematchSlugs;
     QList<std::tuple<Resource*, QString>> m_failedMetadata;
     QList<std::tuple<Resource*, QString, QUrl>> m_failedCheckUpdate;
 


### PR DESCRIPTION
this will pair nicely with the lock PR.
also provide a place for adding categories.
no this is not packwiz compliant but the alternative is to rewrite a huge chunk of code, and write it to a custom format(json,DB, you choose).
So instead of working my ass on that I will patch current implementation and hope rust will fix it

combined with lock column PR this will fix https://github.com/PrismLauncher/PrismLauncher/issues/1896 
but in that case will be blocked by #4470

and no clang-tidy for this one.

