### PR TITLE
Add confirm dialog for updating modpack

### DIFF
--- a/launcher/ui/pages/instance/ManagedPackPage.cpp
+++ b/launcher/ui/pages/instance/ManagedPackPage.cpp
@@ -455,6 +455,18 @@ void FlameManagedPackPage::updateFromFile()
 
 void ManagedPackPage::updatePack(const QUrl& url, bool trusted, const QString& versionID, const QString& versionName)
 {
+    auto response = CustomMessageBox::selectable(this, tr("Confirm Update"),
+                                                 tr("You are about to update the modpack to version \"%1\".\n"
+                                                    "Irreversible changes may be made to the instance's files.\n"
+                                                    "As such, it is strongly recommended to create a backup copy of the instance.\n\n"
+                                                    "Are you sure?")
+                                                     .arg(versionName),
+                                                 QMessageBox::Warning, QMessageBox::Yes | QMessageBox::No, QMessageBox::No)
+                        ->exec();
+    if (response != QMessageBox::Yes) {
+        return;
+    }
+
     QMap<QString, QString> extraInfo;
     // NOTE: Don't use 'm_pack.id' here, since we didn't completely parse all the metadata for the pack, including this field.
     extraInfo.insert("pack_id", m_inst->getManagedPackID());


### PR DESCRIPTION
The updater has had some issues and advising the user to backup seems sensible and long overdue

Not sure if anyone actually lost that much data to the updater, but by the nature of the way the updater works there is always a possibility of stuff being lost (even if it were bug-free)