### PR TITLE
fix(logs): don't hold back text that only looks like a log4j event

### DIFF
--- a/launcher/logs/LogParser.cpp
+++ b/launcher/logs/LogParser.cpp
@@ -86,14 +86,25 @@ void LogParser::clearError()
     m_error = {};  // clear previous error
 }
 
-bool isPotentialLog4JStart(QStringView buffer)
+/// Does this slice begin a log4j event?
+///
+/// Data reaches the parser one whole line at a time (see LogParser::appendLine) and log4j's XMLLayout
+/// never splits the `<log4j:Event` start tag across lines, so a slice that is merely a *prefix* of that
+/// tag can never be completed by later input. Accepting such a prefix used to tear a lone `<` (as in the
+/// emoticon `>w<`) off the end of its line and hold it back until the next line arrived.
+static bool isPotentialLog4JStart(QStringView buffer)
 {
-    static QString target = QStringLiteral("<log4j:event");
-    if (buffer.isEmpty() || buffer[0] != '<') {
+    static constexpr auto target = "<log4j:event"_L1;
+    if (!buffer.startsWith(target, Qt::CaseInsensitive)) {
         return false;
     }
-    auto bufLower = buffer.toString().toLower();
-    return target.startsWith(bufLower) || bufLower.startsWith(target);
+    if (buffer.length() == target.size()) {
+        return true;  // the name is complete, whatever follows it is on the next line
+    }
+    // `<log4j:Eventually` names a different element, and taking it for one of ours would swallow the
+    // rest of the line just like the bare `<` did.
+    auto next = buffer.at(target.size());
+    return next.isSpace() || next == '>' || next == '/';
 }
 
 std::optional<LogParser::ParsedItem> LogParser::parseNext()

--- a/tests/XmlLogs_test.cpp
+++ b/tests/XmlLogs_test.cpp
@@ -113,18 +113,57 @@ class XmlLogParseTest : public QObject {
         QCOMPARE(levels, entry_levels);
     }
 
-   private:
-    LogParser m_parser;
+    void parseAngleBrackets_data()
+    {
+        QTest::addColumn<QStringList>("lines");
+        QTest::addColumn<QStringList>("messages");
 
+        // Text that merely begins to look like a log4j event must not be held back: lines reach the
+        // parser whole, so the rest of `<log4j:Event` can never turn up later on. See #5825.
+        QTest::newRow("trailing left angle bracket")
+            << QStringList{ "[21:16:07] [Render thread/INFO]: happy >w<", "[21:16:08] [Render thread/INFO]: unrelated" }
+            << QStringList{ "[21:16:07] [Render thread/INFO]: happy >w<", "[21:16:08] [Render thread/INFO]: unrelated" };
+        QTest::newRow("trailing partial tag") << QStringList{ "generics are <log", "unrelated" }
+                                              << QStringList{ "generics are <log", "unrelated" };
+        QTest::newRow("lone left angle bracket") << QStringList{ "<", "unrelated" } << QStringList{ "<", "unrelated" };
+        QTest::newRow("unrelated markup") << QStringList{ "<html>", "unrelated" } << QStringList{ "<html>", "unrelated" };
+        QTest::newRow("longer element name") << QStringList{ "talking about <log4j:eventually", "unrelated" }
+                                             << QStringList{ "talking about <log4j:eventually", "unrelated" };
+
+        // ... while real events, spread over several lines or not, still have to be recognised.
+        QTest::newRow("event over several lines")
+            << QStringList{ R"(  <log4j:Event logger="fqq" timestamp="1745005150596" level="INFO" thread="Render thread">)",
+                            R"(    <log4j:Message><![CDATA[Setting user: Ryexandrite]]></log4j:Message>)", R"(  </log4j:Event>)" }
+            << QStringList{ "Setting user: Ryexandrite" };
+        QTest::newRow("event with attributes on the next line")
+            << QStringList{ R"(  <log4j:Event)", R"(      logger="fqq" timestamp="1745005150596" level="INFO" thread="Render thread">)",
+                            R"(    <log4j:Message><![CDATA[Setting user: Ryexandrite]]></log4j:Message>)", R"(  </log4j:Event>)" }
+            << QStringList{ "Setting user: Ryexandrite" };
+        QTest::newRow("event preceded by text")
+            << QStringList{ R"(stray output <log4j:Event logger="fqq" timestamp="1745005150596" level="INFO" thread="Render thread">)"
+                            R"(<log4j:Message><![CDATA[Setting user: Ryexandrite]]></log4j:Message></log4j:Event>)" }
+            << QStringList{ "stray output ", "Setting user: Ryexandrite" };
+    }
+
+    void parseAngleBrackets()
+    {
+        QFETCH(QStringList, lines);
+        QFETCH(QStringList, messages);
+
+        QCOMPARE(parseMessages(lines), messages);
+    }
+
+   private:
     QList<std::pair<MessageLevel, QString>> parseLines(const QStringList& lines)
     {
+        LogParser parser;
         QList<std::pair<MessageLevel, QString>> out;
         MessageLevel last = MessageLevel::Unknown;
 
         for (const auto& line : lines) {
-            m_parser.appendLine(line);
+            parser.appendLine(line);
 
-            auto items = m_parser.parseAvailable();
+            auto items = parser.parseAvailable();
             for (const auto& item : items) {
                 if (std::holds_alternative<LogParser::LogEntry>(item)) {
                     auto entry = std::get<LogParser::LogEntry>(item);
@@ -142,6 +181,27 @@ class XmlLogParseTest : public QObject {
 
                     out.append(std::make_pair(level, msg));
                     last = level;
+                }
+            }
+        }
+        return out;
+    }
+
+    /// The messages the parser produces, without the timestamp formatting parseLines() applies - so that
+    /// expectations do not depend on the time zone the test happens to run in.
+    QStringList parseMessages(const QStringList& lines)
+    {
+        LogParser parser;
+        QStringList out;
+
+        for (const auto& line : lines) {
+            parser.appendLine(line);
+
+            for (const auto& item : parser.parseAvailable()) {
+                if (std::holds_alternative<LogParser::LogEntry>(item)) {
+                    out.append(std::get<LogParser::LogEntry>(item).message);
+                } else if (std::holds_alternative<LogParser::PlainText>(item)) {
+                    out.append(std::get<LogParser::PlainText>(item).message);
                 }
             }
         }


### PR DESCRIPTION
Fixes #5825 — a console line ending in `<` (the reporter's example is the emoticon `>w<`) gets broken apart in the **Minecraft Log** tab.

### What happens

`LogParser::parseNext()` scans each line for a `<` that might begin a log4j event and, when it finds one, stashes the rest of the line as *partial* data to be joined with the next line. `isPotentialLog4JStart()` decided that with

```cpp
return target.startsWith(bufLower) || bufLower.startsWith(target);
```

The first half accepts any **prefix** of `<log4j:event` — including the single character `<`. So `hello >w<` was emitted as plain text `hello >w`, the `<` was held back, and it came back glued to the front of whatever line arrived next:

```
PLAIN : hello >w
PLAIN : <\nsecond line     <- the line break the issue is about
```

The second half has a matching problem in the other direction: it accepts anything that merely *starts* with the token, so `<log4j:eventually` counted as an event and swallowed the rest of the line plus the one after it.

### Why the prefix case can never be real

`appendLine()` is fed one whole line at a time — `LoggedProcess::reprocess()` splits on `\n` and keeps any incomplete trailing line in `m_leftover_line` — and log4j's XMLLayout never breaks the `<log4j:Event` start tag across lines. A slice that is only a prefix of that tag therefore can never be completed by later input, so it is plain text.

So the check now requires the full token *and* that the element name ends there (whitespace, `>`, `/`, or end of line). Events spread over several lines still carry the complete name on their first line and parse exactly as before — including the case where the attributes follow on the next line, which has its own test row.

As a side effect this also drops a `toString().toLower()` allocation from a path that runs for every `<` in every log line.

### Testing

`XmlLogParseTest` gains a data-driven `parseAngleBrackets` case. Four rows fail on the old parser and pass on the new one:

| row | before | after |
|---|---|---|
| `... happy >w<` | `... happy >w` | `... happy >w<` |
| `generics are <log` | `generics are ` | `generics are <log` |
| `<` on its own line | line swallowed, 1 item instead of 2 | 2 items |
| `talking about <log4j:eventually` | line swallowed, 1 item instead of 2 | 2 items |

Three more rows (`<html>`, an event spread over three lines, and text followed by an event on the same line) plus the attributes-on-the-next-line row pass both before and after, so they pin down that the check has not become too strict.

The four existing `parseXml` rows — including the 869-entry TerraFirmaGreg XML capture — are unchanged.

`parseLines()` now builds a local `LogParser` instead of sharing the `m_parser` member. The new rows deliberately leave the parser holding partial data on the unfixed code, which would otherwise leak into the following row and turn one failure into a cascade.