### PR TITLE
fix(logs): read log4j event timestamps as milliseconds

### DIFF
--- a/launcher/logs/LogParser.cpp
+++ b/launcher/logs/LogParser.cpp
@@ -57,7 +57,8 @@ std::optional<LogParser::LogEntry> LogParser::parseAttributes()
                 m_parser.raiseError("log4j:Event Missing required attribute: timestamp");
                 return {};
             }
-            entry.timestamp = QDateTime::fromSecsSinceEpoch(value.trimmed().toLongLong());
+            // log4j's XMLLayout reports the event time in milliseconds
+            entry.timestamp = QDateTime::fromMSecsSinceEpoch(value.trimmed().toLongLong());
         } else if (name == "level"_L1) {
             entry.levelText = value.trimmed().toString();
             entry.level = MessageLevel::fromName(entry.levelText);

--- a/tests/XmlLogs_test.cpp
+++ b/tests/XmlLogs_test.cpp
@@ -21,6 +21,7 @@
 
 #include <QTest>
 
+#include <QDateTime>
 #include <QList>
 #include <QObject>
 #include <QRegularExpression>
@@ -48,6 +49,40 @@ class XmlLogParseTest : public QObject {
                      "[25Jul2026 14:10:58.723] [main/ERROR] [net.minecraftforge.fml.loading.moddiscovery.ModFileParser/LOADING]: error",
                      MessageLevel::Unknown),
                  MessageLevel::Error);
+    }
+
+    void parseEventTimestamp()
+    {
+        // Taken verbatim from testdata/TestLogs/vanilla-1.21.5.xml.log. These two events sit just under
+        // two seconds apart, as they do in the plain text capture of the same startup sequence - read as
+        // seconds they would be 33 minutes apart, in the year 57267.
+        const QStringList lines = {
+            R"(  <log4j:Event logger="com.mojang.datafixers.DataFixerBuilder" timestamp="1745005148589" level="INFO" thread="Datafixer Bootstrap">)",
+            R"(    <log4j:Message><![CDATA[263 Datafixer optimizations took 906 milliseconds]]></log4j:Message>)",
+            R"(  </log4j:Event>)",
+            R"(  <log4j:Event logger="com.mojang.authlib.yggdrasil.YggdrasilAuthenticationService" timestamp="1745005150587" level="INFO" thread="Render thread">)",
+            R"(    <log4j:Message><![CDATA[Environment: Environment[sessionHost=https://sessionserver.mojang.com, servicesHost=https://api.minecraftservices.com, name=PROD]]]></log4j:Message>)",
+            R"(  </log4j:Event>)",
+        };
+
+        LogParser parser;
+        QList<QDateTime> timestamps;
+
+        for (const auto& line : lines) {
+            parser.appendLine(line);
+
+            for (const auto& item : parser.parseAvailable()) {
+                QVERIFY(std::holds_alternative<LogParser::LogEntry>(item));
+                timestamps.append(std::get<LogParser::LogEntry>(item).timestamp);
+            }
+        }
+
+        QCOMPARE(timestamps.length(), 2);
+        // Comparing instants rather than rendered clock times keeps this independent of the time zone.
+        QCOMPARE(timestamps[0], QDateTime::fromMSecsSinceEpoch(1745005148589));
+        QCOMPARE(timestamps[1], QDateTime::fromMSecsSinceEpoch(1745005150587));
+        QCOMPARE(timestamps[0].toUTC().date(), QDate(2025, 4, 18));
+        QCOMPARE(timestamps[0].msecsTo(timestamps[1]), 1998);
     }
 
     void parseXml_data()


### PR DESCRIPTION
The timestamps shown next to log4j events in the **Minecraft Log** tab are wrong.

log4j's XMLLayout reports the event time in **milliseconds** since the epoch, but `LogParser::parseAttributes()` passed it to `QDateTime::fromSecsSinceEpoch()`:

```cpp
entry.timestamp = QDateTime::fromSecsSinceEpoch(value.trimmed().toLongLong());
```

Each entry therefore lands roughly 55 000 years in the future, and once `LaunchTask::parseXmlLogs()` renders it as `HH:mm:ss` the result is a plausible-looking clock time that has nothing to do with when the line was logged. Nothing errors out, which is probably why it went unnoticed — you just get the wrong time.

### Evidence from the repo's own sample log

The first two events of `tests/testdata/TestLogs/vanilla-1.21.5.xml.log`:

```
timestamp="1745005148589"   263 Datafixer optimizations took 906 milliseconds
timestamp="1745005150587"   Environment: Environment[sessionHost=...]
```

Read as milliseconds they are 1998 ms apart, on 2025-04-18 — which matches both the 1.21.5 release window and the plain text capture of the same startup sequence, where those two lines sit two seconds apart. Read as seconds they are 33 minutes apart, in the year 57267.

The same holds for the forge capture: `1745005464389`, `...393`, `...825`, `...890` are 4 ms, 1432 ms and 65 ms apart, and `TerraFirmaGreg-Modern-forge.text.log` indeed shows those four lines within the same second. As seconds, the second gap alone would be 24 minutes.

### Testing

New `parseEventTimestamp` case, using those two events verbatim. On the current parser it fails with

```
Actual   (timestamps[0])                                : +57267/01/04 23:23:09.000[+03]
Expected (QDateTime::fromMSecsSinceEpoch(1745005148589)): 2025/04/18 22:39:08.589[+03]
```

It compares instants rather than rendered clock times and checks the gap in milliseconds, so it does not depend on the time zone it runs in — verified under `UTC`, `Pacific/Kiritimati`, `America/Los_Angeles` and `Europe/Istanbul`.

`entry.timestamp` has no other consumers, so the only visible change is the console showing the correct time.